### PR TITLE
autoshpool: resolve switch targets by working-directory path segment

### DIFF
--- a/autoshpool
+++ b/autoshpool
@@ -88,6 +88,13 @@ get_pid_cwd() {
   readlink "/proc/$1/cwd" 2>/dev/null
 }
 
+session_exists() {
+  # True if an shpool session with exactly this name exists. Best-effort: if
+  # shpool is slow or unavailable we report "no" and let path matching proceed.
+  timeout 2 shpool list 2>/dev/null \
+    | awk -v name="$1" 'NR > 1 && $1 == name { found = 1 } END { exit !found }'
+}
+
 list_shpool_shells() {
   # For simplicity and cross-shell support, treat every child of an shpool
   # process as a shell. Print a tab-separated "pid<TAB>session<TAB>cwd" line for
@@ -121,8 +128,8 @@ dir_vcs_root_name() {
 
 resolve_switch_target() {
   # Resolve the switch argument to a session name, printing it on stdout.
-  # A bare number is taken as a session name and used as-is. Otherwise look for
-  # shells whose working directory contains the argument as a full path segment
+  # A bare number, or the name of an existing session, is used as-is. Otherwise
+  # look for shells whose working directory contains the argument as a segment
   # and reuse the matching shell's session: switch directly when there is a
   # single match, prompt to disambiguate when there are several, and fall back
   # to using the argument as-is when there are none (so new session names still
@@ -132,6 +139,13 @@ resolve_switch_target() {
     ''|*[!0-9]*) ;;                      # not a bare number: try path matching
     *) printf '%s\n' "$arg"; return ;;   # bare number: use as session name
   esac
+
+  # An exact existing session name always wins, so switching to a named session
+  # keeps working even when that name also appears in some shell's path.
+  if session_exists "$arg"; then
+    printf '%s\n' "$arg"
+    return
+  fi
 
   local pid session cwd
   local -a match_pids=() match_sessions=() match_cwds=()

--- a/autoshpool
+++ b/autoshpool
@@ -3,7 +3,11 @@
 #
 # Usage:
 #   autoshpool                - attach to or create a shpool session (loops for switching)
-#   autoshpool switch <session> - request a switch to the named session (from inside shpool)
+#   autoshpool switch <target> - request a switch to a session (from inside shpool)
+#
+# <target> is a session name (e.g. "2"), or any word matching a path segment of
+# a running shell's working directory. For example, "switch sep" finds the shell
+# whose cwd is something like /blah/username/sep/foo and switches to its session.
 #
 # In shrc, replace shpool_loop with:
 #   autoshpool && exit
@@ -73,6 +77,112 @@ create_and_attach_next() {
   done
   echo "You already have more than 100 sessions??" >&2
   return 2
+}
+
+get_pid_session_name() {
+  # Read the SHPOOL_SESSION_NAME from a process's environment.
+  envgrep 'SHPOOL_SESSION_NAME=.*' "$1" 2>/dev/null | tr -d '\0' | cut -f 2- -d =
+}
+
+get_pid_cwd() {
+  readlink "/proc/$1/cwd" 2>/dev/null
+}
+
+list_shpool_shells() {
+  # For simplicity and cross-shell support, treat every child of an shpool
+  # process as a shell. Print a tab-separated "pid<TAB>session<TAB>cwd" line for
+  # each shell that has a SHPOOL_SESSION_NAME and a readable working directory.
+  local shpool_pid child session cwd
+  for shpool_pid in $(pgrep -x shpool 2>/dev/null); do
+    for child in $(pgrep -P "$shpool_pid" 2>/dev/null); do
+      session="$(get_pid_session_name "$child")"
+      test -n "$session" || continue
+      cwd="$(get_pid_cwd "$child")"
+      test -n "$cwd" || continue
+      printf '%s\t%s\t%s\n' "$child" "$session" "$cwd"
+    done
+  done
+}
+
+shell_summary() {
+  # A one-line description of a process and its ancestry, used to help the user
+  # tell otherwise-similar shells apart. Empty if pstree is unavailable.
+  command -v pstree >/dev/null 2>&1 || return 0
+  pstree -ps "$1" 2>/dev/null | head -n 1
+}
+
+dir_vcs_root_name() {
+  # The last component of the version-control root for a directory, or empty if
+  # the directory isn't under version control (we don't require vcs to work).
+  local root
+  root="$(cd "$1" 2>/dev/null && vcs rootdir 2>/dev/null)"
+  test -n "$root" && basename "$root"
+}
+
+resolve_switch_target() {
+  # Resolve the switch argument to a session name, printing it on stdout.
+  # A bare number is taken as a session name and used as-is. Otherwise look for
+  # shells whose working directory contains the argument as a full path segment
+  # and reuse the matching shell's session: switch directly when there is a
+  # single match, prompt to disambiguate when there are several, and fall back
+  # to using the argument as-is when there are none (so new session names still
+  # work). Returns non-zero (without printing) if the user cancels a prompt.
+  local arg="$1"
+  case "$arg" in
+    ''|*[!0-9]*) ;;                      # not a bare number: try path matching
+    *) printf '%s\n' "$arg"; return ;;   # bare number: use as session name
+  esac
+
+  local pid session cwd
+  local -a match_pids=() match_sessions=() match_cwds=()
+  while IFS=$'\t' read -r pid session cwd; do
+    test -n "$session" || continue
+    test -n "$cwd" || continue
+    case "$cwd/" in
+      */"$arg"/*) ;;
+      *) continue ;;
+    esac
+    match_pids+=("$pid")
+    match_sessions+=("$session")
+    match_cwds+=("$cwd")
+  done < <(list_shpool_shells)
+
+  local n="${#match_sessions[@]}"
+  if test "$n" -eq 0; then
+    printf '%s\n' "$arg"          # no match: treat arg as a session name
+    return
+  fi
+  if test "$n" -eq 1; then
+    printf '%s\n' "${match_sessions[0]}"
+    return
+  fi
+
+  # Several shells match: ask the user which one to switch to. Each option shows
+  # the session name, its attached/detached status, the last component of its
+  # version-control root and of the shell's directory, and a one-line process
+  # summary, so the user can tell similar shells apart.
+  local i sel listing status dir
+  listing="$(shpool list 2>/dev/null)"
+  {
+    echo "Multiple shells match '$arg':"
+    for i in "${!match_sessions[@]}"; do
+      status="$(awk -v name="${match_sessions[$i]}" 'NR > 1 && $1 == name { print $NF }' <<<"$listing")"
+      dir="${match_cwds[$i]}"
+      printf '  %d) %s  %s  %s  %s  %s\n' "$((i + 1))" "${match_sessions[$i]}" \
+        "${status:-unknown}" "$(dir_vcs_root_name "$dir")" "$(basename "$dir")" \
+        "$(shell_summary "${match_pids[$i]}")"
+    done
+    printf 'Switch to which? [1-%d] ' "$n"
+  } >&2
+  read -r sel || { echo "Not switching." >&2; return 1; }
+  case "$sel" in
+    ''|*[!0-9]*) echo "Not switching." >&2; return 1 ;;
+  esac
+  if test "$sel" -lt 1 || test "$sel" -gt "$n"; then
+    echo "Not switching." >&2
+    return 1
+  fi
+  printf '%s\n' "${match_sessions[$((sel - 1))]}"
 }
 
 get_switch_session() {
@@ -154,7 +264,8 @@ fi
 # autoshpool (no args) - run the loop
 case "$1" in
   switch)
-    request_switch "$2"
+    target="$(resolve_switch_target "$2")" || exit 1
+    request_switch "$target"
     ;;
   "")
     autoshpool_loop

--- a/autoshpool_test
+++ b/autoshpool_test
@@ -318,6 +318,18 @@ test_switch_numeric_is_session_name() {
   assert_switch_file 2
 }
 
+test_switch_existing_session_name_wins() {
+  # An existing named session is honored even if its name is also a path segment.
+  cat > "$HOME/.shpool_sessions" <<EOF
+work   2025-01-01T00:00:00Z   disconnected
+EOF
+  add_shpool 1000
+  add_shell 2001 1000 "/home/u/work/foo" 5
+  run_autoshpool switch work
+  assert_status 0
+  assert_switch_file work
+}
+
 test_switch_no_match_uses_arg() {
   add_shpool 1000
   add_shell 2001 1000 "/home/u/other/foo" 3
@@ -364,6 +376,7 @@ run_test "skips existing sessions when creating" test_skips_existing_sessions
 run_test "switch resolves a path segment to its session" test_switch_resolves_path_segment
 run_test "switch matches whole path segments only" test_switch_requires_whole_segment
 run_test "switch treats a bare number as a session name" test_switch_numeric_is_session_name
+run_test "switch prefers an existing session name over a path match" test_switch_existing_session_name_wins
 run_test "switch falls back to the argument when nothing matches" test_switch_no_match_uses_arg
 run_test "switch prompts when several shells match" test_switch_prompts_on_multiple_matches
 run_test "switch does not switch when the prompt is cancelled" test_switch_cancel_does_not_switch

--- a/autoshpool_test
+++ b/autoshpool_test
@@ -42,6 +42,38 @@ echo ""
 ROOTDIR
   chmod +x "$TEST_TMPDIR/bin/rootdir"
 
+  # Fake pgrep backed by fixture files:
+  #   .fake_shpool_pids - one shpool pid per line
+  #   .fake_shells      - pid<TAB>ppid<TAB>cwd<TAB>session per shell
+  cat > "$TEST_TMPDIR/bin/pgrep" <<'PGREP'
+#!/bin/bash
+case "$1" in
+  -x) [ "$2" = shpool ] && cat "$HOME/.fake_shpool_pids" 2>/dev/null ;;
+  -P) awk -F'\t' -v p="$2" '$2==p{print $1}' "$HOME/.fake_shells" 2>/dev/null ;;
+esac
+exit 0
+PGREP
+  chmod +x "$TEST_TMPDIR/bin/pgrep"
+
+  # Fake readlink that resolves /proc/<pid>/cwd from the shell fixtures.
+  cat > "$TEST_TMPDIR/bin/readlink" <<'READLINK'
+#!/bin/bash
+t="$1"; pid="${t#/proc/}"; pid="${pid%/cwd}"
+awk -F'\t' -v p="$pid" '$1==p{print $3}' "$HOME/.fake_shells" 2>/dev/null
+exit 0
+READLINK
+  chmod +x "$TEST_TMPDIR/bin/readlink"
+
+  # Fake envgrep that returns SHPOOL_SESSION_NAME from the shell fixtures.
+  cat > "$TEST_TMPDIR/bin/envgrep" <<'ENVGREP'
+#!/bin/bash
+# usage: envgrep <pattern> <pid>
+s=$(awk -F'\t' -v p="$2" '$1==p{print $4}' "$HOME/.fake_shells" 2>/dev/null)
+[ -n "$s" ] && printf 'SHPOOL_SESSION_NAME=%s' "$s"
+exit 0
+ENVGREP
+  chmod +x "$TEST_TMPDIR/bin/envgrep"
+
   # Create a fake timeout that just runs the command
   cat > "$TEST_TMPDIR/bin/timeout" <<'TIMEOUT'
 #!/bin/bash
@@ -60,6 +92,18 @@ TIMEOUT
   rm -f "$TEST_TMPDIR/.autoshpool_switch"
   rm -f "$TEST_TMPDIR/.shpool_calls"
   rm -f "$TEST_TMPDIR/.shpool_sessions"
+  rm -f "$TEST_TMPDIR/.fake_shpool_pids"
+  rm -f "$TEST_TMPDIR/.fake_shells"
+}
+
+# Register a fake shpool process whose children are treated as shells.
+add_shpool() {
+  echo "$1" >> "$HOME/.fake_shpool_pids"
+}
+
+# Register a fake shell: pid, parent shpool pid, cwd, session name.
+add_shell() {
+  printf '%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" >> "$HOME/.fake_shells"
 }
 
 teardown() {
@@ -68,7 +112,16 @@ teardown() {
 
 run_autoshpool() {
   set +e
-  output="$("$SCRIPT_DIR/autoshpool" "$@" 2>&1)"
+  output="$("$SCRIPT_DIR/autoshpool" "$@" </dev/null 2>&1)"
+  status=$?
+  set -e
+}
+
+# Like run_autoshpool, but feeds the first argument to the script on stdin.
+run_autoshpool_input() {
+  local input="$1"; shift
+  set +e
+  output="$(printf '%s\n' "$input" | "$SCRIPT_DIR/autoshpool" "$@" 2>&1)"
   status=$?
   set -e
 }
@@ -221,6 +274,79 @@ EOF
   assert_output_contains "Creating shpool session 3"
 }
 
+assert_switch_file() {
+  local expected="$1"
+  local actual
+  actual="$(cat "$HOME/.autoshpool_switch" 2>/dev/null)"
+  if [ "$actual" != "$expected" ]; then
+    echo "  FAIL: expected switch file '$expected', got '$actual'"
+    echo "  output: $output"
+    return 1
+  fi
+}
+
+assert_no_switch_file() {
+  if [ -e "$HOME/.autoshpool_switch" ]; then
+    echo "  FAIL: expected no switch file, but it exists: $(cat "$HOME/.autoshpool_switch")"
+    return 1
+  fi
+}
+
+test_switch_resolves_path_segment() {
+  add_shpool 1000
+  add_shell 2001 1000 "/home/u/sep/foo" 2
+  run_autoshpool switch sep
+  assert_status 0
+  assert_switch_file 2
+}
+
+test_switch_requires_whole_segment() {
+  # "sep" must not match the "separate" directory.
+  add_shpool 1000
+  add_shell 2001 1000 "/home/u/separate/foo" 5
+  run_autoshpool switch sep
+  assert_status 0
+  assert_switch_file sep
+}
+
+test_switch_numeric_is_session_name() {
+  # A bare number is a session name, even if a shell's path contains it.
+  add_shpool 1000
+  add_shell 2001 1000 "/home/u/2/foo" 9
+  run_autoshpool switch 2
+  assert_status 0
+  assert_switch_file 2
+}
+
+test_switch_no_match_uses_arg() {
+  add_shpool 1000
+  add_shell 2001 1000 "/home/u/other/foo" 3
+  run_autoshpool switch newname
+  assert_status 0
+  assert_switch_file newname
+}
+
+test_switch_prompts_on_multiple_matches() {
+  add_shpool 1000
+  add_shell 2001 1000 "/home/a/sep/foo" 2
+  add_shell 2002 1000 "/home/b/sep/bar" 7
+  # Choosing option 2 selects the second shell's session (7).
+  run_autoshpool_input 2 switch sep
+  assert_status 0
+  assert_output_contains "Multiple shells match 'sep'"
+  assert_switch_file 7
+}
+
+test_switch_cancel_does_not_switch() {
+  add_shpool 1000
+  add_shell 2001 1000 "/home/a/sep/foo" 2
+  add_shell 2002 1000 "/home/b/sep/bar" 7
+  # No valid selection (EOF) cancels: non-zero exit and no switch file.
+  run_autoshpool switch sep
+  [ "$status" -ne 0 ] || { echo "  FAIL: expected non-zero exit"; return 1; }
+  assert_no_switch_file
+}
+
 # --- run ---
 
 run_test "switch writes session name to switch file" test_switch_writes_file
@@ -235,6 +361,12 @@ run_test "preserves specific exit code from shpool attach" test_preserves_exit_c
 run_test "loop handles switch request after session ends" test_loop_handles_switch
 run_test "uses SHPOOL_PREFIX for session names" test_uses_prefix
 run_test "skips existing sessions when creating" test_skips_existing_sessions
+run_test "switch resolves a path segment to its session" test_switch_resolves_path_segment
+run_test "switch matches whole path segments only" test_switch_requires_whole_segment
+run_test "switch treats a bare number as a session name" test_switch_numeric_is_session_name
+run_test "switch falls back to the argument when nothing matches" test_switch_no_match_uses_arg
+run_test "switch prompts when several shells match" test_switch_prompts_on_multiple_matches
+run_test "switch does not switch when the prompt is cancelled" test_switch_cancel_does_not_switch
 
 echo
 echo "$TESTS_RUN tests, $TESTS_PASSED passed, $TESTS_FAILED failed"


### PR DESCRIPTION
## Summary

Makes `autoshpool switch <arg>` accept a **path segment** in addition to a session name. For example, running `shpoolswitch sep` when a shell has cwd `/blah/username/sep/foo` finds that shell's `SHPOOL_SESSION_NAME` (e.g. `2`) and acts like `shpoolswitch 2`.

For simplicity and cross-shell support, **any child of an shpool process is treated as a shell** (matching the approach in `shpoolps`).

## Behavior

`resolve_switch_target` decides what to write to the switch file:

- **Bare number** (e.g. `2`) → used directly as a session name, as before.
- **Word matching a full path segment** of a shell's working directory:
  - **One match** → switches automatically.
  - **Several matches** → prompts the user to disambiguate. Each option shows, on one line: session name, attached/detached status, the last component of `(cd $dir; vcs rootdir)`, the last component of `$dir`, and `pstree -ps <PID> | head -n 1`. Cancelling (invalid/empty selection) does **not** switch and exits non-zero so the caller stays put.
  - **No match** → falls back to using the argument as-is, so creating brand-new session names still works.

Path matching requires a whole segment (`sep` does not match `separate`), and `vcs`/`rootdir` are best-effort — they are not required to be working.

## Implementation notes

- New helpers: `get_pid_session_name` (via `envgrep`), `get_pid_cwd` (via `/proc/<pid>/cwd`), `list_shpool_shells`, `shell_summary` (via `pstree`), and `dir_vcs_root_name`.
- The `switch` dispatch now bails out without switching if resolution is cancelled.

## Tests

Added 6 tests (18 total, all passing) covering: path-segment resolution, whole-segment matching, numeric-as-session-name, no-match fallback, the disambiguation prompt selection, and prompt cancellation. The test harness gained PATH stubs for `pgrep`, `readlink`, and `envgrep` driven by fixture files.

https://claude.ai/code/session_01PXFfePZBuFWiXuwzrrTdmJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXFfePZBuFWiXuwzrrTdmJ)_