### PR TITLE
Replace getopts with manual while/case loop to support long options

### DIFF
--- a/bisect
+++ b/bisect
@@ -13,30 +13,27 @@ error() {
 
 scriptname=bisect
 
-while getopts ":h" option; do
-    case $option in
-    h)
+while test $# -gt 0; do
+    case "$1" in
+    -h|--help)
         usage
         exit 0
         ;;
-    ':')
-        echo "Missing argument to -$OPTARG" 1>&2
-        usage
-        exit 2
+    --)
+        shift
+        break
         ;;
-    '?')
-        echo "Invalid option -$OPTARG" 1>&2
+    -*)
+        echo "Invalid option $1" 1>&2
         usage
         exit 2
         ;;
     *)
-        echo "Program does not support -$option yet" 1>&2
-        usage
-        exit 2
+        break
         ;;
     esac
+    shift
 done
-shift $((OPTIND - 1))
 
 script=$1
 good=$2

--- a/confdist
+++ b/confdist
@@ -57,41 +57,38 @@ read_defaults()
 
 usage()
 {
-	echo "Usage: confdist [-c <config file>] [-v] [<host>...]" 1>&2
+	echo "Usage: confdist [-h] [-v] [<host>...]" 1>&2
+	echo "       confdist [--help] [--verbose] [<host>...]" 1>&2
 }
 
 read_options()
 {
-	while getopts ":hv" flag
+	while test $# -gt 0
 	do
-		case $flag in
-		h)
+		case "$1" in
+		-h|--help)
 			usage
 			exit 0
 			;;
-		v)
+		-v|--verbose)
 			verbose=$(($verbose + 1))
 			;;
-		':')
-			error "Missing argument to -$OPTARG"
-			usage
-			exit 2
+		--)
+			shift
+			break
 			;;
-		'?')
-			error "Unknown option -$OPTARG"
+		-*)
+			error "Unknown option $1"
 			usage
 			exit 2
 			;;
 		*)
-			error "The -$flag option is not supported yet"
-			usage
-			exit 2
+			break
 			;;
 		esac
+		shift
 	done
 	[ $verbose -gt 1 ] && set -x
-
-	shift `expr $OPTIND - 1`
 
 	test $# -gt 0 && hosts="$@"
 }

--- a/confinst
+++ b/confinst
@@ -231,6 +231,12 @@ make_links()
 	done
 }
 
+usage()
+{
+	echo "Usage: confinst [-e] [-h] [-n] [-p <prefix>] [-q] [-v]" 1>&2
+	echo "       confinst [--extract] [--help] [--simulate] [--prefix <prefix>] [--quiet] [--verbose]" 1>&2
+}
+
 destdir="$HOME"
 simulate=false
 extract=false	# now false by default, assume ~/conf is under git
@@ -238,41 +244,49 @@ prefix=.
 quiet=false
 verbose=false
 
-while getopts ":enp:qv" opt
+while test $# -gt 0
 do
-	case $opt in
-	e)
+	case "$1" in
+	-e|--extract)
 		extract=true
 		;;
-	n)
+	-h|--help)
+		usage
+		exit 0
+		;;
+	-n|--simulate)
 		simulate=true
 		;;
-	q)
+	-q|--quiet)
 		quiet=true
 		verbose=false
 		;;
-	p)
-		prefix=$OPTARG
+	-p|--prefix)
+		prefix=$2
+		shift
 		;;
-	v)
+	--prefix=*)
+		prefix=${1#*=}
+		;;
+	-v|--verbose)
 		verbose=true
 		quiet=false
 		;;
-	'?')
-		error "Unknown option -$OPTARG"
-		exit 2
+	--)
+		shift
+		break
 		;;
-	':')
-		error "Missing argument to -$OPTARG"
+	-*)
+		error "Unknown option $1"
+		usage
 		exit 2
 		;;
 	*)
-		error "Bug: -$OPTARG option is missing"
-		exit 1
+		break
 		;;
 	esac
+	shift
 done
-shift $((OPTIND - 1))
 
 if $extract
 then

--- a/gitbackup
+++ b/gitbackup
@@ -65,38 +65,36 @@ fi
 usage()
 {
     cat <<EOF 1>&2
-Usage: gitbackup [-hn]
+Usage: gitbackup [-h] [-n]
+       gitbackup [--help] [--simulate]
 EOF
 }
 
-while getopts ":hn" option
+while test $# -gt 0
 do
-    case $option in
-    h)
+    case "$1" in
+    -h|--help)
         usage
         exit 0
         ;;
-    n)
+    -n|--simulate)
         simulate=true
         ;;
-    ':')
-        echo "Missing argument to -$OPTARG" 1>&2
-        usage
-        exit 2
+    --)
+        shift
+        break
         ;;
-    '?')
-        echo "Invalid option -$OPTARG" 1>&2
+    -*)
+        echo "Invalid option $1" 1>&2
         usage
         exit 2
         ;;
     *)
-        echo "The -$option option is not supported yet" 1>&2
-        usage
-        exit 2
+        break
         ;;
     esac
+    shift
 done
-shift $((OPTIND - 1))
 
 #
 # normalize paths

--- a/gitinitremote
+++ b/gitinitremote
@@ -43,7 +43,8 @@ run()
 usage()
 {
 	cat <<EOF 1>&2
-Usage: $scriptname [-hn] [-r <remote name>] <new remote URL>
+Usage: $scriptname [-h] [-n] [-r <remote name>] <new remote URL>
+       $scriptname [--help] [--simulate] [--remote <remote name>] <new remote URL>
 EOF
 }
 
@@ -53,37 +54,38 @@ refspec=master		# refspec ("branch") to push - can't be changed yet
 local=$PWD			# local directory to create the repository out of
 simulate=false
 
-while getopts ":hnr:" option
+while test $# -gt 0
 do
-	case $option in
-	h)
+	case "$1" in
+	-h|--help)
 		usage
 		exit 0
 		;;
-	n)
+	-n|--simulate)
 		simulate=true
 		;;
-	r)
-		remotename=$OPTARG
+	-r|--remote)
+		remotename=$2
+		shift
 		;;
-	':')
-		error "Missing argument to -$OPTARG"
-		usage
-		exit 2
+	--remote=*)
+		remotename=${1#*=}
 		;;
-	'?')
-		error "Invalid option -$OPTARG"
+	--)
+		shift
+		break
+		;;
+	-*)
+		error "Invalid option $1"
 		usage
 		exit 2
 		;;
 	*)
-		error "The -$option option is not supported yet"
-		usage
-		exit 2
+		break
 		;;
 	esac
+	shift
 done
-shift $((OPTIND - 1))
 
 remote=$1
 

--- a/java-alternatives.sh
+++ b/java-alternatives.sh
@@ -59,7 +59,8 @@ run()
 usage()
 {
 	cat <<EOF >&2
-Usage: java-alternatives.sh [-dhnv] [-p <priority>] [<java root>]
+Usage: java-alternatives.sh [-d] [-h] [-n] [-p <priority>] [-v] [<java root>]
+       java-alternatives.sh [--debug] [--help] [--simulate] [--priority <priority>] [--verbose] [<java root>]
 Example: java-alternatives.sh /usr/jdk1.5.0_22
 EOF
 }
@@ -67,43 +68,44 @@ EOF
 ###
 # process the command line
 #
-while getopts ":dhnp:v" option
+while test $# -gt 0
 do
-	case $option in
-	d)
+	case "$1" in
+	-d|--debug)
 		debug=true
 		;;
-	h)
+	-h|--help)
 		usage
 		exit 0
 		;;
-	n)
+	-n|--simulate)
 		simulate=true
 		;;
-	p)
-		priority=$OPTARG
+	-p|--priority)
+		priority=$2
+		shift
 		;;
-	v)
+	--priority=*)
+		priority=${1#*=}
+		;;
+	-v|--verbose)
 		verbose=true
 		;;
-	':')
-		error "Missing argument to -$OPTARG"
-		usage
-		exit 2
+	--)
+		shift
+		break
 		;;
-	'?')
-		error "Invalid option -$OPTARG"
+	-*)
+		error "Invalid option $1"
 		usage
 		exit 2
 		;;
 	*)
-		error "The -$option option is not supported yet"
-		usage
-		exit 2
+		break
 		;;
 	esac
+	shift
 done
-shift $((OPTIND - 1))
 
 basedir=$1
 if test -z "$basedir"; then

--- a/screenshot
+++ b/screenshot
@@ -2,7 +2,8 @@
 . "$HOME"/.shrc
 usage() {
   cat <<EOF 1>&2
-Usage: $scriptname [-h]
+Usage: $scriptname [-d <delay>] [-h] [-w]
+       $scriptname [--delay <delay>] [--help] [--window]
 EOF
 }
 
@@ -11,36 +12,37 @@ delay=0
 typeset -a args=()
 window=false
 
-while getopts ":d:hw" option; do
-  case $option in
-  d)
-    delay=$OPTARG
+while test $# -gt 0; do
+  case "$1" in
+  -d|--delay)
+    delay=$2
+    shift
     ;;
-  w)
+  --delay=*)
+    delay=${1#*=}
+    ;;
+  -w|--window)
     window=true
     ;;
-  h)
+  -h|--help)
     usage
     exit 0
     ;;
-  ':')
-    echo "Missing argument to -$OPTARG" 1>&2
-    usage
-    exit 2
+  --)
+    shift
+    break
     ;;
-  '?')
-    echo "Invalid option -$OPTARG" 1>&2
+  -*)
+    echo "Invalid option $1" 1>&2
     usage
     exit 2
     ;;
   *)
-    echo "Program does not support -$option yet" 1>&2
-    usage
-    exit 2
+    break
     ;;
   esac
+  shift
 done
-shift $((OPTIND - 1))
 
 cd "$HOME/Pictures"
 


### PR DESCRIPTION
Convert all 7 scripts from getopts to a manual while/case option
parsing loop for cross-platform long option support (Linux, macOS,
FreeBSD) with no external dependencies.

Changes per script:
- bisect: add --help
- confdist: add --help, --verbose
- confinst: add --help, --extract, --simulate, --prefix, --quiet, --verbose
- gitbackup: add --help, --simulate
- gitinitremote: add --help, --simulate, --remote
- java-alternatives.sh: add --debug, --help, --simulate, --priority, --verbose
- screenshot: add --delay, --help, --window

Options taking arguments support both --opt value and --opt=value
forms for long options. Usage text updated to show both short and
long forms. Added --help where it was missing (confinst).

https://claude.ai/code/session_012i5x9iSzUfWKqT9vAnaPPE