### PR TITLE
Make Caps Lock always Compose, never Caps Lock

### DIFF
--- a/setup-macos
+++ b/setup-macos
@@ -73,7 +73,7 @@ configure_karabiner() {
             "complex_modifications": {
                 "rules": [
                     {
-                        "description": "Caps Lock as Compose key (tap for Caps Lock, hold for modifier)",
+                        "description": "Caps Lock as Compose key (never Caps Lock)",
                         "manipulators": [
                             {
                                 "from": {
@@ -85,9 +85,6 @@ configure_karabiner() {
                                 ],
                                 "to_after_key_up": [
                                     { "set_variable": { "name": "compose_mode", "value": 0 } }
-                                ],
-                                "to_if_alone": [
-                                    { "key_code": "caps_lock" }
                                 ],
                                 "type": "basic"
                             }


### PR DESCRIPTION
## Summary
- Remove the `to_if_alone` rule from the Karabiner config that sent a real `caps_lock` on tap
- Caps Lock now always acts as Compose (via `right_option`), never toggles Caps Lock

## Test plan
- [ ] Run `setup-macos` on a Mac with Karabiner-Elements installed
- [ ] Tap Caps Lock — verify it does not toggle Caps Lock
- [ ] Hold Caps Lock + type a compose sequence — verify Compose works

https://claude.ai/code/session_011s1ELwkRvSVeei62V65GkU