### PR TITLE
Add helix editor installation via cargo

### DIFF
--- a/setup
+++ b/setup
@@ -311,6 +311,18 @@ install_shpool() {
     cargo install --locked shpool
 }
 
+# --- Install Helix editor ---
+
+install_helix() {
+    if ! command -v cargo >/dev/null 2>&1; then
+        warn "cargo not found, skipping helix installation"
+        return
+    fi
+
+    info "Installing/updating helix via cargo"
+    cargo install --locked helix-term
+}
+
 # --- Install Nushell ---
 
 install_nushell() {
@@ -494,6 +506,7 @@ if test -f "$CONF_DIR/vcs/Makefile"; then
 fi
 
 install_rust
+install_helix
 install_jj
 install_shpool
 install_nushell

--- a/setup
+++ b/setup
@@ -118,6 +118,7 @@ install_packages() {
                 python3-venv \
                 ripgrep \
                 shellcheck \
+                vim \
                 zsh
             ;;
         redhat)
@@ -147,6 +148,7 @@ install_packages() {
                 python3-pip \
                 ripgrep \
                 ShellCheck \
+                vim \
                 zsh
             ;;
         macos)
@@ -168,6 +170,7 @@ install_packages() {
                 python3 \
                 ripgrep \
                 shellcheck \
+                vim \
                 zsh
             info "Installing macOS applications"
             brew install --cask \


### PR DESCRIPTION
Adds an `install_helix` function that installs the Helix editor via `cargo install --locked helix-term`, following the same pattern as `install_jj`, `install_shpool`, and `install_nushell`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BVVyUU4nYjGzabvVTEK6WZ)_