### PR TITLE
Clean up leftover Nerd Font files on existing installs

### DIFF
--- a/setup
+++ b/setup
@@ -214,6 +214,13 @@ install_fonts() {
     esac
     mkdir -p "$font_dir"
 
+    # Remove any previously installed Ubuntu Mono Nerd Font files; they alter
+    # font metrics and cause kitty to render bold text smaller than regular.
+    if ls "$font_dir"/UbuntuMonoNerdFont*.ttf >/dev/null 2>&1; then
+        info "Removing Ubuntu Mono Nerd Font (caused bold rendering issues in kitty)"
+        rm -f "$font_dir"/UbuntuMonoNerdFont*.ttf
+    fi
+
     # Ubuntu Mono
     if font_installed "Ubuntu Mono" || ls "$font_dir"/UbuntuMono*.ttf >/dev/null 2>&1; then
         info "Ubuntu Mono already installed"


### PR DESCRIPTION
## Summary

- Add a cleanup step in `install_fonts` that removes any `UbuntuMonoNerdFont*.ttf` files from the user font directory

Machines that previously ran `setup` may still have the Nerd Font files in `~/.local/share/fonts` or `~/Library/Fonts`. Without this, the bold-metrics fix from #66 only applies to fresh installs — re-running `setup` on an existing machine would leave the problematic files in place and kitty would continue rendering bold text smaller than regular.

## Test plan

- [ ] On a machine with `UbuntuMonoNerdFont*.ttf` files present, run `setup` and confirm the files are removed and "Removing Ubuntu Mono Nerd Font" is printed
- [ ] On a machine without those files, confirm the step is silently skipped
- [ ] Confirm kitty bold text renders at the correct size after cleanup

https://claude.ai/code/session_01AN7YZVpaNaMPxE4Yo9NvVh

---
_Generated by [Claude Code](https://claude.ai/code/session_01AN7YZVpaNaMPxE4Yo9NvVh)_