### PR TITLE
autoshpool: preserve $PWD when switching to a prefix-matched session

### DIFF
--- a/autoshpool
+++ b/autoshpool
@@ -15,6 +15,7 @@
 #   switchshpool() { autoshpool switch "$1" && exit; }
 
 switch_session_file="$HOME/.autoshpool_switch"
+switch_pwd_file="$HOME/.autoshpool_switch_pwd"
 
 get_current_shpool_session() {
   echo "$SHPOOL_SESSION_NAME"
@@ -81,7 +82,9 @@ handle_already_attached() {
     exit 1
   }
   echo "Session $session does not match prefix '$SHPOOL_PREFIX'; switching to $target"
-  request_switch "$target"
+  # Carry the current directory across the switch so the prefix-matched session
+  # opens where the user already is, instead of wherever the servicing loop sits.
+  request_switch "$target" "$PWD"
 }
 
 abort_if_hung() {
@@ -354,13 +357,25 @@ get_switch_session() {
   cat "$switch_session_file" 2>/dev/null
 }
 
+get_switch_pwd() {
+  cat "$switch_pwd_file" 2>/dev/null
+}
+
 request_switch() {
+  # Record the target session and, optionally, the directory to open it in. A
+  # bare request (e.g. switchshpool to an existing session) leaves the pwd file
+  # absent so the target keeps its own working directory.
   echo "$1" > "$switch_session_file"
+  if test -n "$2"; then
+    echo "$2" > "$switch_pwd_file"
+  else
+    rm -f "$switch_pwd_file"
+  fi
   exit 0
 }
 
 clear_switch() {
-  rm -f "$switch_session_file"
+  rm -f "$switch_session_file" "$switch_pwd_file"
 }
 
 # Start an shpool session with a useful session name.
@@ -381,7 +396,15 @@ autoshpool_loop() {
   while true; do
     switch_session="$(get_switch_session)"
     if test -n "$switch_session"; then
+      switch_pwd="$(get_switch_pwd)"
       clear_switch
+      # A recorded pwd (a prefix-mismatch switch) opens the session there; a
+      # bare switch keeps the target's own directory, so drop any stale value.
+      if test -n "$switch_pwd"; then
+        export SHPOOL_INITIAL_PWD="$switch_pwd"
+      else
+        unset SHPOOL_INITIAL_PWD
+      fi
       shpool attach "$switch_session"
     else
       attach_first_disconnected || create_and_attach_next

--- a/autoshpool_test
+++ b/autoshpool_test
@@ -89,7 +89,9 @@ TIMEOUT
   unset SHPOOL_SESSION_NAME
   unset SHPOOL_PREFIX
   unset SHPOOL_ATTACH_EXIT
+  unset SHPOOL_INITIAL_PWD
   rm -f "$TEST_TMPDIR/.autoshpool_switch"
+  rm -f "$TEST_TMPDIR/.autoshpool_switch_pwd"
   rm -f "$TEST_TMPDIR/.shpool_calls"
   rm -f "$TEST_TMPDIR/.shpool_sessions"
   rm -f "$TEST_TMPDIR/.fake_shpool_pids"
@@ -268,6 +270,58 @@ EOF
   assert_switch_file "myproject:3"
 }
 
+test_attached_mismatch_records_pwd() {
+  # The prefix-mismatch switch records the current directory so the new session
+  # opens where the user already is.
+  export SHPOOL_PREFIX="myproject:"
+  export SHPOOL_SESSION_NAME="other:1"
+  run_autoshpool
+  assert_status 0
+  assert_switch_file "myproject:1"
+  assert_switch_pwd "$PWD"
+}
+
+test_plain_switch_records_no_pwd() {
+  # switchshpool to an existing session keeps the target's own directory, so it
+  # leaves no recorded pwd.
+  run_autoshpool switch mysession
+  assert_status 0
+  assert_switch_file "mysession"
+  assert_no_switch_pwd
+}
+
+test_loop_switch_exports_recorded_pwd() {
+  # When the loop services a switch that carries a pwd, it exports
+  # SHPOOL_INITIAL_PWD so the freshly created session starts there.
+  cat > "$TEST_TMPDIR/bin/shpool" <<'SHPOOL'
+#!/bin/bash
+echo "shpool $*" >> "$HOME/.shpool_calls"
+case "$1" in
+  list)
+    echo "name                           started_at                         status"
+    cat "$HOME/.shpool_sessions" 2>/dev/null
+    exit 0
+    ;;
+  attach)
+    echo "INITIAL_PWD=$SHPOOL_INITIAL_PWD" >> "$HOME/.shpool_env"
+    exit 0
+    ;;
+esac
+SHPOOL
+  chmod +x "$TEST_TMPDIR/bin/shpool"
+
+  echo "myproject:1" > "$HOME/.autoshpool_switch"
+  echo "/home/u/proj" > "$HOME/.autoshpool_switch_pwd"
+  run_autoshpool
+  assert_status 0
+  assert_called "shpool attach myproject:1"
+  if ! grep -qx "INITIAL_PWD=/home/u/proj" "$HOME/.shpool_env"; then
+    echo "  FAIL: expected SHPOOL_INITIAL_PWD=/home/u/proj on attach"
+    echo "  env: $(cat "$HOME/.shpool_env" 2>/dev/null)"
+    return 1
+  fi
+}
+
 test_creates_session_1() {
   run_autoshpool
   assert_status 0
@@ -358,6 +412,24 @@ assert_switch_file() {
 assert_no_switch_file() {
   if [ -e "$HOME/.autoshpool_switch" ]; then
     echo "  FAIL: expected no switch file, but it exists: $(cat "$HOME/.autoshpool_switch")"
+    return 1
+  fi
+}
+
+assert_switch_pwd() {
+  local expected="$1"
+  local actual
+  actual="$(cat "$HOME/.autoshpool_switch_pwd" 2>/dev/null)"
+  if [ "$actual" != "$expected" ]; then
+    echo "  FAIL: expected switch pwd '$expected', got '$actual'"
+    echo "  output: $output"
+    return 1
+  fi
+}
+
+assert_no_switch_pwd() {
+  if [ -e "$HOME/.autoshpool_switch_pwd" ]; then
+    echo "  FAIL: expected no switch pwd file, but it exists: $(cat "$HOME/.autoshpool_switch_pwd")"
     return 1
   fi
 }
@@ -517,6 +589,9 @@ run_test "stays put when the session matches the prefix" test_attached_matching_
 run_test "treats a separatorless name as matching the prefix" test_attached_exact_name_matches_prefix
 run_test "switches to a new prefixed session on mismatch" test_attached_mismatch_switches_to_new
 run_test "reuses a disconnected prefixed session on mismatch" test_attached_mismatch_reuses_disconnected
+run_test "records the current directory for a prefix-mismatch switch" test_attached_mismatch_records_pwd
+run_test "records no directory for a plain switch" test_plain_switch_records_no_pwd
+run_test "loop exports the recorded directory when servicing a switch" test_loop_switch_exports_recorded_pwd
 run_test "creates session 1 when no sessions exist" test_creates_session_1
 run_test "attaches to disconnected session before creating new one" test_attaches_disconnected_first
 run_test "returns non-zero when shpool attach fails" test_returns_nonzero_on_failure


### PR DESCRIPTION
## Problem

When a shell starts inside an shpool session whose name doesn't match the project derived from `$PWD`, `handle_already_attached` requests a switch to a prefix-matched session. That switch is serviced by the **outer** `autoshpool` loop, which runs in a different directory. The switch branch of the loop never set `SHPOOL_INITIAL_PWD`, so the freshly created prefix-matched session opened wherever the loop happened to sit instead of where the user actually was.

## Fix

- Record `$PWD` alongside the switch request (in a companion `~/.autoshpool_switch_pwd` file) when switching because of a prefix mismatch.
- When the loop services a switch that carries a pwd, export `SHPOOL_INITIAL_PWD` from it before attaching, so the new session opens in the user's directory.
- Plain `switchshpool` requests (to an existing session) record no pwd and keep the target session's own working directory; any stale `SHPOOL_INITIAL_PWD` is cleared in that path.

The switch-file format is unchanged (the pwd is carried in a separate file), so the existing switch mechanism keeps working as-is.

## Tests

Added three tests to `autoshpool_test`:
- the prefix-mismatch switch records the current directory,
- a plain switch records no directory,
- the loop exports the recorded directory as `SHPOOL_INITIAL_PWD` when servicing a switch.

All tests pass (`32 tests, 32 passed, 0 failed`). The one pre-existing FAIL line in `test_shpoollist_lists_sessions` exists on `main` and is unrelated to this change.

https://claude.ai/code/session_012uW3kxGohsy5Shpa1qLPKv

---
_Generated by [Claude Code](https://claude.ai/code/session_012uW3kxGohsy5Shpa1qLPKv)_