### PR TITLE
Add vim to setup script

### DIFF
--- a/setup
+++ b/setup
@@ -118,6 +118,7 @@ install_packages() {
                 python3-venv \
                 ripgrep \
                 shellcheck \
+                vim \
                 zsh
             ;;
         redhat)
@@ -147,6 +148,7 @@ install_packages() {
                 python3-pip \
                 ripgrep \
                 ShellCheck \
+                vim \
                 zsh
             ;;
         macos)
@@ -168,6 +170,7 @@ install_packages() {
                 python3 \
                 ripgrep \
                 shellcheck \
+                vim \
                 zsh
             info "Installing macOS applications"
             brew install --cask \


### PR DESCRIPTION
Adds `vim` to the package list for Debian, RedHat, and macOS in the `install_packages` function.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BVVyUU4nYjGzabvVTEK6WZ)_