### PR TITLE
setup-macos: swap Ctrl/Cmd and remap shortcuts for Linux muscle memory

### DIFF
--- a/setup-kde
+++ b/setup-kde
@@ -93,6 +93,14 @@ configure_focus_follows_mouse() {
     kwriteconfig6 --file kwinrc --group Windows --key NextFocusPrefersMouse true
 }
 
+# --- Configure virtual desktops ---
+
+configure_desktops() {
+    info "Configuring 9 virtual desktops"
+    kwriteconfig6 --file kwinrc --group Desktops --key Number 9
+    kwriteconfig6 --file kwinrc --group Desktops --key Rows 1
+}
+
 # --- Configure keybindings ---
 
 set_shortcut() {
@@ -217,6 +225,7 @@ reload_kwin() {
 install_krohnkite
 enable_krohnkite
 configure_focus_follows_mouse
+configure_desktops
 # Reload so Krohnkite registers its default shortcuts in kglobalshortcutsrc
 reload_kwin
 configure_keybindings

--- a/setup-macos
+++ b/setup-macos
@@ -4,12 +4,19 @@
 # Sets up:
 # - Dvorak keyboard layout
 # - Caps Lock as Compose key via Karabiner-Elements
+# - Swap Control and Command keys (for Linux-like Ctrl shortcuts)
+# - Spotlight and Switch to Desktop 1-9 on Option key (physical Win/Super)
 # - Disables auto-correct, auto-capitalize, smart quotes/dashes
 # - Amethyst tiling window manager (layouts, modifiers, margins, focus follows mouse)
 # - skhd application launch shortcuts (browser, terminal, music)
 # - Finder preferences (show hidden files, path bar, file extensions)
 #
-# Requires: defaults
+# Modifier key philosophy (matches Linux muscle memory):
+#   Physical Ctrl (pinky)    → Command  → copy, paste, tabs, close
+#   Physical Win/Super       → Option   → launcher, desktop switching
+#   Physical Alt (by space)  → Control  → available for per-app custom shortcuts
+#
+# Requires: defaults, hidutil
 # Optional: Karabiner-Elements (for Compose key support), skhd (for app shortcuts)
 #
 # Usage:
@@ -108,6 +115,111 @@ configure_karabiner() {
 KARABINER
 }
 
+# --- Swap Control and Command keys ---
+
+configure_modifier_keys() {
+    info "Swapping Control and Command keys"
+
+    # Swap left and right Control <-> Command immediately using hidutil
+    # Makes physical Ctrl (pinky) send Command, physical Cmd send Control
+    hidutil property --set '{"UserKeyMapping":[
+        {"HIDKeyboardModifierMappingSrc":0x7000000E0,"HIDKeyboardModifierMappingDst":0x7000000E3},
+        {"HIDKeyboardModifierMappingSrc":0x7000000E3,"HIDKeyboardModifierMappingDst":0x7000000E0},
+        {"HIDKeyboardModifierMappingSrc":0x7000000E4,"HIDKeyboardModifierMappingDst":0x7000000E7},
+        {"HIDKeyboardModifierMappingSrc":0x7000000E7,"HIDKeyboardModifierMappingDst":0x7000000E4}
+    ]}' >/dev/null
+
+    # Persist across reboots with a LaunchAgent
+    launch_agent_dir="$HOME/Library/LaunchAgents"
+    launch_agent="$launch_agent_dir/com.local.KeyRemapping.plist"
+    mkdir -p "$launch_agent_dir"
+
+    cat > "$launch_agent" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.local.KeyRemapping</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/bin/hidutil</string>
+        <string>property</string>
+        <string>--set</string>
+        <string>{"UserKeyMapping":[{"HIDKeyboardModifierMappingSrc":0x7000000E0,"HIDKeyboardModifierMappingDst":0x7000000E3},{"HIDKeyboardModifierMappingSrc":0x7000000E3,"HIDKeyboardModifierMappingDst":0x7000000E0},{"HIDKeyboardModifierMappingSrc":0x7000000E4,"HIDKeyboardModifierMappingDst":0x7000000E7},{"HIDKeyboardModifierMappingSrc":0x7000000E7,"HIDKeyboardModifierMappingDst":0x7000000E4}]}</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+</dict>
+</plist>
+PLIST
+}
+
+# --- Configure keyboard shortcuts ---
+
+configure_shortcuts() {
+    info "Configuring keyboard shortcuts (Mission Control and Spotlight on Option)"
+
+    # Remap Mission Control shortcuts from Control to Option
+    # so the physical Win/Super key handles desktop switching
+    #
+    # Parameters format: (ASCII code, virtual keycode, modifier flags)
+    # Modifier flags: Option = 524288
+
+    # Spotlight: Option+Space (ID 64)
+    defaults write com.apple.symbolichotkeys AppleSymbolicHotKeys -dict-add 64 '
+        <dict>
+            <key>enabled</key><true/>
+            <key>value</key><dict>
+                <key>parameters</key><array>
+                    <integer>32</integer>
+                    <integer>49</integer>
+                    <integer>524288</integer>
+                </array>
+                <key>type</key><string>standard</string>
+            </dict>
+        </dict>'
+
+    # Disable Finder search window (ID 65) to avoid conflict
+    defaults write com.apple.symbolichotkeys AppleSymbolicHotKeys -dict-add 65 '
+        <dict>
+            <key>enabled</key><false/>
+        </dict>'
+
+    # Switch to Desktop 1-9: Option+1..9 (IDs 118-126)
+    # macOS virtual keycodes for number keys are not sequential:
+    #   1=18 2=19 3=20 4=21 5=23 6=22 7=26 8=28 9=25
+    set -- \
+        118 49 18 \
+        119 50 19 \
+        120 51 20 \
+        121 52 21 \
+        122 53 23 \
+        123 54 22 \
+        124 55 26 \
+        125 56 28 \
+        126 57 25
+    while test $# -ge 3; do
+        hotkey_id=$1 ascii=$2 keycode=$3
+        shift 3
+        defaults write com.apple.symbolichotkeys AppleSymbolicHotKeys -dict-add "$hotkey_id" '
+            <dict>
+                <key>enabled</key><true/>
+                <key>value</key><dict>
+                    <key>parameters</key><array>
+                        <integer>'"$ascii"'</integer>
+                        <integer>'"$keycode"'</integer>
+                        <integer>524288</integer>
+                    </array>
+                    <key>type</key><string>standard</string>
+                </dict>
+            </dict>'
+    done
+
+    # Apply changes
+    /System/Library/PrivateFrameworks/SystemAdministration.framework/Resources/activateSettings -u
+}
+
 # --- Configure Amethyst tiling window manager ---
 
 configure_amethyst() {
@@ -169,6 +281,8 @@ configure_finder() {
 # --- Main ---
 
 configure_keyboard
+configure_modifier_keys
+configure_shortcuts
 configure_amethyst
 configure_skhd
 configure_finder


### PR DESCRIPTION
Swaps Control and Command via hidutil so physical Ctrl (pinky) sends
Command for copy/paste/tabs. Persists across reboots with a LaunchAgent.

Remaps Spotlight to Option+Space and Switch to Desktop 1-9 to
Option+1..9 (physical Win/Super key), matching Linux Super+N behavior.

https://claude.ai/code/session_014qwLfFfH8QsTmmiBPt5ocg