### PR TITLE
Fix misleading comment in autoshpool error handling

### DIFF
--- a/autoshpool
+++ b/autoshpool
@@ -115,7 +115,8 @@ autoshpool_loop() {
 
     if test $rc -ne 0; then
       # Maybe .shrc failed or something.
-      # Stay here so the user can see the error and fix it.
+      # Return non-zero so the caller (shrc) shows the error to the user
+      # and does not cleanly exit and disconnect.
       return $rc
     fi
 


### PR DESCRIPTION
The comment said "Stay here" but the code actually returns from the
function. The effect is the user stays in their shell (because
"autoshpool && exit" won't exit on failure), but the comment should
describe what the code does, not the indirect effect.

https://claude.ai/code/session_01LQc9mUKE6djze5hZnuLBvt