### PR TITLE
pidcat: fix Python 3 regressions from Codex review of #42

### DIFF
--- a/pidcat
+++ b/pidcat
@@ -10,8 +10,10 @@
 #       only the first one (map() returns a one-shot iterator in Py3).
 #     - In `FakeStdinProcess`, expose `sys.stdin.buffer` so piped input
 #       returns bytes for the `.decode()` call below.
-#     - Print log lines as `str`, not `bytes`, to avoid emitting the
-#       `b'...'` repr.
+#     - Write each log line to `sys.stdout.buffer` as UTF-8 bytes,
+#       preserving upstream's locale-independent output (the Py2
+#       `print` of a `str`/bytes), instead of `print(linebuf)` which
+#       would `UnicodeEncodeError` under `LC_ALL=C` on non-ASCII text.
 
 '''
 Copyright 2009, The Android Open Source Project
@@ -372,4 +374,4 @@ while adb.poll() is None:
     message = matcher.sub(replace, message)
 
   linebuf += indent_wrap(message)
-  print(linebuf)
+  sys.stdout.buffer.write(linebuf.encode('utf-8') + b'\n')

--- a/pidcat
+++ b/pidcat
@@ -4,7 +4,14 @@
 #   - Shebang changed from `python` to `python3` for portability on
 #     systems where the unversioned `python` command is not installed.
 #     The `-u` (unbuffered stdout) flag is preserved.
-# No other changes.
+#   - Python 3 fixes:
+#     - Materialize the `named_processes` map() into a list so the
+#       membership test in `match_packages()` works on every line, not
+#       only the first one (map() returns a one-shot iterator in Py3).
+#     - In `FakeStdinProcess`, expose `sys.stdin.buffer` so piped input
+#       returns bytes for the `.decode()` call below.
+#     - Print log lines as `str`, not `bytes`, to avoid emitting the
+#       `b'...'` repr.
 
 '''
 Copyright 2009, The Android Open Source Project
@@ -80,7 +87,7 @@ catchall_package = list(filter(lambda package: package.find(":") == -1, package)
 # Store the name of processes to match exactly.
 named_processes = list(filter(lambda package: package.find(":") != -1, package))
 # Convert default process names from <package>: (cli notation) to <package> (android notation) in the exact names match group.
-named_processes = map(lambda package: package if package.find(":") != len(package) - 1 else package[:-1], named_processes)
+named_processes = [package if package.find(":") != len(package) - 1 else package[:-1] for package in named_processes]
 
 header_size = args.tag_width + 1 + 3 + 1 # space, level, space
 
@@ -199,7 +206,7 @@ if args.clear_logcat:
 # This is a ducktype of the subprocess.Popen object
 class FakeStdinProcess():
   def __init__(self):
-    self.stdout = sys.stdin
+    self.stdout = sys.stdin.buffer
   def poll(self):
     return None
 
@@ -365,4 +372,4 @@ while adb.poll() is None:
     message = matcher.sub(replace, message)
 
   linebuf += indent_wrap(message)
-  print(linebuf.encode('utf-8'))
+  print(linebuf)


### PR DESCRIPTION
Addresses the three P2 review comments on https://github.com/mikelward/scripts/pull/42#pullrequestreview-4242250586. PR #42 was already merged, so these are follow-up fixes.

## Summary

- **`named_processes` (line 83)**: `map()` returns a one-shot iterator in Python 3, so the `token in named_processes` membership test in `match_packages()` only worked for the first line. Materialized to a list comprehension so exact `pkg:proc` filters keep matching across restart/death events.
- **`FakeStdinProcess` (line 202)**: `sys.stdin` returns `str` from `readline()` on Python 3, which made `adb.stdout.readline().decode(...)` raise `AttributeError` for the piped-stdin mode. Switched to `sys.stdin.buffer` so the read loop sees `bytes` consistently with the subprocess case.
- **Log line output (line 368)**: `print(linebuf.encode('utf-8'))` printed a `b'...'` repr under Python 3 instead of the colorized line. Changed to `print(linebuf)`.

The "Modifications from upstream" header at the top of the file is updated to mention these changes (Apache 2.0 §4(b)).

## Test plan

- [x] `python3 -m py_compile pidcat`
- [x] `pidcat --help` runs and prints usage
- [ ] `pidcat com.android.settings` against a device shows colorized lines (no `b'...'` prefix)
- [ ] `adb logcat | pidcat com.android.settings` works end-to-end
- [ ] Killing the target process and relaunching shows "Process … ended" / re-attaches for a `pkg:proc` filter

https://claude.ai/code/session_011R3mhBSsB5V6FfYEJV8gAR

---
_Generated by [Claude Code](https://claude.ai/code/session_011R3mhBSsB5V6FfYEJV8gAR)_