### PR TITLE
autoshpool: make a switch land without a trailing `&& exit`

### DIFF
--- a/autoshpool
+++ b/autoshpool
@@ -2,8 +2,11 @@
 # autoshpool - connect to first existing shpool session or start a new one
 #
 # Usage:
-#   autoshpool                - attach to or create a shpool session (loops for switching)
+#   autoshpool                 - attach to or create a shpool session (loops for switching)
 #   autoshpool switch <target> - request a switch to a session (from inside shpool)
+#   autoshpool switch          - request a switch to the session that fits the
+#                                current directory's project (same choice the
+#                                startup auto-switch makes)
 #
 # <target> is a session name (e.g. "2"), or any word matching a path segment of
 # a running shell's working directory. For example, "switch sep" finds the shell
@@ -13,6 +16,15 @@
 #   autoshpool && exit
 # And replace switchshpool with:
 #   switchshpool() { autoshpool switch "$1" && exit; }
+#
+# A switch is serviced by the outer loop once the current shell lets go of its
+# session. That happens two ways: the shell exits (the `&& exit` above), or
+# autoshpool detaches the session for you. Requesting a switch detaches the
+# current session as a best-effort step, so a switch lands even without a
+# trailing `&& exit` -- e.g. a bare `autoshpool`, or `mjd foo && switchshpool`
+# after moving into another project. Keep the `&& exit` in switchshpool/shrc
+# anyway: it cleanly exits the now-detached shell instead of leaving it parked
+# in a disconnected session.
 
 switch_session_file="$HOME/.autoshpool_switch"
 switch_pwd_file="$HOME/.autoshpool_switch_pwd"
@@ -371,6 +383,16 @@ request_switch() {
   else
     rm -f "$switch_pwd_file"
   fi
+  # Hand the terminal back to the outer loop so the switch lands even when the
+  # caller isn't a shell that will `exit` afterwards (a bare `autoshpool`, or a
+  # manual `switchshpool` without the `&& exit`). Detaching the current session
+  # makes the outer loop's `shpool attach` return; it then attaches the queued
+  # session. Best-effort: when we aren't inside a session, or shpool can't
+  # detach, the caller's `&& exit` (startup/switchshpool) still services the
+  # request, so this never regresses the existing flow.
+  if test -n "$SHPOOL_SESSION_NAME"; then
+    shpool detach "$SHPOOL_SESSION_NAME" 2>/dev/null
+  fi
   exit 0
 }
 
@@ -448,6 +470,7 @@ if is_sourced; then
 fi
 
 # autoshpool switch <session> - request a switch to the named session
+# autoshpool switch           - request a switch to this directory's session
 # autoshpool <shpool args...> - pass through to shpool
 # autoshpool (no args) - run the loop
 case "$1" in
@@ -455,6 +478,17 @@ case "$1" in
     # Load the user's vcs helper (best-effort) so vcs rootdir/unmerged work when
     # matching and describing shells.
     test -r "$HOME/.shrc.vcs" && source "$HOME/.shrc.vcs"
+    if test -z "$2"; then
+      # No target: switch to the session that fits this directory's project --
+      # the same selection the startup auto-switch makes. Reuse
+      # handle_already_attached so the "already matches, stay put" and "mismatch,
+      # switch" choices stay in one place. It only returns here when this shell
+      # isn't inside a session, in which case there's nothing to switch.
+      SHPOOL_PREFIX="${SHPOOL_PREFIX:-$(get_prefix)}"
+      handle_already_attached
+      echo "Not in a shpool session; nothing to switch to" >&2
+      exit 1
+    fi
     target="$(resolve_switch_target "$2")" || exit 1
     request_switch "$target"
     ;;

--- a/autoshpool
+++ b/autoshpool
@@ -391,7 +391,11 @@ request_switch() {
   # detach, the caller's `&& exit` (startup/switchshpool) still services the
   # request, so this never regresses the existing flow.
   if test -n "$SHPOOL_SESSION_NAME"; then
-    shpool detach "$SHPOOL_SESSION_NAME" 2>/dev/null
+    # Bound the detach the way abort_if_hung/session_exists bound their shpool
+    # calls: a wedged daemon or stuck detach RPC must not hang us here, or we'd
+    # never reach the exit below and would strand the caller's `&& exit` fallback
+    # -- the shell would sit in the old session and never service the queue.
+    timeout 2 shpool detach "$SHPOOL_SESSION_NAME" 2>/dev/null
   fi
   exit 0
 }

--- a/autoshpool_test
+++ b/autoshpool_test
@@ -212,6 +212,56 @@ test_switch_exits_0() {
   assert_status 0
 }
 
+test_switch_no_arg_switches_on_mismatch() {
+  # `switchshpool` (no argument) switches to the session that fits the prefix.
+  export SHPOOL_PREFIX="myproject:"
+  export SHPOOL_SESSION_NAME="other:1"
+  run_autoshpool switch
+  assert_status 0
+  assert_output_contains "does not match prefix"
+  assert_switch_file "myproject:1"
+}
+
+test_switch_no_arg_stays_when_matching() {
+  # Already in a matching session: stay put (exit 1 so `&& exit` does not fire).
+  export SHPOOL_PREFIX="myproject:"
+  export SHPOOL_SESSION_NAME="myproject:2"
+  run_autoshpool switch
+  assert_status 1
+  assert_output_contains "Already connected"
+  assert_no_switch_file
+}
+
+test_switch_no_arg_errors_when_not_attached() {
+  export SHPOOL_PREFIX="myproject:"
+  run_autoshpool switch
+  assert_status 1
+  assert_output_contains "Not in a shpool session"
+  assert_no_switch_file
+}
+
+test_switch_detaches_current_session() {
+  # A switch detaches the current session so the outer loop takes over even when
+  # the caller has no trailing `&& exit`.
+  export SHPOOL_SESSION_NAME="other:1"
+  run_autoshpool switch foo
+  assert_status 0
+  assert_switch_file foo
+  assert_called "shpool detach other:1"
+}
+
+test_switch_no_detach_when_not_attached() {
+  # With no current session there is nothing to detach.
+  run_autoshpool switch foo
+  assert_status 0
+  assert_switch_file foo
+  if grep -q "shpool detach" "$HOME/.shpool_calls" 2>/dev/null; then
+    echo "  FAIL: did not expect a detach call"
+    echo "  calls: $(cat "$HOME/.shpool_calls" 2>/dev/null)"
+    return 1
+  fi
+}
+
 test_passthrough_to_shpool() {
   run_autoshpool list
   assert_status 0
@@ -582,6 +632,11 @@ test_shpoollist_empty_when_no_shells() {
 
 run_test "switch writes session name to switch file" test_switch_writes_file
 run_test "switch exits 0" test_switch_exits_0
+run_test "switch with no arg switches to the prefix session" test_switch_no_arg_switches_on_mismatch
+run_test "switch with no arg stays put when already matching" test_switch_no_arg_stays_when_matching
+run_test "switch with no arg errors when not in a session" test_switch_no_arg_errors_when_not_attached
+run_test "switch detaches the current session" test_switch_detaches_current_session
+run_test "switch does not detach when not attached" test_switch_no_detach_when_not_attached
 run_test "unknown subcommand passes through to shpool" test_passthrough_to_shpool
 run_test "passthrough preserves all arguments" test_passthrough_preserves_args
 run_test "exits with error if already in a shpool session" test_exits_if_already_attached


### PR DESCRIPTION
## Problem

`autoshpool` would print `Session X does not match prefix '...'; switching to Y` and then **not switch**. Running `switchshpool <the suggested name>` by hand worked fine.

## Root cause

A switch is only ever *queued* to `~/.autoshpool_switch`; the actual `shpool attach` happens later in the outer loop, but only once the current shell **lets go of its session**. The sole mechanism for that was the caller running `&& exit`:

- `switchshpool() { autoshpool switch "$1" && exit; }` carries `&& exit` → the shell leaves → the outer loop services the queue → **switches**.
- a bare `autoshpool` (or any manual run) has no `&& exit` → the shell stays in the old session → the queued switch is never serviced → **announces "switching" but doesn't**.

It was never a bug in the session *selection* — it was that `autoshpool`, being a child of the interactive shell, had no way to release the terminal.

## Fix

When requesting a switch, detach the current session (`shpool detach "$SHPOOL_SESSION_NAME"`) as a **best-effort** step. That makes the outer loop's `shpool attach` return so it can attach the queued session — even without a trailing `&& exit`.

Purely additive / no regression:
- in a session → detach hands the terminal back to the outer loop → the switch lands (bare `autoshpool` now works too).
- not in a session, or shpool can't detach → falls through to the existing behaviour, where the caller's `&& exit` (startup / `switchshpool`) services the request exactly as before.

Also gives `autoshpool switch` (no target) a useful default: switch to the session that fits the current directory's project, reusing `handle_already_attached` so the "stay put vs. switch" decision stays in one place. So `switchshpool` with no argument does the right thing — e.g. `mjd foo && switchshpool` to land in the correctly named session after moving into another project.

## Tests

Added coverage for the no-arg switch (mismatch → switch, match → stay, not-attached → error) and for the detach step (detaches when in a session, doesn't when not). `34 tests, 34 passed`. Existing end-to-end startup/switch flows verified unchanged.

> Note: this repo has no `shpool` binary to test against, so the exact `shpool detach "$SHPOOL_SESSION_NAME"` invocation is best-effort and worth a quick real-world confirmation. If your `shpool` spells detach differently, only that one line needs adjusting — the fallback keeps everything working in the meantime.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Nj94fem4FDejnVYvKH83F5)_