### PR TITLE
Add micro editor to setup script package installations

### DIFF
--- a/setup
+++ b/setup
@@ -127,6 +127,7 @@ install_packages() {
                 kwin-dev \
                 make \
                 mercurial \
+                micro \
                 npm \
                 p7zip-full \
                 plasma-sdk \
@@ -158,6 +159,7 @@ install_packages() {
                 kwin-devel \
                 make \
                 mercurial \
+                micro \
                 npm \
                 p7zip \
                 p7zip-plugins \
@@ -185,6 +187,7 @@ install_packages() {
                 jq \
                 kitty \
                 mercurial \
+                micro \
                 node \
                 p7zip \
                 python3 \


### PR DESCRIPTION
## Summary

Adds the `micro` editor to the `setup` bootstrap script's package lists for
Debian/apt, RedHat/dnf, and macOS/brew.

`micro` is a friendly *non-modal* terminal editor (normal `Ctrl-S`/`Ctrl-Q`
keys, mouse support, multi-cursor / rectangular column selection), shipped as
a single Go binary. It complements the modal editors already on `main`:

- **vim** — `Ctrl-V` visual-block delete for leading columns, `gq` reflow for markdown
- **helix** — selection-first, batteries-included (the approachable Kakoune)

micro rounds out the set as an easy fallback for quick edits that still
supports column selection. It's the correct package name in apt, dnf, and
Homebrew, so no custom install function is needed.

## Changes

- Add `micro` (alphabetically) to the debian, redhat, and macos package lists.

## Verification

- `sh -n setup` passes.
- `grep -n micro setup` shows it in all three package blocks.

https://claude.ai/code/session_01Uoo75HnfTNHqRjPrugmueU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uoo75HnfTNHqRjPrugmueU)_