### PR TITLE
Add autotmux for per-project tmux sessions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
 test:
 	./autoshpool_test
+	./autotmux_test
 	./mdf_test

--- a/autotmux
+++ b/autotmux
@@ -41,11 +41,21 @@ tmux_session_name() {
   fi
 }
 
+normalize_name() {
+  # tmux cleans "#", ":" and "." out of session names (they are target-syntax
+  # metacharacters), so `new-session -s foo.com` actually creates "foo_com".
+  # Normalize up front so the name we create and the exact "=name" target we
+  # later switch to agree -- otherwise switching to "=foo.com" can't find the
+  # "foo_com" session tmux really made.
+  printf '%s' "$1" | tr '#:.' '___'
+}
+
 attach_or_switch() {
   # Attach to the named session, creating it if necessary. Inside an existing
   # tmux client, switch that client (creating a detached session first if the
   # target doesn't exist); a nested `new-session` would otherwise fail.
-  local name="$1"
+  local name
+  name="$(normalize_name "$1")"
   if test -n "$TMUX"; then
     # Use exact targets ("=name"): a bare -t target matches any session whose
     # name *starts with* "name", so without "=" a project "api" would attach to

--- a/autotmux
+++ b/autotmux
@@ -1,0 +1,67 @@
+#!/bin/bash
+# autotmux - attach to or create a per-project tmux session
+#
+# Usage:
+#   autotmux                 - attach to (or create) this project's tmux session
+#   autotmux switch <name>   - switch to (or create) session <name>
+#   autotmux switch          - switch to (or create) this project's session
+#   autotmux <tmux args...>  - pass through to tmux
+#
+# The session name mirrors autoshpool's naming: inside a VCS workspace it is the
+# basename of the project root; outside one, it is the short hostname. So
+# `cd repo && autotmux` attaches-or-creates a tmux session named after the repo.
+#
+# Outside tmux we `exec tmux new-session -A -s <name>`, which replaces the shell
+# with the session and attaches to it (creating it if necessary). Inside tmux
+# we instead switch the current client to the target session, creating it
+# detached first if it doesn't exist yet, so a nested `tmux new-session` is never
+# attempted.
+
+short_hostname() {
+  # Mirror shrc's short_hostname: the first dot-delimited component of the
+  # hostname, with a leading "$USER-" stripped.
+  local hostname="${HOSTNAME:-$(hostname 2>/dev/null)}"
+  hostname="${hostname%%.*}"
+  hostname="${hostname#${USER:-$USERNAME}-}"
+  printf '%s' "$hostname"
+}
+
+tmux_session_name() {
+  # The tmux session name for the current directory: the basename of the VCS
+  # project root, or the short hostname when not inside a workspace. Load the
+  # user's vcs helper (best-effort) so rootdir works without sourcing the full
+  # shell rc.
+  test -r "$HOME/.shrc.vcs" && source "$HOME/.shrc.vcs"
+  local root
+  root="$(rootdir 2>/dev/null)"
+  if test -n "$root"; then
+    basename "$root"
+  else
+    short_hostname
+  fi
+}
+
+attach_or_switch() {
+  # Attach to the named session, creating it if necessary. Inside an existing
+  # tmux client, switch that client (creating a detached session first if the
+  # target doesn't exist); a nested `new-session` would otherwise fail.
+  local name="$1"
+  if test -n "$TMUX"; then
+    tmux has-session -t "$name" 2>/dev/null || tmux new-session -d -s "$name"
+    tmux switch-client -t "$name"
+  else
+    exec tmux new-session -A -s "$name"
+  fi
+}
+
+case "$1" in
+  switch)
+    attach_or_switch "${2:-$(tmux_session_name)}"
+    ;;
+  "")
+    attach_or_switch "$(tmux_session_name)"
+    ;;
+  *)
+    exec tmux "$@"
+    ;;
+esac

--- a/autotmux
+++ b/autotmux
@@ -47,8 +47,11 @@ attach_or_switch() {
   # target doesn't exist); a nested `new-session` would otherwise fail.
   local name="$1"
   if test -n "$TMUX"; then
-    tmux has-session -t "$name" 2>/dev/null || tmux new-session -d -s "$name"
-    tmux switch-client -t "$name"
+    # Use exact targets ("=name"): a bare -t target matches any session whose
+    # name *starts with* "name", so without "=" a project "api" would attach to
+    # an existing "api-server" instead of creating its own session.
+    tmux has-session -t "=$name" 2>/dev/null || tmux new-session -d -s "$name"
+    tmux switch-client -t "=$name"
   else
     exec tmux new-session -A -s "$name"
   fi

--- a/autotmux_test
+++ b/autotmux_test
@@ -1,0 +1,216 @@
+#!/bin/bash
+# Tests for autotmux
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+setup() {
+  TEST_TMPDIR="$(mktemp -d)"
+  export HOME="$TEST_TMPDIR"
+  export PATH="$TEST_TMPDIR/bin:$PATH"
+
+  mkdir -p "$TEST_TMPDIR/bin"
+
+  # Create a fake tmux that records its calls. has-session reports "missing"
+  # (exit 1) unless the session name is listed in .tmux_sessions, so the
+  # switch-inside-tmux path exercises the create-then-switch branch.
+  cat > "$TEST_TMPDIR/bin/tmux" <<'TMUX'
+#!/bin/bash
+echo "tmux $*" >> "$HOME/.tmux_calls"
+case "$1" in
+  has-session)
+    name="$3"
+    grep -Fxq "$name" "$HOME/.tmux_sessions" 2>/dev/null
+    exit $?
+    ;;
+  new-session)
+    exit "${TMUX_NEW_SESSION_EXIT:-0}"
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+TMUX
+  chmod +x "$TEST_TMPDIR/bin/tmux"
+
+  # Create a fake rootdir that prints the contents of .vcsroot, so tests can
+  # control whether we look "inside a project".
+  cat > "$TEST_TMPDIR/bin/rootdir" <<'ROOTDIR'
+#!/bin/bash
+cat "$HOME/.vcsroot" 2>/dev/null
+ROOTDIR
+  chmod +x "$TEST_TMPDIR/bin/rootdir"
+
+  # Stub .shrc.vcs so autotmux's best-effort `source` is a no-op (the rootdir
+  # binary above is used instead of a shell function).
+  touch "$TEST_TMPDIR/.shrc.vcs"
+
+  # Clean state
+  unset TMUX
+  unset TMUX_NEW_SESSION_EXIT
+  export HOSTNAME="laptop"
+  export USER="mikel"
+  rm -f "$TEST_TMPDIR/.tmux_calls"
+  rm -f "$TEST_TMPDIR/.tmux_sessions"
+  rm -f "$TEST_TMPDIR/.vcsroot"
+}
+
+teardown() {
+  rm -rf "$TEST_TMPDIR"
+}
+
+run_autotmux() {
+  set +e
+  output="$("$SCRIPT_DIR/autotmux" "$@" </dev/null 2>&1)"
+  status=$?
+  set -e
+}
+
+assert_status() {
+  local expected=$1
+  if [ "$status" -ne "$expected" ]; then
+    echo "  FAIL: expected exit status $expected, got $status"
+    echo "  output: $output"
+    TEST_FAILED=1
+    return 1
+  fi
+}
+
+assert_called() {
+  if ! grep -qx "$1" "$HOME/.tmux_calls" 2>/dev/null; then
+    echo "  FAIL: expected call '$1' not found"
+    echo "  calls: $(cat "$HOME/.tmux_calls" 2>/dev/null)"
+    TEST_FAILED=1
+    return 1
+  fi
+}
+
+assert_not_called() {
+  if grep -q "$1" "$HOME/.tmux_calls" 2>/dev/null; then
+    echo "  FAIL: did not expect call matching '$1'"
+    echo "  calls: $(cat "$HOME/.tmux_calls" 2>/dev/null)"
+    TEST_FAILED=1
+    return 1
+  fi
+}
+
+run_test() {
+  local name="$1"
+  local func="$2"
+  TESTS_RUN=$((TESTS_RUN + 1))
+  setup
+  TEST_FAILED=
+  if "$func" && test -z "$TEST_FAILED"; then
+    echo "ok $TESTS_RUN $name"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo "not ok $TESTS_RUN $name"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+  teardown
+}
+
+# --- tests ---
+
+test_bare_creates_project_session() {
+  # Inside a project, bare autotmux attaches to a session named after the root.
+  echo "/home/u/myproject" > "$HOME/.vcsroot"
+  run_autotmux
+  assert_status 0
+  assert_called "tmux new-session -A -s myproject"
+}
+
+test_bare_uses_hostname_outside_project() {
+  # Outside any project, the session is named after the short hostname.
+  : > "$HOME/.vcsroot"      # rootdir prints nothing
+  run_autotmux
+  assert_status 0
+  assert_called "tmux new-session -A -s laptop"
+}
+
+test_short_hostname_strips_user_prefix() {
+  # short_hostname drops a leading "$USER-" and any domain suffix.
+  : > "$HOME/.vcsroot"
+  export HOSTNAME="mikel-box.example.com"
+  run_autotmux
+  assert_status 0
+  assert_called "tmux new-session -A -s box"
+}
+
+test_switch_outside_tmux_creates_session() {
+  # With no $TMUX, switch behaves like a bare attach to the named session.
+  run_autotmux switch work
+  assert_status 0
+  assert_called "tmux new-session -A -s work"
+  assert_not_called "switch-client"
+}
+
+test_switch_inside_tmux_switches_client() {
+  # Inside tmux, switch creates the target detached (it doesn't exist yet) and
+  # switches the current client to it instead of nesting a new-session.
+  export TMUX="/tmp/tmux-1000/default,1234,0"
+  run_autotmux switch work
+  assert_status 0
+  assert_called "tmux new-session -d -s work"
+  assert_called "tmux switch-client -t work"
+  assert_not_called "new-session -A"
+}
+
+test_switch_inside_tmux_existing_session() {
+  # When the target already exists, switch goes straight to switch-client.
+  export TMUX="/tmp/tmux-1000/default,1234,0"
+  echo "work" > "$HOME/.tmux_sessions"
+  run_autotmux switch work
+  assert_status 0
+  assert_called "tmux switch-client -t work"
+  assert_not_called "new-session"
+}
+
+test_switch_no_arg_uses_project_session() {
+  # `autotmux switch` with no target derives this directory's session name.
+  echo "/home/u/myproject" > "$HOME/.vcsroot"
+  run_autotmux switch
+  assert_status 0
+  assert_called "tmux new-session -A -s myproject"
+}
+
+test_passthrough_to_tmux() {
+  # An unknown subcommand passes through to tmux unchanged.
+  run_autotmux list-sessions
+  assert_status 0
+  assert_called "tmux list-sessions"
+}
+
+test_passthrough_preserves_args() {
+  run_autotmux kill-session -t work
+  assert_status 0
+  assert_called "tmux kill-session -t work"
+}
+
+test_preserves_exit_code() {
+  echo "/home/u/myproject" > "$HOME/.vcsroot"
+  export TMUX_NEW_SESSION_EXIT=42
+  run_autotmux
+  assert_status 42
+}
+
+# --- run ---
+
+run_test "bare invocation attaches to the project session" test_bare_creates_project_session
+run_test "bare invocation uses the hostname outside a project" test_bare_uses_hostname_outside_project
+run_test "short_hostname strips a user prefix and domain" test_short_hostname_strips_user_prefix
+run_test "switch outside tmux attaches to the named session" test_switch_outside_tmux_creates_session
+run_test "switch inside tmux creates then switches the client" test_switch_inside_tmux_switches_client
+run_test "switch inside tmux to an existing session just switches" test_switch_inside_tmux_existing_session
+run_test "switch with no argument uses the project session" test_switch_no_arg_uses_project_session
+run_test "unknown subcommand passes through to tmux" test_passthrough_to_tmux
+run_test "passthrough preserves all arguments" test_passthrough_preserves_args
+run_test "preserves the exit code from tmux" test_preserves_exit_code
+
+echo
+echo "$TESTS_RUN tests, $TESTS_PASSED passed, $TESTS_FAILED failed"
+test "$TESTS_FAILED" -eq 0

--- a/autotmux_test
+++ b/autotmux_test
@@ -23,7 +23,8 @@ setup() {
 echo "tmux $*" >> "$HOME/.tmux_calls"
 case "$1" in
   has-session)
-    name="$3"
+    # Strip the leading "=" exact-match marker autotmux passes (-t =name).
+    name="${3#=}"
     grep -Fxq "$name" "$HOME/.tmux_sessions" 2>/dev/null
     exit $?
     ;;
@@ -156,7 +157,7 @@ test_switch_inside_tmux_switches_client() {
   run_autotmux switch work
   assert_status 0
   assert_called "tmux new-session -d -s work"
-  assert_called "tmux switch-client -t work"
+  assert_called "tmux switch-client -t =work"
   assert_not_called "new-session -A"
 }
 
@@ -166,8 +167,19 @@ test_switch_inside_tmux_existing_session() {
   echo "work" > "$HOME/.tmux_sessions"
   run_autotmux switch work
   assert_status 0
-  assert_called "tmux switch-client -t work"
+  assert_called "tmux switch-client -t =work"
   assert_not_called "new-session"
+}
+
+test_switch_inside_tmux_does_not_prefix_match() {
+  # A target ("api") that is only a prefix of an existing session
+  # ("api-server") must create its own session, not switch to the other.
+  export TMUX="/tmp/tmux-1000/default,1234,0"
+  echo "api-server" > "$HOME/.tmux_sessions"
+  run_autotmux switch api
+  assert_status 0
+  assert_called "tmux new-session -d -s api"
+  assert_called "tmux switch-client -t =api"
 }
 
 test_switch_no_arg_uses_project_session() {
@@ -206,6 +218,7 @@ run_test "short_hostname strips a user prefix and domain" test_short_hostname_st
 run_test "switch outside tmux attaches to the named session" test_switch_outside_tmux_creates_session
 run_test "switch inside tmux creates then switches the client" test_switch_inside_tmux_switches_client
 run_test "switch inside tmux to an existing session just switches" test_switch_inside_tmux_existing_session
+run_test "switch inside tmux does not prefix-match another session" test_switch_inside_tmux_does_not_prefix_match
 run_test "switch with no argument uses the project session" test_switch_no_arg_uses_project_session
 run_test "unknown subcommand passes through to tmux" test_passthrough_to_tmux
 run_test "passthrough preserves all arguments" test_passthrough_preserves_args

--- a/autotmux_test
+++ b/autotmux_test
@@ -182,6 +182,23 @@ test_switch_inside_tmux_does_not_prefix_match() {
   assert_called "tmux switch-client -t =api"
 }
 
+test_normalizes_dotted_name_outside_tmux() {
+  # A project like "foo.com" must become "foo_com" so the created session and
+  # any later "=name" target agree (tmux strips #:. from session names).
+  echo "/home/u/foo.com" > "$HOME/.vcsroot"
+  run_autotmux
+  assert_status 0
+  assert_called "tmux new-session -A -s foo_com"
+}
+
+test_normalizes_dotted_name_inside_tmux() {
+  export TMUX="/tmp/tmux-1000/default,1234,0"
+  run_autotmux switch api.server
+  assert_status 0
+  assert_called "tmux new-session -d -s api_server"
+  assert_called "tmux switch-client -t =api_server"
+}
+
 test_switch_no_arg_uses_project_session() {
   # `autotmux switch` with no target derives this directory's session name.
   echo "/home/u/myproject" > "$HOME/.vcsroot"
@@ -219,6 +236,8 @@ run_test "switch outside tmux attaches to the named session" test_switch_outside
 run_test "switch inside tmux creates then switches the client" test_switch_inside_tmux_switches_client
 run_test "switch inside tmux to an existing session just switches" test_switch_inside_tmux_existing_session
 run_test "switch inside tmux does not prefix-match another session" test_switch_inside_tmux_does_not_prefix_match
+run_test "normalizes a dotted session name outside tmux" test_normalizes_dotted_name_outside_tmux
+run_test "normalizes a dotted session name inside tmux" test_normalizes_dotted_name_inside_tmux
 run_test "switch with no argument uses the project session" test_switch_no_arg_uses_project_session
 run_test "unknown subcommand passes through to tmux" test_passthrough_to_tmux
 run_test "passthrough preserves all arguments" test_passthrough_preserves_args


### PR DESCRIPTION
## Summary

Adds `autotmux`, a tmux counterpart to `autoshpool`, as the first half of migrating my session manager from shpool to tmux. shpool support (`autoshpool`) is **left fully intact** — this just adds the tmux binary that the shell configs will call once `conf` is updated to make tmux the default.

`autotmux`:
- bare invocation derives a per-project session name and `exec tmux new-session -A -s "$name"`
- `autotmux switch <name>` switches the current client (`tmux switch-client`) when inside tmux, else `exec tmux new-session -A`
- `autotmux switch` with no target derives this directory's session name
- unknown subcommands pass through to `tmux`

Session naming mirrors `autoshpool` exactly: inside a VCS workspace the name is `basename "$(rootdir)"`; outside one it's the short hostname.

Inside an existing tmux client a bare/`switch` invocation creates the target detached if needed and switches the client to it, so a nested `tmux new-session` is never attempted.

## Tests

New `autotmux_test` (10 cases) stubs `tmux`/`rootdir` on a temp `PATH` and asserts the wrapper invokes tmux with the expected args. Wired into `make test`.

```
10 tests, 10 passed, 0 failed
```

https://claude.ai/code/session_017bfH6VkXWdgMq9AZ6y2G5y

---
_Generated by [Claude Code](https://claude.ai/code/session_017bfH6VkXWdgMq9AZ6y2G5y)_