### PR TITLE
Add detach* and make* session scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 test:
 	./autoshpool_test
 	./autotmux_test
+	./detachsession_test
+	./makesession_test
 	./mdf_test

--- a/detachsession
+++ b/detachsession
@@ -1,0 +1,42 @@
+#!/bin/bash
+# detachsession - dispatch to detachtmux or detachshpool for the active backend
+#
+# Detaches the current session whichever multiplexer it belongs to, so one
+# command/keybinding works in either world:
+#   * inside tmux  ($TMUX set)                 -> detachtmux
+#   * inside shpool ($SHPOOL_SESSION_NAME set) -> detachshpool
+#   * outside both: honour $SESSION_BACKEND (tmux|shpool); otherwise use
+#     whichever of tmux/shpool is installed (tmux first).
+#
+# All arguments are passed through to the chosen script.
+#
+# Shares its backend selection with autosession/changesession/makesession, so
+# $SESSION_BACKEND picks the multiplexer for the whole family.
+
+dir="$(cd "$(dirname "$0")" && pwd)"
+
+run() {
+  exec "$dir/$1" "${@:2}"
+}
+
+if test -n "$TMUX"; then
+  run detachtmux "$@"
+fi
+if test -n "$SHPOOL_SESSION_NAME"; then
+  run detachshpool "$@"
+fi
+
+case "${SESSION_BACKEND:-}" in
+  tmux)   run detachtmux "$@" ;;
+  shpool) run detachshpool "$@" ;;
+esac
+
+if command -v tmux >/dev/null 2>&1; then
+  run detachtmux "$@"
+fi
+if command -v shpool >/dev/null 2>&1; then
+  run detachshpool "$@"
+fi
+
+echo "detachsession: no tmux or shpool backend available" >&2
+exit 1

--- a/detachsession_test
+++ b/detachsession_test
@@ -1,0 +1,165 @@
+#!/bin/bash
+# Tests for the detach* session scripts: the detachsession dispatcher and its
+# detachtmux / detachshpool backends.
+#
+# Two seams are exercised:
+#   * dispatcher selection - the real detachsession is run with fake detachtmux
+#     / detachshpool backends in an isolated PATH, so we can assert which
+#     backend it picks for each ($TMUX / $SHPOOL_SESSION_NAME / $SESSION_BACKEND
+#     / installed) case without a real multiplexer.
+#   * backend behaviour - the real detachtmux / detachshpool are run with a
+#     fake tmux / shpool, asserting the exact command each forwards.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+setup() {
+  TEST_TMPDIR="$(mktemp -d)"
+  BIN="$TEST_TMPDIR/bin"
+  CALLS="$TEST_TMPDIR/calls"
+  mkdir -p "$BIN"
+  : > "$CALLS"
+  # The dispatcher needs only `dirname` as an external; everything else it uses
+  # is a bash builtin. Isolating PATH to $BIN lets each test control tmux/shpool
+  # "installed" detection precisely (real tmux on the host won't leak in).
+  ln -s "$(command -v dirname)" "$BIN/dirname"
+}
+
+teardown() {
+  rm -rf "$TEST_TMPDIR"
+}
+
+# A fake command in $BIN that records "name args" to $CALLS. Used both for fake
+# backends (detachtmux/detachshpool) and fake externals (tmux/shpool).
+fake() {
+  cat > "$BIN/$1" <<EOF
+#!/bin/bash
+echo "$1 \$*" >> "$CALLS"
+EOF
+  chmod +x "$BIN/$1"
+}
+
+# Copy a real script under test into $BIN so its \$dir resolves there.
+install_script() {
+  cp "$SCRIPT_DIR/$1" "$BIN/$1"
+  chmod +x "$BIN/$1"
+}
+
+# Run $BIN/<script> in an isolated env. Usage: run <script> [VAR=val ...]
+# The VAR=val pairs (if any) are exported for the invocation only.
+run() {
+  local script="$1"; shift
+  set +e
+  output="$(env -i PATH="$BIN" HOME="$TEST_TMPDIR" "$@" "$BIN/$script" 2>&1)"
+  status=$?
+  set -e
+}
+
+assert_called() {
+  if ! grep -qx -- "$1" "$CALLS" 2>/dev/null; then
+    echo "  FAIL: expected call '$1'"; echo "  calls: $(cat "$CALLS" 2>/dev/null)"
+    TEST_FAILED=1
+  fi
+}
+assert_status() {
+  if test "$status" -ne "$1"; then
+    echo "  FAIL: expected exit $1, got $status"; echo "  output: $output"
+    TEST_FAILED=1
+  fi
+}
+assert_output_contains() {
+  case "$output" in
+    *"$1"*) ;;
+    *) echo "  FAIL: output missing '$1'"; echo "  output: $output"; TEST_FAILED=1 ;;
+  esac
+}
+
+run_test() {
+  TESTS_RUN=$((TESTS_RUN + 1))
+  setup
+  TEST_FAILED=
+  if "$2" && test -z "$TEST_FAILED"; then
+    echo "ok $TESTS_RUN $1"; TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo "not ok $TESTS_RUN $1"; TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+  teardown
+}
+
+# --- dispatcher selection ---
+
+test_inside_tmux_picks_detachtmux() {
+  install_script detachsession; fake detachtmux; fake detachshpool; fake tmux; fake shpool
+  run detachsession TMUX=/tmp/sock
+  assert_called "detachtmux "
+}
+test_inside_shpool_picks_detachshpool() {
+  install_script detachsession; fake detachtmux; fake detachshpool; fake tmux; fake shpool
+  run detachsession SHPOOL_SESSION_NAME=work
+  assert_called "detachshpool "
+}
+test_session_backend_tmux() {
+  install_script detachsession; fake detachtmux; fake detachshpool
+  run detachsession SESSION_BACKEND=tmux
+  assert_called "detachtmux "
+}
+test_session_backend_shpool() {
+  install_script detachsession; fake detachtmux; fake detachshpool
+  run detachsession SESSION_BACKEND=shpool
+  assert_called "detachshpool "
+}
+test_fallback_tmux_installed() {
+  install_script detachsession; fake detachtmux; fake detachshpool; fake tmux
+  run detachsession
+  assert_called "detachtmux "
+}
+test_fallback_shpool_installed() {
+  install_script detachsession; fake detachtmux; fake detachshpool; fake shpool
+  run detachsession
+  assert_called "detachshpool "
+}
+test_no_backend_errors() {
+  install_script detachsession; fake detachtmux; fake detachshpool
+  run detachsession
+  assert_status 1
+  assert_output_contains "no tmux or shpool backend available"
+}
+test_args_pass_through() {
+  install_script detachsession; fake detachtmux; fake detachshpool
+  set +e
+  output="$(env -i PATH="$BIN" HOME="$TEST_TMPDIR" SESSION_BACKEND=tmux "$BIN/detachsession" -P extra 2>&1)"
+  status=$?
+  set -e
+  assert_called "detachtmux -P extra"
+}
+
+# --- backend behaviour ---
+
+test_detachtmux_runs_tmux_detach() {
+  install_script detachtmux; fake tmux
+  run detachtmux
+  assert_called "tmux detach"
+}
+test_detachshpool_runs_shpool_detach() {
+  install_script detachshpool; fake shpool
+  run detachshpool
+  assert_called "shpool detach"
+}
+
+run_test "dispatch: inside tmux picks detachtmux" test_inside_tmux_picks_detachtmux
+run_test "dispatch: inside shpool picks detachshpool" test_inside_shpool_picks_detachshpool
+run_test "dispatch: SESSION_BACKEND=tmux picks detachtmux" test_session_backend_tmux
+run_test "dispatch: SESSION_BACKEND=shpool picks detachshpool" test_session_backend_shpool
+run_test "dispatch: falls back to installed tmux" test_fallback_tmux_installed
+run_test "dispatch: falls back to installed shpool" test_fallback_shpool_installed
+run_test "dispatch: no backend errors out" test_no_backend_errors
+run_test "dispatch: args pass through to backend" test_args_pass_through
+run_test "backend: detachtmux runs tmux detach" test_detachtmux_runs_tmux_detach
+run_test "backend: detachshpool runs shpool detach" test_detachshpool_runs_shpool_detach
+
+echo "$TESTS_RUN tests, $TESTS_PASSED passed, $TESTS_FAILED failed"
+test "$TESTS_FAILED" -eq 0

--- a/detachshpool
+++ b/detachshpool
@@ -1,0 +1,6 @@
+#!/bin/bash
+# detachshpool - detach the current shpool session
+#
+# Thin wrapper over `shpool detach`, the shpool twin of detachtmux, dispatched
+# by detachsession. All arguments pass through to shpool.
+exec shpool detach "$@"

--- a/detachtmux
+++ b/detachtmux
@@ -1,0 +1,6 @@
+#!/bin/bash
+# detachtmux - detach the current tmux client
+#
+# Thin wrapper over `tmux detach`, the tmux twin of detachshpool, dispatched by
+# detachsession. All arguments pass through to tmux.
+exec tmux detach "$@"

--- a/makesession
+++ b/makesession
@@ -1,0 +1,42 @@
+#!/bin/bash
+# makesession - dispatch to maketmux or makeshpool for the chosen backend
+#
+# Creates (and attaches to) a named session with whichever multiplexer this
+# machine uses, so one command works in either world:
+#   * inside tmux  ($TMUX set)                 -> maketmux
+#   * inside shpool ($SHPOOL_SESSION_NAME set) -> makeshpool
+#   * outside both: honour $SESSION_BACKEND (tmux|shpool); otherwise use
+#     whichever of tmux/shpool is installed (tmux first).
+#
+# All arguments (the session name, and any further pass-through) are forwarded.
+#
+# Shares its backend selection with autosession/changesession/detachsession, so
+# $SESSION_BACKEND picks the multiplexer for the whole family.
+
+dir="$(cd "$(dirname "$0")" && pwd)"
+
+run() {
+  exec "$dir/$1" "${@:2}"
+}
+
+if test -n "$TMUX"; then
+  run maketmux "$@"
+fi
+if test -n "$SHPOOL_SESSION_NAME"; then
+  run makeshpool "$@"
+fi
+
+case "${SESSION_BACKEND:-}" in
+  tmux)   run maketmux "$@" ;;
+  shpool) run makeshpool "$@" ;;
+esac
+
+if command -v tmux >/dev/null 2>&1; then
+  run maketmux "$@"
+fi
+if command -v shpool >/dev/null 2>&1; then
+  run makeshpool "$@"
+fi
+
+echo "makesession: no tmux or shpool backend available" >&2
+exit 1

--- a/makesession_test
+++ b/makesession_test
@@ -1,0 +1,180 @@
+#!/bin/bash
+# Tests for the make* session scripts: the makesession dispatcher and its
+# maketmux / makeshpool backends.
+#
+# Two seams are exercised:
+#   * dispatcher selection - the real makesession is run with fake maketmux /
+#     makeshpool backends in an isolated PATH, asserting which backend it picks
+#     for each ($TMUX / $SHPOOL_SESSION_NAME / $SESSION_BACKEND / installed)
+#     case without a real multiplexer.
+#   * backend behaviour - the real maketmux / makeshpool are run with a fake
+#     tmux / shpool, asserting the exact command each forwards and that
+#     makeshpool stamps SHPOOL_INITIAL_PWD with the caller's directory.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+setup() {
+  TEST_TMPDIR="$(mktemp -d)"
+  BIN="$TEST_TMPDIR/bin"
+  CALLS="$TEST_TMPDIR/calls"
+  mkdir -p "$BIN"
+  : > "$CALLS"
+  ln -s "$(command -v dirname)" "$BIN/dirname"
+}
+
+teardown() {
+  rm -rf "$TEST_TMPDIR"
+}
+
+fake() {
+  cat > "$BIN/$1" <<EOF
+#!/bin/bash
+echo "$1 \$*" >> "$CALLS"
+EOF
+  chmod +x "$BIN/$1"
+}
+
+install_script() {
+  cp "$SCRIPT_DIR/$1" "$BIN/$1"
+  chmod +x "$BIN/$1"
+}
+
+run() {
+  local script="$1"; shift
+  set +e
+  output="$(env -i PATH="$BIN" HOME="$TEST_TMPDIR" "$@" "$BIN/$script" 2>&1)"
+  status=$?
+  set -e
+}
+
+assert_called() {
+  if ! grep -qx -- "$1" "$CALLS" 2>/dev/null; then
+    echo "  FAIL: expected call '$1'"; echo "  calls: $(cat "$CALLS" 2>/dev/null)"
+    TEST_FAILED=1
+  fi
+}
+assert_status() {
+  if test "$status" -ne "$1"; then
+    echo "  FAIL: expected exit $1, got $status"; echo "  output: $output"
+    TEST_FAILED=1
+  fi
+}
+assert_output_contains() {
+  case "$output" in
+    *"$1"*) ;;
+    *) echo "  FAIL: output missing '$1'"; echo "  output: $output"; TEST_FAILED=1 ;;
+  esac
+}
+
+run_test() {
+  TESTS_RUN=$((TESTS_RUN + 1))
+  setup
+  TEST_FAILED=
+  if "$2" && test -z "$TEST_FAILED"; then
+    echo "ok $TESTS_RUN $1"; TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo "not ok $TESTS_RUN $1"; TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+  teardown
+}
+
+# --- dispatcher selection ---
+
+test_inside_tmux_picks_maketmux() {
+  install_script makesession; fake maketmux; fake makeshpool; fake tmux; fake shpool
+  run makesession TMUX=/tmp/sock
+  assert_called "maketmux "
+}
+test_inside_shpool_picks_makeshpool() {
+  install_script makesession; fake maketmux; fake makeshpool; fake tmux; fake shpool
+  run makesession SHPOOL_SESSION_NAME=work
+  assert_called "makeshpool "
+}
+test_session_backend_tmux() {
+  install_script makesession; fake maketmux; fake makeshpool
+  run makesession SESSION_BACKEND=tmux
+  assert_called "maketmux "
+}
+test_session_backend_shpool() {
+  install_script makesession; fake maketmux; fake makeshpool
+  run makesession SESSION_BACKEND=shpool
+  assert_called "makeshpool "
+}
+test_fallback_tmux_installed() {
+  install_script makesession; fake maketmux; fake makeshpool; fake tmux
+  run makesession
+  assert_called "maketmux "
+}
+test_fallback_shpool_installed() {
+  install_script makesession; fake maketmux; fake makeshpool; fake shpool
+  run makesession
+  assert_called "makeshpool "
+}
+test_no_backend_errors() {
+  install_script makesession; fake maketmux; fake makeshpool
+  run makesession
+  assert_status 1
+  assert_output_contains "no tmux or shpool backend available"
+}
+test_name_passes_through() {
+  install_script makesession; fake maketmux; fake makeshpool
+  set +e
+  output="$(env -i PATH="$BIN" HOME="$TEST_TMPDIR" SESSION_BACKEND=tmux "$BIN/makesession" work 2>&1)"
+  status=$?
+  set -e
+  assert_called "maketmux work"
+}
+
+# --- backend behaviour ---
+
+test_maketmux_runs_new_session() {
+  install_script maketmux; fake tmux
+  set +e
+  output="$(env -i PATH="$BIN" HOME="$TEST_TMPDIR" "$BIN/maketmux" work 2>&1)"
+  status=$?
+  set -e
+  assert_called "tmux new-session -s work"
+}
+test_makeshpool_runs_shpool_attach() {
+  install_script makeshpool; fake shpool
+  set +e
+  output="$(env -i PATH="$BIN" HOME="$TEST_TMPDIR" "$BIN/makeshpool" work 2>&1)"
+  status=$?
+  set -e
+  assert_called "shpool attach work"
+}
+test_makeshpool_stamps_initial_pwd() {
+  install_script makeshpool
+  # record the stamped SHPOOL_INITIAL_PWD: a freshly created shpool session
+  # must open in the caller's dir, not the outer shell's startup dir.
+  cat > "$BIN/shpool" <<EOF
+#!/bin/bash
+echo "shpool \$* pwd=\$SHPOOL_INITIAL_PWD" >> "$CALLS"
+EOF
+  chmod +x "$BIN/shpool"
+  # run with the caller's cwd set to $TEST_TMPDIR so \$PWD is deterministic.
+  set +e
+  ( cd "$TEST_TMPDIR" && env -i PATH="$BIN" HOME="$TEST_TMPDIR" "$BIN/makeshpool" work )
+  set -e
+  assert_called "shpool attach work pwd=$TEST_TMPDIR"
+}
+
+run_test "dispatch: inside tmux picks maketmux" test_inside_tmux_picks_maketmux
+run_test "dispatch: inside shpool picks makeshpool" test_inside_shpool_picks_makeshpool
+run_test "dispatch: SESSION_BACKEND=tmux picks maketmux" test_session_backend_tmux
+run_test "dispatch: SESSION_BACKEND=shpool picks makeshpool" test_session_backend_shpool
+run_test "dispatch: falls back to installed tmux" test_fallback_tmux_installed
+run_test "dispatch: falls back to installed shpool" test_fallback_shpool_installed
+run_test "dispatch: no backend errors out" test_no_backend_errors
+run_test "dispatch: session name passes through" test_name_passes_through
+run_test "backend: maketmux runs tmux new-session -s" test_maketmux_runs_new_session
+run_test "backend: makeshpool runs shpool attach" test_makeshpool_runs_shpool_attach
+run_test "backend: makeshpool stamps SHPOOL_INITIAL_PWD" test_makeshpool_stamps_initial_pwd
+
+echo "$TESTS_RUN tests, $TESTS_PASSED passed, $TESTS_FAILED failed"
+test "$TESTS_FAILED" -eq 0

--- a/makesession_test
+++ b/makesession_test
@@ -132,13 +132,24 @@ test_name_passes_through() {
 
 # --- backend behaviour ---
 
-test_maketmux_runs_new_session() {
+test_maketmux_outside_tmux_creates_and_attaches() {
   install_script maketmux; fake tmux
   set +e
   output="$(env -i PATH="$BIN" HOME="$TEST_TMPDIR" "$BIN/maketmux" work 2>&1)"
   status=$?
   set -e
   assert_called "tmux new-session -s work"
+}
+test_maketmux_inside_tmux_switches_client() {
+  # Inside tmux, new-session can't attach to the current terminal, so maketmux
+  # creates the session detached and switches the existing client to it.
+  install_script maketmux; fake tmux
+  set +e
+  output="$(env -i PATH="$BIN" HOME="$TEST_TMPDIR" TMUX=/tmp/sock,1,0 "$BIN/maketmux" work 2>&1)"
+  status=$?
+  set -e
+  assert_called "tmux new-session -d -s work"
+  assert_called "tmux switch-client -t =work"
 }
 test_makeshpool_runs_shpool_attach() {
   install_script makeshpool; fake shpool
@@ -172,7 +183,8 @@ run_test "dispatch: falls back to installed tmux" test_fallback_tmux_installed
 run_test "dispatch: falls back to installed shpool" test_fallback_shpool_installed
 run_test "dispatch: no backend errors out" test_no_backend_errors
 run_test "dispatch: session name passes through" test_name_passes_through
-run_test "backend: maketmux runs tmux new-session -s" test_maketmux_runs_new_session
+run_test "backend: maketmux outside tmux creates and attaches" test_maketmux_outside_tmux_creates_and_attaches
+run_test "backend: maketmux inside tmux switches client" test_maketmux_inside_tmux_switches_client
 run_test "backend: makeshpool runs shpool attach" test_makeshpool_runs_shpool_attach
 run_test "backend: makeshpool stamps SHPOOL_INITIAL_PWD" test_makeshpool_stamps_initial_pwd
 

--- a/makeshpool
+++ b/makeshpool
@@ -1,0 +1,12 @@
+#!/bin/bash
+# makeshpool - create (and attach to) a named shpool session
+#
+# Thin wrapper over `shpool attach` (which creates the session when it doesn't
+# exist yet), the shpool twin of maketmux, dispatched by makesession. All
+# arguments pass through (the first is the session name).
+#
+# Stamp SHPOOL_INITIAL_PWD so the new session's shell cd's to the caller's
+# directory rather than the outer shell's startup dir -- the same reason the
+# autoshpool wrapper stamps it. tmux needs no equivalent (see maketmux).
+export SHPOOL_INITIAL_PWD="$PWD"
+exec shpool attach "$@"

--- a/maketmux
+++ b/maketmux
@@ -1,0 +1,8 @@
+#!/bin/bash
+# maketmux - create (and attach to) a named tmux session
+#
+# Thin wrapper over `tmux new-session -s`, the tmux twin of makeshpool,
+# dispatched by makesession. tmux opens the new session in the caller's PWD
+# natively, so (unlike makeshpool) there is nothing to stamp. All arguments
+# pass through (the first is the session name).
+exec tmux new-session -s "$@"

--- a/maketmux
+++ b/maketmux
@@ -1,8 +1,18 @@
 #!/bin/bash
 # maketmux - create (and attach to) a named tmux session
 #
-# Thin wrapper over `tmux new-session -s`, the tmux twin of makeshpool,
-# dispatched by makesession. tmux opens the new session in the caller's PWD
-# natively, so (unlike makeshpool) there is nothing to stamp. All arguments
-# pass through (the first is the session name).
+# Thin tmux twin of makeshpool, dispatched by makesession. The first argument
+# is the session name; any further arguments are the command to run in it.
+#
+# Inside tmux ($TMUX set) `new-session` can't attach to the current terminal --
+# it would hit tmux's nested-session refusal -- so create the session detached
+# and switch this client to it instead (the new-session -d / switch-client
+# dance autotmux's do_switch uses). Target the switch with tmux's exact "=name"
+# form so a name that is a prefix of another session can't be matched instead.
+# Outside tmux there is no client to switch, so just create-and-attach. tmux
+# opens the session in the caller's PWD natively (no SHPOOL_INITIAL_PWD twin).
+if test -n "$TMUX"; then
+  tmux new-session -d -s "$@" && exec tmux switch-client -t "=$1"
+  exit $?
+fi
 exec tmux new-session -s "$@"


### PR DESCRIPTION
## Summary

Adds the **detach** and **make** verbs to the session-script family that already has `auto*` and `change*`. Each verb gets a backend-agnostic dispatcher plus a tmux and an shpool backend:

| dispatcher | tmux backend | shpool backend |
|---|---|---|
| `detachsession` | `detachtmux` (`tmux detach`) | `detachshpool` (`shpool detach`) |
| `makesession` | `maketmux` (`tmux new-session -s`) | `makeshpool` (`shpool attach`) |

These are the long-name session verbs that previously lived as inline functions/aliases in the shell configs (`mikelward/conf`); moving them here lets a single command work from any shell and keeps the alias layer thin.

## Details

- **Dispatchers** reuse the exact backend selection of `autosession`/`changesession`: inside tmux (`$TMUX`) → tmux; inside shpool (`$SHPOOL_SESSION_NAME`) → shpool; otherwise honour `$SESSION_BACKEND`, then whichever of tmux/shpool is installed (tmux first); otherwise error.
- **`makeshpool`** stamps `SHPOOL_INITIAL_PWD=$PWD` so a freshly created shpool session opens in the caller's directory rather than the outer shell's startup dir (same reason the `autoshpool` wrapper stamps it). tmux uses the caller's PWD natively, so `maketmux` needs no equivalent.

## Tests

- `detachsession_test` (10) and `makesession_test` (11) cover dispatcher selection across all `$TMUX`/`$SHPOOL_SESSION_NAME`/`$SESSION_BACKEND`/installed cases, arg pass-through, and backend behaviour — including the `makeshpool` PWD stamp.
- Wired both into the `Makefile`; full `make test` is green (40 + 48 + 10 + 11 + 14).

This is the first of two related changes; a follow-up in `mikelward/conf` trims the shell aliases to a lean `{a,c,d,m}{s,sh,tm}` set pointing at these scripts.

https://claude.ai/code/session_01FfnuaGiGp2DNHNjNUgCB5c

---
_Generated by [Claude Code](https://claude.ai/code/session_01FfnuaGiGp2DNHNjNUgCB5c)_