### PR TITLE
shpoollist/switch: compact /proc-read process chain on line 1

### DIFF
--- a/autoshpool
+++ b/autoshpool
@@ -121,11 +121,51 @@ list_shpool_shells() {
   done
 }
 
-shell_summary() {
-  # A one-line description of a process and its ancestry, used to help the user
-  # tell otherwise-similar shells apart. Empty if pstree is unavailable.
-  command -v pstree >/dev/null 2>&1 || return 0
-  pstree -ps "$1" 2>/dev/null | head -n 1
+pid_comm() {
+  # The command name of a process, or empty if it is gone.
+  local f; f="$(proc_dir)/$1/comm"
+  test -r "$f" || return 0
+  tr -d '\n' < "$f"
+}
+
+pid_ppid() {
+  # The parent pid of a process, from /proc/<pid>/status.
+  local f; f="$(proc_dir)/$1/status"
+  test -r "$f" || return 0
+  awk '/^PPid:/ { print $2; exit }' "$f"
+}
+
+pid_children() {
+  # The child pids of a process (space-separated), or empty.
+  cat "$(proc_dir)/$1/task/$1/children" 2>/dev/null
+}
+
+pid_first_child() {
+  # shellcheck disable=SC2046  # intentional word-splitting of the pid list
+  set -- $(pid_children "$1")
+  printf '%s' "${1:-}"
+}
+
+shell_chain() {
+  # A cut-down, pstree-style summary for a shell: the command names of the
+  # shell's grandparent, its shpool, the shell itself, and the shell's first
+  # child, joined with "---" (e.g. systemd---shpool---zsh---vim). Read straight
+  # from /proc. Showing the grandparent and child makes an accidental nested
+  # shpool obvious -- shpool turns up in a slot where it shouldn't (e.g.
+  # ...---zsh---shpool).
+  local shell="$1" shpool parent child
+  shpool="$(pid_ppid "$shell")"
+  parent="$(pid_ppid "$shpool")"
+  child="$(pid_first_child "$shell")"
+
+  local chain="" pid comm
+  for pid in "$parent" "$shpool" "$shell" "$child"; do
+    test -n "$pid" || continue
+    comm="$(pid_comm "$pid")"
+    test -n "$comm" || continue
+    chain="${chain:+$chain---}$comm"
+  done
+  printf '%s' "$chain"
 }
 
 dir_vcs_root_name() {
@@ -149,16 +189,16 @@ session_status() {
 }
 
 describe_shell() {
-  # Render a multi-line description of a shell, shared by the switch
-  # disambiguation prompt and shpoollist so both use the same format:
-  #   line 1: session name, status, vcs root basename, working directory basename
-  #   line 2: a one-line process-tree summary
+  # Render a description of a shell, shared by the switch disambiguation prompt
+  # and shpoollist so both use the same format:
+  #   line 1: session name, status, vcs root basename, working directory
+  #           basename, and a cut-down process-tree chain
   #   remaining lines: the vcs unmerged output, unchanged
   local pid="$1" session="$2" cwd="$3" state="$4"
-  printf '%s  %s  %s  %s\n' \
+  printf '%s  %s  %s  %s  %s\n' \
     "$session" "${state:-unknown}" \
-    "$(dir_vcs_root_name "$cwd")" "$(basename "$cwd")"
-  printf '%s\n' "$(shell_summary "$pid")"
+    "$(dir_vcs_root_name "$cwd")" "$(basename "$cwd")" \
+    "$(shell_chain "$pid")"
   dir_vcs_unmerged "$cwd"
 }
 

--- a/autoshpool_test
+++ b/autoshpool_test
@@ -74,12 +74,6 @@ VCS
   chmod +x "$TEST_TMPDIR/bin/vcs"
 
   # Fake pstree so process summaries are deterministic (empty) in tests.
-  cat > "$TEST_TMPDIR/bin/pstree" <<'PSTREE'
-#!/bin/bash
-exit 0
-PSTREE
-  chmod +x "$TEST_TMPDIR/bin/pstree"
-
   # Create a fake timeout that just runs the command
   cat > "$TEST_TMPDIR/bin/timeout" <<'TIMEOUT'
 #!/bin/bash
@@ -107,13 +101,30 @@ add_shpool() {
   echo "$1" >> "$HOME/.fake_shpool_pids"
 }
 
+# Create a fake /proc/<pid> entry: comm, status (with PPid) and a children list.
+# Usage: add_proc <pid> <comm> <ppid> [child-pid...]
+add_proc() {
+  local pid="$1" comm="$2" ppid="$3"; shift 3
+  mkdir -p "$SHPOOL_PROC_DIR/$pid/task/$pid"
+  printf '%s\n' "$comm" > "$SHPOOL_PROC_DIR/$pid/comm"
+  printf 'Name:\t%s\nPPid:\t%s\n' "$comm" "$ppid" > "$SHPOOL_PROC_DIR/$pid/status"
+  printf '%s ' "$@" > "$SHPOOL_PROC_DIR/$pid/task/$pid/children"
+}
+
+# Set the child pids of an existing fake process.
+set_children() {
+  local pid="$1"; shift
+  mkdir -p "$SHPOOL_PROC_DIR/$pid/task/$pid"
+  printf '%s ' "$@" > "$SHPOOL_PROC_DIR/$pid/task/$pid/children"
+}
+
 # Register a fake shell: pid, parent shpool pid, cwd, session name.
 # Records the pid->ppid mapping for pgrep and builds a fake /proc/<pid> entry
-# (environ + cwd symlink) that the real readlink/tr/sed read.
+# (environ, cwd symlink, comm=zsh, status with PPid) that the scripts read.
 add_shell() {
   local pid="$1" ppid="$2" cwd="$3" session="$4"
   printf '%s\t%s\t%s\t%s\n' "$pid" "$ppid" "$cwd" "$session" >> "$HOME/.fake_shells"
-  mkdir -p "$SHPOOL_PROC_DIR/$pid"
+  add_proc "$pid" zsh "$ppid"
   printf 'PATH=/usr/bin\0SHPOOL_SESSION_NAME=%s\0TERM=xterm\0' "$session" \
     > "$SHPOOL_PROC_DIR/$pid/environ"
   ln -sf "$cwd" "$SHPOOL_PROC_DIR/$pid/cwd"
@@ -421,6 +432,32 @@ EOF
   assert_output_contains "abcdef Something"  # vcs unmerged
 }
 
+test_shpoollist_shows_process_chain() {
+  add_proc 100 systemd 0
+  add_proc 1000 shpool 100
+  add_shpool 1000
+  add_shell 2001 1000 "/home/u/work" 5
+  add_proc 3001 vim 2001
+  set_children 2001 3001
+  run_shpoollist
+  assert_status 0
+  assert_output_contains "systemd---shpool---zsh---vim"
+}
+
+test_shpoollist_chain_reveals_nested_shpool() {
+  # A shell running an shpool of its own (e.g. an accidental nested attach)
+  # shows up as shpool in the child slot of the chain.
+  add_proc 100 systemd 0
+  add_proc 1000 shpool 100
+  add_shpool 1000
+  add_shell 2001 1000 "/home/u/work" 5
+  add_proc 3001 shpool 2001
+  set_children 2001 3001
+  run_shpoollist
+  assert_status 0
+  assert_output_contains "zsh---shpool"
+}
+
 test_shpoollist_empty_when_no_shells() {
   run_shpoollist
   assert_status 0
@@ -454,6 +491,8 @@ run_test "switch does not switch when the prompt is cancelled" test_switch_cance
 run_test "switch matches a session by vcs unmerged output" test_switch_matches_vcs_unmerged
 run_test "switch unmerged matching is whole-word" test_switch_unmerged_matches_whole_word
 run_test "shpoollist lists sessions with details" test_shpoollist_lists_sessions
+run_test "shpoollist shows a cut-down process chain" test_shpoollist_shows_process_chain
+run_test "shpoollist chain reveals nested shpool" test_shpoollist_chain_reveals_nested_shpool
 run_test "shpoollist prints nothing when there are no shells" test_shpoollist_empty_when_no_shells
 
 echo


### PR DESCRIPTION
## Summary

Replaces the `pstree` line with a compact process chain on **line 1**, read directly from `/proc` (no `pstree` dependency).

Each shell's chain shows the command names of: the shell's **grandparent**, its **shpool**, the **shell** itself, and the shell's **first child**, joined with `---`:

```
1  connected  alpha  p1  systemd---shpool---zsh---vim
2  disconnected  beta  p2  gdm-session---shpool---zsh---shpool
```

- Printing the **grandparent** covers the case where it isn't `systemd` (and reveals when a shell sits above shpool — i.e. nesting).
- Printing the **child** makes an accidental nested shpool obvious — it shows up as `shpool` in the child slot (`...---zsh---shpool`), no extra marker needed.

Implemented with small `/proc` helpers (`pid_comm`, `pid_ppid`, `pid_children`, `pid_first_child`) that honor the test-only `SHPOOL_PROC_DIR` override.

## Tests

Harness now builds `comm`/`status`/`children` in the fake `/proc` tree. Added tests for the chain and for the nested-shpool case. **25 tests, all passing.**

https://claude.ai/code/session_01PXFfePZBuFWiXuwzrrTdmJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXFfePZBuFWiXuwzrrTdmJ)_