### PR TITLE
Move shpool loop and session switching into autoshpool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+test:
+	./autoshpool_test

--- a/autoshpool
+++ b/autoshpool
@@ -1,5 +1,16 @@
 #!/bin/bash
 # autoshpool - connect to first existing shpool session or start a new one
+#
+# Usage:
+#   autoshpool                - attach to or create a shpool session (loops for switching)
+#   autoshpool switch <session> - request a switch to the named session (from inside shpool)
+#
+# In shrc, replace shpool_loop with:
+#   autoshpool && exit
+# And replace switchshpool with:
+#   switchshpool() { autoshpool switch "$1" && exit; }
+
+switch_session_file="$HOME/.autoshpool_switch"
 
 get_current_shpool_session() {
   echo "$SHPOOL_SESSION_NAME"
@@ -40,8 +51,10 @@ attach_first_disconnected() {
   if test "${#disconnected[@]}" -gt 0; then
     session="${disconnected[0]}"
     echo "Attaching shpool session $session"
-    exec shpool attach "$session"
+    shpool attach "$session"
+    return
   fi
+  return 1
 }
 
 create_and_attach_next() {
@@ -54,14 +67,32 @@ create_and_attach_next() {
     export SHPOOL_INITIAL_PWD="$PWD"
     if test -z "${sessions[$session]}"; then
       echo "Creating shpool session $session"
-      exec shpool attach "$session"
+      shpool attach "$session"
+      return
     fi
   done
   echo "You already have more than 100 sessions??" >&2
-  exit 2
+  return 2
 }
 
-autoshpool_main() {
+get_switch_session() {
+  cat "$switch_session_file" 2>/dev/null
+}
+
+request_switch() {
+  echo "$1" > "$switch_session_file"
+  exit 0
+}
+
+clear_switch() {
+  rm -f "$switch_session_file"
+}
+
+# Start an shpool session with a useful session name.
+# Disconnect if the user cleanly exited the session.
+# Stay connected if there was an error, so the user can see and fix the error.
+# Run in a loop so the user can switch to a different session.
+autoshpool_loop() {
   #exec >>"$HOME/.autoshpool.log" 2>>"$HOME/.autoshpool.log"
 
   exit_if_already_attached
@@ -72,9 +103,30 @@ autoshpool_main() {
 
   abort_if_hung
 
-  attach_first_disconnected
+  while true; do
+    switch_session="$(get_switch_session)"
+    if test -n "$switch_session"; then
+      clear_switch
+      shpool attach "$switch_session"
+    else
+      attach_first_disconnected || create_and_attach_next
+    fi
+    rc=$?
 
-  create_and_attach_next
+    if test $rc -ne 0; then
+      # Maybe .shrc failed or something.
+      # Stay here so the user can see the error and fix it.
+      return $rc
+    fi
+
+    switch_session="$(get_switch_session)"
+    if test -n "$switch_session"; then
+      continue
+    fi
+
+    # autoshpool exited cleanly with no switch pending.
+    return 0
+  done
 }
 
 is_sourced() {
@@ -90,8 +142,21 @@ is_sourced() {
   return 1
 }
 
-test $# -gt 0 && exec shpool "$@"
-
-if ! is_sourced; then
-  autoshpool_main
+if is_sourced; then
+  return
 fi
+
+# autoshpool switch <session> - request a switch to the named session
+# autoshpool <shpool args...> - pass through to shpool
+# autoshpool (no args) - run the loop
+case "$1" in
+  switch)
+    request_switch "$2"
+    ;;
+  "")
+    autoshpool_loop
+    ;;
+  *)
+    exec shpool "$@"
+    ;;
+esac

--- a/autoshpool_test
+++ b/autoshpool_test
@@ -1,0 +1,241 @@
+#!/bin/bash
+# Tests for autoshpool
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+setup() {
+  TEST_TMPDIR="$(mktemp -d)"
+  export HOME="$TEST_TMPDIR"
+  export PATH="$TEST_TMPDIR/bin:$PATH"
+
+  mkdir -p "$TEST_TMPDIR/bin"
+
+  # Create a fake shpool that records its calls
+  cat > "$TEST_TMPDIR/bin/shpool" <<'SHPOOL'
+#!/bin/bash
+echo "shpool $*" >> "$HOME/.shpool_calls"
+case "$1" in
+  list)
+    echo "name                           started_at                         status"
+    cat "$HOME/.shpool_sessions" 2>/dev/null
+    exit 0
+    ;;
+  attach)
+    exit "${SHPOOL_ATTACH_EXIT:-0}"
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+SHPOOL
+  chmod +x "$TEST_TMPDIR/bin/shpool"
+
+  # Create a fake rootdir
+  cat > "$TEST_TMPDIR/bin/rootdir" <<'ROOTDIR'
+#!/bin/bash
+echo ""
+ROOTDIR
+  chmod +x "$TEST_TMPDIR/bin/rootdir"
+
+  # Create a fake timeout that just runs the command
+  cat > "$TEST_TMPDIR/bin/timeout" <<'TIMEOUT'
+#!/bin/bash
+shift
+"$@"
+TIMEOUT
+  chmod +x "$TEST_TMPDIR/bin/timeout"
+
+  # Create stub .shrc.vcs
+  touch "$TEST_TMPDIR/.shrc.vcs"
+
+  # Clean state
+  unset SHPOOL_SESSION_NAME
+  unset SHPOOL_PREFIX
+  unset SHPOOL_ATTACH_EXIT
+  rm -f "$TEST_TMPDIR/.autoshpool_switch"
+  rm -f "$TEST_TMPDIR/.shpool_calls"
+  rm -f "$TEST_TMPDIR/.shpool_sessions"
+}
+
+teardown() {
+  rm -rf "$TEST_TMPDIR"
+}
+
+run_autoshpool() {
+  set +e
+  output="$("$SCRIPT_DIR/autoshpool" "$@" 2>&1)"
+  status=$?
+  set -e
+}
+
+assert_status() {
+  local expected=$1
+  if [ "$status" -ne "$expected" ]; then
+    echo "  FAIL: expected exit status $expected, got $status"
+    echo "  output: $output"
+    return 1
+  fi
+}
+
+assert_output_contains() {
+  if [[ "$output" != *"$1"* ]]; then
+    echo "  FAIL: output does not contain '$1'"
+    echo "  output: $output"
+    return 1
+  fi
+}
+
+assert_called() {
+  if ! grep -q "$1" "$HOME/.shpool_calls" 2>/dev/null; then
+    echo "  FAIL: expected call '$1' not found"
+    echo "  calls: $(cat "$HOME/.shpool_calls" 2>/dev/null)"
+    return 1
+  fi
+}
+
+run_test() {
+  local name="$1"
+  local func="$2"
+  TESTS_RUN=$((TESTS_RUN + 1))
+  setup
+  if "$func"; then
+    echo "ok $TESTS_RUN $name"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo "not ok $TESTS_RUN $name"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+  teardown
+}
+
+# --- tests ---
+
+test_switch_writes_file() {
+  run_autoshpool switch mysession
+  assert_status 0
+  [ "$(cat "$HOME/.autoshpool_switch")" = "mysession" ]
+}
+
+test_switch_exits_0() {
+  run_autoshpool switch foo
+  assert_status 0
+}
+
+test_passthrough_to_shpool() {
+  run_autoshpool list
+  assert_status 0
+  assert_called "shpool list"
+}
+
+test_passthrough_preserves_args() {
+  run_autoshpool attach mysession
+  assert_status 0
+  assert_called "shpool attach mysession"
+}
+
+test_exits_if_already_attached() {
+  export SHPOOL_SESSION_NAME="existing"
+  run_autoshpool
+  assert_status 1
+  assert_output_contains "Already connected"
+}
+
+test_creates_session_1() {
+  run_autoshpool
+  assert_status 0
+  assert_called "shpool attach 1"
+  assert_output_contains "Creating shpool session 1"
+}
+
+test_attaches_disconnected_first() {
+  cat > "$HOME/.shpool_sessions" <<EOF
+2      2025-01-01T00:00:00Z   connected
+3      2025-01-01T00:00:00Z   disconnected
+EOF
+  run_autoshpool
+  assert_status 0
+  assert_called "shpool attach 3"
+  assert_output_contains "Attaching shpool session 3"
+}
+
+test_returns_nonzero_on_failure() {
+  export SHPOOL_ATTACH_EXIT=1
+  run_autoshpool
+  assert_status 1
+}
+
+test_preserves_exit_code() {
+  export SHPOOL_ATTACH_EXIT=42
+  run_autoshpool
+  assert_status 42
+}
+
+test_loop_handles_switch() {
+  cat > "$TEST_TMPDIR/bin/shpool" <<'SHPOOL'
+#!/bin/bash
+echo "shpool $*" >> "$HOME/.shpool_calls"
+case "$1" in
+  list)
+    echo "name                           started_at                         status"
+    cat "$HOME/.shpool_sessions" 2>/dev/null
+    exit 0
+    ;;
+  attach)
+    call_count=$(grep -c "shpool attach" "$HOME/.shpool_calls" 2>/dev/null || echo 0)
+    if [ "$call_count" -le 1 ]; then
+      echo "other" > "$HOME/.autoshpool_switch"
+    fi
+    exit 0
+    ;;
+esac
+SHPOOL
+  chmod +x "$TEST_TMPDIR/bin/shpool"
+
+  run_autoshpool
+  assert_status 0
+  assert_called "shpool attach 1"
+  assert_called "shpool attach other"
+}
+
+test_uses_prefix() {
+  export SHPOOL_PREFIX="myproject:"
+  run_autoshpool
+  assert_status 0
+  assert_called "shpool attach myproject:1"
+}
+
+test_skips_existing_sessions() {
+  export SHPOOL_PREFIX=""
+  cat > "$HOME/.shpool_sessions" <<EOF
+1      2025-01-01T00:00:00Z   connected
+2      2025-01-01T00:00:00Z   connected
+EOF
+  run_autoshpool
+  assert_status 0
+  assert_called "shpool attach 3"
+  assert_output_contains "Creating shpool session 3"
+}
+
+# --- run ---
+
+run_test "switch writes session name to switch file" test_switch_writes_file
+run_test "switch exits 0" test_switch_exits_0
+run_test "unknown subcommand passes through to shpool" test_passthrough_to_shpool
+run_test "passthrough preserves all arguments" test_passthrough_preserves_args
+run_test "exits with error if already in a shpool session" test_exits_if_already_attached
+run_test "creates session 1 when no sessions exist" test_creates_session_1
+run_test "attaches to disconnected session before creating new one" test_attaches_disconnected_first
+run_test "returns non-zero when shpool attach fails" test_returns_nonzero_on_failure
+run_test "preserves specific exit code from shpool attach" test_preserves_exit_code
+run_test "loop handles switch request after session ends" test_loop_handles_switch
+run_test "uses SHPOOL_PREFIX for session names" test_uses_prefix
+run_test "skips existing sessions when creating" test_skips_existing_sessions
+
+echo
+echo "$TESTS_RUN tests, $TESTS_PASSED passed, $TESTS_FAILED failed"
+test "$TESTS_FAILED" -eq 0


### PR DESCRIPTION
Move the shpool_loop and switchshpool logic from shrc into autoshpool
so all shpool session management lives in one place.

- Add session switch file logic using ~/.autoshpool_switch
- Add autoshpool_loop with retry-on-error and switch support
- Replace exec shpool attach with plain shpool attach so the loop works
- autoshpool switch <session> requests a session switch
- Unknown args pass through to shpool (e.g. autoshpool list)
- Add bats tests

In shrc, shpool_loop can be replaced with: autoshpool && exit
And switchshpool with: switchshpool() { autoshpool switch "$1" && exit; }

https://claude.ai/code/session_01GsA5Netx3TkbmpLHvuGpKv