### PR TITLE
confdist: eagerly open the ssh control master before scp

### DIFF
--- a/confdist
+++ b/confdist
@@ -198,7 +198,14 @@ require_tarballs()
 open_ssh_master()
 {
 	local host=$1
-	ssh "$host" true
+	printf "Connecting to $host... "
+	if ssh "$host" true
+	then
+		printf "success\n"
+	else
+		printf "failure\n"
+		return 1
+	fi
 }
 
 trap "exit" INT TERM QUIT

--- a/confdist
+++ b/confdist
@@ -192,6 +192,15 @@ require_tarballs()
 	done
 }
 
+# Open the multiplexed control master eagerly with an ssh call so the first
+# scp -- run with -B (batch mode, no prompts) -- doesn't refuse to ask for a
+# password or passphrase on hosts that need interactive auth.
+open_ssh_master()
+{
+	local host=$1
+	ssh "$host" true
+}
+
 trap "exit" INT TERM QUIT
 
 read_defaults
@@ -201,7 +210,7 @@ setup_ssh_mux
 
 for host in $hosts
 do
-	copy_to $host && install_on $host && distribute_from $host || true
+	open_ssh_master $host && copy_to $host && install_on $host && distribute_from $host || true
 done
 
 # vim: set ts=4 sw=4 tw=0 noet:


### PR DESCRIPTION
## Summary
- Address [Codex review on #79](https://github.com/mikelward/scripts/pull/79#discussion_r3413273754): `scp -B` won't prompt for a password/passphrase, so the first scp couldn't establish the control master on hosts needing interactive auth. Open the master eagerly with a no-op `ssh "$host" true` first.

## Test plan
- [ ] Run `confdist <host>` against a host that needs a password/passphrase and confirm only the eager ssh prompts; subsequent scp/ssh calls reuse the master
- [ ] Run against an unreachable host and confirm the chain short-circuits at `open_ssh_master` (no scp attempts)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcgskFV1RXNy42vf4Ew9gd)_