### PR TITLE
Standardize --locked flag for all cargo install commands

### DIFF
--- a/setup
+++ b/setup
@@ -195,7 +195,7 @@ install_shpool() {
     fi
 
     info "Installing/updating shpool via cargo"
-    cargo install shpool
+    cargo install --locked shpool
 }
 
 # --- Install Nushell ---
@@ -207,7 +207,7 @@ install_nushell() {
     fi
 
     info "Installing/updating nushell via cargo"
-    cargo install nu
+    cargo install --locked nu
 }
 
 # --- Install Starship ---


### PR DESCRIPTION
jj-cli already used --locked but shpool and nu did not. Pass --locked
consistently to ensure reproducible builds from the lockfile.

https://claude.ai/code/session_01Vq3aFPu8BPyKi3XGjsrX9P