### PR TITLE
Fix shpoollist empty output; match vcs unmerged in switch

### DIFF
--- a/autoshpool
+++ b/autoshpool
@@ -79,13 +79,23 @@ create_and_attach_next() {
   return 2
 }
 
+proc_dir() {
+  # Where to read per-process information from (overridable for testing).
+  printf '%s' "${SHPOOL_PROC_DIR:-/proc}"
+}
+
 get_pid_session_name() {
-  # Read the SHPOOL_SESSION_NAME from a process's environment.
-  envgrep 'SHPOOL_SESSION_NAME=.*' "$1" 2>/dev/null | tr -d '\0' | cut -f 2- -d =
+  # The SHPOOL_SESSION_NAME from a process's environment. /proc/<pid>/environ
+  # holds NUL-separated KEY=VALUE pairs. Empty if the process is gone or has no
+  # such variable. Read directly (rather than via a helper like envgrep) so this
+  # works without sourcing the user's shell functions.
+  local environ; environ="$(proc_dir)/$1/environ"
+  test -r "$environ" || return 0
+  tr '\0' '\n' < "$environ" | sed -n 's/^SHPOOL_SESSION_NAME=//p'
 }
 
 get_pid_cwd() {
-  readlink "/proc/$1/cwd" 2>/dev/null
+  readlink "$(proc_dir)/$1/cwd" 2>/dev/null
 }
 
 session_exists() {
@@ -144,23 +154,36 @@ describe_shell() {
   # session name, status, the basename of the vcs root and of the working
   # directory, a one-line process-tree summary, and the vcs unmerged items
   # (flattened onto a single line).
-  local pid="$1" session="$2" cwd="$3" status="$4"
+  local pid="$1" session="$2" cwd="$3" state="$4"
   local unmerged
   unmerged="$(dir_vcs_unmerged "$cwd")"
   printf '%s  %s  %s  %s  %s  %s' \
-    "$session" "${status:-unknown}" \
+    "$session" "${state:-unknown}" \
     "$(dir_vcs_root_name "$cwd")" "$(basename "$cwd")" \
     "$(shell_summary "$pid")" "${unmerged//$'\n'/; }"
+}
+
+shell_matches() {
+  # True if a shell's working directory ($1) matches the argument ($2), either
+  # as a full path segment of the directory or as a whole word in the directory's
+  # vcs unmerged output.
+  local cwd="$1" arg="$2"
+  case "$cwd/" in
+    */"$arg"/*) return 0 ;;
+  esac
+  dir_vcs_unmerged "$cwd" | grep -Fwq -- "$arg"
 }
 
 resolve_switch_target() {
   # Resolve the switch argument to a session name, printing it on stdout.
   # A bare number, or the name of an existing session, is used as-is. Otherwise
-  # look for shells whose working directory contains the argument as a segment
-  # and reuse the matching shell's session: switch directly when there is a
-  # single match, prompt to disambiguate when there are several, and fall back
-  # to using the argument as-is when there are none (so new session names still
-  # work). Returns non-zero (without printing) if the user cancels a prompt.
+  # look for shells that match the argument -- either its working directory
+  # contains the argument as a path segment, or the argument is a whole word in
+  # that directory's vcs unmerged output -- and reuse the matching shell's
+  # session: switch directly when there is a single match, prompt to
+  # disambiguate when there are several, and fall back to using the argument
+  # as-is when there are none (so new session names still work). Returns
+  # non-zero (without printing) if the user cancels a prompt.
   local arg="$1"
   case "$arg" in
     ''|*[!0-9]*) ;;                      # not a bare number: try path matching
@@ -179,10 +202,7 @@ resolve_switch_target() {
   while IFS=$'\t' read -r pid session cwd; do
     test -n "$session" || continue
     test -n "$cwd" || continue
-    case "$cwd/" in
-      */"$arg"/*) ;;
-      *) continue ;;
-    esac
+    shell_matches "$cwd" "$arg" || continue
     match_pids+=("$pid")
     match_sessions+=("$session")
     match_cwds+=("$cwd")
@@ -201,14 +221,14 @@ resolve_switch_target() {
   # Several shells match: ask the user which one to switch to. Each option is
   # rendered with describe_shell (the same format as shpoollist) so the user can
   # tell similar shells apart.
-  local i sel listing status
+  local i sel listing state
   listing="$(shpool list 2>/dev/null)"
   {
     echo "Multiple shells match '$arg':"
     for i in "${!match_sessions[@]}"; do
-      status="$(session_status "${match_sessions[$i]}" "$listing")"
+      state="$(session_status "${match_sessions[$i]}" "$listing")"
       printf '  %d) %s\n' "$((i + 1))" \
-        "$(describe_shell "${match_pids[$i]}" "${match_sessions[$i]}" "${match_cwds[$i]}" "$status")"
+        "$(describe_shell "${match_pids[$i]}" "${match_sessions[$i]}" "${match_cwds[$i]}" "$state")"
     done
     printf 'Switch to which? [1-%d] ' "$n"
   } >&2
@@ -302,6 +322,9 @@ fi
 # autoshpool (no args) - run the loop
 case "$1" in
   switch)
+    # Load the user's vcs helper (best-effort) so vcs rootdir/unmerged work when
+    # matching and describing shells.
+    test -r "$HOME/.shrc.vcs" && source "$HOME/.shrc.vcs"
     target="$(resolve_switch_target "$2")" || exit 1
     request_switch "$target"
     ;;

--- a/autoshpool_test
+++ b/autoshpool_test
@@ -55,24 +55,10 @@ exit 0
 PGREP
   chmod +x "$TEST_TMPDIR/bin/pgrep"
 
-  # Fake readlink that resolves /proc/<pid>/cwd from the shell fixtures.
-  cat > "$TEST_TMPDIR/bin/readlink" <<'READLINK'
-#!/bin/bash
-t="$1"; pid="${t#/proc/}"; pid="${pid%/cwd}"
-awk -F'\t' -v p="$pid" '$1==p{print $3}' "$HOME/.fake_shells" 2>/dev/null
-exit 0
-READLINK
-  chmod +x "$TEST_TMPDIR/bin/readlink"
-
-  # Fake envgrep that returns SHPOOL_SESSION_NAME from the shell fixtures.
-  cat > "$TEST_TMPDIR/bin/envgrep" <<'ENVGREP'
-#!/bin/bash
-# usage: envgrep <pattern> <pid>
-s=$(awk -F'\t' -v p="$2" '$1==p{print $4}' "$HOME/.fake_shells" 2>/dev/null)
-[ -n "$s" ] && printf 'SHPOOL_SESSION_NAME=%s' "$s"
-exit 0
-ENVGREP
-  chmod +x "$TEST_TMPDIR/bin/envgrep"
+  # Per-process info is read from a fake /proc tree (see add_shell), pointed to
+  # by SHPOOL_PROC_DIR. The real readlink/tr/sed read it, so no stubs needed.
+  export SHPOOL_PROC_DIR="$TEST_TMPDIR/proc"
+  mkdir -p "$SHPOOL_PROC_DIR"
 
   # Fake vcs that reads per-directory marker files in the current directory:
   #   .vcsroot  - printed by "vcs rootdir"
@@ -86,6 +72,13 @@ esac
 exit 0
 VCS
   chmod +x "$TEST_TMPDIR/bin/vcs"
+
+  # Fake pstree so process summaries are deterministic (empty) in tests.
+  cat > "$TEST_TMPDIR/bin/pstree" <<'PSTREE'
+#!/bin/bash
+exit 0
+PSTREE
+  chmod +x "$TEST_TMPDIR/bin/pstree"
 
   # Create a fake timeout that just runs the command
   cat > "$TEST_TMPDIR/bin/timeout" <<'TIMEOUT'
@@ -115,8 +108,15 @@ add_shpool() {
 }
 
 # Register a fake shell: pid, parent shpool pid, cwd, session name.
+# Records the pid->ppid mapping for pgrep and builds a fake /proc/<pid> entry
+# (environ + cwd symlink) that the real readlink/tr/sed read.
 add_shell() {
-  printf '%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" >> "$HOME/.fake_shells"
+  local pid="$1" ppid="$2" cwd="$3" session="$4"
+  printf '%s\t%s\t%s\t%s\n' "$pid" "$ppid" "$cwd" "$session" >> "$HOME/.fake_shells"
+  mkdir -p "$SHPOOL_PROC_DIR/$pid"
+  printf 'PATH=/usr/bin\0SHPOOL_SESSION_NAME=%s\0TERM=xterm\0' "$session" \
+    > "$SHPOOL_PROC_DIR/$pid/environ"
+  ln -sf "$cwd" "$SHPOOL_PROC_DIR/$pid/cwd"
 }
 
 teardown() {
@@ -379,6 +379,30 @@ test_switch_cancel_does_not_switch() {
   assert_no_switch_file
 }
 
+test_switch_matches_vcs_unmerged() {
+  # "switch abcdef" finds the shell whose `vcs unmerged` lists abcdef.
+  local d="$TEST_TMPDIR/proj"
+  mkdir -p "$d"
+  printf 'abcdef Something\n123456 Other\n' > "$d/.unmerged"
+  add_shpool 1000
+  add_shell 2001 1000 "$d" 7
+  run_autoshpool switch abcdef
+  assert_status 0
+  assert_switch_file 7
+}
+
+test_switch_unmerged_matches_whole_word() {
+  # "abc" must not match the unmerged item "abcdef".
+  local d="$TEST_TMPDIR/proj"
+  mkdir -p "$d"
+  printf 'abcdef Something\n' > "$d/.unmerged"
+  add_shpool 1000
+  add_shell 2001 1000 "$d" 7
+  run_autoshpool switch abc
+  assert_status 0
+  assert_switch_file abc
+}
+
 test_shpoollist_lists_sessions() {
   local d="$TEST_TMPDIR/proj"
   mkdir -p "$d"
@@ -427,6 +451,8 @@ run_test "switch prefers an existing session name over a path match" test_switch
 run_test "switch falls back to the argument when nothing matches" test_switch_no_match_uses_arg
 run_test "switch prompts when several shells match" test_switch_prompts_on_multiple_matches
 run_test "switch does not switch when the prompt is cancelled" test_switch_cancel_does_not_switch
+run_test "switch matches a session by vcs unmerged output" test_switch_matches_vcs_unmerged
+run_test "switch unmerged matching is whole-word" test_switch_unmerged_matches_whole_word
 run_test "shpoollist lists sessions with details" test_shpoollist_lists_sessions
 run_test "shpoollist prints nothing when there are no shells" test_shpoollist_empty_when_no_shells
 

--- a/shpoollist
+++ b/shpoollist
@@ -9,9 +9,12 @@
 # Reuse the shell-enumeration and formatting helpers from autoshpool.
 source "$(dirname "$0")/autoshpool"
 
+# Load the user's vcs helper (best-effort) for the vcs root/unmerged fields.
+test -r "$HOME/.shrc.vcs" && source "$HOME/.shrc.vcs"
+
 listing="$(shpool list 2>/dev/null)"
 while IFS=$'\t' read -r pid session cwd; do
-  status="$(session_status "$session" "$listing")"
-  describe_shell "$pid" "$session" "$cwd" "$status"
+  state="$(session_status "$session" "$listing")"
+  describe_shell "$pid" "$session" "$cwd" "$state"
   echo
 done < <(list_shpool_shells)


### PR DESCRIPTION
## Summary

Fixes `shpoollist` producing **empty output** despite `shpool list` showing sessions, and adds `vcs unmerged` matching to `autoshpool switch`.

### Root cause

`get_pid_session_name` called `envgrep`, which is a shell function from your dotfiles — it isn't loaded into `shpoollist` (which sources `autoshpool`, not your shell rc) or into the bash `autoshpool` process. A `2>/dev/null` swallowed the resulting `command not found`, so every shell was silently skipped and the loop never iterated.

Sourcing `~/.shrc` (à la `shpoolps`) would only fix `shpoollist`, not `autoshpool switch` (bash, can't safely source a zsh rc on every switch). So instead:

- **Read `SHPOOL_SESSION_NAME` directly from `/proc/<pid>/environ`** (`tr '\0' '\n' | sed -n 's/^SHPOOL_SESSION_NAME=//p'`). No dependency to source, works in bash and zsh, and fixes both `shpoollist` and `autoshpool switch`. The proc path is overridable via `SHPOOL_PROC_DIR` for tests.
- **Source `~/.shrc.vcs`** (best-effort, bash-safe — `autoshpool` already uses it) in `shpoollist` and the `switch` path so the `vcs` root/unmerged fields populate. Missing `vcs` just leaves those fields blank.
- Stopped silencing the error that hid this — the `/proc` read uses a targeted `test -r` guard instead of a blanket `2>/dev/null`.

### Also in this PR

- **`autoshpool switch <arg>`** now also matches a shell when `<arg>` is a whole word in that shell's `vcs unmerged` output (e.g. `switch abcdef` finds the session whose `vcs unmerged` lists `abcdef`), in addition to working-directory path-segment matching. The disambiguation prompt already shows `vcs unmerged`.
- Renamed the `status` variable to `state` (`status` is a read-only special variable in zsh).

## Verification

Reproduced the original bug and confirmed the fix with `envgrep` entirely absent, under **both bash and zsh**: `shpoollist` now lists sessions, with `vcs` fields populated where available and blank otherwise.

## Tests

Test harness now drives a fake `/proc` tree (environ + cwd symlinks) via `SHPOOL_PROC_DIR` instead of stubbing `envgrep`/`readlink`. Added tests for `vcs unmerged` matching (incl. whole-word). **23 tests, all passing.**

https://claude.ai/code/session_01PXFfePZBuFWiXuwzrrTdmJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXFfePZBuFWiXuwzrrTdmJ)_