### PR TITLE
Enable focus follows mouse on KDE and macOS

### DIFF
--- a/setup-kde
+++ b/setup-kde
@@ -3,6 +3,7 @@
 #
 # Sets up:
 # - Krohnkite tiling window manager
+# - Focus follows mouse
 # - Window management and desktop switching keybindings
 # - Application launch shortcuts (browser, terminal, music)
 #
@@ -82,6 +83,14 @@ install_krohnkite() {
 enable_krohnkite() {
     info "Enabling Krohnkite plugin"
     kwriteconfig6 --file kwinrc --group Plugins --key krohnkiteEnabled true
+}
+
+# --- Focus follows mouse ---
+
+configure_focus_follows_mouse() {
+    info "Enabling focus follows mouse"
+    kwriteconfig6 --file kwinrc --group Windows --key FocusPolicy FocusUnderMouse
+    kwriteconfig6 --file kwinrc --group Windows --key NextFocusPrefersMouse true
 }
 
 # --- Configure keybindings ---
@@ -207,6 +216,7 @@ reload_kwin() {
 
 install_krohnkite
 enable_krohnkite
+configure_focus_follows_mouse
 # Reload so Krohnkite registers its default shortcuts in kglobalshortcutsrc
 reload_kwin
 configure_keybindings

--- a/setup-macos
+++ b/setup-macos
@@ -5,7 +5,7 @@
 # - Dvorak keyboard layout
 # - Caps Lock as Compose key via Karabiner-Elements
 # - Disables auto-correct, auto-capitalize, smart quotes/dashes
-# - Amethyst tiling window manager (layouts, modifiers, margins)
+# - Amethyst tiling window manager (layouts, modifiers, margins, focus follows mouse)
 # - skhd application launch shortcuts (browser, terminal, music)
 # - Finder preferences (show hidden files, path bar, file extensions)
 #
@@ -118,6 +118,10 @@ configure_amethyst() {
     if ! test -f "$HOME/.amethyst.yml"; then
         warn "~/.amethyst.yml not found; run confinst after cloning the conf repo"
     fi
+
+    # Enable focus follows mouse
+    info "Enabling focus follows mouse"
+    defaults write com.amethyst.Amethyst focus-follows-mouse -bool true
 }
 
 # --- Configure skhd (application launch shortcuts) ---


### PR DESCRIPTION
Add focus-follows-mouse configuration to both setup scripts:
- KDE: set FocusPolicy to FocusFollowsMouse in kwinrc
- macOS: enable focus-follows-mouse in Amethyst preferences

https://claude.ai/code/session_01GMQLfY3CuM3UvihiB8FA6D