### PR TITLE
confback: preserve symlinks instead of dereferencing them

### DIFF
--- a/confback
+++ b/confback
@@ -15,6 +15,6 @@ for dir in conf/ conf.*/ scripts/ scripts.*/; do
   # '.?*' rather than '.*' so the start directory '.' itself is not pruned
   # (which would make every tarball empty).
   find . '(' -name '.?*' ')' -prune -o '(' -type f -o -type l ')' -print0 |
-  pax -w -z -L -0 -f "$HOME/$tarball"
+  pax -w -z -0 -f "$HOME/$tarball"
   cd "$OLDPWD"
 done


### PR DESCRIPTION
## Summary
- Drop the `-L` flag from the `pax` invocation in `confback` so symlinks in `~/conf*` and `~/scripts*` are archived as symlinks rather than having their targets dereferenced and inlined under the symlink's name.
- For example, a relative `zshrc -> shrc` symlink in the conf dir now survives the backup/restore round-trip as a symlink.

## Test plan
- [ ] Create a conf dir containing a regular file and a relative symlink to it, run `confback`, and confirm `tar -tzvf` shows the symlink preserved (`l` mode, with `->` target).
- [ ] Run `confinst -e` against the resulting tarball and confirm the symlink is restored relative.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4MLdnDTVSPsYYub4HMsfF)_