### PR TITLE
setup-kde: fix Move to Desktop shortcuts by using shifted symbols

### DIFF
--- a/setup-kde
+++ b/setup-kde
@@ -301,12 +301,13 @@ configure_app_shortcuts() {
 configure_keybindings() {
     info "Configuring keybindings"
 
-    # Switch to desktop 1-9
-    n=1
-    while test "$n" -le 9; do
+    # Switch to desktop 1..N. KDE records the shifted variant as the
+    # character produced (Meta+! rather than Meta+Shift+1); writing it
+    # as "Meta+Shift+1" leaves the binding inactive.
+    shifted=('!' '@' '#' '$' '%' '^' '&' '*' '(')
+    for n in $(seq 1 ${#shifted[@]}); do
         set_shortcut "Switch to Desktop $n" "Meta+$n"
-        set_shortcut "Window to Desktop $n" "Meta+Shift+$n"
-        n=$((n + 1))
+        set_shortcut "Window to Desktop $n" "Meta+${shifted[n-1]}"
     done
 
     # Window management


### PR DESCRIPTION
## Summary
- KDE records `Meta+Shift+1` as `Meta+!` (the produced character), so writing the literal `Meta+Shift+N` left the Move-to-Desktop bindings inert.
- Switch the `Window to Desktop N` loop to emit `Meta+!`, `Meta+@`, ... `Meta+(` for desktops 1-9.

## Test plan
- [ ] Run `setup-kde`, log out/in (Wayland) or let `kwin_x11 --replace` apply (X11).
- [ ] Open System Settings → Shortcuts → KWin and confirm "Window to Desktop N" shows `Meta+!` ... `Meta+(`.
- [ ] Press Meta+Shift+2 on a focused window and verify it moves to desktop 2.

---
_Generated by [Claude Code](https://claude.ai/code/session_018unNowLGJzn6jBURUWaTWP)_