### PR TITLE
confinst: report symlink removal in dry-run mode

### DIFF
--- a/confinst
+++ b/confinst
@@ -27,17 +27,16 @@ extract()
 		# Anchor at $HOME so extraction works regardless of the current directory.
 		confdir="$HOME/$(basename "$confball" .tar.gz)"
 
-		if $simulate
-		then
-			info "Would extract $confball into $confdir"
-			continue
-		fi
-
-
 		if test -L "$confdir"
 		then
 			info "Removing symlink $confdir"
 			run rm "$confdir"
+		fi
+
+		if $simulate
+		then
+			info "Would extract $confball into $confdir"
+			continue
 		fi
 
 		create_dir "$confdir"


### PR DESCRIPTION
## Summary
- Addresses review comment on #81 (now merged): the simulate path skipped past the symlink-removal block, so `confinst -n -e` never reported that a real run would delete the symlink.
- Move the symlink check above the simulate-continue guard. `run rm` already emits "Would run rm ..." under simulate, so the dry-run now accurately previews the destructive step.

## Test plan
- [ ] `ln -s /tmp/somewhere ~/conf` then `confinst -n -e` and confirm output mentions both the symlink removal and the would-be extraction.
- [ ] `ln -s /tmp/somewhere ~/conf` then `confinst -e` and confirm the symlink is replaced with a real directory containing the extracted archive.
- [ ] `confinst -e` with a normal directory destination — behavior unchanged.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XYECWbmPKeioyAuBbK59XR)_