### PR TITLE
Fix bugs found in a repo-wide bug hunt

### DIFF
--- a/autoshpool
+++ b/autoshpool
@@ -57,7 +57,7 @@ pick_prefixed_session() {
     return
   fi
   declare -A sessions
-  for session in $(get_shpool_sessions); do
+  for session in $(get_shpool_session_names); do
     sessions[$session]=1
   done
   for num in $(seq 1 100); do
@@ -114,27 +114,29 @@ get_prefix() {
 
 get_shpool_sessions() {
   # Session names can be empty, so need handle rows with only 2 columns specially.
-  shpool list | awk 'NR > 1 && NF == 3 && $1 ~ /^'"${SHPOOL_PREFIX:-.}"'/ { print }'
+  # The prefix is compared as a literal string, not a regex, since project names
+  # can contain regex metacharacters (e.g. "my.proj").
+  shpool list | awk -v prefix="$SHPOOL_PREFIX" \
+    'NR > 1 && NF == 3 && (prefix == "" || index($1, prefix) == 1) { print }'
+}
+
+get_shpool_session_names() {
+  get_shpool_sessions | awk '{ print $1 }'
 }
 
 get_disconnected_shpool_sessions() {
   get_shpool_sessions | awk '$NF == "disconnected" { print $1 }'
 }
 
-attach_first_disconnected() {
+first_disconnected_session() {
   declare -a disconnected=( $(get_disconnected_shpool_sessions) )
-  if test "${#disconnected[@]}" -gt 0; then
-    session="${disconnected[0]}"
-    echo "Attaching shpool session $session"
-    shpool attach "$session"
-    return
-  fi
-  return 1
+  test "${#disconnected[@]}" -gt 0 || return 1
+  printf '%s\n' "${disconnected[0]}"
 }
 
 create_and_attach_next() {
   declare -A sessions
-  for session in $(get_shpool_sessions); do
+  for session in $(get_shpool_session_names); do
     sessions[$session]=1
   done
   for num in $(seq 1 100); do
@@ -261,13 +263,13 @@ session_status() {
 
 status_icon() {
   # A compact icon for a session status ($1), so listings stay narrow:
-  #   attached -> matching white circle, detached -> empty circle.
+  #   attached -> matching white circle, disconnected -> empty circle.
   # Anything else (including an empty/unknown status) falls back to a question
   # mark so unexpected statuses are still visible.
   case "$1" in
-    attached) printf '%s' '●' ;;
-    detached) printf '%s' '○' ;;
-    *)        printf '%s' '?' ;;
+    attached)     printf '%s' '●' ;;
+    disconnected) printf '%s' '○' ;;
+    *)            printf '%s' '?' ;;
   esac
 }
 
@@ -433,7 +435,15 @@ autoshpool_loop() {
       fi
       shpool attach "$switch_session"
     else
-      attach_first_disconnected || create_and_attach_next
+      # Pick the session first so a failed attach is reported as a failure
+      # rather than falling through to create a brand-new session.
+      session="$(first_disconnected_session)"
+      if test -n "$session"; then
+        echo "Attaching shpool session $session"
+        shpool attach "$session"
+      else
+        create_and_attach_next
+      fi
     fi
     rc=$?
 

--- a/autoshpool_test
+++ b/autoshpool_test
@@ -164,6 +164,7 @@ assert_status() {
   if [ "$status" -ne "$expected" ]; then
     echo "  FAIL: expected exit status $expected, got $status"
     echo "  output: $output"
+    TEST_FAILED=1
     return 1
   fi
 }
@@ -172,6 +173,7 @@ assert_output_contains() {
   if [[ "$output" != *"$1"* ]]; then
     echo "  FAIL: output does not contain '$1'"
     echo "  output: $output"
+    TEST_FAILED=1
     return 1
   fi
 }
@@ -180,6 +182,7 @@ assert_called() {
   if ! grep -q "$1" "$HOME/.shpool_calls" 2>/dev/null; then
     echo "  FAIL: expected call '$1' not found"
     echo "  calls: $(cat "$HOME/.shpool_calls" 2>/dev/null)"
+    TEST_FAILED=1
     return 1
   fi
 }
@@ -189,7 +192,11 @@ run_test() {
   local func="$2"
   TESTS_RUN=$((TESTS_RUN + 1))
   setup
-  if "$func"; then
+  # TEST_FAILED catches asserts that fail mid-test: running "$func" as an `if`
+  # condition disables `set -e` inside it, so a failed assert that isn't the
+  # last statement would otherwise be ignored.
+  TEST_FAILED=
+  if "$func" && test -z "$TEST_FAILED"; then
     echo "ok $TESTS_RUN $name"
     TESTS_PASSED=$((TESTS_PASSED + 1))
   else
@@ -381,13 +388,30 @@ test_creates_session_1() {
 
 test_attaches_disconnected_first() {
   cat > "$HOME/.shpool_sessions" <<EOF
-2      2025-01-01T00:00:00Z   connected
+2      2025-01-01T00:00:00Z   attached
 3      2025-01-01T00:00:00Z   disconnected
 EOF
   run_autoshpool
   assert_status 0
   assert_called "shpool attach 3"
   assert_output_contains "Attaching shpool session 3"
+}
+
+test_failed_attach_does_not_create_new_session() {
+  # A failed attach to an existing disconnected session must report the error,
+  # not fall through and silently create a brand-new session.
+  cat > "$HOME/.shpool_sessions" <<EOF
+3      2025-01-01T00:00:00Z   disconnected
+EOF
+  export SHPOOL_ATTACH_EXIT=7
+  run_autoshpool
+  assert_status 7
+  assert_called "shpool attach 3"
+  if grep -q "shpool attach 1" "$HOME/.shpool_calls" 2>/dev/null; then
+    echo "  FAIL: created a new session after a failed attach"
+    echo "  calls: $(cat "$HOME/.shpool_calls" 2>/dev/null)"
+    return 1
+  fi
 }
 
 test_returns_nonzero_on_failure() {
@@ -439,8 +463,8 @@ test_uses_prefix() {
 test_skips_existing_sessions() {
   export SHPOOL_PREFIX=""
   cat > "$HOME/.shpool_sessions" <<EOF
-1      2025-01-01T00:00:00Z   connected
-2      2025-01-01T00:00:00Z   connected
+1      2025-01-01T00:00:00Z   attached
+2      2025-01-01T00:00:00Z   attached
 EOF
   run_autoshpool
   assert_status 0
@@ -455,6 +479,7 @@ assert_switch_file() {
   if [ "$actual" != "$expected" ]; then
     echo "  FAIL: expected switch file '$expected', got '$actual'"
     echo "  output: $output"
+    TEST_FAILED=1
     return 1
   fi
 }
@@ -462,6 +487,7 @@ assert_switch_file() {
 assert_no_switch_file() {
   if [ -e "$HOME/.autoshpool_switch" ]; then
     echo "  FAIL: expected no switch file, but it exists: $(cat "$HOME/.autoshpool_switch")"
+    TEST_FAILED=1
     return 1
   fi
 }
@@ -473,6 +499,7 @@ assert_switch_pwd() {
   if [ "$actual" != "$expected" ]; then
     echo "  FAIL: expected switch pwd '$expected', got '$actual'"
     echo "  output: $output"
+    TEST_FAILED=1
     return 1
   fi
 }
@@ -480,6 +507,7 @@ assert_switch_pwd() {
 assert_no_switch_pwd() {
   if [ -e "$HOME/.autoshpool_switch_pwd" ]; then
     echo "  FAIL: expected no switch pwd file, but it exists: $(cat "$HOME/.autoshpool_switch_pwd")"
+    TEST_FAILED=1
     return 1
   fi
 }
@@ -581,14 +609,14 @@ test_shpoollist_lists_sessions() {
   echo "$TEST_TMPDIR/proj" > "$d/.vcsroot"
   printf 'abcdef Something\n' > "$d/.unmerged"
   cat > "$HOME/.shpool_sessions" <<EOF
-4   2025-01-01T00:00:00Z   connected
+4   2025-01-01T00:00:00Z   attached
 EOF
   add_shpool 1000
   add_shell 2001 1000 "$d" 4
   run_shpoollist
   assert_status 0
   assert_output_contains "4"                 # session name
-  assert_output_contains "connected"         # status
+  assert_output_contains "●"                 # attached status icon
   assert_output_contains "proj"              # basename of vcs root / cwd
   assert_output_contains "abcdef Something"  # vcs unmerged
 }
@@ -649,6 +677,7 @@ run_test "records no directory for a plain switch" test_plain_switch_records_no_
 run_test "loop exports the recorded directory when servicing a switch" test_loop_switch_exports_recorded_pwd
 run_test "creates session 1 when no sessions exist" test_creates_session_1
 run_test "attaches to disconnected session before creating new one" test_attaches_disconnected_first
+run_test "failed attach does not create a new session" test_failed_attach_does_not_create_new_session
 run_test "returns non-zero when shpool attach fails" test_returns_nonzero_on_failure
 run_test "preserves specific exit code from shpool attach" test_preserves_exit_code
 run_test "loop handles switch request after session ends" test_loop_handles_switch

--- a/back
+++ b/back
@@ -18,5 +18,6 @@ $dest = "${filename}.${suffix}";
 die "Backup file $dest already exists" if (-e $dest);
 
 # do the move
-rename($filename, $dest);
+rename($filename, $dest)
+    or die "Cannot rename $filename to $dest: $!\n";
 

--- a/confback
+++ b/confback
@@ -12,7 +12,9 @@ for dir in conf/ conf.*/; do
   echo "Backing up $dir to $tarball"
 
   cd "$dir"
-  find . '(' -name '.*' ')' -prune -o '(' -type f -o -type l ')' -print0 |
+  # '.?*' rather than '.*' so the start directory '.' itself is not pruned
+  # (which would make every tarball empty).
+  find . '(' -name '.?*' ')' -prune -o '(' -type f -o -type l ')' -print0 |
   pax -w -z -L -0 -f "$HOME/$tarball"
   cd "$OLDPWD"
 done

--- a/confinst
+++ b/confinst
@@ -23,7 +23,9 @@ extract()
 	local confdir
 
 	for confball in "$HOME"/conf*.tar.gz; do
-		confdir="$(basename "$confball" .tar.gz)"
+		test -f "$confball" || continue
+		# Anchor at $HOME so extraction works regardless of the current directory.
+		confdir="$HOME/$(basename "$confball" .tar.gz)"
 
 		if $simulate
 		then

--- a/cwhere
+++ b/cwhere
@@ -39,8 +39,12 @@ get_cpp_output()
     if test $? -ne 0; then
         cat "$sourcefile"
         echo "Error: Cannot run cpp" 1>&2
+        rm -f "$sourcefile"
         exit 1
     fi
+    # This function runs in a pipeline subshell, so the parent's EXIT trap
+    # never sees $sourcefile; clean it up here.
+    rm -f "$sourcefile"
 }
 
 # Print the definition of <identifier> and which header file it appears in

--- a/diskspace
+++ b/diskspace
@@ -63,7 +63,7 @@ foreach my $line (@output)
         write;
     }
     # both -t and -m specified
-    if (defined($threshold) && defined($minimum))
+    elsif (defined($threshold) && defined($minimum))
     {
         if ($percent >= $threshold &&
             $avail < $minimum)

--- a/diskuse
+++ b/diskuse
@@ -161,11 +161,11 @@ sub process_dir
 				print STDERR "Skipping $path (not found)\n" if ! $quiet;
 				next;
 			}
-			if (my $alias = $seen{$dev . $ino}) {
+			if (my $alias = $seen{"$dev:$ino"}) {
 				print STDERR "Skipping $path (same as $alias - dev=$dev ino=$ino)\n" if $debug;
 				next;
 			}
-			$seen{$dev . $ino} = $path;
+			$seen{"$dev:$ino"} = $path;
 
 			if (-d _) {
 				if ($singledevice && $dev != $dirdev) {
@@ -236,6 +236,10 @@ sub bytes_to_units
 	elsif ($units eq "T" || $units eq "TB") {
 		$divider = (1024 * 1024 * 1024 * 1024);
 	}
+	else {
+		print STDERR "Unrecognised size unit $units\n";
+		return $size;
+	}
 
 	return int($size / $divider) . " " . $units;
 }
@@ -274,7 +278,7 @@ sub units_to_bytes
 		$size *= (1024 * 1024 * 1024 * 1024);
 	}
 	else {
-		print STDERR "Unrecognised size unit $sizeunits\n";
+		print STDERR "Unrecognised size unit $units\n";
 		return undef;
 	}
 

--- a/filter
+++ b/filter
@@ -10,13 +10,15 @@ fi
 # Decorate, sort, then undecorate lines to ensure line order is preserved, even
 # if the command uses different buffering (e.g. only produces output after
 # reading all input).
-# Undecorate using whitespace rather than just tabs so we can use "column" as
-# the command (column converts the tab separator into spaces).
+# Undecorate by removing the tab separator when it survived (preserving the
+# line's own leading whitespace), falling back to removing any whitespace so we
+# can use "column" as the command (column converts the tab separator into
+# spaces).
 pattern=$1
 shift
 i=0
 {
-while read -r line; do
+while IFS= read -r line || test -n "$line"; do
     i=$((i+1))
     if [[ "$line" =~ $pattern ]]; then
         printf "%d\t%s\n" "$i" "$line" >&3
@@ -26,4 +28,4 @@ while read -r line; do
 done 3> >("$@")
 } |
 sort -k1n |
-sed 's/^[0-9][0-9]*[[:space:]]*//'
+sed -e 's/^[0-9][0-9]*	//' -e t -e 's/^[0-9][0-9]*[[:space:]]*//'

--- a/first
+++ b/first
@@ -15,6 +15,9 @@ git bisect good $oldest
 git bisect bad $newest
 git bisect run not "$@" >/dev/null
 
-first=$(git_rev)
+# refs/bisect/bad is the first "bad" (here: first succeeding) commit; HEAD is
+# merely the last commit bisect happened to test.
+first=$(git rev-parse refs/bisect/bad)
+git bisect reset >/dev/null
 echo "First revision where $* succeeds:"
 git log -1 $first

--- a/fork
+++ b/fork
@@ -1,9 +1,11 @@
 #!/bin/bash
 url="$1"
-git clone "$url"
+git clone "$url" || exit 1
 dir=${url##*/}
 dir=${dir%.git}
-cd "$dir"
+# Guard the cd: rewriting remotes in whatever repository encloses the current
+# directory would be destructive.
+cd "$dir" || exit 1
 git remote add upstream "$url"
 case "$url" in
 "git@github.com:"*)

--- a/fromto
+++ b/fromto
@@ -7,11 +7,11 @@ use warnings;
 use Getopt::Long;
 
 my $invert;
-my $skip;
+my $skip_boundary;
 my $help;
 my $result = GetOptions(
   "invert|v" => \$invert,
-  "skip|s" => \$skip,
+  "skip|s" => \$skip_boundary,
   "help|h" => \$help);
 
 sub usage
@@ -40,7 +40,6 @@ my $from = shift @ARGV;
 my $to = shift @ARGV;
 
 my $started = 0;
-my $skip_boundary = 0;
 
 sub print_boundary {
   if ($invert) {

--- a/fstabtab.py
+++ b/fstabtab.py
@@ -37,4 +37,9 @@ for line in lines:
         print(line, end='')
     else:
         fields = line.split()
-        print(format % tuple(fields))
+        if not fields:
+            print()
+            continue
+        # pad entries with fewer fields (e.g. no dump/pass columns)
+        fields.extend([''] * (len(fieldlens) - len(fields)))
+        print((format % tuple(fields)).rstrip())

--- a/functions
+++ b/functions
@@ -99,6 +99,7 @@ run()
         if test "$logfile"
         then
             "$@" 2>&1 | tee -a "$logfile"
+            return "${PIPESTATUS[0]}"
         else
             "$@"
         fi
@@ -153,14 +154,16 @@ get_size_of_file_or_directory()
 get_free_space_on_filesystem()
 {
 	(
+    local path
     local tmpdir
     local dfout
 
+    path="$1"
     tmpdir=$(get_temporary_directory)
     dfout="$tmpdir"/df.$$
 	trap 'test -n "$dfout" && rm "$dfout"' EXIT
 
-    df -Pk "$tmpdir" > "$dfout"
+    df -Pk "$path" > "$dfout"
     if test $? -ne 0
     then
         error "Cannot determine free disk space"
@@ -180,7 +183,7 @@ get_free_space_on_filesystem()
 
         i=$((i + 1))
     done < "$dfout"
-    error "Cannot determine free space on $filesystem"
+    error "Cannot determine free space on $path"
     exit 1
 	)
 	return $?
@@ -191,7 +194,7 @@ get_filename_part()
 {
     local location
     location=$(get_location_part "$1")
-    echo "${location##/*/}"
+    echo "${location##*/}"
     return 0
 }
 
@@ -353,6 +356,7 @@ append()
 get_address_helper()
 {
     local host
+    local name
     local type
     local address
     local nameserver
@@ -372,7 +376,7 @@ get_address_helper()
         then
             # read lines of the form
             # endbracket.net          A       203.214.81.131
-            while read host type address
+            while read name type address
             do
                 if test "${type}" = "A"
                 then
@@ -384,7 +388,7 @@ get_address_helper()
         fi
         tries=$(($tries - 1))
     done
-    error "Cannot resolve $host using $nameserver"
+    error "Cannot resolve $host using ${nameserver:-default nameservers}"
 	rm "${tmpfile}"
     return 1
 }
@@ -451,7 +455,6 @@ interface_up()
     i=0
 
     netstat -i > "$_temp"
-    cat $_temp
     if test $? -eq 0
     then
         i=0
@@ -483,7 +486,7 @@ interface_up()
             fi
         done < "$_temp"
     else
-        warning "Cannot run netstat -i, falling back to less reliable ifconfig test"
+        warn "Cannot run netstat -i, falling back to less reliable ifconfig test"
     fi
     rm "$_temp"
 
@@ -520,7 +523,7 @@ internet_reachable()
 # get_script_name
 get_script_name()
 {
-    echo "${0##/*/}"
+    echo "${0##*/}"
 }
 
 ###

--- a/gitbackup
+++ b/gitbackup
@@ -123,7 +123,7 @@ fi
 #   /srv/git/proj1.git
 #   /srv/git/proj2/proj2a.git
 #   /srv/git/proj2/proj2b.git
-for srcdir in $(find "$srcroot" -type d -name "*.git")
+while IFS= read -r srcdir
 do
     info "Starting backup of $srcdir on "$(date +"$dateformat")" at "$(date +"$timeformat")
 
@@ -236,7 +236,7 @@ do
     )
 
     info "Finished backup of $srcdir on "$(date +"$dateformat")" at "$(date +"$timeformat")
-done
+done < <(find "$srcroot" -type d -name "*.git")
 
 info "Finished gitbackup on "$(date +"$dateformat")" at "$(date +"$timeformat")
 

--- a/java-alternatives.sh
+++ b/java-alternatives.sh
@@ -273,6 +273,8 @@ get_mapped_directory()
 # determine where each file (program, man page, etc.)
 # should be installed to and build the command line args to
 # update-alternatives --install...
+install=
+slaves=
 files=$(for subdir in $subdirs; do find $basedir/$subdir -type f -print; done)
 for file in $files; do
   
@@ -327,6 +329,11 @@ for file in $files; do
 		notice "Skipping $file: already in use"
 	fi
 done
+
+if test -z "$install"; then
+	error "No bin/java found under $basedir; not running update-alternatives"
+	exit 1
+fi
 
 # TODO: bin/java should honor $dirmap too
 # $slaves already has a newline before it, so don't add one here too

--- a/mdf_test
+++ b/mdf_test
@@ -25,6 +25,7 @@ assert_status() {
     if test "$status" -ne "$1"; then
         echo "  FAIL: expected exit status $1, got $status"
         echo "  output: $output"
+        TEST_FAILED=1
         return 1
     fi
 }
@@ -35,6 +36,7 @@ assert_output_equals() {
         echo "  FAIL: output mismatch"
         echo "  expected: $(printf '%s' "$expected" | sed -n l)"
         echo "  actual:   $(printf '%s' "$output" | sed -n l)"
+        TEST_FAILED=1
         return 1
     fi
 }
@@ -45,6 +47,7 @@ assert_output_contains() {
         *)
             echo "  FAIL: output does not contain '$1'"
             echo "  output: $output"
+            TEST_FAILED=1
             return 1
             ;;
     esac
@@ -54,7 +57,11 @@ run_test() {
     name="$1"
     func="$2"
     TESTS_RUN=$((TESTS_RUN + 1))
-    if "$func"; then
+    # TEST_FAILED catches asserts that fail mid-test: running "$func" as an
+    # `if` condition disables `set -e` inside it, so a failed assert that is
+    # not the last statement would otherwise be ignored.
+    TEST_FAILED=
+    if "$func" && test -z "$TEST_FAILED"; then
         echo "ok $TESTS_RUN $name"
         TESTS_PASSED=$((TESTS_PASSED + 1))
     else

--- a/new
+++ b/new
@@ -12,4 +12,5 @@ if test -f "$template"; then
 	cp "$template" "$filename"
 else
 	echo "There is no template for .$extension files, creating empty file"
+	touch "$filename"
 fi

--- a/notepad
+++ b/notepad
@@ -1,2 +1,2 @@
 #!/bin/bash
-scite
+scite "$@"

--- a/package
+++ b/package
@@ -89,8 +89,12 @@ case "$1" in
         ;;
 esac
 
-# Use cached backend or detect it.
-PACKAGE_BACKEND="${PACKAGE_BACKEND:-$(detect_backend)}"
+# Use cached backend or detect it. The || exit matters: detect_backend's
+# "exit 1" only exits the command-substitution subshell, so the failure has to
+# be propagated here.
+if test -z "$PACKAGE_BACKEND"; then
+    PACKAGE_BACKEND="$(detect_backend)" || exit 1
+fi
 export PACKAGE_BACKEND
 
 command="$1"

--- a/package_test
+++ b/package_test
@@ -39,9 +39,12 @@ teardown() {
     rm -rf "$TEST_TMPDIR"
 }
 
+# Runs package with PACKAGE_TEST_PATH (when set) as the PATH, so backend
+# detection tests can hide the host's real package managers without
+# disturbing the PATH this test script itself runs under.
 run_package() {
     set +e
-    output="$("$SCRIPT_DIR/package" "$@" 2>&1)"
+    output="$(PATH="${PACKAGE_TEST_PATH:-$PATH}" "$SCRIPT_DIR/package" "$@" 2>&1)"
     status=$?
     set -e
 }
@@ -51,6 +54,7 @@ assert_status() {
     if test "$status" -ne "$expected"; then
         echo "  FAIL: expected exit status $expected, got $status"
         echo "  output: $output"
+        TEST_FAILED=1
         return 1
     fi
 }
@@ -61,6 +65,7 @@ assert_output_contains() {
         *)
             echo "  FAIL: output does not contain '$1'"
             echo "  output: $output"
+            TEST_FAILED=1
             return 1
             ;;
     esac
@@ -71,6 +76,7 @@ assert_output_not_contains() {
         *"$1"*)
             echo "  FAIL: output should not contain '$1'"
             echo "  output: $output"
+            TEST_FAILED=1
             return 1
             ;;
         *) ;;
@@ -81,6 +87,7 @@ assert_called() {
     if ! grep -q "$1" "$TEST_TMPDIR/calls" 2>/dev/null; then
         echo "  FAIL: expected call '$1' not found"
         echo "  calls: $(cat "$TEST_TMPDIR/calls" 2>/dev/null)"
+        TEST_FAILED=1
         return 1
     fi
 }
@@ -89,6 +96,7 @@ assert_not_called() {
     if grep -q "$1" "$TEST_TMPDIR/calls" 2>/dev/null; then
         echo "  FAIL: unexpected call '$1' found"
         echo "  calls: $(cat "$TEST_TMPDIR/calls" 2>/dev/null)"
+        TEST_FAILED=1
         return 1
     fi
 }
@@ -98,7 +106,12 @@ run_test() {
     func="$2"
     TESTS_RUN=$((TESTS_RUN + 1))
     setup
-    if "$func"; then
+    # TEST_FAILED catches asserts that fail mid-test: running "$func" as an
+    # `if` condition disables `set -e` inside it, so a failed assert that is
+    # not the last statement would otherwise be ignored.
+    TEST_FAILED=
+    PACKAGE_TEST_PATH=
+    if "$func" && test -z "$TEST_FAILED"; then
         echo "ok $TESTS_RUN $name"
         TESTS_PASSED=$((TESTS_PASSED + 1))
     else
@@ -148,7 +161,7 @@ test_list_commands() {
 
 test_list_commands_one_per_line() {
     run_package --list-commands
-    assert_status 0
+    assert_status 0 || return 1
     count=$(echo "$output" | wc -l)
     if test "$count" -ne 14; then
         echo "  FAIL: expected 14 lines, got $count"
@@ -172,14 +185,18 @@ test_detects_dnf_first() {
 }
 
 test_detects_yum_without_dnf() {
+    # Restrict PATH to the mock dir so the host's real dnf is not found.
     rm "$TEST_TMPDIR/bin/dnf"
+    PACKAGE_TEST_PATH="$TEST_TMPDIR/bin"
     run_package search foo
     assert_status 0 &&
     assert_called "yum"
 }
 
 test_detects_apt_get_without_dnf_or_yum() {
+    # Restrict PATH to the mock dir so the host's real dnf/yum are not found.
     rm "$TEST_TMPDIR/bin/dnf" "$TEST_TMPDIR/bin/yum"
+    PACKAGE_TEST_PATH="$TEST_TMPDIR/bin"
     run_package search foo
     assert_status 0 &&
     assert_called "apt-cache"
@@ -188,7 +205,8 @@ test_detects_apt_get_without_dnf_or_yum() {
 test_error_no_package_manager() {
     # Use empty PATH so no real system package managers are found either
     mkdir -p "$TEST_TMPDIR/empty"
-    PATH="$TEST_TMPDIR/empty" run_package search foo
+    PACKAGE_TEST_PATH="$TEST_TMPDIR/empty"
+    run_package search foo
     assert_status 1 &&
     assert_output_contains "no supported package manager found"
 }

--- a/packageinfo
+++ b/packageinfo
@@ -15,9 +15,21 @@ sed -n '
   s/.*versionName=\([^ ]*\).*/(\1)/
   H
 }
+$ {
+  x
+  /./ {
+    s/\n/ /g
+    p
+  }
+}
 b
 :print
 s/\n/ /g
 p
+$ {
+  x
+  s/\n/ /g
+  p
+}
 b
 ' "$1"

--- a/pidcat
+++ b/pidcat
@@ -106,7 +106,10 @@ if args.current_app and args.filename:
 if args.current_app:
   system_dump_command = base_adb_command + ["shell", "dumpsys", "activity", "activities"]
   system_dump = subprocess.Popen(system_dump_command, stdout=PIPE, stderr=PIPE).communicate()[0]
-  running_package_name = re.search(".*TaskRecord.*A[= ]([^ ^}]*)", str(system_dump)).group(1)
+  match = re.search(".*TaskRecord.*A[= ]([^ ^}]*)", system_dump.decode('utf-8', 'replace'))
+  if match is None:
+    parser.error('Could not find the current app in the dumpsys output; is a device connected?')
+  running_package_name = match.group(1)
   package.append(running_package_name)
 
 if len(package) == 0:
@@ -145,7 +148,9 @@ def colorize(message, fg=None, bg=None):
   return termcolor(fg, bg) + message + RESET if stdout_isatty else message
 
 def indent_wrap(message):
-  if width == -1:
+  # No wrapping if the terminal is narrower than the header, otherwise the
+  # loop below cannot make progress.
+  if width == -1 or width <= header_size:
     return message
   message = message.replace('\t', '    ')
   wrap_area = width - header_size

--- a/precommit
+++ b/precommit
@@ -7,12 +7,19 @@ source ~/.shrc.vcs
 allknown
 
 rootdir="$PWD"
-while IFS=$'\n' read path; do
+tested=""
+while IFS= read -r path; do
+    test -n "$path" || continue
     cd "$rootdir"
     cd "$(dirname "$path")"
     while test "$PWD" != "/"; do
       test -f .Makefile && break
       cd ..
     done
+    # No .Makefile anywhere up the tree: nothing to test for this path.
+    test -f .Makefile || continue
+    # Run the tests once per project, not once per changed file.
+    case "$tested" in *"|$PWD|"*) continue ;; esac
+    tested="$tested|$PWD|"
+    make -f .Makefile test
 done <<<"$(changed)"
-make -f .Makefile test

--- a/pulseprofile.py
+++ b/pulseprofile.py
@@ -31,12 +31,14 @@ def next_profile(output, card_index):
     profiles = []
     profile_nums = {}
     profile_num = 0
-    want = ('    index: %d' % card_index).encode()
     for line in output.splitlines():
-        if line.startswith(want):
-            in_card = True
-        elif line.startswith(b'    index: '):
-            in_card = False
+        # Card headers look like "    index: 1" ("  * index: 1" for the
+        # default card). Compare the parsed number, not a string prefix, so
+        # card 1 does not match cards 10, 11, ...
+        stripped = line.lstrip(b' *')
+        if stripped.startswith(b'index: '):
+            index = int(stripped.split(b':', 1)[1].strip().split()[0])
+            in_card = index == card_index
         if not in_card:
             continue
         if line == (b'\tprofiles:'):
@@ -46,7 +48,9 @@ def next_profile(output, card_index):
             in_profiles = False
             active_profile = line.split(b':', 1)[1].strip().strip(b'<>')
             logger.debug('active profile = %s', active_profile)
-            active_index = profile_nums[active_profile]
+            # The active profile may not be in the dict (e.g. "off" is
+            # skipped); fall back to -1 so the next profile is the first one.
+            active_index = profile_nums.get(active_profile, -1)
             next_index = active_index + 1
             if next_index >= len(profiles):
                 next_index = 0
@@ -77,8 +81,12 @@ def main():
 
     sinks = subprocess.run(['pacmd', 'list-sinks'], capture_output=True)
     card_index = get_active_card_index(sinks.stdout)
+    if card_index is None:
+        sys.exit('pulseprofile: cannot find the default sink\'s card')
     cards = subprocess.run(['pacmd', 'list-cards'], capture_output=True)
     profile = next_profile(cards.stdout, card_index)
+    if profile is None:
+        sys.exit('pulseprofile: cannot find a profile for card %d' % card_index)
     logger.info('Setting profile to %s', profile)
     subprocess.run(['pacmd', 'set-card-profile', str(card_index), profile])
 

--- a/sbtnew
+++ b/sbtnew
@@ -1,6 +1,6 @@
 #!/bin/bash
 tildepwd() {
-    echo "$PWD" | sed "s#^$HOME/#~/#;s#^$HOME$/#~#"
+    echo "$PWD" | sed "s#^$HOME/#~/#;s#^$HOME"'$#~#'
 }
 cd ~/src
 echo "Creating $(tildepwd)/$1"

--- a/showconn
+++ b/showconn
@@ -1,2 +1,2 @@
 #!/bin/sh
-nmcli --terse -f NAME conn show --active | grep -v lo | tr '\n' ' '
+nmcli --terse -f NAME conn show --active | grep -vx lo | tr '\n' ' '

--- a/untar
+++ b/untar
@@ -57,6 +57,10 @@ foreach my $extension (keys %flags_for_extension) {
 	}
 }
 
+if (!$known_extension) {
+	die "untar: Cannot untar $tarfile: unknown file extension\n";
+}
+
 my $tempdir;
 if ($safe) {
 	$tempdir = tempdir $tarfile_without_extension . ".XXXX", DIR => "."
@@ -70,10 +74,6 @@ else {
 	print STDERR "untar: Unsafe mode, expanding into current directory\n";
 }
 
-if (!$known_extension) {
-	die "untar: Cannot untar $tarfile: unknown file extension\n";
-}
-
 push @flags, "-f", $tarfile;
 
 my $status = system $tar, @flags;
@@ -83,6 +83,7 @@ if ($status != 0) {
 		print STDERR "untar: Removing temporary directory $tempdir\n";
 		remove_tree($tempdir);
 	}
+	exit 1;
 }
 
 sub file_description {


### PR DESCRIPTION
A bug hunt across all scripts in the repo. Every fix below was verified against the code, and the impactful ones were reproduced before fixing. All test suites pass: autoshpool_test 38/38 (one new regression test), package_test 50/50, mdf_test 14/14.

## Highlights (silent data loss / destructive)

- **confback**: `find . -name '.*' -prune` pruned the start directory `.` itself, so **every backup tarball was created empty**. Reproduced; now uses `.?*`.
- **autoshpool**: when attaching to an existing disconnected session failed, the `attach_first_disconnected || create_and_attach_next` fallback silently created a brand-new session instead of reporting the error (defeating the loop's "stay connected so the user can see the error" design). Reproduced via the test mock; added a regression test.
- **fork**: an unchecked `cd` meant a failed clone would rewrite `origin` and push in whatever repository encloses the current directory.
- **back**: `rename()` was unchecked, so a failed backup exited 0 while the caller believed the file was backed up.
- **untar**: exited 0 when tar failed; also leaked the temp directory on unknown extensions.
- **confinst -e**: extracted relative to the current directory instead of `$HOME`, and ran on the literal glob when no tarballs exist.

## Wrong results

- **fromto -s** did nothing (option stored in `$skip`, code tested `$skip_boundary`).
- **diskspace -a** printed/counted matching filesystems twice (`if` instead of `elsif`) and corrupted the exit status.
- **diskuse**: hard-link dedup key `$dev . $ino` collides (dev 1/ino 23 == dev 12/ino 3), silently skipping distinct files; division-by-zero crash on unknown `-u` units.
- **packageinfo** never printed the last package (no EOF flush in the sed script).
- **autoshpool/shpoollist**: `status_icon` matched `detached`, a status shpool never reports (it says `disconnected`), so every disconnected session rendered as `?`; `SHPOOL_PREFIX` was interpolated into an awk regex, so prefixes with `.`/`+` matched the wrong sessions.
- **first** reported HEAD (last commit bisect tested) instead of `refs/bisect/bad`, and left the repo in bisect state.
- **filter** stripped indentation from pass-through lines (both in `read` and the undecorating `sed`) and dropped a final unterminated line.
- **showconn**: `grep -v lo` removed any connection whose *name contains* "lo" (e.g. "VeloWifi"); now exact-match.
- **functions**: `get_free_space_on_filesystem` ignored its argument and always reported the temp dir's filesystem; `interface_up` had a debug-leftover `cat` that corrupted stdout and made the status check test the wrong command, plus a call to undefined `warning`; `run()` returned `tee`'s status instead of the command's when logging; `${0##/*/}` is the wrong basename pattern (fails for `./script`, breaking syslog tags); `get_address_helper` clobbered its hostname variable.
- **precommit** ran `make` once, after the loop, in whatever directory the last changed file left it in; now runs once per project that has a `.Makefile`.
- **package**: `detect_backend`'s `exit 1` only exited the command-substitution subshell, producing a second misleading "unsupported backend ''" error.
- **sbtnew**: misplaced `/` in the sed pattern meant `$HOME` was never shown as `~`.
- **new** said "creating empty file" but didn't; **notepad** dropped its file arguments.

## Crashes

- **pidcat**: `indent_wrap` infinite-loops (unbounded memory) on terminals narrower than the header; `--current` raised AttributeError when dumpsys output didn't match (also now decodes bytes instead of regexing over `repr()`).
- **pulseprofile.py**: KeyError when the active profile is `off` (i.e. exactly when you want sound back); card "index: 1" prefix-matched cards 10, 11, …; None propagation when there is no default sink.
- **fstabtab.py**: TypeError on blank lines or fstab entries with fewer fields than the widest row.
- **java-alternatives.sh**: with no `bin/java` found, ran a malformed `update-alternatives` command under sudo (`$install` never initialized); now errors out.
- **gitbackup**: unquoted `$(find ...)` split repo paths containing spaces.

## Test-suite fixes

- In all three suites (autoshpool_test, package_test, mdf_test), a failed assert that wasn't the last statement of a test **could not fail the test**: `if "$func"` disables `set -e` inside the function, and only the last command's status counted. Asserts now set a `TEST_FAILED` flag the harness checks. (This was masking a real failing assertion in test 34.)
- autoshpool_test fixtures used a `connected` status that real shpool never reports (it uses `attached`); the shpoollist test asserted the raw word "connected", which `describe_shell` never prints — it now asserts the actual icon.
- package_test's backend-detection tests inherited the host PATH, so they would invoke the *real* dnf/yum on machines that have them; they now run with PATH restricted to the mock dir.

## Found but intentionally not fixed (need owner judgment)

- **set-ssh-alias.py**: block matching misses `Host<tab>alias`/lowercase `host`, and removal deletes the whole block even when the alias shares it with other hosts (`Host alias other`) — fixing changes user-visible semantics.
- **shpoolps**: the `envgrep 'SHPOOL_SESSION_NAME=.*'` pattern is unanchored and multiple matches get concatenated by `tr -d '\0'`; `envgrep` lives in `~/.shrc` outside this repo, so I couldn't verify the right fix.
- **setup-kde**: `set_shortcut "Krohnkite: Grow Width" "Meta+\\\\"` writes an over-escaped backslash, and `"Meta+,"` collides with kglobalaccel's comma-separated list format — both need a KDE session to verify.
- **chrome**: falls back to `google-chrome-beta` on *any* nonzero exit, not just "not installed"; **clocks**: date-only arguments (`clocks 2026-06-10`) fail in GNU date; **editline** references an undefined `editor_args` array (currently harmless); **total** prints an empty line instead of `0` for empty input.

https://claude.ai/code/session_01UExZuzWHLnVjz17yjNuJ7n

---
_Generated by [Claude Code](https://claude.ai/code/session_01UExZuzWHLnVjz17yjNuJ7n)_