### PR TITLE
autoshpool: fix three audit findings

### DIFF
--- a/autoshpool
+++ b/autoshpool
@@ -90,7 +90,7 @@ handle_already_attached() {
   abort_if_hung
 
   target="$(pick_prefixed_session)" || {
-    echo "Already connected to shpool session $session"
+    echo "No free session number under prefix '$SHPOOL_PREFIX'; staying in $session" >&2
     exit 1
   }
   echo "Session $session does not match prefix '$SHPOOL_PREFIX'; switching to $target"
@@ -438,7 +438,7 @@ clear_switch() {
 autoshpool_loop() {
   #exec >>"$HOME/.autoshpool.log" 2>>"$HOME/.autoshpool.log"
 
-  source "$HOME/.shrc.vcs"
+  test -r "$HOME/.shrc.vcs" && source "$HOME/.shrc.vcs"
 
   SHPOOL_PREFIX="${SHPOOL_PREFIX:-$(get_prefix)}"
 
@@ -491,7 +491,10 @@ autoshpool_loop() {
 
 is_sourced() {
   if test -n "$ZSH_VERSION"; then
-    case $ZSH_EVAL_CONTEXT in *:file:*)
+    # ZSH_EVAL_CONTEXT is a colon-separated list whose last component is "file"
+    # when the script is being sourced (e.g. "toplevel:file"). Match either an
+    # internal ":file:" segment or a trailing ":file".
+    case $ZSH_EVAL_CONTEXT in *:file:*|*:file)
       return 0;;
     esac
   elif test -n "$BASH_VERSION"; then


### PR DESCRIPTION
## Summary

Audit pass on `autoshpool` turned up three small bugs. None of them is the smoking gun for the reported "shell echoes the typed command instead of running it" symptom — the most plausible cause of that is that `~/.shrc.vcs` is doing something with TTY-affecting side effects (stty, bind, prompt setup, traps) while autoshpool sources it. That needs to be fixed in `.shrc.vcs` itself, not here.

- **Guard the `.shrc.vcs` source in `autoshpool_loop`.** The other two call sites (the `switch` case and `shpoollist`) gate the source with `test -r`; this one didn't, so a missing file produced a noisy error.
- **Extend `is_sourced`'s zsh check.** zsh's `ZSH_EVAL_CONTEXT` for a sourced top-level script is typically `toplevel:file` (no trailing colon), which the old `*:file:*` pattern missed. If autoshpool were ever sourced from a zsh rc, the case dispatcher would run and `handle_already_attached`'s `exit 1` could kill the interactive shell. Now matches `*:file` as well.
- **Surface the real reason when `pick_prefixed_session` runs out of session numbers.** It was printing "Already connected to shpool session $session", which is the wrong diagnosis.

## Test plan

- [x] `./autoshpool_test` — all 40 tests pass
- [ ] Manual: run `autoshpool` outside a session with `~/.shrc.vcs` absent and confirm no spurious error
- [ ] Manual: confirm the prefix-mismatch path still switches correctly when there is a free number


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ukp7gFpbjJejbzkZ2kN7jC)_