### PR TITLE
Add helix editor: build from source via cargo, link runtime files

### DIFF
--- a/setup
+++ b/setup
@@ -319,8 +319,15 @@ install_helix() {
         return
     fi
 
+    helix_dir="$SRC_DIR/helix"
+    clone_or_pull "https://github.com/helix-editor/helix" "$helix_dir"
     info "Installing/updating helix via cargo"
-    cargo install --locked helix-term
+    cargo install --path "$helix_dir/helix-term" --locked
+
+    # Link runtime files so hx can find grammars and queries
+    helix_config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/helix"
+    mkdir -p "$helix_config_dir"
+    ln -sfn "$helix_dir/runtime" "$helix_config_dir/runtime"
 }
 
 # --- Install Nushell ---


### PR DESCRIPTION
Installs the Helix editor by cloning the upstream repo into `~/src/helix`, building with `cargo install --path helix-term --locked`, and symlinking the runtime directory to `~/.config/helix/runtime` so grammars and queries are available.