### PR TITLE
Fix Krohnkite layout shortcut action names

### DIFF
--- a/setup-kde
+++ b/setup-kde
@@ -334,9 +334,9 @@ configure_keybindings() {
     set_shortcut "Krohnkite: Shrink Width" "Meta+/"
 
     # Krohnkite: layouts
-    set_shortcut "Krohnkite: Monocle Layout" "Meta+\`"
+    set_shortcut "Krohnkite: Select Layout - Monocle" "Meta+\`"
     set_shortcut "Krohnkite: Previous Layout" "Meta+,"
-    set_shortcut "Krohnkite: Cycle Layout" "Meta+."
+    set_shortcut "Krohnkite: Next Layout" "Meta+."
 
     # Krohnkite: set master
     set_shortcut "Krohnkite: Set master" "Meta+Return"

--- a/setup-kde
+++ b/setup-kde
@@ -333,8 +333,16 @@ configure_keybindings() {
     set_shortcut "Krohnkite: Grow Width" "Meta+\\\\"
     set_shortcut "Krohnkite: Shrink Width" "Meta+/"
 
-    # Krohnkite: layouts
+    # Krohnkite: layouts. Upstream (codeberg anametologin, #23 "group all
+    # layouts together", 2026-03) renamed the layout-selection actions from
+    # "<Layout> Layout" to "Select Layout - <Layout>". KDE never removes stale
+    # shortcut entries, and a given machine may be running either the pre- or
+    # post-rename build, so bind both names for Monocle: whichever the running
+    # build registers takes effect, and the other is an inert orphan (KDE only
+    # acts on names a loaded component actually registers). The cycle actions
+    # (Next/Previous Layout) predate #23 and were not renamed.
     set_shortcut "Krohnkite: Select Layout - Monocle" "Meta+\`"
+    set_shortcut "Krohnkite: Monocle Layout" "Meta+\`"
     set_shortcut "Krohnkite: Previous Layout" "Meta+,"
     set_shortcut "Krohnkite: Next Layout" "Meta+."
 


### PR DESCRIPTION
## What

`setup-kde` bound several Krohnkite shortcuts using action names that don't match what the installed build registers, so they silently failed to bind. Cross-checked against Krohnkite's `shortcuts.qml` (the authoritative list of action `text:` strings).

### Fixes

| Old (broken) | New |
|---|---|
| `Krohnkite: Cycle Layout` | `Krohnkite: Next Layout` (no "Cycle Layout" action exists; `Next Layout` is the forward-cycling action, pairing with `Previous Layout` on Meta+,) |
| `Krohnkite: Monocle Layout` | bound under **both** `Krohnkite: Select Layout - Monocle` **and** `Krohnkite: Monocle Layout` |

### Why Monocle is dual-bound

Upstream (codeberg anametologin, #23 "group all layouts together", 2026-03) renamed the layout-*selection* actions from `<Layout> Layout` to `Select Layout - <Layout>`. `setup-kde` builds the default branch from source (`git clone --depth 1`, no tag), which is post-rename — but an already-installed older build still registers the old name, and KDE never garbage-collects stale shortcut entries. So either name can be the live one depending on the machine. Binding both means whichever the running build registers takes effect; the other is an inert orphan (KDE only acts on names a loaded component actually registers), so there's no conflict.

Only the layout-selection actions were renamed by #23 — the cycle actions (`Next`/`Previous Layout`) and `Set master` are stable single names.

## Verified OK (no change)

`Grow Width`, `Shrink Width`, `Previous Layout`, and `Set master` all match the registered action names exactly.

## Note

On Wayland, newly-registered names only take effect once the post-rename build is the running one (a logout/login after `setup-kde` rebuilds Krohnkite — the script can't hot-swap `kwin_wayland`). The dual-binding makes Meta+` → Monocle work either way, before or after that logout.

https://claude.ai/code/session_0161U2XWYjqte7NPm9U7Havm