### PR TITLE
autoshpool: retry next number when session already attached

### DIFF
--- a/autoshpool
+++ b/autoshpool
@@ -139,14 +139,32 @@ create_and_attach_next() {
   for session in $(get_shpool_session_names); do
     sessions[$session]=1
   done
+  declare errfile
+  errfile=$(mktemp) || return 2
+  # shellcheck disable=SC2064  # expand errfile now, not on trap fire
+  trap "rm -f '$errfile'" RETURN
   for num in $(seq 1 100); do
     declare session="$SHPOOL_PREFIX$num"
-    export SHPOOL_INITIAL_PWD="$PWD"
-    if test -z "${sessions[$session]}"; then
-      echo "Creating shpool session $session"
-      shpool attach "$session"
-      return
+    if test -n "${sessions[$session]}"; then
+      continue
     fi
+    export SHPOOL_INITIAL_PWD="$PWD"
+    echo "Creating shpool session $session"
+    shpool attach "$session" 2>"$errfile"
+    rc=$?
+    cat "$errfile" >&2
+    if test $rc -eq 0; then
+      return 0
+    fi
+    # A "session 'X' already has a terminal attached" failure means our local
+    # name set was stale (shpool's list omitted the row, or another shell raced
+    # us). Mark the name as taken and try the next number rather than
+    # reporting failure. Other errors (shrc broken, daemon gone) propagate.
+    if grep -q "already has a terminal attached" "$errfile"; then
+      sessions[$session]=1
+      continue
+    fi
+    return $rc
   done
   echo "You already have more than 100 sessions??" >&2
   return 2

--- a/autoshpool
+++ b/autoshpool
@@ -139,6 +139,15 @@ create_and_attach_next() {
   for session in $(get_shpool_session_names); do
     sessions[$session]=1
   done
+  declare errfile fifo
+  errfile=$(mktemp) || return 2
+  fifo=$(mktemp -u) || { rm -f "$errfile"; return 2; }
+  if ! mkfifo -m 600 "$fifo"; then
+    rm -f "$errfile"
+    return 2
+  fi
+  # shellcheck disable=SC2064  # expand paths now, not on trap fire
+  trap "rm -f '$errfile' '$fifo'" RETURN
   for num in $(seq 1 100); do
     declare session="$SHPOOL_PREFIX$num"
     if test -n "${sessions[$session]}"; then
@@ -146,19 +155,19 @@ create_and_attach_next() {
     fi
     export SHPOOL_INITIAL_PWD="$PWD"
     echo "Creating shpool session $session"
-    shpool attach "$session"
+    : >"$errfile"
+    # Tee shpool's stderr so it stays visible to the user (live, like a normal
+    # attach) while a copy lands in $errfile for the busy-session check below.
+    # shpool exits 0 even when refusing because the session is already
+    # attached elsewhere (libshpool BusyError -> AttachResult::Done), so the
+    # message itself is the only reliable signal that we should try the next
+    # number instead of treating the attach as successful.
+    tee -a "$errfile" >&2 <"$fifo" &
+    declare tee_pid=$!
+    shpool attach "$session" 2>"$fifo"
     rc=$?
-    if test $rc -eq 0; then
-      return 0
-    fi
-    # shpool may have refused because the session is already attached
-    # elsewhere (our local list was stale: a row the NF == 3 filter dropped,
-    # or another shell raced us). If shpool now reports the name as attached,
-    # treat it as taken and try the next number. Anything else (shrc broken,
-    # daemon gone, session ended up disconnected) propagates so the caller
-    # sees the real error.
-    listing="$(shpool list 2>/dev/null)"
-    if test "$(session_status "$session" "$listing")" = "attached"; then
+    wait "$tee_pid" 2>/dev/null
+    if grep -q "already has a terminal attached" "$errfile"; then
       sessions[$session]=1
       continue
     fi

--- a/autoshpool
+++ b/autoshpool
@@ -139,10 +139,6 @@ create_and_attach_next() {
   for session in $(get_shpool_session_names); do
     sessions[$session]=1
   done
-  declare errfile
-  errfile=$(mktemp) || return 2
-  # shellcheck disable=SC2064  # expand errfile now, not on trap fire
-  trap "rm -f '$errfile'" RETURN
   for num in $(seq 1 100); do
     declare session="$SHPOOL_PREFIX$num"
     if test -n "${sessions[$session]}"; then
@@ -150,17 +146,19 @@ create_and_attach_next() {
     fi
     export SHPOOL_INITIAL_PWD="$PWD"
     echo "Creating shpool session $session"
-    shpool attach "$session" 2>"$errfile"
+    shpool attach "$session"
     rc=$?
-    cat "$errfile" >&2
     if test $rc -eq 0; then
       return 0
     fi
-    # A "session 'X' already has a terminal attached" failure means our local
-    # name set was stale (shpool's list omitted the row, or another shell raced
-    # us). Mark the name as taken and try the next number rather than
-    # reporting failure. Other errors (shrc broken, daemon gone) propagate.
-    if grep -q "already has a terminal attached" "$errfile"; then
+    # shpool may have refused because the session is already attached
+    # elsewhere (our local list was stale: a row the NF == 3 filter dropped,
+    # or another shell raced us). If shpool now reports the name as attached,
+    # treat it as taken and try the next number. Anything else (shrc broken,
+    # daemon gone, session ended up disconnected) propagates so the caller
+    # sees the real error.
+    listing="$(shpool list 2>/dev/null)"
+    if test "$(session_status "$session" "$listing")" = "attached"; then
       sessions[$session]=1
       continue
     fi

--- a/autoshpool_test
+++ b/autoshpool_test
@@ -473,10 +473,10 @@ EOF
 }
 
 test_retries_when_session_already_attached() {
-  # Simulate a stale list: `shpool list` initially does not show session "1",
-  # so autoshpool tries to attach it. The attach fails, and on the next list
-  # the session shows up as "attached" -- meaning it really was taken.
-  # Autoshpool should fall through to attaching "2".
+  # shpool refuses a busy session by printing the message to stderr and
+  # exiting 0 (upstream BusyError -> AttachResult::Done). autoshpool must
+  # detect the message and try the next number rather than treating the
+  # zero exit as success.
   cat > "$TEST_TMPDIR/bin/shpool" <<'SHPOOL'
 #!/bin/bash
 echo "shpool $*" >> "$HOME/.shpool_calls"
@@ -488,12 +488,7 @@ case "$1" in
     ;;
   attach)
     if grep -Fxq "$2" "$HOME/.shpool_already_attached" 2>/dev/null; then
-      # Reveal the hidden row in subsequent list output, the way a real
-      # "already attached" failure would.
-      printf '%s      2025-01-01T00:00:00Z   attached\n' "$2" \
-        >> "$HOME/.shpool_sessions"
       echo "session '$2' already has a terminal attached" >&2
-      exit 1
     fi
     exit 0
     ;;
@@ -506,29 +501,13 @@ SHPOOL
   assert_called "shpool attach 1"
   assert_called "shpool attach 2"
   assert_output_contains "Creating shpool session 2"
+  assert_output_contains "already has a terminal attached"
 }
 
 test_propagates_real_attach_failure() {
-  # A non-zero attach exit where shpool does not report the session as
-  # attached (e.g. shrc broke and the session ended up disconnected) must
-  # propagate the error, not silently try the next number.
-  cat > "$TEST_TMPDIR/bin/shpool" <<'SHPOOL'
-#!/bin/bash
-echo "shpool $*" >> "$HOME/.shpool_calls"
-case "$1" in
-  list)
-    echo "name                           started_at                         status"
-    cat "$HOME/.shpool_sessions" 2>/dev/null
-    exit 0
-    ;;
-  attach)
-    printf '%s      2025-01-01T00:00:00Z   disconnected\n' "$2" \
-      >> "$HOME/.shpool_sessions"
-    exit 7
-    ;;
-esac
-SHPOOL
-  chmod +x "$TEST_TMPDIR/bin/shpool"
+  # A non-zero attach exit with no busy-session message must propagate the
+  # error, not silently try the next number.
+  export SHPOOL_ATTACH_EXIT=7
   run_autoshpool
   assert_status 7
   assert_called "shpool attach 1"

--- a/autoshpool_test
+++ b/autoshpool_test
@@ -473,9 +473,10 @@ EOF
 }
 
 test_retries_when_session_already_attached() {
-  # Simulate a stale list: `shpool list` does not show session "1", so
-  # autoshpool tries to attach it, but `shpool attach 1` reports it is already
-  # attached. Autoshpool should fall through to the next number.
+  # Simulate a stale list: `shpool list` initially does not show session "1",
+  # so autoshpool tries to attach it. The attach fails, and on the next list
+  # the session shows up as "attached" -- meaning it really was taken.
+  # Autoshpool should fall through to attaching "2".
   cat > "$TEST_TMPDIR/bin/shpool" <<'SHPOOL'
 #!/bin/bash
 echo "shpool $*" >> "$HOME/.shpool_calls"
@@ -487,6 +488,10 @@ case "$1" in
     ;;
   attach)
     if grep -Fxq "$2" "$HOME/.shpool_already_attached" 2>/dev/null; then
+      # Reveal the hidden row in subsequent list output, the way a real
+      # "already attached" failure would.
+      printf '%s      2025-01-01T00:00:00Z   attached\n' "$2" \
+        >> "$HOME/.shpool_sessions"
       echo "session '$2' already has a terminal attached" >&2
       exit 1
     fi
@@ -501,7 +506,37 @@ SHPOOL
   assert_called "shpool attach 1"
   assert_called "shpool attach 2"
   assert_output_contains "Creating shpool session 2"
-  assert_output_contains "already has a terminal attached"
+}
+
+test_propagates_real_attach_failure() {
+  # A non-zero attach exit where shpool does not report the session as
+  # attached (e.g. shrc broke and the session ended up disconnected) must
+  # propagate the error, not silently try the next number.
+  cat > "$TEST_TMPDIR/bin/shpool" <<'SHPOOL'
+#!/bin/bash
+echo "shpool $*" >> "$HOME/.shpool_calls"
+case "$1" in
+  list)
+    echo "name                           started_at                         status"
+    cat "$HOME/.shpool_sessions" 2>/dev/null
+    exit 0
+    ;;
+  attach)
+    printf '%s      2025-01-01T00:00:00Z   disconnected\n' "$2" \
+      >> "$HOME/.shpool_sessions"
+    exit 7
+    ;;
+esac
+SHPOOL
+  chmod +x "$TEST_TMPDIR/bin/shpool"
+  run_autoshpool
+  assert_status 7
+  assert_called "shpool attach 1"
+  if grep -q "shpool attach 2" "$HOME/.shpool_calls" 2>/dev/null; then
+    echo "  FAIL: should not have retried with session 2"
+    echo "  calls: $(cat "$HOME/.shpool_calls" 2>/dev/null)"
+    return 1
+  fi
 }
 
 assert_switch_file() {
@@ -716,6 +751,7 @@ run_test "loop handles switch request after session ends" test_loop_handles_swit
 run_test "uses SHPOOL_PREFIX for session names" test_uses_prefix
 run_test "skips existing sessions when creating" test_skips_existing_sessions
 run_test "retries with the next number when a session is already attached" test_retries_when_session_already_attached
+run_test "propagates a real attach failure rather than trying the next number" test_propagates_real_attach_failure
 run_test "switch resolves a path segment to its session" test_switch_resolves_path_segment
 run_test "switch matches whole path segments only" test_switch_requires_whole_segment
 run_test "switch treats a bare number as a session name" test_switch_numeric_is_session_name

--- a/autoshpool_test
+++ b/autoshpool_test
@@ -472,6 +472,38 @@ EOF
   assert_output_contains "Creating shpool session 3"
 }
 
+test_retries_when_session_already_attached() {
+  # Simulate a stale list: `shpool list` does not show session "1", so
+  # autoshpool tries to attach it, but `shpool attach 1` reports it is already
+  # attached. Autoshpool should fall through to the next number.
+  cat > "$TEST_TMPDIR/bin/shpool" <<'SHPOOL'
+#!/bin/bash
+echo "shpool $*" >> "$HOME/.shpool_calls"
+case "$1" in
+  list)
+    echo "name                           started_at                         status"
+    cat "$HOME/.shpool_sessions" 2>/dev/null
+    exit 0
+    ;;
+  attach)
+    if grep -Fxq "$2" "$HOME/.shpool_already_attached" 2>/dev/null; then
+      echo "session '$2' already has a terminal attached" >&2
+      exit 1
+    fi
+    exit 0
+    ;;
+esac
+SHPOOL
+  chmod +x "$TEST_TMPDIR/bin/shpool"
+  echo "1" > "$HOME/.shpool_already_attached"
+  run_autoshpool
+  assert_status 0
+  assert_called "shpool attach 1"
+  assert_called "shpool attach 2"
+  assert_output_contains "Creating shpool session 2"
+  assert_output_contains "already has a terminal attached"
+}
+
 assert_switch_file() {
   local expected="$1"
   local actual
@@ -683,6 +715,7 @@ run_test "preserves specific exit code from shpool attach" test_preserves_exit_c
 run_test "loop handles switch request after session ends" test_loop_handles_switch
 run_test "uses SHPOOL_PREFIX for session names" test_uses_prefix
 run_test "skips existing sessions when creating" test_skips_existing_sessions
+run_test "retries with the next number when a session is already attached" test_retries_when_session_already_attached
 run_test "switch resolves a path segment to its session" test_switch_resolves_path_segment
 run_test "switch matches whole path segments only" test_switch_requires_whole_segment
 run_test "switch treats a bare number as a session name" test_switch_numeric_is_session_name


### PR DESCRIPTION
## Summary
- When `shpool list` misses a row (e.g. an unexpected number of columns slips past the `NF == 3` filter, or another shell races us), `autoshpool` would pick that name as free, then fail with `session 'X' already has a terminal attached`.
- Detect that specific stderr message after a failed `shpool attach` and retry with the next number. Other failures (shrc broken, daemon gone) still propagate so the user can see them.

## Test plan
- [x] `./autoshpool_test` — 39/39 passing, including a new `test_retries_when_session_already_attached` that simulates the stale-list scenario.
- [ ] Manual: run `autoshpool` in a project where a session with the next-up name is already attached elsewhere; confirm it advances to the next number instead of erroring out.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SSpaQkkEqc2rDMQZk5YT3R)_