### PR TITLE
Fix bugs found in a second bug-hunt pass

### DIFF
--- a/browser3
+++ b/browser3
@@ -1,1 +1,3 @@
+#!/bin/bash
+. "$HOME/.shrc"
 chrome --user-data-dir="$HOME/.config/google-chrome-profile3" "$@"

--- a/codeedit
+++ b/codeedit
@@ -16,6 +16,9 @@ args=("$@")
 for ((i=0; i<${#args[@]}; i++)); do
     arg="${args[i]}"
     case "$arg" in +*)
+        # only convert when a filename precedes; args[-1] would clobber
+        # the last element
+        test "$i" -gt 0 || continue
         file="${args[i-1]}"
         line="${arg#+}"
         args[i-1]="--goto"

--- a/diskuse
+++ b/diskuse
@@ -172,7 +172,7 @@ sub process_dir
 					print STDERR "Skipping $path (different device)\n" if $debug;
 					next;
 				}
-				process_dir ($path, \@fileinfo);
+				process_dir ($path, $fileinforef);
 				if ($subdirsize) {
 					$dirsize{$dir} += $dirsize{$path};
 				}
@@ -198,12 +198,11 @@ sub process_dir
 				}
 			}
 		}
+		closedir($dirhandle);
 	}
 	else {
 		print STDERR "Can't open $dir: $!\n";
 	}
-
-	closedir($dirhandle);
 }
 
 # given a size in bytes and a unit, return a string describing that size in those units
@@ -360,10 +359,14 @@ if ($quiet) {
 
 if ($maxage =~ /(\d*)(\D+)/) {
 	$maxage = units_to_seconds($1, $2);
+	# don't run with the age filter silently disabled
+	defined($maxage) or exit 2;
 }
 
 if ($minsize =~ /(\d*)([A-Za-z]+)$/) {
 	$minsize = units_to_bytes($1, $2);
+	# don't run with the size filter silently disabled
+	defined($minsize) or exit 2;
 }
 
 # TODO get file system device id, skip files on other devices

--- a/editline
+++ b/editline
@@ -1,12 +1,19 @@
 #!/bin/bash
 declare -a args
 for arg in "$@"; do
-    file="${arg%:[0-9]*}"
-    file="$(realpath "$file")"
-    args+=("$file")
-    case "$arg" in *:*)
-        num="${arg##*:}"
-        args+=("+$num")
+    num="${arg##*:}"
+    case "$num" in
+    ''|*[!0-9]*)
+        # no numeric :line suffix (the whole arg when there is no colon)
+        args+=("$(realpath "$arg")")
+        ;;
+    *)
+        if test "$num" = "$arg"; then
+            # no colon at all
+            args+=("$(realpath "$arg")")
+        else
+            args+=("$(realpath "${arg%:*}")" "+$num")
+        fi
         ;;
     esac
 done

--- a/editroot
+++ b/editroot
@@ -22,12 +22,21 @@ if test $# -eq 0; then
     "$EDITOR"
 else
     line=${1##*:}
-    if test "$line" != "$1"; then
-      file=${1%:$line}
-    else
+    case "$line" in
+    *[!0-9]*|'')
+      # not a pure line number (or no colon suffix at all)
       file=$1
       line=
-    fi
+      ;;
+    *)
+      if test "$line" != "$1"; then
+        file=${1%:$line}
+      else
+        file=$1
+        line=
+      fi
+      ;;
+    esac
 
     set -- "$file" ${line:++$line}
 

--- a/exectrace
+++ b/exectrace
@@ -1,5 +1,5 @@
 #!/bin/bash
-
-exec 3>&1
-exec 4>&2
-strace -e trace=execve -f "$@" 2>&1 1>&3 | grep execve | sed -e 's/^\[pid[^]]*\] //' 1>&4
+# Print the commands a program executes, without disturbing its own output.
+# The trace is piped through -o so the traced program keeps stdout and stderr
+# to itself (redirecting fd 2 would also swallow the program's own errors).
+exec strace -e trace=execve -f -o '|grep execve | sed -e "s/^ *[0-9]*  *//" >&2' "$@"

--- a/gitinitremote
+++ b/gitinitremote
@@ -166,7 +166,15 @@ if ! $localalreadyrepo; then
 fi
 
 # the initial branch may be master or main depending on init.defaultBranch
-refspec=$(git symbolic-ref --short HEAD)                                        || die "cannot determine current branch"
+if ! refspec=$(git symbolic-ref --short HEAD 2>/dev/null); then
+	if $simulate; then
+		# in simulate mode the repo may not actually have been created;
+		# use the branch git init would create
+		refspec=$(git config --get init.defaultBranch) || refspec=master
+	else
+		die "cannot determine current branch"
+	fi
+fi
 
 # git push does not accept --quiet option
 run git push "$remotename" "$refspec"                                           || die "git push failed"

--- a/gitinitremote
+++ b/gitinitremote
@@ -50,7 +50,7 @@ EOF
 
 # defaults
 remotename=origin	# what to call the remote
-refspec=master		# refspec ("branch") to push - can't be changed yet
+refspec=			# refspec ("branch") to push - taken from HEAD after the initial commit
 local=$PWD			# local directory to create the repository out of
 simulate=false
 
@@ -165,13 +165,16 @@ if ! $localalreadyrepo; then
 	run git commit --quiet --message "Initial commit" "$local"                  || die "git commit failed"
 fi
 
+# the initial branch may be master or main depending on init.defaultBranch
+refspec=$(git symbolic-ref --short HEAD)                                        || die "cannot determine current branch"
+
 # git push does not accept --quiet option
 run git push "$remotename" "$refspec"                                           || die "git push failed"
 
 # make the new remote the "upstream" (make "pull" without args work)
 # in git >= 1.7, this can be done by adding the "-u" flag to "push"
-run git config branch.master.remote "$remotename"
-run git config branch.master.merge refs/heads/"$refspec"
+run git config branch."$refspec".remote "$remotename"
+run git config branch."$refspec".merge refs/heads/"$refspec"
 
 notice "Successfully created remote $remote as $remotename"
 

--- a/google-music
+++ b/google-music
@@ -1,2 +1,2 @@
 #!/bin/bash
-exec chrome --app="https://music.google.com" ${CHROME_MUSIC_USER_DATA_DIR+--user-data-dir="$CHROME_MUSIC_USER_DATA_DIR"}
+exec chrome --app="https://music.google.com" ${CHROME_MUSIC_USER_DATA_DIR:+--user-data-dir="$CHROME_MUSIC_USER_DATA_DIR"}

--- a/he
+++ b/he
@@ -6,7 +6,7 @@
 # he bash continue
 # he rsync -v
 
-scriptname=he
+scriptname=${0##*/}
 
 usage()
 {
@@ -27,8 +27,13 @@ if test $# -lt 1; then
 fi
 
 manpage="$1"
-# show the SYNOPSIS section if no section or option was given
-option="${2:-SYNOPSIS}"
+# with no section or option given, show the section matching the name this
+# script was invoked as: desc shows DESCRIPTION, he/syn show SYNOPSIS
+case $scriptname in
+desc) default_section=DESCRIPTION;;
+*)    default_section=SYNOPSIS;;
+esac
+option="${2:-$default_section}"
 
 # handle manpage(number)
 case $manpage in *\(*\))
@@ -41,9 +46,11 @@ case $manpage in *\(*\))
 esac
 
 he() {
-perl -n -e '
+# the option is passed via the environment so quotes, $, @, spaces, etc. in
+# it can't break the shell quoting or interpolate in the perl string
+OPTION="$option" perl -n -e '
 BEGIN {
-    $option = "'$option'";
+    $option = $ENV{OPTION};
     $inside_option = 0;
 }
 if (!$inside_option) {

--- a/mailifnotempty
+++ b/mailifnotempty
@@ -14,17 +14,13 @@ my $subject = shift @ARGV;
 if (!eof(STDIN))
 {
 
-    my $command = '/usr/bin/mail';
-    if (defined($subject))
-    {
-        $command .= sprintf ' -s "%s"', $subject;
-    }
-    if (defined($address))
-    {
-        $command .= sprintf ' "%s"', $address;
-    }
-    open(PIPE, "|$command")
-        or die "Cannot invoke $command";
+    # list form so quotes/$/backticks in the subject or address can't be
+    # interpreted by a shell
+    my @command = ('/usr/bin/mail');
+    push @command, '-s', $subject if defined($subject);
+    push @command, $address;
+    open(PIPE, '|-', @command)
+        or die "Cannot invoke @command";
 
     while ($line = <STDIN>)
     {

--- a/media
+++ b/media
@@ -1,3 +1,4 @@
+#!/bin/sh
 # Control media playback.
 
 send_key() {
@@ -20,5 +21,6 @@ up)
 stop)
     send_key XF86AudioStop;;
 *)
-    printf 'media: Unknown command %s\n' "$1" >&2;;
+    printf 'media: Unknown command %s\n' "$1" >&2
+    exit 2;;
 esac

--- a/screensaver
+++ b/screensaver
@@ -56,4 +56,12 @@ maybe_xscreensaver() {
   esac
 }
 
+case "${1:-}" in
+  init|lock) ;;
+  *)
+    echo "Usage: ${0##*/} init|lock" 1>&2
+    exit 2
+    ;;
+esac
+
 maybe_xsecurelock "$@" || maybe_xscreensaver "$@" || maybe_xfce4_screensaver "$@" || exit 1

--- a/screenshot
+++ b/screenshot
@@ -15,6 +15,11 @@ window=false
 while test $# -gt 0; do
   case "$1" in
   -d|--delay)
+    if test $# -lt 2; then
+      echo "Option $1 requires an argument" 1>&2
+      usage
+      exit 2
+    fi
     delay=$2
     shift
     ;;
@@ -44,7 +49,7 @@ while test $# -gt 0; do
   shift
 done
 
-cd "$HOME/Pictures"
+cd "$HOME/Pictures" || exit 1
 
 sleep $delay
 

--- a/screenshot-window
+++ b/screenshot-window
@@ -1,1 +1,2 @@
+#!/bin/sh
 screenshot -w

--- a/setup
+++ b/setup
@@ -483,9 +483,11 @@ KEYBOARD
             return
             ;;
     esac
-    # Apply to current X/Wayland session if running
+    # Apply to current X/Wayland session if running. Don't let a failure
+    # (e.g. Wayland without Xwayland) abort the whole bootstrap under set -e.
     if command -v setxkbmap >/dev/null 2>&1 && test -n "${DISPLAY:-${WAYLAND_DISPLAY:-}}"; then
-        setxkbmap -layout us -variant dvorak -option "" -option compose:caps
+        setxkbmap -layout us -variant dvorak -option "" -option compose:caps \
+            || warn "setxkbmap failed; keyboard layout not applied to this session"
     fi
 }
 

--- a/setup-kde
+++ b/setup-kde
@@ -52,14 +52,16 @@ install_krohnkite() {
     cd "$KROHNKITE_DIR"
 
     # Build using go-task (preferred) or make (fallback). The binary is
-    # named "task" when installed via go install (see setup), "go-task" when
-    # installed from Fedora's package.
-    if command -v task >/dev/null 2>&1; then
-        info "Building Krohnkite with task"
-        task package
-    elif command -v go-task >/dev/null 2>&1; then
+    # named "go-task" from Fedora's package, or "task" when installed via
+    # go install (see setup) -- but "task" can also be Taskwarrior, so
+    # check the version banner before trusting it.
+    if command -v go-task >/dev/null 2>&1; then
         info "Building Krohnkite with go-task"
         go-task package
+    elif command -v task >/dev/null 2>&1 \
+            && task --version 2>/dev/null | grep -q '^Task version'; then
+        info "Building Krohnkite with task"
+        task package
     elif test -f Makefile; then
         info "Building Krohnkite with make"
         make

--- a/setup-kde
+++ b/setup-kde
@@ -51,8 +51,13 @@ install_krohnkite() {
 
     cd "$KROHNKITE_DIR"
 
-    # Build using go-task (preferred) or make (fallback)
-    if command -v go-task >/dev/null 2>&1; then
+    # Build using go-task (preferred) or make (fallback). The binary is
+    # named "task" when installed via go install (see setup), "go-task" when
+    # installed from Fedora's package.
+    if command -v task >/dev/null 2>&1; then
+        info "Building Krohnkite with task"
+        task package
+    elif command -v go-task >/dev/null 2>&1; then
         info "Building Krohnkite with go-task"
         go-task package
     elif test -f Makefile; then
@@ -273,7 +278,7 @@ remove_stale_app_shortcut_groups() {
 import re, sys, pathlib
 p = pathlib.Path(sys.argv[1])
 text = p.read_text()
-new = re.sub(r'(?ms)^\[scripts-[^\]]+\.desktop\]\n(?:(?!^\[).*\n?)*', '', text)
+new = re.sub(r'(?m)^\[scripts-[^\]]+\.desktop\]\n(?:(?!\[).*\n?)*', '', text)
 if new != text:
     p.write_text(new)
 PY

--- a/setup-macos
+++ b/setup-macos
@@ -39,7 +39,7 @@ configure_keyboard() {
     # This adds Dvorak; the user may still need to remove other layouts in System Settings
     defaults write com.apple.HIToolbox AppleCurrentKeyboardLayoutInputSourceID \
         "com.apple.keylayout.Dvorak"
-    defaults write com.apple.HIToolbox AppleEnabledInputSources -array \
+    defaults write com.apple.HIToolbox AppleEnabledInputSources -array-add \
         '<dict><key>InputSourceKind</key><string>Keyboard Layout</string><key>KeyboardLayout ID</key><integer>16300</integer><key>KeyboardLayout Name</key><string>Dvorak</string></dict>'
 
     # Disable auto-correct, auto-capitalize, smart quotes/dashes
@@ -206,7 +206,7 @@ configure_app_shortcuts() {
             <key>NSMenuItem</key>
             <dict>
                 <key>default</key>
-                <string>Launch WORKFLOWNAME</string>
+                <string>WORKFLOWNAME</string>
             </dict>
             <key>NSMessage</key>
             <string>runWorkflowAsService</string>

--- a/terminal
+++ b/terminal
@@ -6,7 +6,16 @@ exec_dash_e() {
   program=$1
   shift
   test $# -eq 0 && exec "$program"
-  exec "$program" -e "$*"
+  # -e takes a single string the terminal re-parses with shell-style
+  # splitting, so quote each argument to preserve the word boundaries.
+  exec "$program" -e "$(printf '%q ' "$@")"
+}
+exec_dash_e_args() {
+  program=$1
+  shift
+  test $# -eq 0 && exec "$program"
+  # xterm-style -e: the command and its arguments follow as separate words.
+  exec "$program" -e "$@"
 }
 exec_positional() {
   program=$1
@@ -22,4 +31,4 @@ exists mate-terminal && exec_dash_e mate-terminal "$@"
 exists gnome-terminal && exec_positional gnome-terminal "$@"
 exists terminator && exec_dash_e terminator "$@"
 exists sakura && exec_dash_e sakura "$@"
-exists xterm && exec_dash_e xterm "$@"
+exists xterm && exec_dash_e_args xterm "$@"

--- a/youtube-music
+++ b/youtube-music
@@ -1,3 +1,3 @@
 #!/bin/bash
 . "$HOME/.shrc"
-exec chrome --app="https://music.youtube.com" ${CHROME_MUSIC_USER_DATA_DIR+--user-data-dir="$CHROME_MUSIC_USER_DATA_DIR"}
+exec chrome --app="https://music.youtube.com" ${CHROME_MUSIC_USER_DATA_DIR:+--user-data-dir="$CHROME_MUSIC_USER_DATA_DIR"}


### PR DESCRIPTION
A second, deeper pass over the files the first hunt (#70, #72) covered lightly — the big `setup*` scripts and the small launchers. ~20 new bugs, the important ones reproduced before fixing. Test suites still pass (38 + 14 + 50).

## Destructive / high impact

- **setup-kde**: `remove_stale_app_shortcut_groups` used a `(?ms)` regex where the DOTALL flag made `.*` consume to end-of-file, so removing one stale `[scripts-*.desktop]` group **deleted every group after it in `kglobalshortcutsrc`** (verified: `[plasmashell]`, `[services]` etc. wiped). Now `(?m)` only — verified it removes exactly the stale group.
- **terminal**: the `-e`-style terminals got `"$*"`, which flattens argument boundaries; `terminal_on_workstation`'s `bash -i -c '…'` was re-split by the terminal so the ssh never ran on xfce4/mate/terminator/sakura. Arguments are now `printf '%q '`-quoted into the `-e` string, and xterm gets them positionally (its `-e` consumes the rest of argv).
- **setup-macos**: the workflow Info.plist template said `Launch WORKFLOWNAME` while every caller already passes names beginning with "Launch ", so the Services menu items were named "Launch Launch …" and the `pbs NSServicesStatus` keys never matched — **none of the Option+key launcher shortcuts ever bound**.
- **setup-macos**: `defaults write … AppleEnabledInputSources -array` *replaces* all input sources with just Dvorak (killing other layouts/IMEs); the comment says "adds", so it's now `-array-add`.

## Wrong results

- **he / desc / syn**: `desc` and `syn` are symlinks to `he`, but `he` never looked at `$0`, so all three showed SYNOPSIS. The default section now comes from the invoked name (`desc` → DESCRIPTION). Separately, the option was spliced unquoted into the shell command *and* into a Perl double-quoted string — `he perlvar '$_'` interpolated to nothing, and a quote in the argument was a shell syntax error. It's now passed via the environment. Both repro'd and fixed.
- **gitinitremote**: hardcoded `master` — with `init.defaultBranch=main` the push died *after* the remote bare repo was created, and `branch.master.*` pointed at a nonexistent branch. The branch is now read from `HEAD` after the initial commit.
- **setup-kde**: only looked for `go-task`, but `setup` installs the binary as `task`, so the preferred Krohnkite build path was dead on Debian. Checks both now.
- **codeedit**: `codeedit +10 file` hit `args[i-1]` with `i=0`, which in bash is `args[-1]` — the *last* element — destroying the filename (repro'd).
- **editline / editroot**: any colon suffix was treated as a line number, so `file:tag` opened the wrong path and passed `+tag` to vim, which executes it as an Ex command. Both now require a numeric suffix.
- **diskuse**: recursion passed the global `@fileinfo` instead of `$fileinforef`; an unrecognized `-s`/`-a` unit (e.g. `-s 100m` — size units are uppercase) silently disabled that filter entirely (now exits 2); `closedir` ran on an undefined handle after a failed `opendir`.
- **mailifnotempty**: subject/address were interpolated into a shell pipe string, so quotes/`$`/backticks broke it (or executed); now uses list-form `open '|-'`.
- **exectrace**: the traced program's own stderr was funneled through `grep execve` and discarded. The trace now goes through `strace -o '|…'` so the program keeps both its streams — verified before/after.
- **media**: unknown subcommand printed an error but exited 0.

## Smaller fixes

- Missing shebangs in **media**, **browser3**, **screenshot-window** (ENOEXEC when launched by non-shell programs like WM keybindings); **browser3** also lacked the `.shrc` source its siblings have.
- **music/google-music/youtube-music**: `${VAR+…}` passed an empty `--user-data-dir=` when the variable was set-but-empty; now `${VAR:+…}`.
- **screenshot**: `-d` without a value made `sleep` error and shot immediately; unchecked `cd` could drop screenshots in the wrong directory.
- **screensaver**: unknown/missing subcommand exited 0 having done nothing; now prints usage, exits 2.
- **setup**: `setxkbmap` failure (Wayland without Xwayland) no longer aborts the whole bootstrap under `set -e`.

## Checked and cleared (so they don't get re-flagged)

`gitinitremote`'s `test -z … || test … && die` chain (left-associativity makes it correct); `quote`'s in-array `#` comment; `clocks`' `IFS='|'`-dependent date expansion (fragile but correct); `snap`'s wmctrl parsing; `leftright`'s pipeline; `vol`'s pactl→amixer fallback (only its comment states the reverse order); `confdist`'s dead `run()`/`$simulate` (unreachable, left alone).

https://claude.ai/code/session_01UExZuzWHLnVjz17yjNuJ7n

---
_Generated by [Claude Code](https://claude.ai/code/session_01UExZuzWHLnVjz17yjNuJ7n)_