### PR TITLE
Anchor envgrep pattern in shpoolps

### DIFF
--- a/shpoolps
+++ b/shpoolps
@@ -10,8 +10,10 @@ pgrep -U "$(whoami)" -f -- '^-(bash|zsh)$' | while read pid; do
   shpool) ;;
   *) continue;;
   esac
-  # Get the shpool session name.
-  shpool_session_name=$(envgrep 'SHPOOL_SESSION_NAME=.*' $pid | tr -d '\0')
+  # Get the shpool session name. Anchor the pattern so variables like
+  # OLD_SHPOOL_SESSION_NAME don't match, and take only the first match so
+  # multiple matches can't be concatenated into one garbage string.
+  shpool_session_name=$(envgrep '^SHPOOL_SESSION_NAME=.*' $pid | tr '\0' '\n' | head -n 1)
   if test -n "$shpool_session_name"; then
     shpool_session_name=$(cut -f 2- -d = <<<"$shpool_session_name")
     # Get a one-line list of the children.


### PR DESCRIPTION
Follow-up to #70 (the one `shpoolps` finding left for owner judgment).

The unanchored `envgrep 'SHPOOL_SESSION_NAME=.*'` matched any environ entry *containing* that substring (e.g. `OLD_SHPOOL_SESSION_NAME=x`), and `tr -d '\0'` then concatenated multiple matches into a single garbage string before the `cut`.

Now the pattern is anchored with `^` and only the first match is used (`tr '\0' '\n' | head -n 1`), matching how autoshpool's own environ parsing is anchored.

Note: I couldn't exercise `envgrep` itself since it lives in `~/.shrc` outside this repo — worth a quick local run of `shpoolps` to confirm.

https://claude.ai/code/session_01UExZuzWHLnVjz17yjNuJ7n

---
_Generated by [Claude Code](https://claude.ai/code/session_01UExZuzWHLnVjz17yjNuJ7n)_