### PR TITLE
Document mikelward.com/setup redirect as the preferred short URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,18 @@
 Bootstrap a new machine by running the setup script directly from GitHub:
 
 ```sh
-curl -fsSL https://github.com/mikelward/scripts/raw/main/setup | sh
+curl -fsSL https://mikelward.com/setup | sh
 ```
 
 or
 
 ```sh
-wget -qO- https://github.com/mikelward/scripts/raw/main/setup | sh
+wget -qO- https://mikelward.com/setup | sh
 ```
 
-These shorter URLs redirect to `raw.githubusercontent.com` automatically.
+The short URLs redirect to the raw script on GitHub. You can also use the full URLs:
+
+```sh
+curl -fsSL https://github.com/mikelward/scripts/raw/main/setup | sh
+wget -qO- https://github.com/mikelward/scripts/raw/main/setup | sh
+```

--- a/setup
+++ b/setup
@@ -2,9 +2,13 @@
 # Bootstrap script for setting up a new machine.
 #
 # Usage:
-#     wget -qO- https://github.com/mikelward/scripts/raw/main/setup | sh
+#     curl -fsSL https://mikelward.com/setup | sh
 #  or
+#     wget -qO- https://mikelward.com/setup | sh
+#
+# The full GitHub URLs also work:
 #     curl -fsSL https://github.com/mikelward/scripts/raw/main/setup | sh
+#     wget -qO- https://github.com/mikelward/scripts/raw/main/setup | sh
 
 set -e
 


### PR DESCRIPTION
Both README.md and the setup script header now show the shorter
mikelward.com/setup URL first, with the full GitHub raw URLs as
an alternative.

https://claude.ai/code/session_01TX5NgySZFHyDDx9drXq6Cy