### PR TITLE
confinst: replace symlink destination with real directory when extracting

### DIFF
--- a/confinst
+++ b/confinst
@@ -34,6 +34,12 @@ extract()
 		fi
 
 
+		if test -L "$confdir"
+		then
+			info "Removing symlink $confdir"
+			run rm "$confdir"
+		fi
+
 		create_dir "$confdir"
 
 		info "Extracting $confball into $confdir"


### PR DESCRIPTION
## Summary
- When the extraction destination already exists as a symlink, remove it so the tarball is unpacked at the intended location instead of following the symlink.

## Test plan
- [ ] `ln -s /tmp/somewhere ~/conf` then run `confinst -e` and confirm `~/conf` is replaced with a real directory containing the extracted archive.
- [ ] Run `confinst -n -e` with a symlinked destination to verify the simulate path reports the removal without performing it.
- [ ] Run `confinst -e` with a normal directory destination to confirm behavior is unchanged.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XYECWbmPKeioyAuBbK59XR)_