### PR TITLE
Remove Ubuntu Mono Nerd Font installation

### DIFF
--- a/setup
+++ b/setup
@@ -226,20 +226,6 @@ install_fonts() {
         done
     fi
 
-    # Ubuntu Mono Nerd Font
-    if font_installed "UbuntuMono Nerd Font" || ls "$font_dir"/UbuntuMonoNerdFont*.ttf >/dev/null 2>&1; then
-        info "Ubuntu Mono Nerd Font already installed"
-    else
-        info "Installing Ubuntu Mono Nerd Font"
-        nerd_url="https://github.com/ryanoasis/nerd-fonts/releases/latest/download/UbuntuMono.tar.xz"
-        nerd_tmp="${TMPDIR:-/tmp}/nerd-fonts-$$"
-        mkdir -p "$nerd_tmp"
-        curl -fsSL "$nerd_url" | tar -xJ -C "$nerd_tmp"
-        # Install only .ttf files, skip Windows-compatible ones
-        find "$nerd_tmp" -name '*.ttf' ! -name '*Windows*' -exec cp {} "$font_dir/" \;
-        rm -rf "$nerd_tmp"
-    fi
-
     # Refresh font cache on Linux
     if command -v fc-cache >/dev/null 2>&1; then
         info "Refreshing font cache"


### PR DESCRIPTION
## Summary

- Remove the Ubuntu Mono Nerd Font download and install step from `setup`

The Nerd Font patcher alters font metrics, which causes kitty to scale the bold face down relative to regular — making bold text appear smaller. Ubuntu Mono alone is sufficient; kitty has built-in Powerline and box-drawing glyph support.

## Test plan

- [ ] Run `setup` and confirm only Ubuntu Mono (not the Nerd Font) is installed
- [ ] Confirm bold text in kitty renders at the same size as regular text

https://claude.ai/code/session_01AN7YZVpaNaMPxE4Yo9NvVh

---
_Generated by [Claude Code](https://claude.ai/code/session_01AN7YZVpaNaMPxE4Yo9NvVh)_