### PR TITLE
Add shpoollist with shared session-detail formatting

### DIFF
--- a/autoshpool
+++ b/autoshpool
@@ -126,6 +126,33 @@ dir_vcs_root_name() {
   test -n "$root" && basename "$root"
 }
 
+dir_vcs_unmerged() {
+  # The unmerged items vcs reports for a directory, or empty. Best-effort: we
+  # don't require vcs to be working.
+  (cd "$1" 2>/dev/null && vcs unmerged 2>/dev/null)
+}
+
+session_status() {
+  # The status column shpool reports for a session ($1), given the output of
+  # `shpool list` ($2). Empty if the session isn't listed.
+  awk -v name="$1" 'NR > 1 && $1 == name { print $NF }' <<<"$2"
+}
+
+describe_shell() {
+  # Render a one-line, multi-field description of a shell, shared by the switch
+  # disambiguation prompt and shpoollist so both use the same format. Fields:
+  # session name, status, the basename of the vcs root and of the working
+  # directory, a one-line process-tree summary, and the vcs unmerged items
+  # (flattened onto a single line).
+  local pid="$1" session="$2" cwd="$3" status="$4"
+  local unmerged
+  unmerged="$(dir_vcs_unmerged "$cwd")"
+  printf '%s  %s  %s  %s  %s  %s' \
+    "$session" "${status:-unknown}" \
+    "$(dir_vcs_root_name "$cwd")" "$(basename "$cwd")" \
+    "$(shell_summary "$pid")" "${unmerged//$'\n'/; }"
+}
+
 resolve_switch_target() {
   # Resolve the switch argument to a session name, printing it on stdout.
   # A bare number, or the name of an existing session, is used as-is. Otherwise
@@ -171,20 +198,17 @@ resolve_switch_target() {
     return
   fi
 
-  # Several shells match: ask the user which one to switch to. Each option shows
-  # the session name, its attached/detached status, the last component of its
-  # version-control root and of the shell's directory, and a one-line process
-  # summary, so the user can tell similar shells apart.
-  local i sel listing status dir
+  # Several shells match: ask the user which one to switch to. Each option is
+  # rendered with describe_shell (the same format as shpoollist) so the user can
+  # tell similar shells apart.
+  local i sel listing status
   listing="$(shpool list 2>/dev/null)"
   {
     echo "Multiple shells match '$arg':"
     for i in "${!match_sessions[@]}"; do
-      status="$(awk -v name="${match_sessions[$i]}" 'NR > 1 && $1 == name { print $NF }' <<<"$listing")"
-      dir="${match_cwds[$i]}"
-      printf '  %d) %s  %s  %s  %s  %s\n' "$((i + 1))" "${match_sessions[$i]}" \
-        "${status:-unknown}" "$(dir_vcs_root_name "$dir")" "$(basename "$dir")" \
-        "$(shell_summary "${match_pids[$i]}")"
+      status="$(session_status "${match_sessions[$i]}" "$listing")"
+      printf '  %d) %s\n' "$((i + 1))" \
+        "$(describe_shell "${match_pids[$i]}" "${match_sessions[$i]}" "${match_cwds[$i]}" "$status")"
     done
     printf 'Switch to which? [1-%d] ' "$n"
   } >&2

--- a/autoshpool_test
+++ b/autoshpool_test
@@ -74,6 +74,19 @@ exit 0
 ENVGREP
   chmod +x "$TEST_TMPDIR/bin/envgrep"
 
+  # Fake vcs that reads per-directory marker files in the current directory:
+  #   .vcsroot  - printed by "vcs rootdir"
+  #   .unmerged - printed by "vcs unmerged"
+  cat > "$TEST_TMPDIR/bin/vcs" <<'VCS'
+#!/bin/bash
+case "$1" in
+  rootdir)  cat "$PWD/.vcsroot" 2>/dev/null ;;
+  unmerged) cat "$PWD/.unmerged" 2>/dev/null ;;
+esac
+exit 0
+VCS
+  chmod +x "$TEST_TMPDIR/bin/vcs"
+
   # Create a fake timeout that just runs the command
   cat > "$TEST_TMPDIR/bin/timeout" <<'TIMEOUT'
 #!/bin/bash
@@ -122,6 +135,13 @@ run_autoshpool_input() {
   local input="$1"; shift
   set +e
   output="$(printf '%s\n' "$input" | "$SCRIPT_DIR/autoshpool" "$@" 2>&1)"
+  status=$?
+  set -e
+}
+
+run_shpoollist() {
+  set +e
+  output="$("$SCRIPT_DIR/shpoollist" "$@" </dev/null 2>&1)"
   status=$?
   set -e
 }
@@ -359,6 +379,33 @@ test_switch_cancel_does_not_switch() {
   assert_no_switch_file
 }
 
+test_shpoollist_lists_sessions() {
+  local d="$TEST_TMPDIR/proj"
+  mkdir -p "$d"
+  echo "$TEST_TMPDIR/proj" > "$d/.vcsroot"
+  printf 'abcdef Something\n' > "$d/.unmerged"
+  cat > "$HOME/.shpool_sessions" <<EOF
+4   2025-01-01T00:00:00Z   connected
+EOF
+  add_shpool 1000
+  add_shell 2001 1000 "$d" 4
+  run_shpoollist
+  assert_status 0
+  assert_output_contains "4"                 # session name
+  assert_output_contains "connected"         # status
+  assert_output_contains "proj"              # basename of vcs root / cwd
+  assert_output_contains "abcdef Something"  # vcs unmerged
+}
+
+test_shpoollist_empty_when_no_shells() {
+  run_shpoollist
+  assert_status 0
+  if [ -n "$output" ]; then
+    echo "  FAIL: expected empty output, got: $output"
+    return 1
+  fi
+}
+
 # --- run ---
 
 run_test "switch writes session name to switch file" test_switch_writes_file
@@ -380,6 +427,8 @@ run_test "switch prefers an existing session name over a path match" test_switch
 run_test "switch falls back to the argument when nothing matches" test_switch_no_match_uses_arg
 run_test "switch prompts when several shells match" test_switch_prompts_on_multiple_matches
 run_test "switch does not switch when the prompt is cancelled" test_switch_cancel_does_not_switch
+run_test "shpoollist lists sessions with details" test_shpoollist_lists_sessions
+run_test "shpoollist prints nothing when there are no shells" test_shpoollist_empty_when_no_shells
 
 echo
 echo "$TESTS_RUN tests, $TESTS_PASSED passed, $TESTS_FAILED failed"

--- a/shpoollist
+++ b/shpoollist
@@ -1,0 +1,17 @@
+#!/bin/bash
+# shpoollist - list shpool sessions with useful details
+#
+# Prints one line per shell (treating every child of an shpool process as a
+# shell), using the same format as autoshpool's switch disambiguation prompt:
+# the session name, its status, the basename of its vcs root and working
+# directory, a one-line process-tree summary, and any vcs unmerged items.
+
+# Reuse the shell-enumeration and formatting helpers from autoshpool.
+source "$(dirname "$0")/autoshpool"
+
+listing="$(shpool list 2>/dev/null)"
+while IFS=$'\t' read -r pid session cwd; do
+  status="$(session_status "$session" "$listing")"
+  describe_shell "$pid" "$session" "$cwd" "$status"
+  echo
+done < <(list_shpool_shells)


### PR DESCRIPTION
## Summary

Adds a `shpoollist` command that lists every shpool shell with useful details, and factors the per-shell line into a shared helper so `autoshpool switch`'s disambiguation prompt and `shpoollist` use the **same format**.

Treating any child of an shpool process as a shell, each line shows:

1. shpool session name
2. attached/detached status (from `shpool list`)
3. `basename $(vcs rootdir)`
4. `basename $PWD` (the shell's working directory)
5. `pstree -ps $PID | head -n 1`
6. `vcs unmerged` (flattened onto one line)

## Changes

- **`shpoollist`** (new): sources `autoshpool` to reuse the shell-enumeration and formatting helpers, then prints one line per shell.
- **`autoshpool`**: new `dir_vcs_unmerged`, `session_status`, and `describe_shell` helpers. The switch disambiguation prompt now renders each option via `describe_shell`, so it matches `shpoollist`'s format and additionally shows `vcs unmerged` items.
- All `vcs` calls remain best-effort (not required to be working).

## Tests

Added a `vcs` PATH stub (driven by `.vcsroot`/`.unmerged` marker files) and two `shpoollist` tests (lists sessions with details; empty when no shells). **21 tests, all passing.**

## Follow-up

Per discussion, matching `autoshpool switch <arg>` against `vcs unmerged` output (so `switch abcdef` finds the session whose `vcs unmerged` lists `abcdef`) will come as a separate change.

https://claude.ai/code/session_01PXFfePZBuFWiXuwzrrTdmJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXFfePZBuFWiXuwzrrTdmJ)_