### PR TITLE
Refactor is_sourced check in autoshpool

### DIFF
--- a/autoshpool
+++ b/autoshpool
@@ -131,12 +131,14 @@ autoshpool_loop() {
 }
 
 is_sourced() {
-  if [ -n "$ZSH_VERSION" ]; then
+  if test -n "$ZSH_VERSION"; then
     case $ZSH_EVAL_CONTEXT in *:file:*)
       return 0;;
     esac
+  elif test -n "$BASH_VERSION"; then
+    test "${BASH_SOURCE[0]}" != "$0" && return 0
   else
-    case ${0##*/} in dash|-dash|bash|-bash|ksh|-ksh|sh|-sh)
+    case ${0##*/} in dash|-dash|ksh|-ksh|sh|-sh)
       return 0;;
     esac
   fi


### PR DESCRIPTION
Use test instead of [ to match preferred style. Replace fragile $0
shell-name matching with BASH_SOURCE[0] for reliable sourcing detection
in bash. Keep ZSH_EVAL_CONTEXT check for zsh.

https://claude.ai/code/session_013doHsfxkyFJYhugfBpBZWh