### PR TITLE
pidcat: preserve whitespace in raw -a pass-through

### DIFF
--- a/pidcat
+++ b/pidcat
@@ -427,8 +427,10 @@ while adb.poll() is None:
   if parsed is None:
     # Lines that match no format (e.g. `-v raw`, which has no metadata) carry
     # no PID and so can't be package-filtered; show them verbatim under -a.
+    # Write the original line (only the line ending removed) so leading
+    # indentation in stack traces / pretty-printed payloads is preserved.
     if args.all and line:
-      sys.stdout.buffer.write(line.encode('utf-8') + b'\n')
+      sys.stdout.buffer.write(raw_line.rstrip(b'\r\n') + b'\n')
       displayed_any = True
     continue
 


### PR DESCRIPTION
## Summary
Follow-up to #44. A late review comment noted that the `-v raw` pass-through under `-a` lost leading indentation and trailing spaces, because the read loop `.strip()`s every line before the pass-through writes it.

This writes the original bytes with only the line ending removed, so indented stack traces and pretty-printed payloads in a raw capture display verbatim. The stripped `line` is still used for the non-blank check and for all format matching, so other modes are unaffected.

## Test plan
- [x] `pidcat -a -f raw.log` preserves leading spaces, tabs, and trailing spaces (verified with `cat -A`)
- [x] Blank raw lines are still skipped
- [x] Brief package-filter regression still works

https://claude.ai/code/session_01W6JmZVcAWXqBD81HDbjgJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6JmZVcAWXqBD81HDbjgJa)_