### PR TITLE
Make font installation conditional using fc-list

### DIFF
--- a/setup
+++ b/setup
@@ -196,6 +196,13 @@ install_packages() {
 
 # --- Install fonts ---
 
+# Returns true if the given font family is already known to fontconfig.
+# Falls back to false if fc-list is unavailable (caller should do a file check).
+font_installed() {
+    family="$1"
+    command -v fc-list >/dev/null 2>&1 && fc-list | grep -qi "$family"
+}
+
 install_fonts() {
     case "$OS" in
         macos)
@@ -208,7 +215,7 @@ install_fonts() {
     mkdir -p "$font_dir"
 
     # Ubuntu Mono
-    if ls "$font_dir"/UbuntuMono*.ttf >/dev/null 2>&1; then
+    if font_installed "Ubuntu Mono" || ls "$font_dir"/UbuntuMono*.ttf >/dev/null 2>&1; then
         info "Ubuntu Mono already installed"
     else
         info "Installing Ubuntu Mono"
@@ -220,7 +227,7 @@ install_fonts() {
     fi
 
     # Ubuntu Mono Nerd Font
-    if ls "$font_dir"/UbuntuMonoNerdFont*.ttf >/dev/null 2>&1; then
+    if font_installed "UbuntuMono Nerd Font" || ls "$font_dir"/UbuntuMonoNerdFont*.ttf >/dev/null 2>&1; then
         info "Ubuntu Mono Nerd Font already installed"
     else
         info "Installing Ubuntu Mono Nerd Font"


### PR DESCRIPTION
## Summary

- Add a `font_installed` helper that queries `fc-list` to check whether a font family is already registered with fontconfig (covering both system-wide and user-local installs)
- Update the Ubuntu Mono and Ubuntu Mono Nerd Font checks to call `font_installed` first, falling back to the existing local-file glob if `fc-list` is unavailable (e.g. macOS without fontconfig)
- Prevents downloading duplicate copies when the fonts are already installed via a package manager or a previous run

## Test plan

- [ ] On a machine with Ubuntu Mono installed via apt (`fonts-ubuntu`), run `setup` and confirm "Ubuntu Mono already installed" is printed without downloading anything
- [ ] On a fresh machine (no fonts present), confirm both fonts are downloaded and installed as before
- [ ] On macOS (no `fc-list`), confirm the file-glob fallback still works correctly

https://claude.ai/code/session_01AN7YZVpaNaMPxE4Yo9NvVh

---
_Generated by [Claude Code](https://claude.ai/code/session_01AN7YZVpaNaMPxE4Yo9NvVh)_