### PR TITLE
Add Python VCS wrapper scripts (vcs-git, vcs-hg, vcs-jj)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+.pytest_cache/
+.vcs_cache

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,3 @@
 test:
 	./autoshpool_test
+	python3 -m pytest vcs_git_test.py vcs_hg_test.py vcs_jj_test.py -v

--- a/vcs-dispatch
+++ b/vcs-dispatch
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""VCS dispatcher - detects the version control system and delegates to vcs-git/vcs-hg/vcs-jj.
+
+Usage: vcs-dispatch <command> [args...]
+       vcs-dispatch                  (prints the detected VCS name)
+
+Walks up from $PWD looking for .jj, .hg, .git markers.
+Caches the result in .vcs_cache for speed.
+"""
+
+import os
+import sys
+import subprocess
+
+
+def warn(msg):
+    print(msg, file=sys.stderr)
+
+
+def detect_vcs():
+    """Detect VCS by walking up from cwd. Returns (vcs, rootdir) or (None, None)."""
+    d = os.getcwd()
+    while True:
+        for marker, name in [(".jj", "jj"), (".hg", "hg"), (".git", "git")]:
+            if os.path.exists(os.path.join(d, marker)):
+                return name, d
+        parent = os.path.dirname(d)
+        if parent == d:
+            break
+        d = parent
+    return None, None
+
+
+def read_cache():
+    """Read .vcs_cache if present. Returns (vcs, rootdir) or (None, None)."""
+    try:
+        with open(".vcs_cache") as f:
+            lines = f.read().splitlines()
+            if len(lines) >= 2:
+                parts = lines[0].split()
+                vcs_name = parts[0] if parts else None
+                rootdir = lines[1]
+                return vcs_name, rootdir
+    except (OSError, IndexError):
+        pass
+    return None, None
+
+
+def write_cache(vcs_name, rootdir):
+    """Write .vcs_cache, ignoring errors (e.g. read-only fs)."""
+    try:
+        with open(".vcs_cache", "w") as f:
+            f.write(f"{vcs_name} - -\n{rootdir}\n")
+    except OSError:
+        pass
+
+
+def get_vcs():
+    """Get VCS name, using cache if available."""
+    vcs_name, rootdir = read_cache()
+    if vcs_name and rootdir:
+        return vcs_name, rootdir
+
+    vcs_name, rootdir = detect_vcs()
+    if vcs_name and rootdir and os.access(".", os.W_OK):
+        write_cache(vcs_name, rootdir)
+    return vcs_name, rootdir
+
+
+def clear_cache():
+    """Remove all .vcs_cache files under current directory."""
+    for dirpath, dirnames, filenames in os.walk("."):
+        if ".vcs_cache" in filenames:
+            try:
+                os.remove(os.path.join(dirpath, ".vcs_cache"))
+            except OSError:
+                pass
+
+
+def main():
+    # Special case: "vcs-dispatch cv" clears caches
+    if len(sys.argv) >= 2 and sys.argv[1] == "cv":
+        clear_cache()
+        return 0
+
+    vcs_name, rootdir = get_vcs()
+
+    if vcs_name is None:
+        warn("vcs-dispatch: no version control system detected")
+        return 1
+
+    # No command: just print the VCS name
+    if len(sys.argv) < 2:
+        print(vcs_name)
+        return 0
+
+    # Delegate to vcs-<name>
+    script = f"vcs-{vcs_name}"
+    # Look for the script next to this one first
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    script_path = os.path.join(script_dir, script)
+    if os.access(script_path, os.X_OK):
+        return subprocess.call([script_path] + sys.argv[1:])
+    else:
+        # Fall back to PATH
+        return subprocess.call([script] + sys.argv[1:])
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/vcs-git
+++ b/vcs-git
@@ -1,0 +1,520 @@
+#!/usr/bin/env python3
+"""Git VCS operations.
+
+Usage: vcs-git <command> [args...]
+
+Implements a uniform VCS interface for git repositories.
+"""
+
+import os
+import sys
+import subprocess
+
+
+def run(args, **kwargs):
+    """Run a command, passing through stdin/stdout/stderr."""
+    return subprocess.call(args, **kwargs)
+
+
+def run_output(args, **kwargs):
+    """Run a command and capture its stdout."""
+    try:
+        return subprocess.check_output(args, stderr=subprocess.DEVNULL, **kwargs).decode().strip()
+    except subprocess.CalledProcessError:
+        return None
+
+
+def warn(msg):
+    print(msg, file=sys.stderr)
+
+
+def git(*args):
+    return run(["git"] + list(args))
+
+
+def git_output(*args):
+    return run_output(["git"] + list(args))
+
+
+def rootdir():
+    return git_output("rev-parse", "--show-toplevel")
+
+
+def git_dir():
+    return git_output("rev-parse", "--git-dir")
+
+
+# --- commands ---
+
+def cmd_absorb(args):
+    return git("absorb", *args)
+
+
+def cmd_add(args):
+    return git("add", "--intent-to-add", *args)
+
+
+def cmd_addremove(args):
+    return git("add", "--all", *args)
+
+
+def cmd_amend(args):
+    flags, files = _split_flags(args)
+    if not files:
+        flags.append("--all")
+    return git("commit", "--amend", "--no-edit", *flags, *files)
+
+
+def cmd_annotate(args):
+    return git("blame", *args)
+
+
+def cmd_base(args):
+    branch = git_output("rev-parse", "--abbrev-ref", "HEAD")
+    if branch == "HEAD":
+        sys.stdout.write("(detached) ")
+        sys.stdout.flush()
+    return git("--no-pager", "log", "-1", "--oneline", *args)
+
+
+def cmd_blame(args):
+    return git("blame", *args)
+
+
+def cmd_branch(args):
+    output = git_output("branch")
+    if output is None:
+        return 1
+    for line in output.splitlines():
+        if line.startswith("* "):
+            print(line[2:])
+            return 0
+    return 1
+
+
+def cmd_branches(args):
+    return git("branch", *args)
+
+
+def cmd_change(args):
+    return cmd_amend(args)
+
+
+def cmd_changed(args):
+    return git("diff", "--name-only", *args)
+
+
+def cmd_changelog(args):
+    return git("log", "--oneline", *args)
+
+
+def cmd_changes(args):
+    return git("diff", *args)
+
+
+def cmd_checkout(args):
+    return git("checkout", *args)
+
+
+def cmd_commit(args):
+    flags, files = _split_flags(args)
+    if not files:
+        flags.append("--all")
+    return git("commit", *flags, *files)
+
+
+def cmd_commitforce(args):
+    return cmd_commit(["--no-verify"] + list(args))
+
+
+def cmd_copy(args):
+    if not args:
+        warn("usage: copy <source>... <dest>")
+        return 1
+    ret = run(["cp"] + list(args))
+    if ret != 0:
+        return ret
+    return git("add", args[-1])
+
+
+def cmd_describe(args):
+    return git("commit", "--amend", "--only", "--allow-empty", *args)
+
+
+def cmd_diffedit(args):
+    return git("rebase", "--interactive", *args)
+
+
+def cmd_diffs(args):
+    return git("diff", *args)
+
+
+def cmd_diffstat(args):
+    return git("diff", "--stat", *args)
+
+
+def cmd_drop(args):
+    if not args:
+        warn("usage: drop <commit>")
+        return 1
+    return git("rebase", "--onto", args[0] + "~", args[0])
+
+
+def cmd_evolve(args):
+    warn("no automatic evolve in git; use: git rebase --onto <new> <old> <branch>")
+    return 1
+
+
+def cmd_fastforward(args):
+    return git("pull", "--ff-only")
+
+
+def cmd_fetchtime(args):
+    gd = git_dir()
+    if gd is None:
+        return 1
+    fetch_head = os.path.join(gd, "FETCH_HEAD")
+    if os.path.isfile(fetch_head):
+        print(int(os.path.getmtime(fetch_head)))
+        return 0
+    return 1
+
+
+def cmd_fix(args):
+    return git("fix", *args)
+
+
+def cmd_goto(args):
+    return git("checkout", *args)
+
+
+def cmd_graft(args):
+    return git("cherry-pick", *args)
+
+
+def cmd_graph(args):
+    fmt = "--pretty=format:%C(auto)%h%C(auto)%d %s"
+    if not args:
+        ret = run(["git", "--no-pager", "log", "--graph", fmt, "@{upstream}..HEAD"],
+                   stderr=subprocess.DEVNULL)
+        if ret != 0:
+            ret = git("--no-pager", "log", "--graph", fmt)
+        return ret
+    return git("--no-pager", "log", "--graph", fmt, *args)
+
+
+def cmd_histedit(args):
+    return git("rebase", "--interactive", *args)
+
+
+def cmd_hook(args):
+    if not args:
+        warn("usage: hook <hook-name> [args...]")
+        return 1
+    gd = git_dir()
+    if gd is None:
+        return 1
+    script = os.path.join(gd, "hooks", args[0])
+    if os.access(script, os.X_OK):
+        return run([script] + list(args[1:]))
+    else:
+        warn(f"No {script} hook")
+        return 1
+
+
+def cmd_ignore(args):
+    root = rootdir()
+    if root is None:
+        return 1
+    with open(os.path.join(root, ".gitignore"), "a") as f:
+        for arg in args:
+            f.write(arg + "\n")
+    return 0
+
+
+def cmd_incoming(args):
+    return git("log", "--oneline", "HEAD..@{upstream}", *args)
+
+
+def cmd_lint(args):
+    return git("lint", *args)
+
+
+def cmd_map(args):
+    branch = git_output("rev-parse", "--abbrev-ref", "HEAD")
+    if branch != "HEAD":
+        return cmd_base(args)
+    return cmd_graph(args)
+
+
+def cmd_move(args):
+    return git("mv", *args)
+
+
+def cmd_mv(args):
+    return git("mv", *args)
+
+
+def cmd_next(args):
+    head = git_output("rev-parse", "HEAD")
+    if head is None:
+        return 1
+    output = git_output("rev-list", "--children", "--all")
+    if output is None:
+        warn("no next commit")
+        return 1
+    for line in output.splitlines():
+        parts = line.split()
+        if parts[0] == head and len(parts) > 1:
+            return git("checkout", parts[1])
+    warn("no next commit")
+    return 1
+
+
+def cmd_outgoing(args):
+    return git("--no-pager", "log", "--oneline", "@{upstream}..HEAD", *args)
+
+
+def cmd_pending(args):
+    ret = run(["git", "--no-pager", "log", "--oneline", "@{upstream}..HEAD"],
+              stderr=subprocess.DEVNULL)
+    if ret != 0:
+        return git("status", "--short")
+    return ret
+
+
+def cmd_pick(args):
+    return git("cherry-pick", *args)
+
+
+def cmd_precommit(args):
+    return cmd_hook(["pre-commit"] + list(args))
+
+
+def cmd_prereview(args):
+    return cmd_hook(["pre-commit"] + list(args))
+
+
+def cmd_prev(args):
+    return git("checkout", "HEAD~")
+
+
+def cmd_presubmit(args):
+    return cmd_hook(["pre-push"] + list(args))
+
+
+def cmd_projectroot(args):
+    return git("root")
+
+
+def cmd_pull(args):
+    return git("pull", "--rebase", *args)
+
+
+def cmd_push(args):
+    return git("push", *args)
+
+
+def cmd_rebase(args):
+    return git("rebase", *args)
+
+
+def cmd_recommit(args):
+    return cmd_amend(args)
+
+
+def cmd_remove(args):
+    return git("rm", *args)
+
+
+def cmd_rename(args):
+    return git("mv", *args)
+
+
+def cmd_resolve(args):
+    return git("mergetool", *args)
+
+
+def cmd_mergetool(args):
+    return git("mergetool", *args)
+
+
+def cmd_restore(args):
+    return git("checkout", "--", *args)
+
+
+def cmd_revert(args):
+    if not args:
+        return git("reset", "--hard", "HEAD")
+    return git("checkout", "--", *args)
+
+
+def cmd_review(args):
+    return _github_review(args)
+
+
+def cmd_reword(args):
+    return git("commit", "--amend", "--only", "--allow-empty", *args)
+
+
+def cmd_rm(args):
+    return git("rm", *args)
+
+
+def cmd_rootdir(args):
+    r = rootdir()
+    if r:
+        print(r)
+        return 0
+    return 1
+
+
+def cmd_show(args):
+    return git("show", *args)
+
+
+def cmd_split(args):
+    return git("rebase", "-i", *args)
+
+
+def cmd_squash(args):
+    return git("merge", "--squash", *args)
+
+
+def cmd_status(args):
+    return git("status", "--short", "--untracked-files=all", *args)
+
+
+def cmd_submit(args):
+    return git("push", *args)
+
+
+def cmd_submitforce(args):
+    return git("push", "--no-verify", *args)
+
+
+def cmd_track(args):
+    return git("add", "--intent-to-add", *args)
+
+
+def cmd_undo(args):
+    return git("reset", "--mixed", "HEAD~")
+
+
+def cmd_unamend(args):
+    return git("reset", "--mixed", "HEAD@{1}")
+
+
+def cmd_uncommit(args):
+    return git("reset", "--soft", "HEAD~")
+
+
+def cmd_unknown(args):
+    root = rootdir()
+    if root is None:
+        return 1
+    return run(["git", "-C", root, "ls-files", "-od", "--exclude-standard"])
+
+
+def cmd_untrack(args):
+    return git("rm", "--cached", *args)
+
+
+def cmd_upload(args):
+    return _github_review(args)
+
+
+def cmd_uploadchain(args):
+    return _github_review(args)
+
+
+# --- helpers ---
+
+def _split_flags(args):
+    """Split args into flags and positional arguments, like the shell versions."""
+    flags = []
+    files = []
+    it = iter(args)
+    for arg in it:
+        if arg == "--":
+            flags.append(arg)
+            files.extend(it)
+            break
+        elif arg in ("-m", "-C", "-c", "-F", "-t"):
+            flags.append(arg)
+            try:
+                flags.append(next(it))
+            except StopIteration:
+                pass
+        elif arg.startswith("-"):
+            flags.append(arg)
+        else:
+            files.append(arg)
+            files.extend(it)
+            break
+    return flags, files
+
+
+def _github_review(args):
+    """Send current change for review (GitHub/Gerrit aware)."""
+    reviewers = []
+    push_flags = []
+    it = iter(args)
+    for arg in it:
+        if arg in ("-r", "-m", "--reviewer"):
+            try:
+                reviewers.append(next(it))
+            except StopIteration:
+                pass
+        elif arg.startswith("--reviewer="):
+            reviewers.append(arg.split("=", 1)[1])
+        else:
+            push_flags.append(arg)
+
+    # Detect hosting from remote URL
+    origin_url = git_output("remote", "get-url", "origin") or ""
+    hosting = ""
+    if "github.com" in origin_url:
+        hosting = "github"
+    elif "gerrit" in origin_url or "googlesource.com" in origin_url:
+        hosting = "gerrit"
+
+    if hosting == "gerrit":
+        reviewer_suffix = "".join(f"%r={r}" for r in reviewers)
+        branch = git_output("rev-parse", "--abbrev-ref", "HEAD") or "HEAD"
+        return git("push", "origin", f"HEAD:refs/for/master/{branch}{reviewer_suffix}", *push_flags)
+    elif hosting == "github":
+        ret = git("push", *push_flags)
+        if ret != 0:
+            return ret
+        gh_args = ["gh", "pr", "create"]
+        for r in reviewers:
+            gh_args.extend(["-r", r])
+        return run(gh_args)
+    else:
+        return git("push", *push_flags)
+
+
+COMMANDS = {name[4:]: func for name, func in globals().copy().items()
+            if name.startswith("cmd_") and callable(func)}
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: vcs-git <command> [args...]", file=sys.stderr)
+        print(f"Commands: {', '.join(sorted(COMMANDS))}", file=sys.stderr)
+        return 1
+
+    command = sys.argv[1]
+    args = sys.argv[2:]
+
+    func = COMMANDS.get(command)
+    if func is None:
+        warn(f"vcs-git: unknown command '{command}'")
+        return 1
+
+    return func(args) or 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/vcs-hg
+++ b/vcs-hg
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+"""Mercurial VCS operations.
+
+Usage: vcs-hg <command> [args...]
+
+Implements a uniform VCS interface for Mercurial repositories.
+"""
+
+import os
+import shutil
+import sys
+import subprocess
+
+
+def run(args, **kwargs):
+    return subprocess.call(args, **kwargs)
+
+
+def run_output(args, **kwargs):
+    try:
+        return subprocess.check_output(args, stderr=subprocess.DEVNULL, **kwargs).decode().strip()
+    except subprocess.CalledProcessError:
+        return None
+
+
+def warn(msg):
+    print(msg, file=sys.stderr)
+
+
+HG_CMD = "chg" if shutil.which("chg") else "hg"
+
+
+def hg(*args):
+    return run([HG_CMD] + list(args))
+
+
+def hg_output(*args):
+    return run_output([HG_CMD] + list(args))
+
+
+def rootdir():
+    return hg_output("root")
+
+
+# --- commands ---
+
+def cmd_absorb(args):
+    return hg("--config", "extensions.absorb=", "absorb", "--apply-changes", *args)
+
+
+def cmd_add(args):
+    return hg("add", *args)
+
+
+def cmd_addremove(args):
+    return hg("addremove", *args)
+
+
+def cmd_amend(args):
+    return hg("amend", *args)
+
+
+def cmd_annotate(args):
+    return hg("annotate", *args)
+
+
+def cmd_base(args):
+    return hg("--pager", "never", "log", "-r", ".", "--template", "{onelinesummary}\\n", *args)
+
+
+def cmd_blame(args):
+    return hg("blame", *args)
+
+
+def cmd_branch(args):
+    return hg("branch")
+
+
+def cmd_branches(args):
+    return hg("branches", *args)
+
+
+def cmd_change(args):
+    if not args:
+        return hg("commit", "--amend", "-e")
+    return hg("commit", "--amend", *args)
+
+
+def cmd_changed(args):
+    if not args:
+        return hg("status", "--no-status")
+    return hg("log", *args, "--template", "{files}\\n")
+
+
+def cmd_changelog(args):
+    return hg("log", "--template", "{onelinesummary}\\n", *args)
+
+
+def cmd_changes(args):
+    return hg("diff", *args)
+
+
+def cmd_checkout(args):
+    return hg("checkout", *args)
+
+
+def cmd_commit(args):
+    return hg("commit", *args)
+
+
+def cmd_commitforce(args):
+    return hg("--config", "hooks.precommit=", "--config", "hooks.pre-commit=", "commit", *args)
+
+
+def cmd_describe(args):
+    if not args:
+        return hg("commit", "--amend", "-e")
+    return hg("commit", "--amend", *args)
+
+
+def cmd_diffedit(args):
+    return hg("histedit", *args)
+
+
+def cmd_diffs(args):
+    return hg("diff", *args)
+
+
+def cmd_diffstat(args):
+    return hg("diff", "--stat", *args)
+
+
+def cmd_drop(args):
+    return hg("prune", *args)
+
+
+def cmd_evolve(args):
+    return hg("evolve", *args)
+
+
+def cmd_fastforward(args):
+    ret = run(["hg", "sync", "--tool=internal:fail"], stderr=subprocess.DEVNULL)
+    if ret != 0:
+        hg("rebase", "--abort")
+        return 1
+    return 0
+
+
+def cmd_fetchtime(args):
+    root = rootdir()
+    if root is None:
+        return 1
+    changelog = os.path.join(root, ".hg", "store", "00changelog.i")
+    if os.path.isfile(changelog):
+        print(int(os.path.getmtime(changelog)))
+        return 0
+    return 1
+
+
+def cmd_fix(args):
+    return hg("fix", *args)
+
+
+def cmd_goto(args):
+    return hg("update", *args)
+
+
+def cmd_graft(args):
+    return hg("graft", *args)
+
+
+def cmd_graph(args):
+    if not args:
+        return hg("--pager", "never", "log", "--graph", "--template", "oneline",
+                   "-r", "draft() and not obsolete()")
+    return hg("--pager", "never", "log", "--graph", "--template", "oneline", *args)
+
+
+def cmd_histedit(args):
+    return hg("histedit", *args)
+
+
+def cmd_ignore(args):
+    root = rootdir()
+    if root is None:
+        return 1
+    with open(os.path.join(root, ".hgignore"), "a") as f:
+        for arg in args:
+            f.write(arg + "\n")
+    return 0
+
+
+def cmd_incoming(args):
+    return hg("incoming", "--template", "{onelinesummary}\\n", *args)
+
+
+def cmd_lint(args):
+    return hg("lint", *args)
+
+
+def cmd_map(args):
+    # Check if at tip
+    output = hg_output("--pager", "never", "log", "-r", ". and last(heads(branch(.)))",
+                       "--template", "x")
+    if output:
+        return cmd_base(args)
+    return cmd_graph(args)
+
+
+def cmd_move(args):
+    return hg("rename", *args)
+
+
+def cmd_mv(args):
+    return hg("rename", *args)
+
+
+def cmd_next(args):
+    return hg("update", "-r", "min(children(.))", *args)
+
+
+def cmd_copy(args):
+    return hg("copy", *args)
+
+
+def cmd_outgoing(args):
+    return hg("--pager", "never", "--quiet", "log", "-r", "draft() and not obsolete()",
+              "--template", "{onelinesummary}\\n", *args)
+
+
+def cmd_pending(args):
+    return hg("--pager", "never", "status", *args)
+
+
+def cmd_pick(args):
+    return hg("graft", *args)
+
+
+def cmd_precommit(args):
+    return hg("precommit", *args)
+
+
+def cmd_prereview(args):
+    return hg("prereview", *args)
+
+
+def cmd_prev(args):
+    return hg("update", "-r", ".^", *args)
+
+
+def cmd_presubmit(args):
+    return hg("presubmit", *args)
+
+
+def cmd_projectroot(args):
+    return hg("root")
+
+
+def cmd_pull(args):
+    return hg("pull", "--update", "--rebase", *args)
+
+
+def cmd_push(args):
+    return hg("push", *args)
+
+
+def cmd_rebase(args):
+    return hg("rebase", *args)
+
+
+def cmd_recommit(args):
+    return hg("commit", "--amend", *args)
+
+
+def cmd_remove(args):
+    return hg("remove", *args)
+
+
+def cmd_rename(args):
+    return hg("rename", *args)
+
+
+def cmd_resolve(args):
+    return hg("resolve", *args)
+
+
+def cmd_mergetool(args):
+    return hg("resolve", *args)
+
+
+def cmd_restore(args):
+    return hg("revert", *args)
+
+
+def cmd_revert(args):
+    return hg("revert", *args)
+
+
+def cmd_review(args):
+    warn("hg review not supported")
+    return 1
+
+
+def cmd_reword(args):
+    if not args:
+        return hg("commit", "--amend", "-e")
+    return hg("commit", "--amend", *args)
+
+
+def cmd_rm(args):
+    return hg("remove", *args)
+
+
+def cmd_rootdir(args):
+    return hg("root")
+
+
+def cmd_show(args):
+    return hg("export", *args)
+
+
+def cmd_split(args):
+    return hg("split", *args)
+
+
+def cmd_squash(args):
+    return hg("fold", *args)
+
+
+def cmd_status(args):
+    return hg("status", *args)
+
+
+def cmd_submit(args):
+    return hg("submit", *args)
+
+
+def cmd_submitforce(args):
+    return hg("--config", "hooks.preoutgoing=", "--config", "hooks.pre-push=", "submit", *args)
+
+
+def cmd_track(args):
+    return hg("add", *args)
+
+
+def cmd_unamend(args):
+    return hg("unamend", *args)
+
+
+def cmd_uncommit(args):
+    return hg("--config", "extensions.uncommit=", "uncommit", *args)
+
+
+def cmd_undo(args):
+    return hg("undo", *args)
+
+
+def cmd_unknown(args):
+    return hg("status", "--unknown", "--deleted")
+
+
+def cmd_untrack(args):
+    return hg("forget", *args)
+
+
+def cmd_upload(args):
+    if not args:
+        return hg("push", "-r", ".")
+    return hg("push", *args)
+
+
+def cmd_uploadchain(args):
+    return hg("uploadchain", *args)
+
+
+COMMANDS = {name[4:]: func for name, func in globals().copy().items()
+            if name.startswith("cmd_") and callable(func)}
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: vcs-hg <command> [args...]", file=sys.stderr)
+        print(f"Commands: {', '.join(sorted(COMMANDS))}", file=sys.stderr)
+        return 1
+
+    command = sys.argv[1]
+    args = sys.argv[2:]
+
+    func = COMMANDS.get(command)
+    if func is None:
+        warn(f"vcs-hg: unknown command '{command}'")
+        return 1
+
+    return func(args) or 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/vcs-jj
+++ b/vcs-jj
@@ -1,0 +1,503 @@
+#!/usr/bin/env python3
+"""Jujutsu VCS operations.
+
+Usage: vcs-jj <command> [args...]
+
+Implements a uniform VCS interface for Jujutsu repositories.
+"""
+
+import os
+import sys
+import subprocess
+
+
+def run(args, **kwargs):
+    return subprocess.call(args, **kwargs)
+
+
+def run_output(args, **kwargs):
+    try:
+        return subprocess.check_output(args, stderr=subprocess.DEVNULL, **kwargs).decode().strip()
+    except subprocess.CalledProcessError:
+        return None
+
+
+def warn(msg):
+    print(msg, file=sys.stderr)
+
+
+def jj(*args):
+    return run(["jj"] + list(args))
+
+
+def jj_output(*args):
+    return run_output(["jj"] + list(args))
+
+
+def rootdir():
+    return jj_output("workspace", "root")
+
+
+def backend():
+    root = rootdir()
+    if root is None:
+        return None
+    store_type = os.path.join(root, ".jj", "repo", "store", "type")
+    if os.path.isfile(store_type):
+        with open(store_type) as f:
+            return f.read().strip()
+    return None
+
+
+def hosting():
+    b = backend()
+    if b != "git":
+        return None
+    root = rootdir()
+    if root is None:
+        return None
+    git_dir = os.path.join(root, ".jj", "repo", "store", "git")
+    origin_url = run_output(["git", "-C", git_dir, "remote", "get-url", "origin"])
+    if origin_url is None:
+        return None
+    if "github.com" in origin_url:
+        return "github"
+    if "gitlab.com" in origin_url or "gitlab." in origin_url:
+        return "gitlab"
+    if "bitbucket.org" in origin_url:
+        return "bitbucket"
+    if "sr.ht" in origin_url:
+        return "sourcehut"
+    if "googlesource.com" in origin_url:
+        return "gerrit"
+    return None
+
+
+# --- commands ---
+
+def cmd_absorb(args):
+    return jj("absorb", *args)
+
+
+def cmd_add(args):
+    return jj("file", "track", *args)
+
+
+def cmd_addremove(args):
+    # jj auto-tracks all files
+    return 0
+
+
+def cmd_amend(args):
+    return jj("squash", *args)
+
+
+def cmd_annotate(args):
+    return jj("file", "annotate", *args)
+
+
+def cmd_base(args):
+    tmpl = ('if(self.contained_in("@"), '
+            'if(description.first_line(), "@ " ++ change_id.shortest() ++ " " ++ description.first_line() ++ "\\n"), '
+            '"* " ++ change_id.shortest() ++ " " ++ description.first_line() ++ "\\n")')
+    return jj("--no-pager", "log", "--no-graph", "-r", "@|@-", "--template", tmpl, *args)
+
+
+def cmd_blame(args):
+    return jj("file", "annotate", *args)
+
+
+def cmd_branch(args):
+    # no current bookmark concept in jj
+    return 0
+
+
+def cmd_branches(args):
+    return jj("bookmark", "list", *args)
+
+
+def cmd_change(args):
+    return jj("describe", *args)
+
+
+def cmd_changed(args):
+    return jj("diff", "--summary", *args)
+
+
+def cmd_changelog(args):
+    return jj("log", "--template=builtin_log_oneline", *args)
+
+
+def cmd_changes(args):
+    return jj("diff", *args)
+
+
+def cmd_checkout(args):
+    return jj("new", *args)
+
+
+def cmd_commit(args):
+    return jj("commit", *args)
+
+
+def cmd_commitforce(args):
+    return jj("commit", *args)
+
+
+def cmd_copy(args):
+    return run(["cp"] + list(args))
+
+
+def cmd_describe(args):
+    return jj("describe", *args)
+
+
+def cmd_diffedit(args):
+    return jj("diffedit", *args)
+
+
+def cmd_diffs(args):
+    return jj("diff", *args)
+
+
+def cmd_diffstat(args):
+    return jj("diff", "--stat", *args)
+
+
+def cmd_drop(args):
+    return jj("abandon", *args)
+
+
+def cmd_evolve(args):
+    warn("jj automatically rebases descendants; nothing to do")
+    return 0
+
+
+def cmd_fastforward(args):
+    b = backend()
+    if b == "git":
+        return jj("git", "fetch", *args)
+    return jj("piper", "pull", *args)
+
+
+def cmd_fetchtime(args):
+    root = rootdir()
+    if root is None:
+        return 1
+    fetch_head = os.path.join(root, ".jj", "repo", "store", "git", "FETCH_HEAD")
+    if os.path.isfile(fetch_head):
+        print(int(os.path.getmtime(fetch_head)))
+        return 0
+    return 1
+
+
+def cmd_fix(args):
+    return jj("fix", *args)
+
+
+def cmd_goto(args):
+    return jj("new", *args)
+
+
+def cmd_graft(args):
+    return jj("duplicate", *args)
+
+
+def cmd_graph(args):
+    tmpl = ('change_id.shortest() ++ " " ++ '
+            'if(description, description.first_line(), "(no description set)") ++ '
+            'if(bookmarks, " [" ++ bookmarks.join(", ") ++ "]", "") ++ "\\n"')
+    if not args:
+        return jj("log", "--template", tmpl,
+                   "-r", "mutable() ~ empty() ~ ancestors(remote_bookmarks())")
+    return jj("log", "--template", tmpl, *args)
+
+
+def cmd_histedit(args):
+    warn("no interactive histedit in jj; use: jj squash, jj split, jj edit")
+    return 1
+
+
+def cmd_ignore(args):
+    root = rootdir()
+    if root is None:
+        return 1
+    with open(os.path.join(root, ".gitignore"), "a") as f:
+        for arg in args:
+            f.write(arg + "\n")
+    return 0
+
+
+def cmd_incoming(args):
+    return jj("op", "log", *args)
+
+
+def cmd_lint(args):
+    return jj("fix", *args)
+
+
+def cmd_map(args):
+    # Check if at tip
+    output = jj_output("--no-pager", "log", "--no-graph",
+                       "-r", "children(@) | (children(@-) ~ @)",
+                       "--template", '"x"')
+    if not output:
+        return cmd_base(args)
+    return cmd_graph(args)
+
+
+def cmd_move(args):
+    return _rename(args)
+
+
+def cmd_mv(args):
+    return _rename(args)
+
+
+def cmd_next(args):
+    return jj("next", *args)
+
+
+def cmd_outgoing(args):
+    return jj("--no-pager", "log", "--no-graph",
+              "-r", "mutable() ~ empty() ~ ancestors(remote_bookmarks())",
+              "--template", 'change_id.shortest() ++ " " ++ description.first_line() ++ "\\n"',
+              *args)
+
+
+def cmd_pending(args):
+    return jj("--no-pager", "log", "-r", "mutable() ~ empty()", *args)
+
+
+def cmd_pick(args):
+    return jj("duplicate", *args)
+
+
+def cmd_precommit(args):
+    return jj("fix", *args)
+
+
+def cmd_prev(args):
+    return jj("prev", *args)
+
+
+def cmd_presubmit(args):
+    b = backend()
+    if b == "git":
+        warn("no presubmit for git-backed repos; run tests locally")
+        return 1
+    return jj("piper", "presubmit", *args)
+
+
+def cmd_projectroot(args):
+    return jj("workspace", "root")
+
+
+def cmd_pull(args):
+    b = backend()
+    if b == "git":
+        return jj("git", "fetch", *args)
+    return jj("sync", *args)
+
+
+def cmd_push(args):
+    b = backend()
+    if b == "git":
+        return jj("git", "push", *args)
+    return jj("upload", *args)
+
+
+def cmd_rebase(args):
+    return jj("rebase", *args)
+
+
+def cmd_recommit(args):
+    return jj("describe", *args)
+
+
+def cmd_remove(args):
+    ret = run(["rm"] + list(args))
+    if ret != 0:
+        return ret
+    return jj("file", "untrack", *args)
+
+
+def cmd_rename(args):
+    return _rename(args)
+
+
+def cmd_resolve(args):
+    return jj("resolve", *args)
+
+
+def cmd_mergetool(args):
+    return jj("resolve", *args)
+
+
+def cmd_restore(args):
+    return jj("restore", *args)
+
+
+def cmd_revert(args):
+    return jj("revert", *args)
+
+
+def cmd_review(args):
+    return _github_review(args)
+
+
+def cmd_reword(args):
+    if not args:
+        return jj("describe")
+    return jj("describe", "-m", *args)
+
+
+def cmd_rm(args):
+    return cmd_remove(args)
+
+
+def cmd_rootdir(args):
+    r = rootdir()
+    if r:
+        print(r)
+        return 0
+    return 1
+
+
+def cmd_show(args):
+    return jj("show", *args)
+
+
+def cmd_split(args):
+    return jj("split", *args)
+
+
+def cmd_squash(args):
+    return jj("squash", *args)
+
+
+def cmd_status(args):
+    # Only show status for undescribed commits
+    desc = jj_output("log", "--no-graph", "-r", "@", "-T", "description")
+    if desc is None:
+        return 1
+    if not desc:
+        return jj("diff", "--summary", *args)
+    return 0
+
+
+def cmd_submit(args):
+    b = backend()
+    if b == "git":
+        return jj("git", "push", *args)
+    return jj("submit", *args)
+
+
+def cmd_submitforce(args):
+    b = backend()
+    if b == "git":
+        return jj("git", "push", *args)
+    return jj("submit", *args)
+
+
+def cmd_track(args):
+    return jj("file", "track", *args)
+
+
+def cmd_unamend(args):
+    return jj("undo", *args)
+
+
+def cmd_uncommit(args):
+    return jj("squash", "--from", "@-", "--into", "@", *args)
+
+
+def cmd_undo(args):
+    return jj("undo", *args)
+
+
+def cmd_unknown(args):
+    return jj("file", "list", "--untracked", *args)
+
+
+def cmd_untrack(args):
+    return jj("untrack", *args)
+
+
+def cmd_upload(args):
+    return _github_review(args)
+
+
+def cmd_uploadchain(args):
+    return _github_review(args)
+
+
+# --- helpers ---
+
+def _rename(args):
+    if len(args) != 2:
+        warn("usage: rename <source> <dest>")
+        return 1
+    return run(["mv", args[0], args[1]])
+
+
+def _github_review(args):
+    """Send current change for review."""
+    reviewers = []
+    push_flags = []
+    it = iter(args)
+    for arg in it:
+        if arg in ("-r", "-m", "--reviewer"):
+            try:
+                reviewers.append(next(it))
+            except StopIteration:
+                pass
+        elif arg.startswith("--reviewer="):
+            reviewers.append(arg.split("=", 1)[1])
+        else:
+            push_flags.append(arg)
+
+    b = backend()
+    if b == "git":
+        ret = jj("git", "push", *push_flags)
+        if ret != 0:
+            return ret
+        h = hosting()
+        if h == "github":
+            bookmark = jj_output("bookmark", "list", "-r", "@")
+            head = None
+            if bookmark:
+                head = bookmark.split(":")[0].strip()
+            gh_args = ["gh", "pr", "create"]
+            for r in reviewers:
+                gh_args.extend(["-r", r])
+            if head:
+                gh_args.extend(["--head", head])
+            return run(gh_args)
+        return 0
+    return jj("upload", *push_flags)
+
+
+COMMANDS = {name[4:]: func for name, func in globals().copy().items()
+            if name.startswith("cmd_") and callable(func)}
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: vcs-jj <command> [args...]", file=sys.stderr)
+        print(f"Commands: {', '.join(sorted(COMMANDS))}", file=sys.stderr)
+        return 1
+
+    command = sys.argv[1]
+    args = sys.argv[2:]
+
+    func = COMMANDS.get(command)
+    if func is None:
+        warn(f"vcs-jj: unknown command '{command}'")
+        return 1
+
+    return func(args) or 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/vcs_git_test.py
+++ b/vcs_git_test.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""Tests for vcs-git."""
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+SCRIPT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "vcs-git")
+
+
+def vcs_git(*args, cwd=None, capture=True):
+    """Run vcs-git with the given arguments."""
+    cmd = [sys.executable, SCRIPT] + list(args)
+    if capture:
+        r = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
+        return r
+    return subprocess.call(cmd, cwd=cwd)
+
+
+def git(*args, cwd=None):
+    """Run raw git and return output."""
+    return subprocess.run(["git"] + list(args), cwd=cwd, capture_output=True, text=True)
+
+
+class GitTestBase(unittest.TestCase):
+    """Base class that creates a temporary git repo for each test."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix="vcs-git-test-")
+        git("init", cwd=self.tmpdir)
+        git("config", "user.email", "test@test.com", cwd=self.tmpdir)
+        git("config", "user.name", "Test User", cwd=self.tmpdir)
+        git("config", "commit.gpgsign", "false", cwd=self.tmpdir)
+        # Create initial commit
+        self._write_file("README", "hello\n")
+        git("add", "README", cwd=self.tmpdir)
+        git("commit", "-m", "initial", cwd=self.tmpdir)
+        self.orig_dir = os.getcwd()
+        os.chdir(self.tmpdir)
+
+    def tearDown(self):
+        os.chdir(self.orig_dir)
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _write_file(self, name, content=""):
+        path = os.path.join(self.tmpdir, name)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as f:
+            f.write(content)
+        return path
+
+    def _read_file(self, name):
+        with open(os.path.join(self.tmpdir, name)) as f:
+            return f.read()
+
+
+class TestNoArgs(unittest.TestCase):
+    def test_no_command_prints_usage(self):
+        r = vcs_git()
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("Usage:", r.stderr)
+
+    def test_unknown_command(self):
+        r = vcs_git("nonexistent_cmd_xyz")
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("unknown command", r.stderr)
+
+    def test_command_list_shown(self):
+        r = vcs_git()
+        self.assertIn("Commands:", r.stderr)
+
+
+class TestBranch(GitTestBase):
+    def test_branch_shows_current(self):
+        r = vcs_git("branch", cwd=self.tmpdir)
+        # default branch name varies, but should print something
+        self.assertEqual(r.returncode, 0)
+        self.assertTrue(r.stdout.strip())
+
+    def test_branches_lists_all(self):
+        git("checkout", "-b", "feature", cwd=self.tmpdir)
+        git("checkout", "-", cwd=self.tmpdir)
+        r = vcs_git("branches", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("feature", r.stdout)
+
+
+class TestStatus(GitTestBase):
+    def test_status_clean(self):
+        r = vcs_git("status", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        self.assertEqual(r.stdout.strip(), "")
+
+    def test_status_shows_untracked(self):
+        self._write_file("newfile", "data")
+        r = vcs_git("status", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("newfile", r.stdout)
+
+    def test_status_shows_modified(self):
+        self._write_file("README", "changed\n")
+        r = vcs_git("status", cwd=self.tmpdir)
+        self.assertIn("README", r.stdout)
+
+
+class TestCommit(GitTestBase):
+    def test_commit_all(self):
+        self._write_file("README", "updated\n")
+        r = vcs_git("commit", "-m", "update readme", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        log = git("log", "--oneline", cwd=self.tmpdir)
+        self.assertIn("update readme", log.stdout)
+
+    def test_commit_specific_file(self):
+        self._write_file("a.txt", "a\n")
+        self._write_file("b.txt", "b\n")
+        git("add", "a.txt", "b.txt", cwd=self.tmpdir)
+        r = vcs_git("commit", "-m", "just a", "a.txt", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        # b.txt should still be staged
+        status = git("status", "--short", cwd=self.tmpdir)
+        self.assertIn("b.txt", status.stdout)
+
+    def test_commit_with_flags(self):
+        self._write_file("README", "v2\n")
+        r = vcs_git("commit", "-m", "flagged commit", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+
+
+class TestAmend(GitTestBase):
+    def test_amend(self):
+        self._write_file("README", "amended\n")
+        r = vcs_git("amend", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        log = git("log", "--oneline", cwd=self.tmpdir)
+        # Should still be one commit
+        self.assertEqual(len(log.stdout.strip().splitlines()), 1)
+
+
+class TestAdd(GitTestBase):
+    def test_add_intent(self):
+        self._write_file("new.txt", "new\n")
+        r = vcs_git("add", "new.txt", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        status = git("status", "--short", cwd=self.tmpdir)
+        self.assertIn("new.txt", status.stdout)
+
+    def test_addremove(self):
+        self._write_file("new.txt", "new\n")
+        r = vcs_git("addremove", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+
+
+class TestDiff(GitTestBase):
+    def test_changes_shows_diff(self):
+        self._write_file("README", "modified\n")
+        r = vcs_git("changes", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("modified", r.stdout)
+
+    def test_changed_shows_filenames(self):
+        self._write_file("README", "modified\n")
+        r = vcs_git("changed", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("README", r.stdout)
+
+    def test_diffstat(self):
+        self._write_file("README", "modified\n")
+        r = vcs_git("diffstat", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("README", r.stdout)
+
+
+class TestLog(GitTestBase):
+    def test_changelog(self):
+        r = vcs_git("changelog", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("initial", r.stdout)
+
+    def test_base(self):
+        r = vcs_git("base", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("initial", r.stdout)
+
+    def test_graph(self):
+        r = vcs_git("graph", "--all", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("initial", r.stdout)
+
+
+class TestNavigation(GitTestBase):
+    def test_prev(self):
+        self._write_file("f2.txt", "f2\n")
+        git("add", "f2.txt", cwd=self.tmpdir)
+        git("commit", "-m", "second", cwd=self.tmpdir)
+        r = vcs_git("prev", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        # HEAD should be detached at initial commit
+        log = git("log", "-1", "--oneline", cwd=self.tmpdir)
+        self.assertIn("initial", log.stdout)
+
+    def test_next(self):
+        self._write_file("f2.txt", "f2\n")
+        git("add", "f2.txt", cwd=self.tmpdir)
+        git("commit", "-m", "second", cwd=self.tmpdir)
+        git("checkout", "HEAD~", cwd=self.tmpdir)
+        r = vcs_git("next", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        log = git("log", "-1", "--oneline", cwd=self.tmpdir)
+        self.assertIn("second", log.stdout)
+
+
+class TestCheckout(GitTestBase):
+    def test_checkout_branch(self):
+        git("checkout", "-b", "feature", cwd=self.tmpdir)
+        git("checkout", "-", cwd=self.tmpdir)
+        r = vcs_git("checkout", "feature", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        branch = git("rev-parse", "--abbrev-ref", "HEAD", cwd=self.tmpdir)
+        self.assertEqual(branch.stdout.strip(), "feature")
+
+    def test_goto(self):
+        git("checkout", "-b", "feat2", cwd=self.tmpdir)
+        git("checkout", "-", cwd=self.tmpdir)
+        r = vcs_git("goto", "feat2", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+
+
+class TestFileOps(GitTestBase):
+    def test_move(self):
+        r = vcs_git("move", "README", "README2", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "README2")))
+
+    def test_remove(self):
+        r = vcs_git("remove", "README", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        self.assertFalse(os.path.exists(os.path.join(self.tmpdir, "README")))
+
+    def test_copy(self):
+        r = vcs_git("copy", "README", "README_COPY", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "README_COPY")))
+
+    def test_ignore(self):
+        r = vcs_git("ignore", "*.pyc", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        content = self._read_file(".gitignore")
+        self.assertIn("*.pyc", content)
+
+
+class TestUndo(GitTestBase):
+    def test_undo(self):
+        self._write_file("README", "v2\n")
+        git("add", "-A", cwd=self.tmpdir)
+        git("commit", "-m", "v2", cwd=self.tmpdir)
+        r = vcs_git("undo", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        # Should have uncommitted changes now
+        status = git("status", "--short", cwd=self.tmpdir)
+        self.assertIn("README", status.stdout)
+
+    def test_uncommit(self):
+        self._write_file("README", "v2\n")
+        git("add", "-A", cwd=self.tmpdir)
+        git("commit", "-m", "v2", cwd=self.tmpdir)
+        r = vcs_git("uncommit", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        # Changes should be staged
+        status = git("diff", "--cached", "--name-only", cwd=self.tmpdir)
+        self.assertIn("README", status.stdout)
+
+    def test_revert_all(self):
+        self._write_file("README", "dirty\n")
+        r = vcs_git("revert", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        self.assertEqual(self._read_file("README"), "hello\n")
+
+    def test_revert_file(self):
+        self._write_file("README", "dirty\n")
+        r = vcs_git("revert", "README", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        self.assertEqual(self._read_file("README"), "hello\n")
+
+    def test_restore(self):
+        self._write_file("README", "dirty\n")
+        r = vcs_git("restore", "README", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        self.assertEqual(self._read_file("README"), "hello\n")
+
+
+class TestTrack(GitTestBase):
+    def test_track(self):
+        self._write_file("new.txt", "new\n")
+        r = vcs_git("track", "new.txt", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        status = git("status", "--short", cwd=self.tmpdir)
+        self.assertIn("new.txt", status.stdout)
+
+    def test_untrack(self):
+        self._write_file("tracked.txt", "data\n")
+        git("add", "tracked.txt", cwd=self.tmpdir)
+        git("commit", "-m", "add tracked", cwd=self.tmpdir)
+        r = vcs_git("untrack", "tracked.txt", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+
+
+class TestUnknown(GitTestBase):
+    def test_unknown_lists_untracked(self):
+        self._write_file("mystery.txt", "who am i\n")
+        r = vcs_git("unknown", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("mystery.txt", r.stdout)
+
+
+class TestRootdir(GitTestBase):
+    def test_rootdir(self):
+        r = vcs_git("rootdir", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        self.assertEqual(r.stdout.strip(), self.tmpdir)
+
+
+class TestFetchtime(GitTestBase):
+    def test_fetchtime_no_fetch_head(self):
+        r = vcs_git("fetchtime", cwd=self.tmpdir)
+        # No FETCH_HEAD yet
+        self.assertNotEqual(r.returncode, 0)
+
+
+class TestShow(GitTestBase):
+    def test_show(self):
+        r = vcs_git("show", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("initial", r.stdout)
+
+
+class TestDescribe(GitTestBase):
+    def test_describe_with_message(self):
+        r = vcs_git("describe", "-m", "new description", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        log = git("log", "-1", "--format=%s", cwd=self.tmpdir)
+        self.assertEqual(log.stdout.strip(), "new description")
+
+
+class TestReword(GitTestBase):
+    def test_reword_with_message(self):
+        # reword uses --allow-empty so it should work even with -m
+        r = vcs_git("reword", "-m", "reworded", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        log = git("log", "-1", "--format=%s", cwd=self.tmpdir)
+        self.assertEqual(log.stdout.strip(), "reworded")
+
+
+class TestEvolve(GitTestBase):
+    def test_evolve_warns(self):
+        r = vcs_git("evolve", cwd=self.tmpdir)
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("no automatic evolve", r.stderr)
+
+
+class TestMap(GitTestBase):
+    def test_map_at_tip(self):
+        r = vcs_git("map", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("initial", r.stdout)
+
+    def test_map_detached(self):
+        self._write_file("f2.txt", "f2\n")
+        git("add", "f2.txt", cwd=self.tmpdir)
+        git("commit", "-m", "second", cwd=self.tmpdir)
+        git("checkout", "HEAD~", cwd=self.tmpdir)
+        r = vcs_git("map", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+
+
+class TestCommitForce(GitTestBase):
+    def test_commitforce(self):
+        self._write_file("README", "forced\n")
+        r = vcs_git("commitforce", "-m", "forced commit", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+
+
+class TestDrop(GitTestBase):
+    def test_drop_no_args(self):
+        r = vcs_git("drop", cwd=self.tmpdir)
+        self.assertNotEqual(r.returncode, 0)
+
+
+class TestSplitFlags(GitTestBase):
+    def test_commit_with_dash_dash(self):
+        self._write_file("a.txt", "a\n")
+        git("add", "a.txt", cwd=self.tmpdir)
+        r = vcs_git("commit", "-m", "with separator", "--", "a.txt", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vcs_hg_test.py
+++ b/vcs_hg_test.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Tests for vcs-hg."""
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+SCRIPT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "vcs-hg")
+
+
+def vcs_hg(*args, cwd=None, capture=True):
+    cmd = [sys.executable, SCRIPT] + list(args)
+    if capture:
+        return subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
+    return subprocess.call(cmd, cwd=cwd)
+
+
+def hg(*args, cwd=None):
+    return subprocess.run(["hg"] + list(args), cwd=cwd, capture_output=True, text=True,
+                          env={**os.environ, "HGPLAIN": "1"})
+
+
+class HgTestBase(unittest.TestCase):
+    """Base class that creates a temporary hg repo for each test."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix="vcs-hg-test-")
+        hg("init", cwd=self.tmpdir)
+        # Configure user
+        hgrc = os.path.join(self.tmpdir, ".hg", "hgrc")
+        with open(hgrc, "w") as f:
+            f.write("[ui]\nusername = Test User <test@test.com>\n")
+        # Create initial commit
+        self._write_file("README", "hello\n")
+        hg("add", "README", cwd=self.tmpdir)
+        hg("commit", "-m", "initial", cwd=self.tmpdir)
+        self.orig_dir = os.getcwd()
+        os.chdir(self.tmpdir)
+
+    def tearDown(self):
+        os.chdir(self.orig_dir)
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _write_file(self, name, content=""):
+        path = os.path.join(self.tmpdir, name)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as f:
+            f.write(content)
+        return path
+
+    def _read_file(self, name):
+        with open(os.path.join(self.tmpdir, name)) as f:
+            return f.read()
+
+
+class TestNoArgs(unittest.TestCase):
+    def test_no_command_prints_usage(self):
+        r = vcs_hg()
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("Usage:", r.stderr)
+
+    def test_unknown_command(self):
+        r = vcs_hg("nonexistent_cmd_xyz")
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("unknown command", r.stderr)
+
+
+class TestBranch(HgTestBase):
+    def test_branch(self):
+        r = vcs_hg("branch", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        self.assertEqual(r.stdout.strip(), "default")
+
+
+class TestStatus(HgTestBase):
+    def test_status_clean(self):
+        r = vcs_hg("status", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        self.assertEqual(r.stdout.strip(), "")
+
+    def test_status_shows_modified(self):
+        self._write_file("README", "changed\n")
+        r = vcs_hg("status", cwd=self.tmpdir)
+        self.assertIn("README", r.stdout)
+
+    def test_status_shows_untracked(self):
+        self._write_file("newfile", "data")
+        r = vcs_hg("status", cwd=self.tmpdir)
+        self.assertIn("newfile", r.stdout)
+
+
+class TestCommit(HgTestBase):
+    def test_commit(self):
+        self._write_file("README", "updated\n")
+        r = vcs_hg("commit", "-m", "update readme", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        log = hg("log", "--template", "{desc}\\n", cwd=self.tmpdir)
+        self.assertIn("update readme", log.stdout)
+
+
+class TestAdd(HgTestBase):
+    def test_add(self):
+        self._write_file("new.txt", "new\n")
+        r = vcs_hg("add", "new.txt", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+
+    def test_addremove(self):
+        self._write_file("new.txt", "new\n")
+        r = vcs_hg("addremove", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+
+
+class TestDiff(HgTestBase):
+    def test_changes(self):
+        self._write_file("README", "modified\n")
+        r = vcs_hg("changes", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("modified", r.stdout)
+
+    def test_diffstat(self):
+        self._write_file("README", "modified\n")
+        r = vcs_hg("diffstat", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("README", r.stdout)
+
+
+class TestLog(HgTestBase):
+    def test_changelog(self):
+        r = vcs_hg("changelog", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        # Output depends on template, but should have something
+        self.assertTrue(r.stdout.strip())
+
+
+class TestFileOps(HgTestBase):
+    def test_move(self):
+        r = vcs_hg("move", "README", "README2", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "README2")))
+
+    def test_remove(self):
+        r = vcs_hg("remove", "README", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+
+    def test_copy(self):
+        r = vcs_hg("copy", "README", "README_COPY", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "README_COPY")))
+
+
+class TestRevert(HgTestBase):
+    def test_revert(self):
+        self._write_file("README", "dirty\n")
+        r = vcs_hg("revert", "README", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        self.assertEqual(self._read_file("README"), "hello\n")
+
+    def test_restore(self):
+        self._write_file("README", "dirty\n")
+        r = vcs_hg("restore", "README", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        self.assertEqual(self._read_file("README"), "hello\n")
+
+
+class TestRootdir(HgTestBase):
+    def test_rootdir(self):
+        r = vcs_hg("rootdir", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        self.assertEqual(r.stdout.strip(), self.tmpdir)
+
+
+class TestIgnore(HgTestBase):
+    def test_ignore(self):
+        r = vcs_hg("ignore", "*.pyc", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        content = self._read_file(".hgignore")
+        self.assertIn("*.pyc", content)
+
+
+class TestTrack(HgTestBase):
+    def test_track(self):
+        self._write_file("new.txt", "new\n")
+        r = vcs_hg("track", "new.txt", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+
+    def test_untrack(self):
+        self._write_file("tracked.txt", "data\n")
+        hg("add", "tracked.txt", cwd=self.tmpdir)
+        hg("commit", "-m", "add tracked", cwd=self.tmpdir)
+        r = vcs_hg("untrack", "tracked.txt", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+
+
+class TestUnknown(HgTestBase):
+    def test_unknown(self):
+        self._write_file("mystery.txt", "who am i\n")
+        r = vcs_hg("unknown", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("mystery.txt", r.stdout)
+
+
+class TestShow(HgTestBase):
+    def test_show(self):
+        r = vcs_hg("show", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("initial", r.stdout)
+
+
+class TestReview(HgTestBase):
+    def test_review_not_supported(self):
+        r = vcs_hg("review", cwd=self.tmpdir)
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("not supported", r.stderr)
+
+
+class TestFetchtime(HgTestBase):
+    def test_fetchtime(self):
+        r = vcs_hg("fetchtime", cwd=self.tmpdir)
+        # changelog should exist after a commit
+        self.assertEqual(r.returncode, 0)
+        self.assertTrue(r.stdout.strip().isdigit())
+
+
+class TestNav(HgTestBase):
+    def test_prev(self):
+        self._write_file("f2.txt", "f2\n")
+        hg("add", "f2.txt", cwd=self.tmpdir)
+        hg("commit", "-m", "second", cwd=self.tmpdir)
+        r = vcs_hg("prev", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        log = hg("log", "-r", ".", "--template", "{desc}", cwd=self.tmpdir)
+        self.assertEqual(log.stdout, "initial")
+
+
+class TestChanged(HgTestBase):
+    def test_changed_no_args(self):
+        self._write_file("README", "modified\n")
+        r = vcs_hg("changed", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("README", r.stdout)
+
+
+class TestGoto(HgTestBase):
+    def test_goto(self):
+        self._write_file("f2.txt", "f2\n")
+        hg("add", "f2.txt", cwd=self.tmpdir)
+        hg("commit", "-m", "second", cwd=self.tmpdir)
+        r = vcs_hg("goto", "0", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vcs_jj_test.py
+++ b/vcs_jj_test.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""Tests for vcs-jj."""
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+SCRIPT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "vcs-jj")
+
+
+def vcs_jj(*args, cwd=None, capture=True):
+    cmd = [sys.executable, SCRIPT] + list(args)
+    if capture:
+        return subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
+    return subprocess.call(cmd, cwd=cwd)
+
+
+def jj(*args, cwd=None):
+    return subprocess.run(["jj"] + list(args), cwd=cwd, capture_output=True, text=True)
+
+
+class JjTestBase(unittest.TestCase):
+    """Base class that creates a temporary jj repo (git-backed) for each test."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix="vcs-jj-test-")
+        jj("git", "init", cwd=self.tmpdir)
+        jj("config", "set", "--repo", "user.name", "Test User", cwd=self.tmpdir)
+        jj("config", "set", "--repo", "user.email", "test@test.com", cwd=self.tmpdir)
+        # Create initial commit
+        self._write_file("README", "hello\n")
+        jj("commit", "-m", "initial", cwd=self.tmpdir)
+        self.orig_dir = os.getcwd()
+        os.chdir(self.tmpdir)
+
+    def tearDown(self):
+        os.chdir(self.orig_dir)
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _write_file(self, name, content=""):
+        path = os.path.join(self.tmpdir, name)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as f:
+            f.write(content)
+        return path
+
+    def _read_file(self, name):
+        with open(os.path.join(self.tmpdir, name)) as f:
+            return f.read()
+
+
+class TestNoArgs(unittest.TestCase):
+    def test_no_command_prints_usage(self):
+        r = vcs_jj()
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("Usage:", r.stderr)
+
+    def test_unknown_command(self):
+        r = vcs_jj("nonexistent_cmd_xyz")
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("unknown command", r.stderr)
+
+
+class TestStatus(JjTestBase):
+    def test_status_no_description(self):
+        # Working copy has no description, so should show diff summary
+        self._write_file("new.txt", "new\n")
+        r = vcs_jj("status", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+
+    def test_status_with_description(self):
+        # Describe the working copy - status should show nothing
+        jj("describe", "-m", "described", cwd=self.tmpdir)
+        r = vcs_jj("status", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        # Should produce no file list since it's described
+        self.assertEqual(r.stdout.strip(), "")
+
+
+class TestCommit(JjTestBase):
+    def test_commit(self):
+        self._write_file("README", "updated\n")
+        r = vcs_jj("commit", "-m", "update readme", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+
+    def test_commitforce(self):
+        self._write_file("README", "forced\n")
+        r = vcs_jj("commitforce", "-m", "forced", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+
+
+class TestDescribe(JjTestBase):
+    def test_describe(self):
+        r = vcs_jj("describe", "-m", "my description", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        log = jj("log", "--no-graph", "-r", "@", "-T", "description", cwd=self.tmpdir)
+        self.assertIn("my description", log.stdout)
+
+    def test_change(self):
+        r = vcs_jj("change", "-m", "changed description", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+
+
+class TestDiff(JjTestBase):
+    def test_changes(self):
+        self._write_file("README", "modified\n")
+        r = vcs_jj("changes", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("modified", r.stdout)
+
+    def test_changed(self):
+        self._write_file("README", "modified\n")
+        r = vcs_jj("changed", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("README", r.stdout)
+
+    def test_diffstat(self):
+        self._write_file("README", "modified\n")
+        r = vcs_jj("diffstat", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("README", r.stdout)
+
+    def test_diffs(self):
+        self._write_file("README", "modified\n")
+        r = vcs_jj("diffs", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+
+
+class TestLog(JjTestBase):
+    def test_changelog(self):
+        r = vcs_jj("changelog", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("initial", r.stdout)
+
+    def test_graph(self):
+        r = vcs_jj("graph", "-r", "all()", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+
+    def test_base(self):
+        r = vcs_jj("base", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+
+
+class TestFileOps(JjTestBase):
+    def test_add(self):
+        self._write_file("new.txt", "new\n")
+        r = vcs_jj("add", "new.txt", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+
+    def test_addremove(self):
+        r = vcs_jj("addremove", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+
+    def test_rename(self):
+        r = vcs_jj("rename", "README", "README2", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "README2")))
+
+    def test_rename_wrong_args(self):
+        r = vcs_jj("rename", "README", cwd=self.tmpdir)
+        self.assertNotEqual(r.returncode, 0)
+
+    def test_copy(self):
+        r = vcs_jj("copy", "README", "README_COPY", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "README_COPY")))
+
+    def test_ignore(self):
+        r = vcs_jj("ignore", "*.pyc", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        content = self._read_file(".gitignore")
+        self.assertIn("*.pyc", content)
+
+
+class TestNavigation(JjTestBase):
+    def test_prev(self):
+        self._write_file("README", "v2\n")
+        jj("commit", "-m", "second", cwd=self.tmpdir)
+        r = vcs_jj("prev", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+
+    def test_next(self):
+        self._write_file("README", "v2\n")
+        jj("commit", "-m", "second", cwd=self.tmpdir)
+        vcs_jj("prev", cwd=self.tmpdir)
+        r = vcs_jj("next", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+
+
+class TestDrop(JjTestBase):
+    def test_drop(self):
+        r = vcs_jj("drop", "@", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+
+
+class TestRestore(JjTestBase):
+    def test_restore(self):
+        self._write_file("README", "modified\n")
+        r = vcs_jj("restore", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        self.assertEqual(self._read_file("README"), "hello\n")
+
+
+class TestShow(JjTestBase):
+    def test_show(self):
+        self._write_file("README", "shown\n")
+        jj("describe", "-m", "show me", cwd=self.tmpdir)
+        r = vcs_jj("show", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("show me", r.stdout)
+
+
+class TestRootdir(JjTestBase):
+    def test_rootdir(self):
+        r = vcs_jj("rootdir", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        self.assertEqual(r.stdout.strip(), self.tmpdir)
+
+
+class TestEvolve(JjTestBase):
+    def test_evolve_message(self):
+        r = vcs_jj("evolve", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("automatically rebases", r.stderr)
+
+
+class TestHistedit(JjTestBase):
+    def test_histedit_warns(self):
+        r = vcs_jj("histedit", cwd=self.tmpdir)
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("no interactive histedit", r.stderr)
+
+
+class TestBranch(JjTestBase):
+    def test_branch_returns_ok(self):
+        r = vcs_jj("branch", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+
+    def test_branches(self):
+        r = vcs_jj("branches", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+
+
+class TestSquash(JjTestBase):
+    def test_squash(self):
+        self._write_file("README", "squashed\n")
+        r = vcs_jj("squash", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+
+
+class TestSplit(JjTestBase):
+    def test_split_noninteractive(self):
+        # split requires interactive input, just verify it doesn't crash on invocation
+        # (it will fail but shouldn't error in our wrapper)
+        r = vcs_jj("split", "--help", cwd=self.tmpdir)
+        # --help should succeed
+        self.assertEqual(r.returncode, 0)
+
+
+class TestReword(JjTestBase):
+    def test_reword_with_message(self):
+        r = vcs_jj("reword", "new description", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+        log = jj("log", "--no-graph", "-r", "@", "-T", "description", cwd=self.tmpdir)
+        self.assertIn("new description", log.stdout)
+
+
+class TestUndo(JjTestBase):
+    def test_undo(self):
+        jj("describe", "-m", "will undo", cwd=self.tmpdir)
+        r = vcs_jj("undo", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+
+
+class TestBookmarks(JjTestBase):
+    def test_branches_empty(self):
+        r = vcs_jj("branches", cwd=self.tmpdir)
+        self.assertEqual(r.returncode, 0)
+
+
+class TestPresubmit(JjTestBase):
+    def test_presubmit_git_backend(self):
+        r = vcs_jj("presubmit", cwd=self.tmpdir)
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("no presubmit", r.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implement the shell VCS functions from shrc.vcs as standalone Python
scripts callable as e.g. "vcs-git branch", "vcs-jj amend". This enables
use from fish and other non-bash shells without sourcing bash functions.

Includes vcs-dispatch for auto-detecting the VCS and delegating, plus
112 tests across all three backends.

https://claude.ai/code/session_01Atszkn2VsyfvKbxXYEzRBC