### PR TITLE
Name multiplexer sessions by vcs session, not rootdir basename

### DIFF
--- a/autoshpool
+++ b/autoshpool
@@ -98,8 +98,11 @@ abort_if_hung() {
 }
 
 get_prefix() {
-  # Use the current project name with a colon at the end, or empty string.
-  local prefix="$(basename "$(rootdir)")"
+  # The current checkout's session id (vcs session: the project name for a
+  # citc client, the jj workspace name, else the branch name) with a colon at
+  # the end, or empty string when not under version control. A branch name
+  # can't collide with the ':' separator -- git forbids ':' in ref names.
+  local prefix="$(command vcs session 2>/dev/null)"
   test -n "$prefix" && echo "$prefix:"
 }
 

--- a/autoshpool_test
+++ b/autoshpool_test
@@ -61,12 +61,14 @@ PGREP
   mkdir -p "$SHPOOL_PROC_DIR"
 
   # Fake vcs that reads per-directory marker files in the current directory:
-  #   .vcsroot  - printed by "vcs rootdir"
-  #   .unmerged - printed by "vcs unmerged"
+  #   .vcsroot    - printed by "vcs rootdir"
+  #   .vcssession - printed by "vcs session" (the session-name source)
+  #   .unmerged   - printed by "vcs unmerged"
   cat > "$TEST_TMPDIR/bin/vcs" <<'VCS'
 #!/bin/bash
 case "$1" in
   rootdir)  cat "$PWD/.vcsroot" 2>/dev/null ;;
+  session)  cat "$PWD/.vcssession" 2>/dev/null ;;
   unmerged) cat "$PWD/.unmerged" 2>/dev/null ;;
 esac
 exit 0

--- a/autotmux
+++ b/autotmux
@@ -56,7 +56,13 @@ sanitize_session_name() {
   # matches any session whose name merely *starts with* it. Only applied to
   # generated names, never to a resolved existing name (which already reflects
   # exactly what tmux stored).
+  #  - '/' is autotmux's own separator (TMUX_SEP). A branch name often contains
+  #    it (e.g. "feature/foo"); left in, the generated name "feature/foo/1"
+  #    would also match the prefix "feature/", cross-wiring a different
+  #    project's sessions. Fold it to '_' so each name has exactly one
+  #    separator boundary and prefix matching stays unambiguous.
   local name="${1//[#.:]/_}"
+  name="${name//\//_}"
   case "$name" in
     ['$%=']*) name="_${name#?}" ;;
   esac
@@ -73,14 +79,18 @@ get_current_tmux_session() {
 }
 
 get_prefix() {
-  # The current project name with the separator appended, or empty string when
-  # we're not under version control (we don't force a prefix then).
-  local root name
-  root="$(rootdir 2>/dev/null)"
-  test -n "$root" || return 0
-  # Normalize '.'/':' (see sanitize_session_name) so the prefix equals the name
-  # tmux actually stores and the resulting targets stay switchable.
-  name="$(sanitize_session_name "$(basename "$root")")"
+  # The current checkout's session id with the separator appended, or empty
+  # string when we're not under version control (we don't force a prefix then).
+  # `vcs session` is the project name for a citc client, the jj workspace name,
+  # else the branch name -- so sibling branches/worktrees get distinct prefixes.
+  local name
+  name="$(command vcs session 2>/dev/null)"
+  test -n "$name" || return 0
+  # Normalize separators/metacharacters (see sanitize_session_name) so the
+  # prefix equals the name tmux actually stores and the resulting targets stay
+  # switchable. This also folds '/' (common in branch names) to '_' so it can't
+  # be confused with TMUX_SEP and break prefix matching.
+  name="$(sanitize_session_name "$name")"
   printf '%s%s' "$name" "$TMUX_SEP"
 }
 

--- a/autotmux_test
+++ b/autotmux_test
@@ -82,12 +82,14 @@ ROOTDIR
   chmod +x "$TEST_TMPDIR/bin/rootdir"
 
   # Fake vcs that reads per-directory marker files in the current directory:
-  #   .vcsroot  - printed by "vcs rootdir"
-  #   .unmerged - printed by "vcs unmerged"
+  #   .vcsroot    - printed by "vcs rootdir"
+  #   .vcssession - printed by "vcs session" (the session-name source)
+  #   .unmerged   - printed by "vcs unmerged"
   cat > "$TEST_TMPDIR/bin/vcs" <<'VCS'
 #!/bin/bash
 case "$1" in
   rootdir)  cat "$PWD/.vcsroot" 2>/dev/null ;;
+  session)  cat "$PWD/.vcssession" 2>/dev/null ;;
   unmerged) cat "$PWD/.unmerged" 2>/dev/null ;;
 esac
 exit 0
@@ -267,18 +269,39 @@ test_creates_next_number_with_space_in_name() {
   assert_called "tmux new-session -s my project/2"
 }
 
-test_sanitizes_prefix_metacharacters() {
-  # A project basename with '.', ':' or '#' must be normalized to '_' when
-  # building the prefix, since tmux rewrites those characters in stored session
-  # names and treats them specially (target metacharacters / format expansion).
-  cat > "$TEST_TMPDIR/bin/rootdir" <<'ROOTDIR'
+test_prefix_from_vcs_session() {
+  # The session prefix comes from `vcs session` (a feature branch, jj
+  # workspace, or project name), so sibling branches get distinct session
+  # groups rather than all collapsing onto the repository name.
+  cat > "$TEST_TMPDIR/bin/vcs" <<'VCS'
 #!/bin/bash
-echo "/home/u/a.b:c#d"
-ROOTDIR
-  chmod +x "$TEST_TMPDIR/bin/rootdir"
+case "$1" in
+  session) echo 'feature' ;;
+esac
+exit 0
+VCS
+  chmod +x "$TEST_TMPDIR/bin/vcs"
   run_autotmux
   assert_status 0
-  assert_called "tmux new-session -s a_b_c_d/1"
+  assert_called "tmux new-session -s feature/1"
+}
+
+test_sanitizes_prefix_metacharacters() {
+  # The prefix comes from `vcs session`. A name with '.', ':' or '#' must be
+  # normalized to '_' (tmux rewrites those in stored session names and treats
+  # them specially), and '/' -- common in branch names -- must fold to '_' too
+  # since it is TMUX_SEP and would otherwise break prefix matching.
+  cat > "$TEST_TMPDIR/bin/vcs" <<'VCS'
+#!/bin/bash
+case "$1" in
+  session) echo 'a.b:c#d/e' ;;
+esac
+exit 0
+VCS
+  chmod +x "$TEST_TMPDIR/bin/vcs"
+  run_autotmux
+  assert_status 0
+  assert_called "tmux new-session -s a_b_c_d_e/1"
 }
 
 test_reuses_separatorless_session() {
@@ -578,13 +601,16 @@ test_switch_normalizes_leading_dollar() {
 }
 
 test_normalizes_leading_equals_prefix() {
-  # A project basename starting with a sigil is normalized when building the
-  # prefix, so it can't be mis-resolved as id/exact-match target syntax.
-  cat > "$TEST_TMPDIR/bin/rootdir" <<'ROOTDIR'
+  # A session name starting with a sigil is normalized when building the prefix,
+  # so it can't be mis-resolved as id/exact-match target syntax.
+  cat > "$TEST_TMPDIR/bin/vcs" <<'VCS'
 #!/bin/bash
-echo "/home/u/=api"
-ROOTDIR
-  chmod +x "$TEST_TMPDIR/bin/rootdir"
+case "$1" in
+  session) echo '=api' ;;
+esac
+exit 0
+VCS
+  chmod +x "$TEST_TMPDIR/bin/vcs"
   run_autotmux
   assert_status 0
   assert_called "tmux new-session -s _api/1"
@@ -711,7 +737,8 @@ run_test "attaches to disconnected session before creating new one" test_attache
 run_test "skips existing sessions when creating" test_skips_existing_sessions
 run_test "attaches to a disconnected session whose name has a space" test_attaches_disconnected_with_space_in_name
 run_test "creates the next number when a space-named session is attached" test_creates_next_number_with_space_in_name
-run_test "normalizes '.' and ':' in the project prefix" test_sanitizes_prefix_metacharacters
+run_test "derives the session prefix from vcs session" test_prefix_from_vcs_session
+run_test "normalizes '.', ':' and '/' in the session prefix" test_sanitizes_prefix_metacharacters
 run_test "reuses a detached separatorless session at startup" test_reuses_separatorless_session
 run_test "reuses a detached separatorless session on mismatch switch" test_mismatch_switch_reuses_separatorless_session
 run_test "uses TMUX_PREFIX for session names" test_uses_prefix


### PR DESCRIPTION
## What

`autotmux` and `autoshpool` derived their session-group prefix from `basename(rootdir)`, so every branch in one clone collapsed into a single session group. This switches `get_prefix` to use `vcs session` instead.

With `vcs session` (see mikelward/vcs#41): a feature branch (or non-default jj workspace) gets its own prefix, while the default branch / default workspace / a citc client still map to the repository name.

## `/` handling

Also folds `/` → `_` in `autotmux`'s `sanitize_session_name`. Branch names commonly contain `/`, which is tmux's prefix separator (`TMUX_SEP`); left in, the generated name `feature/foo/1` would also match the prefix `feature/`, cross-wiring an unrelated `feature` shell's sessions.

`autoshpool` needs no such change — its separator is `:`, which git forbids in ref names, so a branch name can never collide with it.

## Tests

Updated the `autotmux`/`autoshpool` test stubs to serve `vcs session`, added a test that the prefix is derived from `vcs session`, and extended the sanitization test to cover `/`. All scripts tests pass.

> Depends on mikelward/vcs#41 (the `vcs session` subcommand).

https://claude.ai/code/session_015zr5RBMkummxctz9gE5kZt

---
_Generated by [Claude Code](https://claude.ai/code/session_015zr5RBMkummxctz9gE5kZt)_