### PR TITLE
shpoollist/switch: split shell description across multiple lines

### DIFF
--- a/autoshpool
+++ b/autoshpool
@@ -149,18 +149,17 @@ session_status() {
 }
 
 describe_shell() {
-  # Render a one-line, multi-field description of a shell, shared by the switch
-  # disambiguation prompt and shpoollist so both use the same format. Fields:
-  # session name, status, the basename of the vcs root and of the working
-  # directory, a one-line process-tree summary, and the vcs unmerged items
-  # (flattened onto a single line).
+  # Render a multi-line description of a shell, shared by the switch
+  # disambiguation prompt and shpoollist so both use the same format:
+  #   line 1: session name, status, vcs root basename, working directory basename
+  #   line 2: a one-line process-tree summary
+  #   remaining lines: the vcs unmerged output, unchanged
   local pid="$1" session="$2" cwd="$3" state="$4"
-  local unmerged
-  unmerged="$(dir_vcs_unmerged "$cwd")"
-  printf '%s  %s  %s  %s  %s  %s' \
+  printf '%s  %s  %s  %s\n' \
     "$session" "${state:-unknown}" \
-    "$(dir_vcs_root_name "$cwd")" "$(basename "$cwd")" \
-    "$(shell_summary "$pid")" "${unmerged//$'\n'/; }"
+    "$(dir_vcs_root_name "$cwd")" "$(basename "$cwd")"
+  printf '%s\n' "$(shell_summary "$pid")"
+  dir_vcs_unmerged "$cwd"
 }
 
 shell_matches() {
@@ -227,8 +226,8 @@ resolve_switch_target() {
     echo "Multiple shells match '$arg':"
     for i in "${!match_sessions[@]}"; do
       state="$(session_status "${match_sessions[$i]}" "$listing")"
-      printf '  %d) %s\n' "$((i + 1))" \
-        "$(describe_shell "${match_pids[$i]}" "${match_sessions[$i]}" "${match_cwds[$i]}" "$state")"
+      printf '%d) ' "$((i + 1))"
+      describe_shell "${match_pids[$i]}" "${match_sessions[$i]}" "${match_cwds[$i]}" "$state"
     done
     printf 'Switch to which? [1-%d] ' "$n"
   } >&2


### PR DESCRIPTION
## Summary

The shared `describe_shell` output (used by `shpoollist` and the `autoshpool switch` disambiguation prompt) was one long line per shell. This splits it across multiple lines, as requested:

- **Line 1:** session name, attached/detached status, `vcs rootdir` basename, `$PWD` basename
- **Line 2:** `pstree -ps <PID> | head -n 1`
- **Remaining lines:** `vcs unmerged` output, unchanged (no longer flattened)

`shpoollist` keeps a blank line between shells; the `switch` prompt prefixes each block with its `N)` selector.

### Example

```
1  connected  alpha  sep1
init---shpool---zsh
shared Task one
2  disconnected  beta  sep2
init---shpool---zsh
shared Task two
```

## Tests

23 tests passing; output verified for both `shpoollist` and the ambiguous `switch` prompt.

https://claude.ai/code/session_01PXFfePZBuFWiXuwzrrTdmJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXFfePZBuFWiXuwzrrTdmJ)_