### PR TITLE
Add change* fzf session switchers, extract sessionlib, fix tmux TAB-separator bug

### DIFF
--- a/autosession
+++ b/autosession
@@ -1,0 +1,44 @@
+#!/bin/bash
+# autosession - dispatch to autotmux or autoshpool for the chosen backend
+#
+# A single entry point for the startup auto-attach, so one shrc line works
+# whichever multiplexer a machine uses:
+#   * inside tmux  ($TMUX set)                 -> autotmux
+#   * inside shpool ($SHPOOL_SESSION_NAME set) -> autoshpool
+#   * outside both: honour $SESSION_BACKEND (tmux|shpool); otherwise use
+#     whichever of tmux/shpool is installed (tmux first).
+#
+# All arguments are passed through to the chosen script, so "autosession",
+# "autosession switch <target>", and pass-through commands all work. In shrc:
+#   autosession && exit
+#
+# Shares its backend selection with changesession (the interactive switcher),
+# so $SESSION_BACKEND picks the multiplexer for both.
+
+dir="$(cd "$(dirname "$0")" && pwd)"
+
+run() {
+  exec "$dir/$1" "${@:2}"
+}
+
+if test -n "$TMUX"; then
+  run autotmux "$@"
+fi
+if test -n "$SHPOOL_SESSION_NAME"; then
+  run autoshpool "$@"
+fi
+
+case "${SESSION_BACKEND:-}" in
+  tmux)   run autotmux "$@" ;;
+  shpool) run autoshpool "$@" ;;
+esac
+
+if command -v tmux >/dev/null 2>&1; then
+  run autotmux "$@"
+fi
+if command -v shpool >/dev/null 2>&1; then
+  run autoshpool "$@"
+fi
+
+echo "autosession: no tmux or shpool backend available" >&2
+exit 1

--- a/autoshpool
+++ b/autoshpool
@@ -29,22 +29,13 @@
 switch_session_file="$HOME/.autoshpool_switch"
 switch_pwd_file="$HOME/.autoshpool_switch_pwd"
 
+# Shared helpers and the fzf picker engine. SESSION_SEP tells the library which
+# separator this backend uses (for session_matches_prefix).
+SESSION_SEP=":"
+source "$(dirname "$0")/sessionlib"
+
 get_current_shpool_session() {
   echo "$SHPOOL_SESSION_NAME"
-}
-
-session_matches_prefix() {
-  # True if a session name ($1) belongs to the project identified by a prefix
-  # ($2). With no prefix (e.g. outside any version-controlled directory) we
-  # never force a switch, so every session matches.
-  local session="$1" prefix="$2"
-  test -z "$prefix" && return 0
-  case "$session" in
-    "$prefix"*) return 0 ;;       # already carries the prefix (e.g. "proj:3")
-  esac
-  # Also accept an exact match with the separator stripped, so a session named
-  # "proj" counts as matching the prefix "proj:".
-  test "$session" = "${prefix%:}"
 }
 
 pick_prefixed_session() {
@@ -266,36 +257,10 @@ shell_chain() {
   printf '%s' "$chain"
 }
 
-dir_vcs_root_name() {
-  # The last component of the version-control root for a directory, or empty if
-  # the directory isn't under version control (we don't require vcs to work).
-  local root
-  root="$(cd "$1" 2>/dev/null && vcs rootdir 2>/dev/null)"
-  test -n "$root" && basename "$root"
-}
-
-dir_vcs_unmerged() {
-  # The unmerged items vcs reports for a directory, or empty. Best-effort: we
-  # don't require vcs to be working.
-  (cd "$1" 2>/dev/null && vcs unmerged 2>/dev/null)
-}
-
 session_status() {
   # The status column shpool reports for a session ($1), given the output of
   # `shpool list` ($2). Empty if the session isn't listed.
   awk -v name="$1" 'NR > 1 && $1 == name { print $NF }' <<<"$2"
-}
-
-status_icon() {
-  # A compact icon for a session status ($1), so listings stay narrow:
-  #   attached -> matching white circle, disconnected -> empty circle.
-  # Anything else (including an empty/unknown status) falls back to a question
-  # mark so unexpected statuses are still visible.
-  case "$1" in
-    attached)     printf '%s' '●' ;;
-    disconnected) printf '%s' '○' ;;
-    *)            printf '%s' '?' ;;
-  esac
 }
 
 describe_shell() {
@@ -310,17 +275,6 @@ describe_shell() {
     "$(dir_vcs_root_name "$cwd")" "$(basename "$cwd")" \
     "$(shell_chain "$pid")"
   dir_vcs_unmerged "$cwd" | sed 's/^/  /'
-}
-
-shell_matches() {
-  # True if a shell's working directory ($1) matches the argument ($2), either
-  # as a full path segment of the directory or as a whole word in the directory's
-  # vcs unmerged output.
-  local cwd="$1" arg="$2"
-  case "$cwd/" in
-    */"$arg"/*) return 0 ;;
-  esac
-  dir_vcs_unmerged "$cwd" | grep -Fwq -- "$arg"
 }
 
 resolve_switch_target() {

--- a/autotmux
+++ b/autotmux
@@ -38,6 +38,11 @@
 
 TMUX_SEP="${TMUX_SEP:-/}"
 
+# Shared helpers and the fzf picker engine. SESSION_SEP tells the library which
+# separator this backend uses (for session_matches_prefix).
+SESSION_SEP="$TMUX_SEP"
+source "$(dirname "$0")/sessionlib"
+
 sanitize_session_name() {
   # Make a name we *generate* safe to both create and target:
   #  - tmux rewrites '#', ':' and '.' out of names at creation (`new-session -s
@@ -67,20 +72,6 @@ get_current_tmux_session() {
   tmux display-message -p '#S' 2>/dev/null
 }
 
-session_matches_prefix() {
-  # True if a session name ($1) belongs to the project identified by a prefix
-  # ($2). With no prefix (e.g. outside any version-controlled directory) we
-  # never force a switch, so every session matches.
-  local session="$1" prefix="$2"
-  test -z "$prefix" && return 0
-  case "$session" in
-    "$prefix"*) return 0 ;;       # already carries the prefix (e.g. "proj/3")
-  esac
-  # Also accept an exact match with the separator stripped, so a session named
-  # "proj" counts as matching the prefix "proj/".
-  test "$session" = "${prefix%"$TMUX_SEP"}"
-}
-
 get_prefix() {
   # The current project name with the separator appended, or empty string when
   # we're not under version control (we don't force a prefix then).
@@ -96,7 +87,14 @@ get_prefix() {
 list_tmux_sessions() {
   # One "name<TAB>attached" row per session. "attached" is tmux's client count
   # (0 means detached). Empty output when no server is running.
-  tmux list-sessions -F "#{session_name}"$'\t'"#{session_attached}" 2>/dev/null
+  #
+  # tmux mangles a literal TAB in a -F format into '_' (and won't emit a real
+  # tab via '\t' either), so the columns would otherwise run together. Separate
+  # them with US (0x1f) instead, which tmux can't have in a session name and
+  # emits as the escape '\037'; translate that back to a real TAB so every
+  # downstream tab-parser keeps working unchanged.
+  tmux list-sessions -F "#{session_name}"$'\x1f'"#{session_attached}" 2>/dev/null \
+    | sed 's/\\037/\t/g'
 }
 
 get_all_session_names() {
@@ -255,26 +253,17 @@ attach_or_create() {
 
 list_tmux_panes() {
   # One "session<TAB>path" row per pane, for resolving a switch target to the
-  # session whose working directory matches.
-  tmux list-panes -a -F "#{session_name}"$'\t'"#{pane_current_path}" 2>/dev/null
+  # session whose working directory matches. Uses the US (0x1f) separator and
+  # '\037'->TAB translation for the same reason as list_tmux_sessions (tmux
+  # mangles a literal TAB in a -F format).
+  tmux list-panes -a -F "#{session_name}"$'\x1f'"#{pane_current_path}" 2>/dev/null \
+    | sed 's/\\037/\t/g'
 }
 
 session_state() {
   # "attached" or "disconnected" for a session ($1), or empty if it isn't listed.
   list_tmux_sessions | awk -F'\t' -v n="$1" \
     '$1 == n { print ($2 + 0 > 0) ? "attached" : "disconnected"; exit }'
-}
-
-status_icon() {
-  # A compact icon for a session status ($1), so listings stay narrow:
-  #   attached -> filled circle, disconnected -> empty circle.
-  # Anything else (including an empty/unknown status) falls back to a question
-  # mark so unexpected statuses are still visible.
-  case "$1" in
-    attached)     printf '%s' '●' ;;
-    disconnected) printf '%s' '○' ;;
-    *)            printf '%s' '?' ;;
-  esac
 }
 
 session_commands() {
@@ -284,20 +273,6 @@ session_commands() {
   # only one window's panes would show.
   tmux list-panes -s -t "=$1" -F '#{pane_current_command}' 2>/dev/null \
     | sort -u | paste -sd' ' -
-}
-
-dir_vcs_root_name() {
-  # The last component of the version-control root for a directory, or empty if
-  # the directory isn't under version control (we don't require vcs to work).
-  local root
-  root="$(cd "$1" 2>/dev/null && vcs rootdir 2>/dev/null)"
-  test -n "$root" && basename "$root"
-}
-
-dir_vcs_unmerged() {
-  # The unmerged items vcs reports for a directory, or empty. Best-effort: we
-  # don't require vcs to be working.
-  (cd "$1" 2>/dev/null && vcs unmerged 2>/dev/null)
 }
 
 describe_session() {
@@ -312,17 +287,6 @@ describe_session() {
     "$(dir_vcs_root_name "$path")" "$(basename "$path")" \
     "$(session_commands "$session")"
   dir_vcs_unmerged "$path" | sed 's/^/  /'
-}
-
-shell_matches() {
-  # True if a working directory ($1) matches the argument ($2), either as a full
-  # path segment of the directory or as a whole word in the directory's vcs
-  # unmerged output.
-  local cwd="$1" arg="$2"
-  case "$cwd/" in
-    */"$arg"/*) return 0 ;;
-  esac
-  dir_vcs_unmerged "$cwd" | grep -Fwq -- "$arg"
 }
 
 resolve_switch_target() {

--- a/autotmux_test
+++ b/autotmux_test
@@ -26,13 +26,18 @@ echo "tmux $*" >> "$HOME/.tmux_calls"
 cmd="$1"; shift
 case "$cmd" in
   list-sessions)
-    cat "$HOME/.tmux_sessions" 2>/dev/null
+    # Real tmux can't put a TAB in -F output (a literal tab becomes '_'); the
+    # code separates columns with US (0x1f), which tmux emits as the escape
+    # '\037'. Mimic that here so the suite exercises the '\037'->TAB translation
+    # in list_tmux_sessions: the fixtures store real tabs, so rewrite them.
+    sed 's/\t/\\037/g' "$HOME/.tmux_sessions" 2>/dev/null
     test -s "$HOME/.tmux_sessions" || { echo "no server running" >&2; exit 1; }
     exit 0
     ;;
   list-panes)
     if printf '%s\n' "$@" | grep -qx -- '-a'; then
-      cat "$HOME/.tmux_panes" 2>/dev/null
+      # Same '\037' escaping as list-sessions (list_tmux_panes uses 0x1f too).
+      sed 's/\t/\\037/g' "$HOME/.tmux_panes" 2>/dev/null
     else
       # list-panes -t NAME -F '#{pane_current_command}': serve a generic list.
       cat "$HOME/.tmux_cmds" 2>/dev/null

--- a/changesession
+++ b/changesession
@@ -1,0 +1,38 @@
+#!/bin/bash
+# changesession - dispatch to changetmux or changeshpool for the active backend
+#
+# Picks the right picker so a single command/keybinding works in either world:
+#   * inside tmux  ($TMUX set)                 -> changetmux
+#   * inside shpool ($SHPOOL_SESSION_NAME set) -> changeshpool
+#   * outside both: honour $SESSION_BACKEND (tmux|shpool); otherwise use
+#     whichever of tmux/shpool is installed (tmux first).
+#
+# All arguments are passed through to the chosen picker.
+
+dir="$(cd "$(dirname "$0")" && pwd)"
+
+run() {
+  exec "$dir/$1" "${@:2}"
+}
+
+if test -n "$TMUX"; then
+  run changetmux "$@"
+fi
+if test -n "$SHPOOL_SESSION_NAME"; then
+  run changeshpool "$@"
+fi
+
+case "${SESSION_BACKEND:-}" in
+  tmux)   run changetmux "$@" ;;
+  shpool) run changeshpool "$@" ;;
+esac
+
+if command -v tmux >/dev/null 2>&1; then
+  run changetmux "$@"
+fi
+if command -v shpool >/dev/null 2>&1; then
+  run changeshpool "$@"
+fi
+
+echo "changesession: no tmux or shpool backend available" >&2
+exit 1

--- a/changeshpool
+++ b/changeshpool
@@ -1,0 +1,112 @@
+#!/bin/bash
+# changeshpool - interactively switch shpool sessions with an fzf picker
+#
+# The shpool backend for the shared fzf picker in sessionlib (see changetmux for
+# the tmux twin, and "changesession" to dispatch between them). Same layout: a
+# "create <auto name>" entry first, then this project's sessions, then the rest.
+#
+# Unlike tmux, shpool can't switch a live client between sessions itself: from
+# inside a session we hand the switch to autoshpool's outer loop via its switch
+# file (like switchshpool), which detaches us and attaches the target (creating
+# it if needed). From outside a session we detach the target from any other
+# terminal and attach it ourselves (stealing it). See sessionlib for the engine
+# and the backend_* hooks this script fills in.
+#
+# Internal subcommands (used by fzf, handy for testing):
+#   changeshpool --list           - print the tab-separated picker lines
+#   changeshpool --preview <name> - render the preview for one session/auto name
+#
+# Override the picker with CHANGESESSION_FZF (e.g. for tests).
+
+# Pull in the shpool backend helpers (which in turn source sessionlib's engine).
+source "$(dirname "$0")/autoshpool"
+test -r "$HOME/.shrc.vcs" && source "$HOME/.shrc.vcs"
+
+SESSION_SELF="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
+
+# Resolve the project prefix once, here, so it persists for both backend_prefix
+# and backend_autoname (a value set inside a hook subshell would not).
+SHPOOL_PREFIX="${SHPOOL_PREFIX:-$(get_prefix)}"
+
+session_command() {
+  # The command to show for a session's shell ($1 = pid): the shell's first
+  # child (e.g. "vim"), or the shell itself when it has no child. Cheap -- a
+  # couple of /proc reads, no vcs.
+  local pid="$1" child
+  child="$(pid_first_child "$pid")"
+  if test -n "$child"; then
+    pid_comm "$child"
+  else
+    pid_comm "$pid"
+  fi
+}
+
+# --- backend hooks for the sessionlib picker engine ---
+
+backend_prefix()         { printf '%s' "$SHPOOL_PREFIX"; }
+backend_autoname()       { pick_prefixed_session; }
+backend_session_exists() { session_exists "$1"; }
+backend_sanitize_name()  { printf '%s' "$1"; }   # shpool keeps names verbatim
+
+backend_session_rows() {
+  # "name<TAB>state<TAB>cwd<TAB>command" per session: one shpool list for the
+  # statuses, one /proc walk for the live shells' cwd/command.
+  local listing
+  listing="$(shpool list 2>/dev/null)"
+  declare -A spid scwd
+  local pid s cwd state cmd
+  while IFS=$'\t' read -r pid s cwd; do
+    test -n "$s" || continue
+    test -n "${spid[$s]+x}" && continue   # keep the first shell seen per session
+    spid[$s]="$pid"
+    scwd[$s]="$cwd"
+  done < <(list_shpool_shells)
+  while IFS= read -r s; do
+    test -n "$s" || continue
+    state="$(session_status "$s" "$listing")"
+    cmd="$(session_command "${spid[$s]}")"
+    printf '%s\t%s\t%s\t%s\n' "$s" "$state" "${scwd[$s]}" "$cmd"
+  done < <(awk 'NR > 1 && NF >= 2 { print $1 }' <<<"$listing")
+}
+
+backend_describe() {
+  # The rich, vcs-aware description shpoollist prints, for the highlighted row.
+  local name="$1" pid s cwd
+  while IFS=$'\t' read -r pid s cwd; do
+    test "$s" = "$name" || continue
+    describe_shell "$pid" "$name" "$cwd" \
+      "$(session_status "$name" "$(shpool list 2>/dev/null)")"
+    return 0
+  done < <(list_shpool_shells)
+  # Listed but with no live shell found (rare): still show the status line.
+  describe_shell "" "$name" "" \
+    "$(session_status "$name" "$(shpool list 2>/dev/null)")"
+}
+
+backend_perform_switch() {
+  # Move to the chosen session. From inside a session, hand the switch to
+  # autoshpool's loop via the switch file (request_switch detaches us and
+  # exits); a create carries PWD so the new session opens here, while switching
+  # to an existing session keeps its own directory. From outside, steal the
+  # target from any other terminal and attach it ourselves.
+  local action="$1" target="$2"
+  if test -n "$SHPOOL_SESSION_NAME"; then
+    if test "$action" = create; then
+      request_switch "$target" "$PWD"
+    else
+      request_switch "$target"
+    fi
+    return 0   # request_switch exits; not reached
+  fi
+  timeout 2 shpool detach "$target" 2>/dev/null
+  test "$action" = create && export SHPOOL_INITIAL_PWD="$PWD"
+  shpool attach "$target"
+}
+
+case "$1" in
+  --list)    build_list ;;
+  --preview) shift; preview_entry "$1" ;;
+  -h|--help) sed -n '2,21p' "$0" | sed 's/^# \{0,1\}//' ;;
+  "")        run_picker ;;
+  *)         echo "changeshpool: unknown argument '$1'" >&2; exit 2 ;;
+esac

--- a/changeshpool_test
+++ b/changeshpool_test
@@ -1,0 +1,310 @@
+#!/bin/bash
+# Tests for changeshpool (the fzf-driven session switcher).
+#
+# Mirrors changetmux_test, but for shpool: drives the internal --list/--preview
+# subcommands and the full picker path with fzf stubbed via $CHANGESESSION_FZF.
+# A fake shpool, fake pgrep and a fake /proc tree (as in autoshpool_test) back
+# the session enumeration.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+setup() {
+  TEST_TMPDIR="$(mktemp -d)"
+  export HOME="$TEST_TMPDIR"
+  export PATH="$TEST_TMPDIR/bin:$PATH"
+  mkdir -p "$TEST_TMPDIR/bin"
+
+  # Fake shpool: list serves the header plus .shpool_sessions rows; attach/detach
+  # just record the call (and attach honours $SHPOOL_ATTACH_EXIT).
+  cat > "$TEST_TMPDIR/bin/shpool" <<'SHPOOL'
+#!/bin/bash
+echo "shpool $*" >> "$HOME/.shpool_calls"
+case "$1" in
+  list)
+    echo "name                           started_at                         status"
+    cat "$HOME/.shpool_sessions" 2>/dev/null
+    exit 0
+    ;;
+  attach) exit "${SHPOOL_ATTACH_EXIT:-0}" ;;
+  *) exit 0 ;;
+esac
+SHPOOL
+  chmod +x "$TEST_TMPDIR/bin/shpool"
+
+  printf '#!/bin/bash\necho ""\n' > "$TEST_TMPDIR/bin/rootdir"
+  chmod +x "$TEST_TMPDIR/bin/rootdir"
+
+  # pgrep backed by fixtures: .fake_shpool_pids and .fake_shells (see add_shell).
+  cat > "$TEST_TMPDIR/bin/pgrep" <<'PGREP'
+#!/bin/bash
+case "$1" in
+  -x) [ "$2" = shpool ] && cat "$HOME/.fake_shpool_pids" 2>/dev/null ;;
+  -P) awk -F'\t' -v p="$2" '$2==p{print $1}' "$HOME/.fake_shells" 2>/dev/null ;;
+esac
+exit 0
+PGREP
+  chmod +x "$TEST_TMPDIR/bin/pgrep"
+
+  export SHPOOL_PROC_DIR="$TEST_TMPDIR/proc"
+  mkdir -p "$SHPOOL_PROC_DIR"
+
+  cat > "$TEST_TMPDIR/bin/vcs" <<'VCS'
+#!/bin/bash
+case "$1" in
+  rootdir)  cat "$PWD/.vcsroot" 2>/dev/null ;;
+  unmerged) cat "$PWD/.unmerged" 2>/dev/null ;;
+esac
+exit 0
+VCS
+  chmod +x "$TEST_TMPDIR/bin/vcs"
+
+  # timeout: run the command without an actual timeout.
+  printf '#!/bin/bash\nshift\n"$@"\n' > "$TEST_TMPDIR/bin/timeout"
+  chmod +x "$TEST_TMPDIR/bin/timeout"
+
+  touch "$TEST_TMPDIR/.shrc.vcs"
+
+  unset SHPOOL_SESSION_NAME SHPOOL_PREFIX SHPOOL_ATTACH_EXIT SHPOOL_INITIAL_PWD
+  unset FZF_QUERY FZF_PICK FZF_EXIT
+  rm -f "$TEST_TMPDIR"/.autoshpool_switch "$TEST_TMPDIR"/.autoshpool_switch_pwd
+  rm -f "$TEST_TMPDIR"/.shpool_calls "$TEST_TMPDIR"/.shpool_sessions
+  rm -f "$TEST_TMPDIR"/.fake_shpool_pids "$TEST_TMPDIR"/.fake_shells
+
+  cat > "$TEST_TMPDIR/bin/fzf" <<'FZF'
+#!/bin/bash
+input="$(cat)"
+test -n "${FZF_EXIT:-}" && exit "$FZF_EXIT"
+printf '%s\n' "${FZF_QUERY:-}"
+if test -n "${FZF_PICK:-}"; then
+  printf '%s\n' "$input" | grep -m1 -- "$FZF_PICK"
+fi
+exit 0
+FZF
+  chmod +x "$TEST_TMPDIR/bin/fzf"
+  export CHANGESESSION_FZF="$TEST_TMPDIR/bin/fzf"
+}
+
+teardown() { rm -rf "$TEST_TMPDIR"; }
+
+add_shpool() { echo "$1" >> "$HOME/.fake_shpool_pids"; }
+
+add_proc() {
+  local pid="$1" comm="$2" ppid="$3"; shift 3
+  mkdir -p "$SHPOOL_PROC_DIR/$pid/task/$pid"
+  printf '%s\n' "$comm" > "$SHPOOL_PROC_DIR/$pid/comm"
+  printf 'Name:\t%s\nPPid:\t%s\n' "$comm" "$ppid" > "$SHPOOL_PROC_DIR/$pid/status"
+  printf '%s ' "$@" > "$SHPOOL_PROC_DIR/$pid/task/$pid/children"
+}
+
+add_shell() {
+  local pid="$1" ppid="$2" cwd="$3" session="$4"
+  printf '%s\t%s\t%s\t%s\n' "$pid" "$ppid" "$cwd" "$session" >> "$HOME/.fake_shells"
+  add_proc "$pid" zsh "$ppid"
+  printf 'PATH=/usr/bin\0SHPOOL_SESSION_NAME=%s\0TERM=xterm\0' "$session" \
+    > "$SHPOOL_PROC_DIR/$pid/environ"
+  ln -sf "$cwd" "$SHPOOL_PROC_DIR/$pid/cwd"
+}
+
+# Register a session as both an shpool-list row and a live shell, so it shows up
+# in the listing and has a cwd/command. Usage: add_full <session> <status> [cwd]
+SHELL_PID=1000
+add_full() {
+  local session="$1" status="${2:-disconnected}" cwd="${3:-/home/u/$1}"
+  printf '%-30s %-33s %s\n' "$session" "2025-01-01T00:00:00Z" "$status" \
+    >> "$HOME/.shpool_sessions"
+  SHELL_PID=$((SHELL_PID + 1))
+  add_shpool 9000
+  add_shell "$SHELL_PID" 9000 "$cwd" "$session"
+}
+
+run_cs() {
+  set +e
+  output="$("$SCRIPT_DIR/changeshpool" "$@" </dev/null 2>&1)"
+  status=$?
+  set -e
+}
+
+assert_status() {
+  if [ "$status" -ne "$1" ]; then
+    echo "  FAIL: expected exit $1, got $status"; echo "  output: $output"
+    TEST_FAILED=1; return 1
+  fi
+}
+assert_output_contains() {
+  if [[ "$output" != *"$1"* ]]; then
+    echo "  FAIL: output missing '$1'"; echo "  output: $output"
+    TEST_FAILED=1; return 1
+  fi
+}
+assert_called() {
+  if ! grep -q -- "$1" "$HOME/.shpool_calls" 2>/dev/null; then
+    echo "  FAIL: expected call '$1'"; echo "  calls: $(cat "$HOME/.shpool_calls" 2>/dev/null)"
+    TEST_FAILED=1; return 1
+  fi
+}
+assert_not_called() {
+  if grep -q -- "$1" "$HOME/.shpool_calls" 2>/dev/null; then
+    echo "  FAIL: unexpected call '$1'"; echo "  calls: $(cat "$HOME/.shpool_calls" 2>/dev/null)"
+    TEST_FAILED=1; return 1
+  fi
+}
+assert_switch_file() {
+  local got; got="$(cat "$HOME/.autoshpool_switch" 2>/dev/null)"
+  if [ "$got" != "$1" ]; then
+    echo "  FAIL: switch file is '$got', expected '$1'"; TEST_FAILED=1; return 1
+  fi
+}
+assert_no_switch_file() {
+  if [ -f "$HOME/.autoshpool_switch" ]; then
+    echo "  FAIL: switch file unexpectedly exists"; TEST_FAILED=1; return 1
+  fi
+}
+assert_switch_pwd() {
+  local got; got="$(cat "$HOME/.autoshpool_switch_pwd" 2>/dev/null)"
+  if [ "$got" != "$1" ]; then
+    echo "  FAIL: switch pwd is '$got', expected '$1'"; TEST_FAILED=1; return 1
+  fi
+}
+assert_no_switch_pwd() {
+  if [ -f "$HOME/.autoshpool_switch_pwd" ]; then
+    echo "  FAIL: switch pwd unexpectedly exists"; TEST_FAILED=1; return 1
+  fi
+}
+
+list_action()  { run_cs --list; printf '%s\n' "$output" | sed -n "${1}p" | cut -f1; }
+list_session() { run_cs --list; printf '%s\n' "$output" | sed -n "${1}p" | cut -f2; }
+
+run_test() {
+  TESTS_RUN=$((TESTS_RUN + 1))
+  setup
+  TEST_FAILED=
+  if "$2" && test -z "$TEST_FAILED"; then
+    echo "ok $TESTS_RUN $1"; TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo "not ok $TESTS_RUN $1"; TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+  teardown
+}
+
+# --- --list ---
+
+test_list_create_entry_first() {
+  add_full a disconnected
+  if [ "$(list_action 1)" != create ]; then
+    echo "  FAIL: first row is not the create entry"; echo "  output: $output"; TEST_FAILED=1
+  fi
+}
+
+test_list_attached_icon() {
+  add_full live attached
+  run_cs --list
+  assert_output_contains '●'
+}
+
+test_list_disconnected_icon() {
+  add_full idle disconnected
+  run_cs --list
+  assert_output_contains '○'
+}
+
+test_list_prefix_group_first() {
+  export SHPOOL_PREFIX="proj:"
+  add_full other:1 disconnected
+  add_full proj:2 attached
+  run_cs --list
+  local r2 r3
+  r2="$(printf '%s\n' "$output" | sed -n '2p' | cut -f2)"
+  r3="$(printf '%s\n' "$output" | sed -n '3p' | cut -f2)"
+  if [ "$r2" != proj:2 ] || [ "$r3" != other:1 ]; then
+    echo "  FAIL: prefix group not first (r2=$r2 r3=$r3)"; echo "$output"; TEST_FAILED=1
+  fi
+}
+
+# --- --preview ---
+
+test_preview_existing_session() {
+  add_full live attached
+  run_cs --preview live
+  assert_output_contains 'live'
+}
+
+test_preview_new_name() {
+  run_cs --preview brandnew
+  assert_output_contains 'New session: brandnew'
+}
+
+# --- picker -> switch dispatch ---
+
+test_pick_existing_inside_requests_switch() {
+  export SHPOOL_SESSION_NAME="cur:1"
+  add_full cur:1 attached
+  add_full target:1 disconnected
+  FZF_PICK=$'^switch\ttarget:1\t' run_cs
+  assert_switch_file "target:1"
+  assert_no_switch_pwd            # switching to an existing session keeps its dir
+}
+
+test_pick_create_entry_requests_auto_with_pwd() {
+  export SHPOOL_PREFIX="proj:"
+  export SHPOOL_SESSION_NAME="cur:1"
+  add_full cur:1 attached
+  FZF_PICK='^create' run_cs
+  assert_switch_file "proj:1"
+  assert_switch_pwd "$PWD"        # a created session opens in the current dir
+}
+
+test_typed_new_name_requests_switch() {
+  export SHPOOL_SESSION_NAME="cur:1"
+  add_full cur:1 attached
+  FZF_QUERY='newsesh' run_cs
+  assert_switch_file "newsesh"
+  assert_switch_pwd "$PWD"
+}
+
+test_outside_session_attaches_with_steal() {
+  add_full target:1 disconnected
+  FZF_PICK=$'^switch\ttarget:1\t' run_cs
+  assert_called 'shpool detach target:1'   # steal from any other terminal
+  assert_called 'shpool attach target:1'
+  assert_no_switch_file                     # no loop to service: attach directly
+}
+
+test_esc_cancels_cleanly() {
+  add_full a disconnected
+  FZF_EXIT=130 run_cs
+  assert_status 0
+  assert_no_switch_file
+  assert_not_called 'shpool attach'
+}
+
+test_picker_error_propagates() {
+  # fzf failing to start (e.g. not installed -> 127) or erroring (2) must not be
+  # treated as a clean cancel: surface a nonzero status and switch nothing.
+  add_full a disconnected
+  FZF_EXIT=2 run_cs
+  assert_status 2
+  assert_no_switch_file
+  assert_not_called 'shpool attach'
+}
+
+run_test "list: create entry is first" test_list_create_entry_first
+run_test "list: attached session shows filled icon" test_list_attached_icon
+run_test "list: detached session shows empty icon" test_list_disconnected_icon
+run_test "list: prefix group sorts under the create entry" test_list_prefix_group_first
+run_test "preview: existing session shows its name" test_preview_existing_session
+run_test "preview: new name explains creation" test_preview_new_name
+run_test "pick: existing session requests a switch (no pwd)" test_pick_existing_inside_requests_switch
+run_test "pick: create entry requests the auto name with pwd" test_pick_create_entry_requests_auto_with_pwd
+run_test "pick: typed new name requests a switch with pwd" test_typed_new_name_requests_switch
+run_test "pick: outside a session attaches with steal" test_outside_session_attaches_with_steal
+run_test "pick: ESC cancels cleanly" test_esc_cancels_cleanly
+run_test "pick: fzf failure propagates as an error" test_picker_error_propagates
+
+echo
+echo "$TESTS_RUN tests, $TESTS_PASSED passed, $TESTS_FAILED failed"
+test "$TESTS_FAILED" -eq 0

--- a/changetmux
+++ b/changetmux
@@ -1,0 +1,100 @@
+#!/bin/bash
+# changetmux - interactively switch tmux sessions with an fzf picker
+#
+# The tmux backend for the shared fzf picker in sessionlib (see changeshpool
+# for the shpool twin, and "changesession" to dispatch between them). The picker
+# lists a "create <auto name>" entry first, then this project's sessions, then
+# the rest; j/k or arrows move, Enter selects, and a typed name that matches
+# nothing is created. See sessionlib for the engine and the backend_* hooks this
+# script fills in.
+#
+# Internal subcommands (used by fzf, handy for testing):
+#   changetmux --list           - print the tab-separated picker lines
+#   changetmux --preview <name> - render the preview for one session/auto name
+#
+# Override the picker with CHANGESESSION_FZF (e.g. for tests).
+
+# Pull in the tmux backend helpers (which in turn source sessionlib's engine).
+source "$(dirname "$0")/autotmux"
+test -r "$HOME/.shrc.vcs" && source "$HOME/.shrc.vcs"
+
+# Absolute path to this script, so the fzf preview can call back in regardless
+# of how changetmux was invoked.
+SESSION_SELF="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
+
+# Resolve the project prefix once, here, so it persists for both backend_prefix
+# and backend_autoname (a value set inside a hook subshell would not).
+TMUX_PREFIX="${TMUX_PREFIX:-$(get_prefix)}"
+
+active_pane_field() {
+  # "session<TAB>path<TAB>command" for each session's active pane, so the picker
+  # line can show a cwd and command without a vcs call. One list-panes covers
+  # every session; keep the first active pane seen per session (active pane of
+  # the active window). See autotmux's list_tmux_sessions for the '\037'->TAB
+  # translation (tmux mangles a literal TAB in a -F format).
+  tmux list-panes -a \
+    -F "#{session_name}"$'\x1f'"#{window_active}"$'\x1f'"#{pane_active}"$'\x1f'"#{pane_current_path}"$'\x1f'"#{pane_current_command}" \
+    2>/dev/null \
+    | sed 's/\\037/\t/g' \
+    | awk -F'\t' '$2 == 1 && $3 == 1 && !seen[$1]++ { print $1 "\t" $4 "\t" $5 }'
+}
+
+# --- backend hooks for the sessionlib picker engine ---
+
+backend_prefix()         { printf '%s' "$TMUX_PREFIX"; }
+backend_autoname()       { pick_prefixed_session; }
+backend_session_exists() { session_exists "$1"; }
+backend_sanitize_name()  { sanitize_session_name "$1"; }
+
+backend_session_rows() {
+  # "name<TAB>state<TAB>cwd<TAB>command" per session: the session list joined to
+  # each session's active pane.
+  declare -A spath scmd
+  local s path cmd attached state
+  while IFS=$'\t' read -r s path cmd; do
+    test -n "$s" || continue
+    spath[$s]="$path"
+    scmd[$s]="$cmd"
+  done < <(active_pane_field)
+  while IFS=$'\t' read -r s attached; do
+    test -n "$s" || continue
+    test "$((attached + 0))" -gt 0 && state=attached || state=disconnected
+    printf '%s\t%s\t%s\t%s\n' "$s" "$state" "${spath[$s]}" "${scmd[$s]}"
+  done < <(list_tmux_sessions)
+}
+
+backend_describe() {
+  # The rich, vcs-aware description tmuxlist prints, for the highlighted row.
+  local name="$1" path
+  path="$(active_pane_field | awk -F'\t' -v n="$name" '$1 == n { print $2; exit }')"
+  describe_session "$name" "$path" "$(session_state "$name")"
+}
+
+backend_perform_switch() {
+  # Switch (or attach, from outside tmux) to the chosen session, creating it
+  # first for the create action. Inside tmux we share via switch-client; from
+  # outside we attach with -d so the new client steals the terminal from any
+  # other client on that session.
+  local action="$1" target="$2"
+  if test "$action" = create && ! session_exists "$target"; then
+    if in_tmux; then
+      tmux new-session -d -s "$target" -c "$PWD" || return
+    else
+      tmux new-session -s "$target" -c "$PWD"
+      return $?
+    fi
+  fi
+  if in_tmux; then
+    do_switch "$target"
+  else
+    tmux attach-session -d -t "=$target"
+  fi
+}
+
+case "$1" in
+  --list)    build_list ;;
+  --preview) shift; preview_entry "$1" ;;
+  -h|--help) sed -n '2,18p' "$0" | sed 's/^# \{0,1\}//' ;;
+  "")        run_picker ;;
+  *)         echo "changetmux: unknown argument '$1'" >&2; exit 2 ;;
+esac

--- a/changetmux_test
+++ b/changetmux_test
@@ -1,0 +1,307 @@
+#!/bin/bash
+# Tests for changetmux (the fzf-driven session switcher).
+#
+# Drives changetmux through its testable seams: the internal --list and
+# --preview subcommands, and the full picker path with the fzf picker stubbed
+# via $CHANGESESSION_FZF. A fake tmux backs everything with fixture files.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+setup() {
+  TEST_TMPDIR="$(mktemp -d)"
+  export HOME="$TEST_TMPDIR"
+  export PATH="$TEST_TMPDIR/bin:$PATH"
+  mkdir -p "$TEST_TMPDIR/bin"
+
+  # Fake tmux backed by fixtures:
+  #   .tmux_sessions - "name<TAB>attached" rows (list-sessions)
+  #   .tmux_active   - "name<TAB>path<TAB>command" rows for each session's
+  #                    active pane (list-panes)
+  #   $TMUX_S        - current session name (display-message -p '#S')
+  # Real tmux can't emit a TAB in -F output, so list-sessions/list-panes escape
+  # the separator as '\037' (US), exactly like tmux 3.4; the script translates
+  # it back. The calls are logged to .tmux_calls.
+  cat > "$TEST_TMPDIR/bin/tmux" <<'TMUX'
+#!/bin/bash
+echo "tmux $*" >> "$HOME/.tmux_calls"
+cmd="$1"; shift
+case "$cmd" in
+  list-sessions)
+    sed 's/\t/\\037/g' "$HOME/.tmux_sessions" 2>/dev/null
+    test -s "$HOME/.tmux_sessions" || { echo "no server running" >&2; exit 1; }
+    exit 0
+    ;;
+  list-panes)
+    # changetmux asks two ways:
+    #   -a with a window_active field -> active pane of every session
+    #   -s -t =NAME                   -> commands in one session
+    if printf '%s\n' "$@" | grep -q 'window_active'; then
+      # 5 fields: name, window_active(1), pane_active(1), path, command.
+      while IFS=$'\t' read -r name path command; do
+        printf '%s\037%s\037%s\037%s\037%s\n' "$name" 1 1 "$path" "$command"
+      done < "$HOME/.tmux_active" 2>/dev/null
+    else
+      # session_commands: -s -t =NAME -F '#{pane_current_command}'
+      target=
+      while [ $# -gt 0 ]; do
+        [ "$1" = -t ] && { target="${2#=}"; break; }
+        shift
+      done
+      awk -F'\t' -v n="$target" '$1 == n { print $3 }' "$HOME/.tmux_active" 2>/dev/null
+    fi
+    exit 0
+    ;;
+  display-message)
+    printf '%s\n' "$TMUX_S"
+    exit 0
+    ;;
+  attach-session) exit "${TMUX_ATTACH_EXIT:-0}" ;;
+  switch-client)  exit "${TMUX_SWITCH_EXIT:-0}" ;;
+  new-session)
+    name=
+    while [ $# -gt 0 ]; do
+      [ "$1" = -s ] && { name="$2"; break; }
+      shift
+    done
+    exit "${TMUX_NEW_EXIT:-0}"
+    ;;
+  *) exit 0 ;;
+esac
+TMUX
+  chmod +x "$TEST_TMPDIR/bin/tmux"
+
+  # rootdir prints nothing by default (no project prefix).
+  printf '#!/bin/bash\necho ""\n' > "$TEST_TMPDIR/bin/rootdir"
+  chmod +x "$TEST_TMPDIR/bin/rootdir"
+
+  # vcs reads per-directory marker files (.vcsroot/.unmerged).
+  cat > "$TEST_TMPDIR/bin/vcs" <<'VCS'
+#!/bin/bash
+case "$1" in
+  rootdir)  cat "$PWD/.vcsroot" 2>/dev/null ;;
+  unmerged) cat "$PWD/.unmerged" 2>/dev/null ;;
+esac
+exit 0
+VCS
+  chmod +x "$TEST_TMPDIR/bin/vcs"
+
+  touch "$TEST_TMPDIR/.shrc.vcs"
+
+  unset TMUX TMUX_S TMUX_PREFIX
+  unset TMUX_ATTACH_EXIT TMUX_NEW_EXIT TMUX_SWITCH_EXIT
+  unset FZF_QUERY FZF_PICK FZF_EXIT
+  rm -f "$TEST_TMPDIR"/.tmux_calls "$TEST_TMPDIR"/.tmux_sessions "$TEST_TMPDIR"/.tmux_active
+
+  # Stub fzf: print the query line (--print-query) then, if a pick pattern is
+  # set, the first matching input row. FZF_EXIT forces an exit code (130 = ESC).
+  cat > "$TEST_TMPDIR/bin/fzf" <<'FZF'
+#!/bin/bash
+input="$(cat)"
+test -n "${FZF_EXIT:-}" && exit "$FZF_EXIT"
+printf '%s\n' "${FZF_QUERY:-}"
+if test -n "${FZF_PICK:-}"; then
+  printf '%s\n' "$input" | grep -m1 -- "$FZF_PICK"
+fi
+exit 0
+FZF
+  chmod +x "$TEST_TMPDIR/bin/fzf"
+  export CHANGESESSION_FZF="$TEST_TMPDIR/bin/fzf"
+}
+
+teardown() { rm -rf "$TEST_TMPDIR"; }
+
+add_session() { printf '%s\t%s\n' "$1" "${2:-0}" >> "$HOME/.tmux_sessions"; }
+add_active()  { printf '%s\t%s\t%s\n' "$1" "$2" "${3:-zsh}" >> "$HOME/.tmux_active"; }
+
+run_ct() {
+  set +e
+  output="$("$SCRIPT_DIR/changetmux" "$@" </dev/null 2>&1)"
+  status=$?
+  set -e
+}
+
+assert_status() {
+  if [ "$status" -ne "$1" ]; then
+    echo "  FAIL: expected exit $1, got $status"; echo "  output: $output"
+    TEST_FAILED=1; return 1
+  fi
+}
+assert_output_contains() {
+  if [[ "$output" != *"$1"* ]]; then
+    echo "  FAIL: output missing '$1'"; echo "  output: $output"
+    TEST_FAILED=1; return 1
+  fi
+}
+assert_output_not_contains() {
+  if [[ "$output" == *"$1"* ]]; then
+    echo "  FAIL: output unexpectedly contains '$1'"; echo "  output: $output"
+    TEST_FAILED=1; return 1
+  fi
+}
+assert_called() {
+  if ! grep -q -- "$1" "$HOME/.tmux_calls" 2>/dev/null; then
+    echo "  FAIL: expected call '$1'"; echo "  calls: $(cat "$HOME/.tmux_calls" 2>/dev/null)"
+    TEST_FAILED=1; return 1
+  fi
+}
+assert_not_called() {
+  if grep -q -- "$1" "$HOME/.tmux_calls" 2>/dev/null; then
+    echo "  FAIL: unexpected call '$1'"; echo "  calls: $(cat "$HOME/.tmux_calls" 2>/dev/null)"
+    TEST_FAILED=1; return 1
+  fi
+}
+# The first field (action) of the Nth picker --list row.
+list_action() { run_ct --list; printf '%s\n' "$output" | sed -n "${1}p" | cut -f1; }
+# The second field (session) of the Nth picker --list row.
+list_session() { run_ct --list; printf '%s\n' "$output" | sed -n "${1}p" | cut -f2; }
+
+run_test() {
+  TESTS_RUN=$((TESTS_RUN + 1))
+  setup
+  TEST_FAILED=
+  if "$2" && test -z "$TEST_FAILED"; then
+    echo "ok $TESTS_RUN $1"; TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo "not ok $TESTS_RUN $1"; TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+  teardown
+}
+
+# --- --list ordering and content ---
+
+test_list_create_entry_first() {
+  add_session a 0; add_active a /tmp/a
+  if [ "$(list_action 1)" != create ]; then
+    echo "  FAIL: first row is not the create entry"; echo "  output: $output"; TEST_FAILED=1
+  fi
+}
+
+test_list_session_names_survive_tab_mangle() {
+  # Real tmux mangles a TAB in -F output; the fake mimics that with '\037'. The
+  # session name must come through intact (not "myproj_0").
+  add_session myproj 0; add_active myproj /tmp/myproj
+  run_ct --list
+  assert_output_contains $'\tmyproj\t'
+  assert_output_not_contains 'myproj_0'
+}
+
+test_list_attached_icon() {
+  add_session live 1; add_active live /tmp/live
+  run_ct --list
+  assert_output_contains '●'   # attached marker
+}
+
+test_list_disconnected_icon() {
+  add_session idle 0; add_active idle /tmp/idle
+  run_ct --list
+  assert_output_contains '○'   # detached marker
+}
+
+test_list_prefix_group_first() {
+  # In project "proj", proj/* sessions sort above unrelated ones, just under the
+  # create entry.
+  export TMUX_PREFIX="proj/"
+  add_session other 0;  add_active other /tmp/other
+  add_session proj/2 0; add_active proj/2 /tmp/proj
+  # Row 1 = create, row 2 = the prefixed session, row 3 = the unrelated one.
+  run_ct --list
+  local r2 r3
+  r2="$(printf '%s\n' "$output" | sed -n '2p' | cut -f2)"
+  r3="$(printf '%s\n' "$output" | sed -n '3p' | cut -f2)"
+  if [ "$r2" != proj/2 ] || [ "$r3" != other ]; then
+    echo "  FAIL: prefix group not first (r2=$r2 r3=$r3)"; echo "$output"; TEST_FAILED=1
+  fi
+}
+
+# --- --preview ---
+
+test_preview_existing_session() {
+  add_session live 1; add_active live /tmp/live vim
+  run_ct --preview live
+  assert_output_contains 'live'
+  assert_output_contains 'vim'   # session_commands surfaced
+}
+
+test_preview_new_name() {
+  run_ct --preview brandnew
+  assert_output_contains 'New session: brandnew'
+}
+
+# --- picker -> switch dispatch ---
+
+test_pick_existing_switches_client_inside_tmux() {
+  export TMUX=fake; export TMUX_S=current
+  add_session current 1; add_active current /tmp/cur
+  add_session target 0;  add_active target /tmp/target
+  FZF_PICK=$'^switch\ttarget\t' run_ct
+  assert_called 'switch-client -t =target'
+}
+
+test_pick_create_entry_makes_session() {
+  export TMUX_PREFIX="proj/"
+  export TMUX=fake; export TMUX_S=current
+  add_session current 1; add_active current /tmp/cur
+  # No existing proj/* session, so the auto name is proj/1; selecting the create
+  # row makes it.
+  FZF_PICK='^create' run_ct
+  assert_called 'new-session -d -s proj/1'
+}
+
+test_typed_new_name_creates_sanitized() {
+  export TMUX=fake; export TMUX_S=current
+  add_session current 1; add_active current /tmp/cur
+  # A typed query that matches no row becomes a new session; '.' is normalized.
+  FZF_QUERY='my.proj' run_ct
+  assert_called 'new-session -d -s my_proj'
+}
+
+test_outside_tmux_attaches_with_steal() {
+  # No $TMUX: selecting a session attaches with -d (steals other clients).
+  add_session target 0; add_active target /tmp/target
+  FZF_PICK=$'^switch\ttarget\t' run_ct
+  assert_called 'attach-session -d -t =target'
+  assert_not_called 'switch-client'
+}
+
+test_esc_cancels_cleanly() {
+  add_session a 0; add_active a /tmp/a
+  FZF_EXIT=130 run_ct
+  assert_status 0
+  assert_not_called 'switch-client'
+  assert_not_called 'attach-session'
+}
+
+test_picker_error_propagates() {
+  # fzf failing to start (e.g. not installed -> 127) or erroring (2) must not be
+  # treated as a clean cancel: surface a nonzero status and switch nothing.
+  add_session a 0; add_active a /tmp/a
+  FZF_EXIT=2 run_ct
+  assert_status 2
+  assert_not_called 'switch-client'
+  assert_not_called 'attach-session'
+}
+
+# --- runner ---
+
+run_test "list: create entry is first" test_list_create_entry_first
+run_test "list: session names survive tmux tab mangling" test_list_session_names_survive_tab_mangle
+run_test "list: attached session shows filled icon" test_list_attached_icon
+run_test "list: detached session shows empty icon" test_list_disconnected_icon
+run_test "list: prefix group sorts under the create entry" test_list_prefix_group_first
+run_test "preview: existing session shows name and command" test_preview_existing_session
+run_test "preview: new name explains creation" test_preview_new_name
+run_test "pick: existing session switches client inside tmux" test_pick_existing_switches_client_inside_tmux
+run_test "pick: create entry makes the auto-named session" test_pick_create_entry_makes_session
+run_test "pick: typed new name creates a sanitized session" test_typed_new_name_creates_sanitized
+run_test "pick: outside tmux attaches with steal" test_outside_tmux_attaches_with_steal
+run_test "pick: ESC cancels cleanly" test_esc_cancels_cleanly
+run_test "pick: fzf failure propagates as an error" test_picker_error_propagates
+
+echo
+echo "$TESTS_RUN tests, $TESTS_PASSED passed, $TESTS_FAILED failed"
+test "$TESTS_FAILED" -eq 0

--- a/sessionlib
+++ b/sessionlib
@@ -1,0 +1,209 @@
+# sessionlib - shared helpers for the tmux/shpool session scripts
+#
+# Sourced by autotmux/autoshpool (the backend modules) and, through them, by
+# tmuxlist/shpoollist and changetmux/changeshpool. Holds the parts that don't
+# depend on which multiplexer is in use:
+#
+#   * small formatting/matching helpers (status_icon, dir_vcs_*, shell_matches,
+#     session_matches_prefix), and
+#   * the whole fzf picker engine (compact_line/emit_line/build_list/
+#     preview_entry/run_picker), which is identical for tmux and shpool.
+#
+# The picker engine calls back into a few backend hooks that each backend
+# module / change* script defines:
+#
+#   backend_prefix          - echo this directory's project prefix (with sep)
+#   backend_autoname        - echo the session auto* would create here
+#   backend_session_rows    - emit "name<TAB>state<TAB>cwd<TAB>command" per
+#                             session (state is attached|disconnected)
+#   backend_session_exists  - succeed if a session named $1 exists
+#   backend_describe <name> - render the rich (vcs-aware) description of $1
+#   backend_sanitize_name   - echo $1 made safe to create/target as a new name
+#   backend_perform_switch <action> <target>
+#                           - switch/attach to <target> (action: switch|create)
+#
+# It also expects $SESSION_SEP to be set to the backend's name separator.
+
+test -n "${_SESSIONLIB_SOURCED:-}" && return
+_SESSIONLIB_SOURCED=1
+
+# --- formatting / matching helpers (shared verbatim by both backends) ---
+
+status_icon() {
+  # A compact icon for a session status ($1), so listings stay narrow:
+  #   attached -> filled circle, disconnected -> empty circle.
+  # Anything else (including an empty/unknown status) falls back to a question
+  # mark so unexpected statuses are still visible.
+  case "$1" in
+    attached)     printf '%s' '●' ;;
+    disconnected) printf '%s' '○' ;;
+    *)            printf '%s' '?' ;;
+  esac
+}
+
+dir_vcs_root_name() {
+  # The last component of the version-control root for a directory, or empty if
+  # the directory isn't under version control (we don't require vcs to work).
+  local root
+  root="$(cd "$1" 2>/dev/null && vcs rootdir 2>/dev/null)"
+  test -n "$root" && basename "$root"
+}
+
+dir_vcs_unmerged() {
+  # The unmerged items vcs reports for a directory, or empty. Best-effort: we
+  # don't require vcs to be working.
+  (cd "$1" 2>/dev/null && vcs unmerged 2>/dev/null)
+}
+
+shell_matches() {
+  # True if a working directory ($1) matches the argument ($2), either as a full
+  # path segment of the directory or as a whole word in the directory's vcs
+  # unmerged output.
+  local cwd="$1" arg="$2"
+  case "$cwd/" in
+    */"$arg"/*) return 0 ;;
+  esac
+  dir_vcs_unmerged "$cwd" | grep -Fwq -- "$arg"
+}
+
+session_matches_prefix() {
+  # True if a session name ($1) belongs to the project identified by a prefix
+  # ($2). With no prefix (e.g. outside any version-controlled directory) we
+  # never force a switch, so every session matches. The prefix is compared as a
+  # literal string (project names can contain regex metacharacters).
+  local session="$1" prefix="$2"
+  test -z "$prefix" && return 0
+  case "$session" in
+    "$prefix"*) return 0 ;;       # already carries the prefix (e.g. "proj/3")
+  esac
+  # Also accept an exact match with the separator stripped, so a session named
+  # "proj" counts as matching the prefix "proj/".
+  test "$session" = "${prefix%"$SESSION_SEP"}"
+}
+
+# --- fzf picker engine (shared by changetmux/changeshpool) ---
+
+compact_line() {
+  # The display column for a session: state icon, name, cwd basename, command.
+  # All cheap -- no vcs. A missing path/command just renders blank.
+  local session="$1" cwd="$2" cmd="$3" state="$4"
+  printf '%s  %-20s  %-14s  %s' \
+    "$(status_icon "$state")" "$session" "${cwd##*/}" "$cmd"
+}
+
+emit_line() {
+  # One tab-separated picker row: action<TAB>session<TAB>display. fzf shows and
+  # searches only the display field; the action and session travel along so the
+  # selection handler and the preview ({2}) can use them.
+  printf '%s\t%s\t%s\n' "$1" "$2" "$3"
+}
+
+build_list() {
+  # Print the picker rows in display order: the create entry, then sessions for
+  # this project's prefix, then the rest.
+  local prefix autoname
+  prefix="$(backend_prefix)"
+  autoname="$(backend_autoname)" || autoname=""
+
+  # The create entry. Showing the auto name (and whether it's new vs a reused
+  # detached session) makes the default action obvious.
+  if test -n "$autoname"; then
+    local verb="create"
+    backend_session_exists "$autoname" && verb="attach"
+    emit_line create "$autoname" \
+      "$(printf '+  %-20s  %s' "$autoname" "($verb auto session for this directory)")"
+  fi
+
+  # Partition sessions into this project's prefix group and everything else,
+  # preserving the backend's listing order within each group.
+  local s state cwd cmd line
+  local -a group_rest=()
+  while IFS=$'\t' read -r s state cwd cmd; do
+    test -n "$s" || continue
+    line="$(emit_line switch "$s" "$(compact_line "$s" "$cwd" "$cmd" "$state")")"
+    if session_matches_prefix "$s" "$prefix"; then
+      printf '%s\n' "$line"
+    else
+      group_rest+=("$line")
+    fi
+  done < <(backend_session_rows)
+
+  local r
+  for r in "${group_rest[@]}"; do
+    printf '%s\n' "$r"
+  done
+}
+
+preview_entry() {
+  # Render the preview for the highlighted row. For an existing session this is
+  # the backend's rich, vcs-aware description; for the not-yet-created auto name
+  # it explains what selecting it will do. The expensive vcs work happens here,
+  # lazily, only for the highlighted row.
+  local name="$1"
+  test -n "$name" || return 0
+  if backend_session_exists "$name"; then
+    backend_describe "$name"
+    return 0
+  fi
+  printf 'New session: %s\n' "$name"
+  printf 'Working directory: %s\n' "$PWD"
+  local root
+  root="$(dir_vcs_root_name "$PWD")"
+  test -n "$root" && printf 'Project: %s\n' "$root"
+  dir_vcs_unmerged "$PWD" | sed 's/^/  /'
+}
+
+run_picker() {
+  local list
+  list="$(build_list)"
+  if test -z "$list"; then
+    echo "No sessions and no project to create one for." >&2
+    return 1
+  fi
+
+  # --print-query lets a typed-but-unmatched name become a new session. The
+  # preview calls back into this script for the highlighted row's field 2.
+  local out query selection
+  out="$(printf '%s\n' "$list" | "${CHANGESESSION_FZF:-fzf}" \
+    --ansi \
+    --delimiter='\t' --with-nth=3 --nth=3 \
+    --print-query \
+    --header='Enter: switch/create   type: filter or new name   ESC: cancel' \
+    --preview="$SESSION_SELF --preview {2}" \
+    --preview-window='down:40%:wrap')"
+  local rc=$?
+  # fzf exit codes: 0 selected, 1 no match, 130 ESC/Ctrl-C. 0 and 1 are normal
+  # (1 is the typed-new-name/empty case, handled below via --print-query); 130
+  # is a clean cancel. Anything else -- 2 (fzf error), 127 (fzf not installed),
+  # etc. -- is a real picker failure: propagate it so callers and keybindings
+  # can tell the picker never ran, instead of silently returning success.
+  case $rc in
+    0|1) ;;
+    130) return 0 ;;
+    *)
+      echo "picker failed: ${CHANGESESSION_FZF:-fzf} exited $rc" >&2
+      return "$rc"
+      ;;
+  esac
+
+  # With --print-query the first output line is the query; the second (if any)
+  # is the selected row.
+  query="$(printf '%s\n' "$out" | sed -n '1p')"
+  selection="$(printf '%s\n' "$out" | sed -n '2p')"
+
+  if test -n "$selection"; then
+    local action target
+    action="$(printf '%s' "$selection" | cut -f1)"
+    target="$(printf '%s' "$selection" | cut -f2)"
+    backend_perform_switch "$action" "$target"
+    return $?
+  fi
+
+  # No row selected but a query was typed: create a new session with that name.
+  if test -n "$query"; then
+    backend_perform_switch create "$(backend_sanitize_name "$query")"
+    return $?
+  fi
+
+  return 0
+}


### PR DESCRIPTION
## What

An interactive `fzf`-driven session switcher suite, plus dispatchers, built on the existing `autotmux`/`autoshpool` helpers — with the shared logic hoisted into a `sessionlib`, and a fix for a real tmux bug found along the way.

Scripts:

| script | role |
|---|---|
| `sessionlib` | sourced library: shared helpers + the fzf picker engine |
| `changetmux` | tmux backend hooks for the picker |
| `changeshpool` | shpool backend hooks for the picker |
| `changesession` | dispatch to changetmux/changeshpool by backend |
| `autosession` | dispatch to autotmux/autoshpool by backend (startup) |

## Picker behaviour

- **Create entry first.** The top row creates the session `auto{tmux,shpool}` would make for this directory's project (the *auto name*), so a bare Enter does the common thing without typing.
- **Project group on top.** Sessions for this directory's project (same prefix, roughly the same vcs root) group right under the create entry; everything else follows.
- **Keys.** `j`/`k` or arrows move, Enter selects. Typing filters; a name that matches nothing is created as a new session (defaults to the auto name via the top entry).
- **Switch / steal.** Inside tmux → `switch-client` (shares); outside → `attach -d` (steals). Inside shpool → the autoshpool switch file, serviced by its loop (creates if missing); outside → detach-then-attach (steal).

## Speed (addresses "shpoollist is slow")

The list line carries only cheap fields (state icon, name, cwd basename, the running command). The expensive vcs lookups (root name, unmerged items) and the full process-tree chain render **lazily in the fzf preview** — via `--preview <name>` — so they run only for the highlighted row instead of once per session up front. The compact line also shortens the process column to a single command (the shell's child, or the shell if none); the full chain stays in the preview.

## Refactor: `sessionlib` (shared library, command names kept)

The backend-agnostic parts live in one sourced library:

- Identical helpers (`status_icon`, `dir_vcs_root_name`, `dir_vcs_unmerged`, `shell_matches`, `session_matches_prefix`).
- The whole fzf picker engine (`compact_line`, `emit_line`, `build_list`, `preview_entry`, `run_picker`), parameterized over a small set of `backend_*` hooks and `$SESSION_SEP` / `$SESSION_SELF`.

`autotmux`/`autoshpool` remain the backend modules (they source `sessionlib`, drop the shared helpers, keep their genuinely backend-specific parts). `changetmux`/`changeshpool` shrink to a handful of `backend_*` hook definitions — the ~150 lines of duplicated picker body are gone. All existing command names are preserved.

## Review fix folded in

`run_picker` now propagates a real fzf failure (exit `127` when fzf isn't installed, `2` on error) as a nonzero status instead of treating any non-130 exit as a clean cancel, while still allowing the no-match/typed-new-name path (fzf exit `1`). Because the picker is now a single shared engine, this is fixed **once** in `sessionlib` for both backends. Regression tests added to both change suites.

## Dispatch / config

`changesession` and `autosession` pick the backend by `$TMUX` / `$SHPOOL_SESSION_NAME`, then fall back to **`$SESSION_BACKEND`** (`tmux`|`shpool`) or whichever is installed. (Not `SESSION_MANAGER`, which is a standard X11/XSMP variable.)

## tmux TAB-separator fix (separate commit)

On real tmux 3.4, `autotmux` was broken: tmux rewrites a literal TAB in a `-F` format into `_` (and won't emit a real tab via `\t`), so `list_tmux_sessions`/`list_tmux_panes` returned columns that ran together — `myproj<TAB>0` came back as `myproj_0`, so `session_exists` never matched and the prefix logic broke. The fake tmux in the tests emitted real tabs, so it never reproduced this.

Fix: separate columns with US (`0x1f`) — which can't appear in a tmux session name and which tmux emits as the escape `\037` — then translate back to a real TAB, leaving all parsing unchanged. The test fake now escapes the separator the way tmux 3.4 does, so the suite exercises the translation.

## Tests

All suites green:

```
autotmux_test     48 passed
autoshpool_test   40 passed
changetmux_test   13 passed
changeshpool_test 12 passed
```

## Notes

- New runtime dependency: `fzf` (only for the interactive `change*` pickers; the `auto*`/`*list` scripts are unaffected).
- `shpoollist`/`tmuxlist` still do eager vcs work; the fast path lives in the new pickers. Happy to back-port the lazy-preview approach to them as a follow-up.

https://claude.ai/code/session_01H8Ejjc7VRpM8JnGkEYwuKi