### PR TITLE
pidcat: add -f/--file flag to read logcat from a file

### DIFF
--- a/pidcat
+++ b/pidcat
@@ -14,6 +14,9 @@
 #       preserving upstream's locale-independent output (the Py2
 #       `print` of a `str`/bytes), instead of `print(linebuf)` which
 #       would `UnicodeEncodeError` under `LC_ALL=C` on non-ASCII text.
+#   - Added a `-f`/`--file` flag to read a saved logcat capture from a
+#     file instead of a connected device, and skip the `adb shell ps`
+#     pid lookup when not reading from a live device.
 
 '''
 Copyright 2009, The Android Open Source Project
@@ -57,6 +60,7 @@ parser.add_argument('-s', '--serial', dest='device_serial', help='Device serial 
 parser.add_argument('-d', '--device', dest='use_device', action='store_true', help='Use first device for log input (adb -d option)')
 parser.add_argument('-e', '--emulator', dest='use_emulator', action='store_true', help='Use first emulator for log input (adb -e option)')
 parser.add_argument('-c', '--clear', dest='clear_logcat', action='store_true', help='Clear the entire log before running')
+parser.add_argument('-f', '--file', dest='filename', metavar='FILE', help='Read log input from FILE instead of a connected device')
 parser.add_argument('-t', '--tag', dest='tag', action='append', help='Filter output by specified tag(s)')
 parser.add_argument('-i', '--ignore-tag', dest='ignored_tag', action='append', help='Filter output by ignoring specified tag(s)')
 parser.add_argument('-v', '--version', action='version', version='%(prog)s ' + __version__, help='Print the version number and exit')
@@ -207,15 +211,23 @@ if args.clear_logcat:
 
 # This is a ducktype of the subprocess.Popen object
 class FakeStdinProcess():
-  def __init__(self):
-    self.stdout = sys.stdin.buffer
+  def __init__(self, stream):
+    self.stdout = stream
   def poll(self):
     return None
 
-if sys.stdin.isatty():
+if args.filename:
+  try:
+    adb = FakeStdinProcess(open(args.filename, 'rb'))
+  except OSError as e:
+    parser.error('cannot read %s: %s' % (args.filename, e.strerror))
+  reading_from_device = False
+elif sys.stdin.isatty():
   adb = subprocess.Popen(adb_command, stdin=PIPE, stdout=PIPE)
+  reading_from_device = True
 else:
-  adb = FakeStdinProcess()
+  adb = FakeStdinProcess(sys.stdin.buffer)
+  reading_from_device = False
 pids = set()
 last_tag = None
 app_pid = None
@@ -269,23 +281,24 @@ def parse_start_proc(line):
 def tag_in_tags_regex(tag, tags):
   return any(re.match(r'^' + t + r'$', tag) for t in map(str.strip, tags))
 
-ps_command = base_adb_command + ['shell', 'ps']
-ps_pid = subprocess.Popen(ps_command, stdin=PIPE, stdout=PIPE, stderr=PIPE)
-while True:
-  try:
-    line = ps_pid.stdout.readline().decode('utf-8', 'replace').strip()
-  except KeyboardInterrupt:
-    break
-  if len(line) == 0:
-    break
+if reading_from_device:
+  ps_command = base_adb_command + ['shell', 'ps']
+  ps_pid = subprocess.Popen(ps_command, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+  while True:
+    try:
+      line = ps_pid.stdout.readline().decode('utf-8', 'replace').strip()
+    except KeyboardInterrupt:
+      break
+    if len(line) == 0:
+      break
 
-  pid_match = PID_LINE.match(line)
-  if pid_match is not None:
-    pid = pid_match.group(1)
-    proc = pid_match.group(2)
-    if proc in catchall_package:
-      seen_pids = True
-      pids.add(pid)
+    pid_match = PID_LINE.match(line)
+    if pid_match is not None:
+      pid = pid_match.group(1)
+      proc = pid_match.group(2)
+      if proc in catchall_package:
+        seen_pids = True
+        pids.add(pid)
 
 while adb.poll() is None:
   try:

--- a/pidcat
+++ b/pidcat
@@ -15,11 +15,12 @@
 #       `print` of a `str`/bytes), instead of `print(linebuf)` which
 #       would `UnicodeEncodeError` under `LC_ALL=C` on non-ASCII text.
 #   - Added a `-f`/`--file` flag to read a saved logcat capture from a
-#     file instead of a connected device, and skip the `adb shell ps`
-#     pid lookup when not reading from a live device. When such input is
-#     filtered by package but contains no "Start proc" lines (so no PID
-#     can be resolved and nothing matches), warn on stderr and suggest
-#     `-a`/`--all`.
+#     file instead of a connected device. In this offline mode the
+#     `adb shell ps` pid lookup and `--clear` are skipped so no device is
+#     touched (a live `adb logcat | pidcat` stdin pipe still runs `ps`,
+#     matching upstream). When the file is filtered by package but
+#     contains no "Start proc" lines (so no PID can be resolved and
+#     nothing matches), warn on stderr and suggest `-a`/`--all`.
 
 '''
 Copyright 2009, The Android Open Source Project
@@ -203,8 +204,8 @@ adb_command = base_adb_command[:]
 adb_command.append('logcat')
 adb_command.extend(['-v', 'brief'])
 
-# Clear log before starting logcat
-if args.clear_logcat:
+# Clear log before starting logcat (never touch a device when reading a file)
+if args.clear_logcat and not args.filename:
   adb_clear_command = list(adb_command)
   adb_clear_command.append('-c')
   adb_clear = subprocess.Popen(adb_clear_command)
@@ -224,13 +225,10 @@ if args.filename:
     adb = FakeStdinProcess(open(args.filename, 'rb'))
   except OSError as e:
     parser.error('cannot read %s: %s' % (args.filename, e.strerror))
-  reading_from_device = False
 elif sys.stdin.isatty():
   adb = subprocess.Popen(adb_command, stdin=PIPE, stdout=PIPE)
-  reading_from_device = True
 else:
   adb = FakeStdinProcess(sys.stdin.buffer)
-  reading_from_device = False
 pids = set()
 any_pids_found = False
 last_tag = None
@@ -285,7 +283,10 @@ def parse_start_proc(line):
 def tag_in_tags_regex(tag, tags):
   return any(re.match(r'^' + t + r'$', tag) for t in map(str.strip, tags))
 
-if reading_from_device:
+# Resolve already-running PIDs from the device. Skipped only for file
+# input (-f), which is offline; a live stdin pipe (adb logcat | pidcat)
+# can still reach the device, matching upstream behavior.
+if not args.filename:
   ps_command = base_adb_command + ['shell', 'ps']
   ps_pid = subprocess.Popen(ps_command, stdin=PIPE, stdout=PIPE, stderr=PIPE)
   while True:
@@ -399,9 +400,8 @@ while adb.poll() is None:
 # discovered from "Start proc" lines in the log. A clipped capture that
 # begins after the app was already running won't contain those lines, so
 # nothing matches. Point the user at -a/--all rather than failing silently.
-if not reading_from_device and not args.all and not any_pids_found:
-  source = args.filename if args.filename else 'the input'
+if args.filename and not args.all and not any_pids_found:
   sys.stderr.write(
     'pidcat: no process start lines found in %s, so %s could not be mapped '
     'to a PID and no lines matched. Use -a/--all to show every line.\n'
-    % (source, ', '.join(package)))
+    % (args.filename, ', '.join(package)))

--- a/pidcat
+++ b/pidcat
@@ -30,10 +30,14 @@
 #   - Parse every logcat format, not just `brief`: `brief`, `process`,
 #     `tag`, `thread`, `time`, `threadtime` (adb's default for a bare
 #     `adb logcat`) and the multi-line `long` format (coalesced into a
-#     synthetic brief line). Formats without a PID (`tag`, `raw`) can only
-#     be shown with `-a`/`--all`. As part of this, true EOF is now detected
-#     from the raw read so blank lines (record separators in `long`, or
-#     stray blanks elsewhere) no longer terminate input early.
+#     synthetic brief line, and flushed at EOF even without a trailing
+#     blank separator). Formats without a PID (`tag`, `raw`) can't be
+#     package-filtered; under `-a`/`--all` such lines (and any other line
+#     that matches no format) are shown verbatim. True EOF is detected from
+#     the raw read so blank lines (record separators in `long`, or stray
+#     blanks elsewhere) no longer terminate input early. The "nothing
+#     matched" hint now fires whenever no line was displayed, including
+#     `tag` captures that happen to contain a `Start proc` marker.
 
 '''
 Copyright 2009, The Android Open Source Project
@@ -299,6 +303,7 @@ else:
   adb = FakeStdinProcess(sys.stdin.buffer)
 pids = set()
 any_pids_found = False
+displayed_any = False  # whether any actual log line was printed
 long_pid = None  # set while coalescing a multi-line `-v long` record
 last_tag = None
 app_pid = None
@@ -393,24 +398,29 @@ while adb.poll() is None:
   except KeyboardInterrupt:
     break
   if not raw_line:  # genuine EOF (a blank line is b'\n', not b'')
-    break
-  line = raw_line.decode('utf-8', 'replace').strip()
+    if long_pid is None:
+      break
+    # Flush a `long` record that ended without its trailing blank separator.
+    line = '%s/%s(%s): %s' % (long_level, long_tag, long_pid, ' '.join(long_lines))
+    long_pid = None
+  else:
+    line = raw_line.decode('utf-8', 'replace').strip()
 
-  # `long` format spans multiple lines: a "[ ... PID:TID L/Tag ]" header,
-  # the message on the following line(s), then a blank separator. Coalesce
-  # each record into a synthetic brief line and let the normal path handle it.
-  long_header = LOG_LONG_HEADER.match(line)
-  if long_header:
-    long_pid, long_level, long_tag = long_header.groups()
-    long_lines = []
-    continue
-  if long_pid is not None:
-    if line == '':
-      line = '%s/%s(%s): %s' % (long_level, long_tag, long_pid, ' '.join(long_lines))
-      long_pid = None
-    else:
-      long_lines.append(line)
+    # `long` format spans multiple lines: a "[ ... PID:TID L/Tag ]" header,
+    # the message on the following line(s), then a blank separator. Coalesce
+    # each record into a synthetic brief line and let the normal path handle it.
+    long_header = LOG_LONG_HEADER.match(line)
+    if long_header:
+      long_pid, long_level, long_tag = long_header.groups()
+      long_lines = []
       continue
+    if long_pid is not None:
+      if line == '':
+        line = '%s/%s(%s): %s' % (long_level, long_tag, long_pid, ' '.join(long_lines))
+        long_pid = None
+      else:
+        long_lines.append(line)
+        continue
 
   bug_line = BUG_LINE.match(line)
   if bug_line is not None:
@@ -418,6 +428,11 @@ while adb.poll() is None:
 
   parsed = parse_log_line(line)
   if parsed is None:
+    # Lines that match no format (e.g. `-v raw`, which has no metadata) carry
+    # no PID and so can't be package-filtered; show them verbatim under -a.
+    if args.all and line:
+      sys.stdout.buffer.write(line.encode('utf-8') + b'\n')
+      displayed_any = True
     continue
 
   level, tag, owner, message = parsed
@@ -496,14 +511,14 @@ while adb.poll() is None:
 
   linebuf += indent_wrap(message)
   sys.stdout.buffer.write(linebuf.encode('utf-8') + b'\n')
+  displayed_any = True
 
-# In pipe / file mode the only PID source is the "Start proc" markers in
-# the stream. A capture (or live pipe) that begins after the app was
-# already running has none, so a package filter matches nothing. Say so
-# rather than failing silently.
-if input_mode != 'device' and not args.all and not any_pids_found:
+# In pipe / file mode PIDs are resolved only from the "Start proc" markers
+# in the stream. If a package filter matched nothing (no markers, or a
+# format such as `tag`/`raw` that carries no PID), say so rather than
+# failing silently.
+if input_mode != 'device' and not args.all and not displayed_any:
   source = args.filename if input_mode == 'file' else 'the piped input'
   sys.stderr.write(
-    'pidcat: no process start lines found in %s, so %s could not be mapped '
-    'to a PID and no lines matched. Use -a/--all to show every line.\n'
-    % (source, ', '.join(package)))
+    'pidcat: no lines matched %s in %s. Use -a/--all to show every line.\n'
+    % (', '.join(package), source))

--- a/pidcat
+++ b/pidcat
@@ -16,7 +16,10 @@
 #       would `UnicodeEncodeError` under `LC_ALL=C` on non-ASCII text.
 #   - Added a `-f`/`--file` flag to read a saved logcat capture from a
 #     file instead of a connected device, and skip the `adb shell ps`
-#     pid lookup when not reading from a live device.
+#     pid lookup when not reading from a live device. When such input is
+#     filtered by package but contains no "Start proc" lines (so no PID
+#     can be resolved and nothing matches), warn on stderr and suggest
+#     `-a`/`--all`.
 
 '''
 Copyright 2009, The Android Open Source Project
@@ -229,6 +232,7 @@ else:
   adb = FakeStdinProcess(sys.stdin.buffer)
   reading_from_device = False
 pids = set()
+any_pids_found = False
 last_tag = None
 app_pid = None
 
@@ -299,6 +303,7 @@ if reading_from_device:
       if proc in catchall_package:
         seen_pids = True
         pids.add(pid)
+        any_pids_found = True
 
 while adb.poll() is None:
   try:
@@ -323,6 +328,7 @@ while adb.poll() is None:
     line_package, target, line_pid, line_uid, line_gids = start
     if match_packages(line_package):
       pids.add(line_pid)
+      any_pids_found = True
 
       app_pid = line_pid
 
@@ -388,3 +394,14 @@ while adb.poll() is None:
 
   linebuf += indent_wrap(message)
   sys.stdout.buffer.write(linebuf.encode('utf-8') + b'\n')
+
+# When reading a saved capture, package filtering relies on the PIDs
+# discovered from "Start proc" lines in the log. A clipped capture that
+# begins after the app was already running won't contain those lines, so
+# nothing matches. Point the user at -a/--all rather than failing silently.
+if not reading_from_device and not args.all and not any_pids_found:
+  source = args.filename if args.filename else 'the input'
+  sys.stderr.write(
+    'pidcat: no process start lines found in %s, so %s could not be mapped '
+    'to a PID and no lines matched. Use -a/--all to show every line.\n'
+    % (source, ', '.join(package)))

--- a/pidcat
+++ b/pidcat
@@ -27,6 +27,11 @@
 #     a pipe/file is filtered by package but has no `Start proc` markers (so
 #     no PID can be resolved and nothing matches), warn on stderr and
 #     suggest `-a`/`--all`.
+#   - Parse all single-line logcat formats, not just `brief`: `brief`,
+#     `process`, `tag`, `thread`, `time` and `threadtime` (adb's default
+#     for a bare `adb logcat`). Formats without a PID (`tag`, `raw`) can
+#     only be shown with `-a`/`--all`. The multi-line `long` format is not
+#     supported; its header is detected and a one-time hint is printed.
 
 '''
 Copyright 2009, The Android Open Source Project
@@ -202,9 +207,50 @@ PID_START_DALVIK = re.compile(r'^E/dalvikvm\(\s*(\d+)\): >>>>> ([a-zA-Z0-9._:]+)
 PID_KILL  = re.compile(r'^Killing (\d+):([a-zA-Z0-9._:]+)/[^:]+: (.*)$')
 PID_LEAVE = re.compile(r'^No longer want ([a-zA-Z0-9._:]+) \(pid (\d+)\): .*$')
 PID_DEATH = re.compile(r'^Process ([a-zA-Z0-9._:]+) \(pid (\d+)\) has died.?$')
-LOG_LINE  = re.compile(r'^([A-Z])/(.+?)\( *(\d+)\): (.*?)$')
+# logcat line formats (see `adb logcat -v <format>`). Device mode forces
+# `brief`, but piped/-f input may use any of these; only formats that carry
+# a PID can be filtered by package.
+LOG_DATE = r'\d\d-\d\d \d\d:\d\d:\d\d\.\d+'
+LOG_THREADTIME = re.compile(r'^' + LOG_DATE + r' +(\d+) +(\d+) +([A-Z]) +(.+?) *: (.*)$')
+LOG_TIME       = re.compile(r'^' + LOG_DATE + r' ([A-Z])/(.+?)\( *(\d+)\): (.*)$')
+LOG_BRIEF      = re.compile(r'^([A-Z])/(.+?)\( *(\d+)\): (.*)$')
+LOG_THREAD     = re.compile(r'^([A-Z])\( *(\d+): *\w+\) (.*)$')
+LOG_PROCESS    = re.compile(r'^([A-Z])\( *(\d+)\) (.*?)(?:  \((.+)\))?$')
+LOG_TAG        = re.compile(r'^([A-Z])/(.+?): (.*)$')
+LOG_LONG_HEADER = re.compile(r'^\[ ' + LOG_DATE + r' +\d+: *\d+ [A-Z]/.+ \]$')
 BUG_LINE  = re.compile(r'.*nativeGetEnabledTags.*')
 BACKTRACE_LINE = re.compile(r'^#(.*?)pc\s(.*?)$')
+
+def parse_log_line(line):
+  # Returns (level, tag, owner_pid, message), with owner_pid None for
+  # formats that don't carry a PID (those can only be shown via -a/--all).
+  # Order matters: try date-prefixed and PID-bearing forms before the
+  # looser tag form so a fuller match isn't pre-empted.
+  m = LOG_THREADTIME.match(line)
+  if m:
+    pid, _tid, level, tag, message = m.groups()
+    return level, tag.strip(), pid, message
+  m = LOG_TIME.match(line)
+  if m:
+    level, tag, pid, message = m.groups()
+    return level, tag.strip(), pid, message
+  m = LOG_BRIEF.match(line)
+  if m:
+    level, tag, pid, message = m.groups()
+    return level, tag.strip(), pid, message
+  m = LOG_THREAD.match(line)
+  if m:
+    level, pid, message = m.groups()
+    return level, '', pid, message
+  m = LOG_PROCESS.match(line)
+  if m:
+    level, pid, message, tag = m.groups()
+    return level, (tag or '').strip(), pid, message
+  m = LOG_TAG.match(line)
+  if m:
+    level, tag, message = m.groups()
+    return level, tag.strip(), None, message
+  return None
 
 adb_command = base_adb_command[:]
 adb_command.append('logcat')
@@ -248,6 +294,7 @@ else:
   adb = FakeStdinProcess(sys.stdin.buffer)
 pids = set()
 any_pids_found = False
+warned_long = False
 last_tag = None
 app_pid = None
 
@@ -347,12 +394,16 @@ while adb.poll() is None:
   if bug_line is not None:
     continue
 
-  log_line = LOG_LINE.match(line)
-  if log_line is None:
+  parsed = parse_log_line(line)
+  if parsed is None:
+    if not warned_long and LOG_LONG_HEADER.match(line):
+      warned_long = True
+      sys.stderr.write(
+        'pidcat: input looks like `-v long` format, which is not supported; '
+        'use a single-line format such as -v brief or -v threadtime.\n')
     continue
 
-  level, tag, owner, message = log_line.groups()
-  tag = tag.strip()
+  level, tag, owner, message = parsed
   start = parse_start_proc(line)
   if start:
     line_package, target, line_pid, line_uid, line_gids = start

--- a/pidcat
+++ b/pidcat
@@ -96,6 +96,9 @@ if args.use_device:
 if args.use_emulator:
   base_adb_command.append('-e')
 
+if args.current_app and args.filename:
+  parser.error('--current queries a connected device and cannot be combined with -f/--file')
+
 if args.current_app:
   system_dump_command = base_adb_command + ["shell", "dumpsys", "activity", "activities"]
   system_dump = subprocess.Popen(system_dump_command, stdout=PIPE, stderr=PIPE).communicate()[0]
@@ -418,7 +421,11 @@ while adb.poll() is None:
     continue
 
   level, tag, owner, message = parsed
-  start = parse_start_proc(line)
+  # `parse_start_proc` keys off the "<prefix>: Start proc ..." shape, which
+  # is present in brief/time/threadtime lines but not in process/thread
+  # formats (e.g. "I( 100) Start proc ..."). Retry against the parsed
+  # message, which is uniform across formats, so PID seeding still works.
+  start = parse_start_proc(line) or parse_start_proc('x: ' + message)
   if start:
     line_package, target, line_pid, line_uid, line_gids = start
     if match_packages(line_package):

--- a/pidcat
+++ b/pidcat
@@ -209,7 +209,7 @@ TAGTYPES = {
   'F': colorize(' F ', fg=BLACK, bg=RED),
 }
 
-PID_LINE = re.compile(r'^\w+\s+(\w+)\s+\w+\s+\w+\s+\w+\s+\w+\s+\w+\s+\w\s([\w|\.|\/]+)$')
+PID_LINE = re.compile(r'^\w+\s+(\w+)\s+\w+\s+\w+\s+\w+\s+\w+\s+\w+\s+\w\s([\w|\.|\/:]+)$')
 PID_START = re.compile(r'^.*: Start proc ([a-zA-Z0-9._:]+) for ([a-z]+ [^:]+): pid=(\d+) uid=(\d+) gids=(.*)$')
 PID_START_5_1 = re.compile(r'^.*: Start proc (\d+):([a-zA-Z0-9._:]+)/[a-z0-9]+ for (.*)$')
 PID_START_DALVIK = re.compile(r'^E/dalvikvm\(\s*(\d+)\): >>>>> ([a-zA-Z0-9._:]+) \[ userId:0 \| appId:(\d+) \]$')
@@ -302,7 +302,6 @@ elif input_mode == 'device':
 else:
   adb = FakeStdinProcess(sys.stdin.buffer)
 pids = set()
-any_pids_found = False
 displayed_any = False  # whether any actual log line was printed
 long_pid = None  # set while coalescing a multi-line `-v long` record
 last_tag = None
@@ -358,39 +357,37 @@ def tag_in_tags_regex(tag, tags):
   return any(re.match(r'^' + t + r'$', tag) for t in map(str.strip, tags))
 
 # Seed the set of PIDs to follow for already-running processes.
-#   - device mode: ask the connected device directly. `pidof` is exact and
-#     stable across Android versions; fall back to scraping `ps` only on
-#     older devices that lack it.
+#   - device mode: ask the connected device directly, taking the union of
+#     `pidof` (exact and stable across Android versions) and a `ps` scrape.
+#     `ps` also covers devices without `pidof` and lets a catchall package
+#     filter pick up secondary processes (e.g. com.example:remote).
 #   - pipe / file mode: don't query any device, since it may not be the one
 #     that produced these logs. Rely solely on the `Start proc` markers
 #     parsed from the stream itself (handled in the read loop below).
-if input_mode == 'device':
+if input_mode == 'device' and package:
   for proc_name in package:
     pidof_command = base_adb_command + ['shell', 'pidof', proc_name]
     pidof_out = subprocess.Popen(pidof_command, stdin=PIPE, stdout=PIPE, stderr=PIPE).communicate()[0]
     for pid in pidof_out.decode('utf-8', 'replace').split():
       if pid.isdigit():
         pids.add(pid)
-        any_pids_found = True
 
-  if not any_pids_found:
-    ps_command = base_adb_command + ['shell', 'ps']
-    ps_pid = subprocess.Popen(ps_command, stdin=PIPE, stdout=PIPE, stderr=PIPE)
-    while True:
-      try:
-        line = ps_pid.stdout.readline().decode('utf-8', 'replace').strip()
-      except KeyboardInterrupt:
-        break
-      if len(line) == 0:
-        break
+  ps_command = base_adb_command + ['shell', 'ps']
+  ps_pid = subprocess.Popen(ps_command, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+  while True:
+    try:
+      line = ps_pid.stdout.readline().decode('utf-8', 'replace').strip()
+    except KeyboardInterrupt:
+      break
+    if len(line) == 0:
+      break
 
-      pid_match = PID_LINE.match(line)
-      if pid_match is not None:
-        pid = pid_match.group(1)
-        proc = pid_match.group(2)
-        if proc in catchall_package:
-          pids.add(pid)
-          any_pids_found = True
+    pid_match = PID_LINE.match(line)
+    if pid_match is not None:
+      pid = pid_match.group(1)
+      proc = pid_match.group(2)
+      if match_packages(proc):
+        pids.add(pid)
 
 while adb.poll() is None:
   try:
@@ -445,7 +442,6 @@ while adb.poll() is None:
     line_package, target, line_pid, line_uid, line_gids = start
     if match_packages(line_package):
       pids.add(line_pid)
-      any_pids_found = True
 
       app_pid = line_pid
 

--- a/pidcat
+++ b/pidcat
@@ -27,11 +27,13 @@
 #     a pipe/file is filtered by package but has no `Start proc` markers (so
 #     no PID can be resolved and nothing matches), warn on stderr and
 #     suggest `-a`/`--all`.
-#   - Parse all single-line logcat formats, not just `brief`: `brief`,
-#     `process`, `tag`, `thread`, `time` and `threadtime` (adb's default
-#     for a bare `adb logcat`). Formats without a PID (`tag`, `raw`) can
-#     only be shown with `-a`/`--all`. The multi-line `long` format is not
-#     supported; its header is detected and a one-time hint is printed.
+#   - Parse every logcat format, not just `brief`: `brief`, `process`,
+#     `tag`, `thread`, `time`, `threadtime` (adb's default for a bare
+#     `adb logcat`) and the multi-line `long` format (coalesced into a
+#     synthetic brief line). Formats without a PID (`tag`, `raw`) can only
+#     be shown with `-a`/`--all`. As part of this, true EOF is now detected
+#     from the raw read so blank lines (record separators in `long`, or
+#     stray blanks elsewhere) no longer terminate input early.
 
 '''
 Copyright 2009, The Android Open Source Project
@@ -217,7 +219,7 @@ LOG_BRIEF      = re.compile(r'^([A-Z])/(.+?)\( *(\d+)\): (.*)$')
 LOG_THREAD     = re.compile(r'^([A-Z])\( *(\d+): *\w+\) (.*)$')
 LOG_PROCESS    = re.compile(r'^([A-Z])\( *(\d+)\) (.*?)(?:  \((.+)\))?$')
 LOG_TAG        = re.compile(r'^([A-Z])/(.+?): (.*)$')
-LOG_LONG_HEADER = re.compile(r'^\[ ' + LOG_DATE + r' +\d+: *\d+ [A-Z]/.+ \]$')
+LOG_LONG_HEADER = re.compile(r'^\[ ' + LOG_DATE + r' +(\d+): *\d+ +([A-Z])/(.+?) +\]$')
 BUG_LINE  = re.compile(r'.*nativeGetEnabledTags.*')
 BACKTRACE_LINE = re.compile(r'^#(.*?)pc\s(.*?)$')
 
@@ -294,7 +296,7 @@ else:
   adb = FakeStdinProcess(sys.stdin.buffer)
 pids = set()
 any_pids_found = False
-warned_long = False
+long_pid = None  # set while coalescing a multi-line `-v long` record
 last_tag = None
 app_pid = None
 
@@ -384,11 +386,28 @@ if input_mode == 'device':
 
 while adb.poll() is None:
   try:
-    line = adb.stdout.readline().decode('utf-8', 'replace').strip()
+    raw_line = adb.stdout.readline()
   except KeyboardInterrupt:
     break
-  if len(line) == 0:
+  if not raw_line:  # genuine EOF (a blank line is b'\n', not b'')
     break
+  line = raw_line.decode('utf-8', 'replace').strip()
+
+  # `long` format spans multiple lines: a "[ ... PID:TID L/Tag ]" header,
+  # the message on the following line(s), then a blank separator. Coalesce
+  # each record into a synthetic brief line and let the normal path handle it.
+  long_header = LOG_LONG_HEADER.match(line)
+  if long_header:
+    long_pid, long_level, long_tag = long_header.groups()
+    long_lines = []
+    continue
+  if long_pid is not None:
+    if line == '':
+      line = '%s/%s(%s): %s' % (long_level, long_tag, long_pid, ' '.join(long_lines))
+      long_pid = None
+    else:
+      long_lines.append(line)
+      continue
 
   bug_line = BUG_LINE.match(line)
   if bug_line is not None:
@@ -396,11 +415,6 @@ while adb.poll() is None:
 
   parsed = parse_log_line(line)
   if parsed is None:
-    if not warned_long and LOG_LONG_HEADER.match(line):
-      warned_long = True
-      sys.stderr.write(
-        'pidcat: input looks like `-v long` format, which is not supported; '
-        'use a single-line format such as -v brief or -v threadtime.\n')
     continue
 
   level, tag, owner, message = parsed

--- a/pidcat
+++ b/pidcat
@@ -15,12 +15,18 @@
 #       `print` of a `str`/bytes), instead of `print(linebuf)` which
 #       would `UnicodeEncodeError` under `LC_ALL=C` on non-ASCII text.
 #   - Added a `-f`/`--file` flag to read a saved logcat capture from a
-#     file instead of a connected device. In this offline mode the
-#     `adb shell ps` pid lookup and `--clear` are skipped so no device is
-#     touched (a live `adb logcat | pidcat` stdin pipe still runs `ps`,
-#     matching upstream). When the file is filtered by package but
-#     contains no "Start proc" lines (so no PID can be resolved and
-#     nothing matches), warn on stderr and suggest `-a`/`--all`.
+#     file instead of a connected device, and made PID discovery depend on
+#     how the logs arrive:
+#       * device mode (pidcat runs `adb logcat` itself): resolve PIDs from
+#         the connected device with `pidof`, falling back to scraping `ps`
+#         on older devices that lack it;
+#       * pipe / file mode: never query a device (it may not be the one
+#         that produced the logs) and rely solely on the `Start proc`
+#         markers parsed from the stream.
+#     `--clear` and the device PID lookup now run only in device mode. When
+#     a pipe/file is filtered by package but has no `Start proc` markers (so
+#     no PID can be resolved and nothing matches), warn on stderr and
+#     suggest `-a`/`--all`.
 
 '''
 Copyright 2009, The Android Open Source Project
@@ -204,8 +210,19 @@ adb_command = base_adb_command[:]
 adb_command.append('logcat')
 adb_command.extend(['-v', 'brief'])
 
-# Clear log before starting logcat (never touch a device when reading a file)
-if args.clear_logcat and not args.filename:
+# Determine where log lines come from:
+#   'device' - we run `adb logcat` ourselves against the connected device
+#   'pipe'   - log lines are piped in on stdin (e.g. adb logcat | pidcat)
+#   'file'   - log lines are read from a saved capture (-f)
+if args.filename:
+  input_mode = 'file'
+elif sys.stdin.isatty():
+  input_mode = 'device'
+else:
+  input_mode = 'pipe'
+
+# Clear the device log before starting (only when we own the device).
+if args.clear_logcat and input_mode == 'device':
   adb_clear_command = list(adb_command)
   adb_clear_command.append('-c')
   adb_clear = subprocess.Popen(adb_clear_command)
@@ -220,12 +237,12 @@ class FakeStdinProcess():
   def poll(self):
     return None
 
-if args.filename:
+if input_mode == 'file':
   try:
     adb = FakeStdinProcess(open(args.filename, 'rb'))
   except OSError as e:
     parser.error('cannot read %s: %s' % (args.filename, e.strerror))
-elif sys.stdin.isatty():
+elif input_mode == 'device':
   adb = subprocess.Popen(adb_command, stdin=PIPE, stdout=PIPE)
 else:
   adb = FakeStdinProcess(sys.stdin.buffer)
@@ -283,28 +300,40 @@ def parse_start_proc(line):
 def tag_in_tags_regex(tag, tags):
   return any(re.match(r'^' + t + r'$', tag) for t in map(str.strip, tags))
 
-# Resolve already-running PIDs from the device. Skipped only for file
-# input (-f), which is offline; a live stdin pipe (adb logcat | pidcat)
-# can still reach the device, matching upstream behavior.
-if not args.filename:
-  ps_command = base_adb_command + ['shell', 'ps']
-  ps_pid = subprocess.Popen(ps_command, stdin=PIPE, stdout=PIPE, stderr=PIPE)
-  while True:
-    try:
-      line = ps_pid.stdout.readline().decode('utf-8', 'replace').strip()
-    except KeyboardInterrupt:
-      break
-    if len(line) == 0:
-      break
-
-    pid_match = PID_LINE.match(line)
-    if pid_match is not None:
-      pid = pid_match.group(1)
-      proc = pid_match.group(2)
-      if proc in catchall_package:
-        seen_pids = True
+# Seed the set of PIDs to follow for already-running processes.
+#   - device mode: ask the connected device directly. `pidof` is exact and
+#     stable across Android versions; fall back to scraping `ps` only on
+#     older devices that lack it.
+#   - pipe / file mode: don't query any device, since it may not be the one
+#     that produced these logs. Rely solely on the `Start proc` markers
+#     parsed from the stream itself (handled in the read loop below).
+if input_mode == 'device':
+  for proc_name in package:
+    pidof_command = base_adb_command + ['shell', 'pidof', proc_name]
+    pidof_out = subprocess.Popen(pidof_command, stdin=PIPE, stdout=PIPE, stderr=PIPE).communicate()[0]
+    for pid in pidof_out.decode('utf-8', 'replace').split():
+      if pid.isdigit():
         pids.add(pid)
         any_pids_found = True
+
+  if not any_pids_found:
+    ps_command = base_adb_command + ['shell', 'ps']
+    ps_pid = subprocess.Popen(ps_command, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+    while True:
+      try:
+        line = ps_pid.stdout.readline().decode('utf-8', 'replace').strip()
+      except KeyboardInterrupt:
+        break
+      if len(line) == 0:
+        break
+
+      pid_match = PID_LINE.match(line)
+      if pid_match is not None:
+        pid = pid_match.group(1)
+        proc = pid_match.group(2)
+        if proc in catchall_package:
+          pids.add(pid)
+          any_pids_found = True
 
 while adb.poll() is None:
   try:
@@ -396,12 +425,13 @@ while adb.poll() is None:
   linebuf += indent_wrap(message)
   sys.stdout.buffer.write(linebuf.encode('utf-8') + b'\n')
 
-# When reading a saved capture, package filtering relies on the PIDs
-# discovered from "Start proc" lines in the log. A clipped capture that
-# begins after the app was already running won't contain those lines, so
-# nothing matches. Point the user at -a/--all rather than failing silently.
-if args.filename and not args.all and not any_pids_found:
+# In pipe / file mode the only PID source is the "Start proc" markers in
+# the stream. A capture (or live pipe) that begins after the app was
+# already running has none, so a package filter matches nothing. Say so
+# rather than failing silently.
+if input_mode != 'device' and not args.all and not any_pids_found:
+  source = args.filename if input_mode == 'file' else 'the piped input'
   sys.stderr.write(
     'pidcat: no process start lines found in %s, so %s could not be mapped '
     'to a PID and no lines matched. Use -a/--all to show every line.\n'
-    % (args.filename, ', '.join(package)))
+    % (source, ', '.join(package)))


### PR DESCRIPTION
## Summary
- Add a `-f`/`--file FILE` flag to `pidcat` so it can colorize a saved logcat capture instead of requiring a connected device.
- Skip the `adb shell ps` pid lookup when input isn't a live device (file or piped stdin), so no device contact is attempted.
- Generalize `FakeStdinProcess` to wrap any stream, and report a clean error (instead of a traceback) when the file can't be opened.

## Test plan
- [x] `./pidcat -f sample.log com.example.app` filters and colorizes lines for the matching package only
- [x] `./pidcat -f /missing.log` exits with a clean `cannot read ...` message (exit 2)
- [x] `./pidcat --help` lists `-f FILE, --file FILE`
- [ ] Confirm live-device path (`./pidcat <pkg>`) still works against an attached device

https://claude.ai/code/session_01W6JmZVcAWXqBD81HDbjgJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6JmZVcAWXqBD81HDbjgJa)_