### PR TITLE
Expand macOS support in setup script

### DIFF
--- a/setup
+++ b/setup
@@ -69,6 +69,23 @@ detect_os() {
     esac
 }
 
+# --- Install Homebrew (macOS) ---
+
+install_homebrew() {
+    if command -v brew >/dev/null 2>&1; then
+        info "Homebrew already installed"
+        return
+    fi
+    info "Installing Homebrew"
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    # Add Homebrew to PATH for the rest of this script
+    if test -x /opt/homebrew/bin/brew; then
+        eval "$(/opt/homebrew/bin/brew shellenv)"
+    elif test -x /usr/local/bin/brew; then
+        eval "$(/usr/local/bin/brew shellenv)"
+    fi
+}
+
 # --- Install system packages ---
 
 install_packages() {
@@ -126,11 +143,7 @@ install_packages() {
                 zsh
             ;;
         macos)
-            if ! command -v brew >/dev/null 2>&1; then
-                warn "Homebrew not found, skipping package installation"
-                warn "Install Homebrew from https://brew.sh then re-run this script"
-                return
-            fi
+            install_homebrew
             info "Installing system packages"
             brew install \
                 bat \
@@ -148,6 +161,12 @@ install_packages() {
                 ripgrep \
                 shellcheck \
                 zsh
+            info "Installing macOS applications"
+            brew install --cask \
+                amethyst \
+                iterm2 \
+                karabiner-elements \
+                rectangle
             ;;
         *)
             warn "Unsupported OS, skipping package installation"
@@ -234,7 +253,7 @@ KEYBOARD
             sudo localectl set-x11-keymap us "" dvorak compose:caps
             ;;
         macos)
-            info "Skipping keyboard configuration on macOS (use System Settings)"
+            # Handled by setup-macos
             return
             ;;
         *)
@@ -280,11 +299,12 @@ install_jj
 install_shpool
 install_nushell
 
-if test "$OS" != "macos"; then
+if test "$OS" = "macos"; then
+    info "Configuring macOS desktop environment"
+    "$SCRIPTS_DIR/setup-macos"
+else
     info "Configuring KDE desktop environment"
     "$SCRIPTS_DIR/setup-kde"
-else
-    info "Skipping KDE setup on macOS"
 fi
 
 # --- Install root config ---
@@ -293,6 +313,12 @@ mkdir -p "$SRC_DIR"
 clone_or_pull "$ROOT_REPO" "$ROOT_DIR"
 make -C "$ROOT_DIR"
 sudo make -C "$ROOT_DIR" install
-root_group=$(getent group 0 | cut -d: -f1)
-sudo gpasswd -a "$USER" "$root_group"
-info "Added $USER to $root_group group (log out and back in for this to take effect)"
+if test "$OS" = "macos"; then
+    # macOS: the admin group (GID 80) already has sudo access; the wheel/admin
+    # group membership is managed by Directory Services, not /etc/group.
+    info "On macOS, use System Settings to manage admin group membership"
+else
+    root_group=$(getent group 0 | cut -d: -f1)
+    sudo gpasswd -a "$USER" "$root_group"
+    info "Added $USER to $root_group group (log out and back in for this to take effect)"
+fi

--- a/setup-macos
+++ b/setup-macos
@@ -1,0 +1,127 @@
+#!/bin/sh
+# Configure macOS desktop environment.
+#
+# Sets up:
+# - Dvorak keyboard layout
+# - Caps Lock as Compose key via Karabiner-Elements
+# - Disables auto-correct, auto-capitalize, smart quotes/dashes
+# - Finder preferences (show hidden files, path bar, file extensions)
+#
+# Requires: defaults
+# Optional: Karabiner-Elements (for Compose key support)
+#
+# Usage:
+#     setup-macos
+
+set -e
+
+info() {
+    printf "%s\n" "$*"
+}
+
+warn() {
+    printf "Warning: %s\n" "$*" >&2
+}
+
+# --- Configure keyboard ---
+
+configure_keyboard() {
+    info "Configuring keyboard"
+
+    # Set Dvorak as the input source
+    # This adds Dvorak; the user may still need to remove other layouts in System Settings
+    defaults write com.apple.HIToolbox AppleCurrentKeyboardLayoutInputSourceID \
+        "com.apple.keylayout.Dvorak"
+    defaults write com.apple.HIToolbox AppleEnabledInputSources -array \
+        '<dict><key>InputSourceKind</key><string>Keyboard Layout</string><key>KeyboardLayout ID</key><integer>16300</integer><key>KeyboardLayout Name</key><string>Dvorak</string></dict>'
+
+    # Disable auto-correct, auto-capitalize, smart quotes/dashes
+    defaults write NSGlobalDomain NSAutomaticSpellingCorrectionEnabled -bool false
+    defaults write NSGlobalDomain NSAutomaticCapitalizationEnabled -bool false
+    defaults write NSGlobalDomain NSAutomaticQuoteSubstitutionEnabled -bool false
+    defaults write NSGlobalDomain NSAutomaticDashSubstitutionEnabled -bool false
+    defaults write NSGlobalDomain NSAutomaticPeriodSubstitutionEnabled -bool false
+
+    # Configure Karabiner-Elements: Caps Lock as Compose key
+    configure_karabiner
+}
+
+# --- Configure Karabiner-Elements ---
+
+configure_karabiner() {
+    karabiner_dir="$HOME/.config/karabiner"
+    karabiner_conf="$karabiner_dir/karabiner.json"
+
+    if ! command -v /Library/Application\ Support/org.pqrs/Karabiner-Elements/bin/karabiner_cli \
+        >/dev/null 2>&1 && ! test -d "/Applications/Karabiner-Elements.app"; then
+        warn "Karabiner-Elements not installed yet, writing config for later"
+    fi
+
+    mkdir -p "$karabiner_dir"
+
+    if test -f "$karabiner_conf"; then
+        info "Karabiner config already exists, not overwriting"
+        info "To use Caps Lock as Compose, add the caps_lock rule manually"
+        return
+    fi
+
+    info "Writing Karabiner-Elements config (Caps Lock → Compose key behavior)"
+    cat > "$karabiner_conf" <<'KARABINER'
+{
+    "profiles": [
+        {
+            "complex_modifications": {
+                "rules": [
+                    {
+                        "description": "Caps Lock as Compose key (tap for Caps Lock, hold for modifier)",
+                        "manipulators": [
+                            {
+                                "from": {
+                                    "key_code": "caps_lock",
+                                    "modifiers": { "optional": ["any"] }
+                                },
+                                "to": [
+                                    { "set_variable": { "name": "compose_mode", "value": 1 } }
+                                ],
+                                "to_after_key_up": [
+                                    { "set_variable": { "name": "compose_mode", "value": 0 } }
+                                ],
+                                "to_if_alone": [
+                                    { "key_code": "caps_lock" }
+                                ],
+                                "type": "basic"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "name": "Default profile",
+            "selected": true,
+            "simple_modifications": [
+                {
+                    "from": { "key_code": "caps_lock" },
+                    "to": [{ "key_code": "right_option" }]
+                }
+            ]
+        }
+    ]
+}
+KARABINER
+}
+
+# --- Configure Finder ---
+
+configure_finder() {
+    info "Configuring Finder"
+    defaults write com.apple.finder AppleShowAllFiles -bool true
+    defaults write com.apple.finder ShowPathbar -bool true
+    defaults write NSGlobalDomain AppleShowAllExtensions -bool true
+    killall Finder 2>/dev/null || true
+}
+
+# --- Main ---
+
+configure_keyboard
+configure_finder
+
+info "macOS configured successfully"


### PR DESCRIPTION
Install Homebrew automatically, add cask apps (Amethyst, iTerm2,
Karabiner-Elements, Rectangle), configure Dvorak keyboard layout with
Caps Lock as Compose via Karabiner, set Finder preferences (show hidden
files, path bar, extensions), and fix getent/gpasswd calls on macOS.

https://claude.ai/code/session_014yG1YzVJSMz8EyQocRW4Va