### PR TITLE
Add tmuxlist: vcs-aware tmux session listing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 test:
 	./autoshpool_test
 	./autotmux_test
+	./tmuxlist_test
 	./mdf_test

--- a/tmuxlist
+++ b/tmuxlist
@@ -1,0 +1,47 @@
+#!/bin/bash
+# tmuxlist - list tmux sessions with useful details (vcs-aware)
+#
+# Prints one line per session, using the same shape as shpoollist so the two
+# backends look the same in `sessionlist`: a status icon (attached/detached),
+# the session name, the basename of the active pane's vcs root and working
+# directory, the pane's foreground command, and any vcs unmerged items.
+#
+# One row per session is produced by listing only the active pane of each
+# session's active window.
+
+# Load the user's vcs helper (best-effort) for the vcs root/unmerged fields.
+test -r "$HOME/.shrc.vcs" && source "$HOME/.shrc.vcs"
+
+status_icon() {
+  # A compact icon for a session's attached state, matching shpoollist:
+  #   attached -> filled circle, detached -> empty circle.
+  case "$1" in
+    1) printf '%s' '●' ;;
+    *) printf '%s' '○' ;;
+  esac
+}
+
+dir_vcs_root_name() {
+  # The last component of the version-control root for a directory, or empty if
+  # the directory isn't under version control (we don't require vcs to work).
+  local root
+  root="$(cd "$1" 2>/dev/null && vcs rootdir 2>/dev/null)"
+  test -n "$root" && basename "$root"
+}
+
+dir_vcs_unmerged() {
+  # The unmerged items vcs reports for a directory, or empty. Best-effort.
+  (cd "$1" 2>/dev/null && vcs unmerged 2>/dev/null)
+}
+
+# List the active pane of each session's active window, one row per session.
+tmux list-panes -a \
+  -f '#{&&:#{window_active},#{pane_active}}' \
+  -F '#{session_name}	#{session_attached}	#{pane_current_path}	#{pane_current_command}' \
+  2>/dev/null \
+| while IFS=$'\t' read -r session attached cwd command; do
+    printf '%s  %s  %s  %s  %s\n' \
+      "$(status_icon "$attached")" "$session" \
+      "$(dir_vcs_root_name "$cwd")" "$(basename "$cwd")" "$command"
+    dir_vcs_unmerged "$cwd" | sed 's/^/  /'
+  done

--- a/tmuxlist
+++ b/tmuxlist
@@ -15,9 +15,12 @@ test -r "$HOME/.shrc.vcs" && source "$HOME/.shrc.vcs"
 status_icon() {
   # A compact icon for a session's attached state, matching shpoollist:
   #   attached -> filled circle, detached -> empty circle.
+  # session_attached is the *number* of clients attached, so it can be 2, 3,
+  # ... for a session shared by multiple clients; treat any nonzero count as
+  # attached.
   case "$1" in
-    1) printf '%s' '●' ;;
-    *) printf '%s' '○' ;;
+    ''|0) printf '%s' '○' ;;
+    *)    printf '%s' '●' ;;
   esac
 }
 

--- a/tmuxlist_test
+++ b/tmuxlist_test
@@ -124,6 +124,21 @@ test_detached_icon() {
   assert_output_contains "spare"
 }
 
+test_multi_client_counts_as_attached() {
+  # session_attached is a client count; 2+ clients must still show attached.
+  local d="$TEST_TMPDIR/proj"
+  mkdir -p "$d"
+  add_pane "shared" 3 "$d" "vim"
+  run_tmuxlist
+  assert_status 0
+  assert_output_contains "●"                 # attached, not detached
+  if [[ "$output" == *"○"* ]]; then
+    echo "  FAIL: multi-client session showed the detached icon"
+    echo "  output: $output"
+    return 1
+  fi
+}
+
 test_lists_multiple_sessions() {
   local a="$TEST_TMPDIR/a" b="$TEST_TMPDIR/b"
   mkdir -p "$a" "$b"
@@ -148,6 +163,7 @@ test_empty_when_no_sessions() {
 
 run_test "lists a session with vcs-aware details" test_lists_session_details
 run_test "shows the detached icon for unattached sessions" test_detached_icon
+run_test "treats a multi-client session as attached" test_multi_client_counts_as_attached
 run_test "lists multiple sessions" test_lists_multiple_sessions
 run_test "prints nothing when there are no sessions" test_empty_when_no_sessions
 

--- a/tmuxlist_test
+++ b/tmuxlist_test
@@ -1,0 +1,156 @@
+#!/bin/bash
+# Tests for tmuxlist
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+setup() {
+  TEST_TMPDIR="$(mktemp -d)"
+  export HOME="$TEST_TMPDIR"
+  export PATH="$TEST_TMPDIR/bin:$PATH"
+
+  mkdir -p "$TEST_TMPDIR/bin"
+
+  # Fake tmux whose `list-panes` prints the fixture file verbatim, so a test
+  # can hand tmuxlist whatever session rows it wants. The real format string is
+  # ignored; the fixture already contains tab-separated columns.
+  cat > "$TEST_TMPDIR/bin/tmux" <<'TMUX'
+#!/bin/bash
+case "$1" in
+  list-panes) cat "$HOME/.tmux_panes" 2>/dev/null ;;
+esac
+exit 0
+TMUX
+  chmod +x "$TEST_TMPDIR/bin/tmux"
+
+  # Fake vcs that reads per-directory marker files in the current directory:
+  #   .vcsroot  - printed by "vcs rootdir"
+  #   .unmerged - printed by "vcs unmerged"
+  cat > "$TEST_TMPDIR/bin/vcs" <<'VCS'
+#!/bin/bash
+case "$1" in
+  rootdir)  cat "$PWD/.vcsroot" 2>/dev/null ;;
+  unmerged) cat "$PWD/.unmerged" 2>/dev/null ;;
+esac
+exit 0
+VCS
+  chmod +x "$TEST_TMPDIR/bin/vcs"
+
+  # Stub .shrc.vcs so tmuxlist's best-effort `source` is a no-op (the vcs
+  # binary above is used instead of a shell function).
+  touch "$TEST_TMPDIR/.shrc.vcs"
+
+  rm -f "$TEST_TMPDIR/.tmux_panes"
+}
+
+teardown() {
+  rm -rf "$TEST_TMPDIR"
+}
+
+# Append a session row to the fake `tmux list-panes` output.
+# Usage: add_pane <session> <attached> <cwd> <command>
+add_pane() {
+  printf '%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" >> "$HOME/.tmux_panes"
+}
+
+run_tmuxlist() {
+  set +e
+  output="$("$SCRIPT_DIR/tmuxlist" "$@" </dev/null 2>&1)"
+  status=$?
+  set -e
+}
+
+assert_status() {
+  if [ "$status" -ne "$1" ]; then
+    echo "  FAIL: expected exit status $1, got $status"
+    echo "  output: $output"
+    TEST_FAILED=1
+    return 1
+  fi
+}
+
+assert_output_contains() {
+  if [[ "$output" != *"$1"* ]]; then
+    echo "  FAIL: output does not contain '$1'"
+    echo "  output: $output"
+    TEST_FAILED=1
+    return 1
+  fi
+}
+
+run_test() {
+  local name="$1" func="$2"
+  TESTS_RUN=$((TESTS_RUN + 1))
+  setup
+  TEST_FAILED=
+  if "$func" && test -z "$TEST_FAILED"; then
+    echo "ok $TESTS_RUN $name"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo "not ok $TESTS_RUN $name"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+  teardown
+}
+
+# --- tests ---
+
+test_lists_session_details() {
+  local d="$TEST_TMPDIR/proj"
+  mkdir -p "$d"
+  echo "$d" > "$d/.vcsroot"
+  printf 'abcdef Something\n' > "$d/.unmerged"
+  add_pane "work" 1 "$d" "vim"
+  run_tmuxlist
+  assert_status 0
+  assert_output_contains "●"                 # attached status icon
+  assert_output_contains "work"              # session name
+  assert_output_contains "proj"              # basename of vcs root / cwd
+  assert_output_contains "vim"               # foreground command
+  assert_output_contains "abcdef Something"  # vcs unmerged
+}
+
+test_detached_icon() {
+  local d="$TEST_TMPDIR/proj"
+  mkdir -p "$d"
+  add_pane "spare" 0 "$d" "zsh"
+  run_tmuxlist
+  assert_status 0
+  assert_output_contains "○"                 # detached status icon
+  assert_output_contains "spare"
+}
+
+test_lists_multiple_sessions() {
+  local a="$TEST_TMPDIR/a" b="$TEST_TMPDIR/b"
+  mkdir -p "$a" "$b"
+  add_pane "one" 1 "$a" "vim"
+  add_pane "two" 0 "$b" "bash"
+  run_tmuxlist
+  assert_status 0
+  assert_output_contains "one"
+  assert_output_contains "two"
+}
+
+test_empty_when_no_sessions() {
+  run_tmuxlist
+  assert_status 0
+  if [ -n "$output" ]; then
+    echo "  FAIL: expected empty output, got: $output"
+    return 1
+  fi
+}
+
+# --- run ---
+
+run_test "lists a session with vcs-aware details" test_lists_session_details
+run_test "shows the detached icon for unattached sessions" test_detached_icon
+run_test "lists multiple sessions" test_lists_multiple_sessions
+run_test "prints nothing when there are no sessions" test_empty_when_no_sessions
+
+echo
+echo "$TESTS_RUN tests, $TESTS_PASSED passed, $TESTS_FAILED failed"
+test "$TESTS_FAILED" -eq 0


### PR DESCRIPTION
## Summary

Adds `tmuxlist`, a vcs-aware tmux session listing that mirrors `shpoollist`'s format, so the two backends look the same when surfaced through the shell configs' upcoming backend-agnostic `sessionlist` dispatcher (conf side, separate PR).

`tmuxlist` prints one row per session (the active pane of each session's active window):
- status icon — ● attached / ○ detached
- session name
- basename of the active pane's vcs root and working directory
- the pane's foreground command
- any `vcs unmerged` items, indented

It loads `~/.shrc.vcs` best-effort for the vcs fields, exactly like `shpoollist`.

## Tests

New `tmuxlist_test` (4 cases) stubs `tmux list-panes` and `vcs` on a temp PATH. Wired into `make test`.

```
40 tests, 40 passed, 0 failed   # autoshpool
13 tests, 13 passed, 0 failed   # autotmux
 4 tests,  4 passed, 0 failed   # tmuxlist
14 tests, 14 passed, 0 failed   # mdf
```

Follow-up to the tmux migration (autotmux). The conf PR adds the `sessionlist` dispatcher and the `as`/`sw`/`sls` alias family that calls this.

https://claude.ai/code/session_017bfH6VkXWdgMq9AZ6y2G5y

---
_Generated by [Claude Code](https://claude.ai/code/session_017bfH6VkXWdgMq9AZ6y2G5y)_