### PR TITLE
autoshpool: auto-switch to a prefix-matching session on mismatch

### DIFF
--- a/autoshpool
+++ b/autoshpool
@@ -71,6 +71,11 @@ handle_already_attached() {
     exit 1
   fi
 
+  # Only the mismatch path lists sessions, so guard it against a hung shpool
+  # here -- otherwise a stuck daemon hangs shell startup instead of reporting
+  # "shpool not responding". Matching sessions still exit without listing.
+  abort_if_hung
+
   target="$(pick_prefixed_session)" || {
     echo "Already connected to shpool session $session"
     exit 1

--- a/autoshpool
+++ b/autoshpool
@@ -20,12 +20,63 @@ get_current_shpool_session() {
   echo "$SHPOOL_SESSION_NAME"
 }
 
-exit_if_already_attached() {
+session_matches_prefix() {
+  # True if a session name ($1) belongs to the project identified by a prefix
+  # ($2). With no prefix (e.g. outside any version-controlled directory) we
+  # never force a switch, so every session matches.
+  local session="$1" prefix="$2"
+  test -z "$prefix" && return 0
+  case "$session" in
+    "$prefix"*) return 0 ;;       # already carries the prefix (e.g. "proj:3")
+  esac
+  # Also accept an exact match with the separator stripped, so a session named
+  # "proj" counts as matching the prefix "proj:".
+  test "$session" = "${prefix%:}"
+}
+
+pick_prefixed_session() {
+  # Print the session to switch to for the current SHPOOL_PREFIX: reuse the
+  # first disconnected session that already matches, otherwise the next free
+  # numbered name. Mirrors the selection the main loop makes for a new shell.
+  declare -a disconnected=( $(get_disconnected_shpool_sessions) )
+  if test "${#disconnected[@]}" -gt 0; then
+    printf '%s\n' "${disconnected[0]}"
+    return
+  fi
+  declare -A sessions
+  for session in $(get_shpool_sessions); do
+    sessions[$session]=1
+  done
+  for num in $(seq 1 100); do
+    declare session="$SHPOOL_PREFIX$num"
+    if test -z "${sessions[$session]}"; then
+      printf '%s\n' "$session"
+      return
+    fi
+  done
+  return 2
+}
+
+handle_already_attached() {
+  # When this shell is already inside a session, either stay put (the session
+  # belongs to this directory's project) or request a switch to a session that
+  # does. Switching here lets the outer loop service it like switchshpool, so a
+  # shell started in a project whose prefix differs from its session name lands
+  # in a correctly named session instead.
   session=$(get_current_shpool_session)
-  if test -n "$session"; then
+  test -n "$session" || return 0
+
+  if session_matches_prefix "$session" "$SHPOOL_PREFIX"; then
     echo "Already connected to shpool session $session"
     exit 1
   fi
+
+  target="$(pick_prefixed_session)" || {
+    echo "Already connected to shpool session $session"
+    exit 1
+  }
+  echo "Session $session does not match prefix '$SHPOOL_PREFIX'; switching to $target"
+  request_switch "$target"
 }
 
 abort_if_hung() {
@@ -314,11 +365,11 @@ clear_switch() {
 autoshpool_loop() {
   #exec >>"$HOME/.autoshpool.log" 2>>"$HOME/.autoshpool.log"
 
-  exit_if_already_attached
-
   source "$HOME/.shrc.vcs"
 
   SHPOOL_PREFIX="${SHPOOL_PREFIX:-$(get_prefix)}"
+
+  handle_already_attached
 
   abort_if_hung
 

--- a/autoshpool_test
+++ b/autoshpool_test
@@ -229,6 +229,45 @@ test_exits_if_already_attached() {
   assert_output_contains "Already connected"
 }
 
+test_attached_matching_prefix_stays() {
+  export SHPOOL_PREFIX="myproject:"
+  export SHPOOL_SESSION_NAME="myproject:2"
+  run_autoshpool
+  assert_status 1
+  assert_output_contains "Already connected"
+  assert_no_switch_file
+}
+
+test_attached_exact_name_matches_prefix() {
+  # A session named "myproject" (no separator) belongs to prefix "myproject:".
+  export SHPOOL_PREFIX="myproject:"
+  export SHPOOL_SESSION_NAME="myproject"
+  run_autoshpool
+  assert_status 1
+  assert_output_contains "Already connected"
+  assert_no_switch_file
+}
+
+test_attached_mismatch_switches_to_new() {
+  export SHPOOL_PREFIX="myproject:"
+  export SHPOOL_SESSION_NAME="other:1"
+  run_autoshpool
+  assert_status 0
+  assert_output_contains "does not match prefix"
+  assert_switch_file "myproject:1"
+}
+
+test_attached_mismatch_reuses_disconnected() {
+  export SHPOOL_PREFIX="myproject:"
+  export SHPOOL_SESSION_NAME="other:1"
+  cat > "$HOME/.shpool_sessions" <<EOF
+myproject:3   2025-01-01T00:00:00Z   disconnected
+EOF
+  run_autoshpool
+  assert_status 0
+  assert_switch_file "myproject:3"
+}
+
 test_creates_session_1() {
   run_autoshpool
   assert_status 0
@@ -474,6 +513,10 @@ run_test "switch exits 0" test_switch_exits_0
 run_test "unknown subcommand passes through to shpool" test_passthrough_to_shpool
 run_test "passthrough preserves all arguments" test_passthrough_preserves_args
 run_test "exits with error if already in a shpool session" test_exits_if_already_attached
+run_test "stays put when the session matches the prefix" test_attached_matching_prefix_stays
+run_test "treats a separatorless name as matching the prefix" test_attached_exact_name_matches_prefix
+run_test "switches to a new prefixed session on mismatch" test_attached_mismatch_switches_to_new
+run_test "reuses a disconnected prefixed session on mismatch" test_attached_mismatch_reuses_disconnected
 run_test "creates session 1 when no sessions exist" test_creates_session_1
 run_test "attaches to disconnected session before creating new one" test_attaches_disconnected_first
 run_test "returns non-zero when shpool attach fails" test_returns_nonzero_on_failure


### PR DESCRIPTION
## Problem

You sometimes end up in an shpool session whose name doesn't match the VCS rootdir prefix — e.g. a session named `1` (or `other:1`) while sitting in the `myproject` repo.

## Change

When `autoshpool` runs at shell startup and finds it's already inside a session, it now checks whether that session belongs to the current directory's project:

- **Match** → behave as before (stay put, "Already connected").
- **Mismatch** → `request_switch` to a session that *does* match the prefix, reusing the same selection the main loop uses (first disconnected prefixed session, else the next free numbered name). The outer loop services the switch exactly like `switchshpool`, so the shell lands in a correctly named session.

Matching rules:
- A session matches if its name starts with the prefix (`myproject:3`) **or** equals the prefix with the separator stripped (`myproject` matches `myproject:`).
- With **no prefix** (outside any VCS repo) nothing is ever forced to switch.

The already-attached check now runs *after* `.shrc.vcs` is sourced and `SHPOOL_PREFIX` is computed, so the inner shell compares against the prefix for its *current* directory.

## Notes / caveats

- The new session is named correctly, but (like `switchshpool` to a new name today) it starts in the outer loop's cwd rather than the directory that triggered the switch. Fixing that would mean threading a desired PWD through the switch file — out of scope here, happy to follow up.
- This only triggers when in a VCS dir whose prefix differs from the session name, so non-repo shells are unaffected.

## Tests

Added four cases to `autoshpool_test` (matching prefix stays, separatorless name matches, mismatch creates a new prefixed session, mismatch reuses a disconnected one). Full suite passes (29 tests).

> Note: there's a pre-existing stale assertion in `test_shpoollist_lists_sessions` (checks for `connected` while the status icon renders `?`); it predates this change and doesn't fail the suite, so I left it alone.

https://claude.ai/code/session_014xT9iRYLw1ukunEhVsHTX8

---
_Generated by [Claude Code](https://claude.ai/code/session_014xT9iRYLw1ukunEhVsHTX8)_