### PR TITLE
autotmux/changetmux: translate raw 0x1f from tmux -F output

### DIFF
--- a/autotmux
+++ b/autotmux
@@ -90,11 +90,12 @@ list_tmux_sessions() {
   #
   # tmux mangles a literal TAB in a -F format into '_' (and won't emit a real
   # tab via '\t' either), so the columns would otherwise run together. Separate
-  # them with US (0x1f) instead, which tmux can't have in a session name and
-  # emits as the escape '\037'; translate that back to a real TAB so every
-  # downstream tab-parser keeps working unchanged.
+  # them with US (0x1f) instead, which tmux can't have in a session name.
+  # Different tmux versions emit the 0x1f back as either the raw byte or the
+  # 4-char escape '\037' (3.4); translate both to a real TAB. Use ANSI-C
+  # quoting throughout so the patterns mirror the format string's $'\x1f'.
   tmux list-sessions -F "#{session_name}"$'\x1f'"#{session_attached}" 2>/dev/null \
-    | sed 's/\\037/\t/g'
+    | sed $'s/\x1f/\t/g; s/\\\\037/\t/g'
 }
 
 get_all_session_names() {
@@ -254,10 +255,10 @@ attach_or_create() {
 list_tmux_panes() {
   # One "session<TAB>path" row per pane, for resolving a switch target to the
   # session whose working directory matches. Uses the US (0x1f) separator and
-  # '\037'->TAB translation for the same reason as list_tmux_sessions (tmux
-  # mangles a literal TAB in a -F format).
+  # translates both the raw byte and the 4-char '\037' escape back to TAB, for
+  # the same reason as list_tmux_sessions (tmux mangles a literal TAB in -F).
   tmux list-panes -a -F "#{session_name}"$'\x1f'"#{pane_current_path}" 2>/dev/null \
-    | sed 's/\\037/\t/g'
+    | sed $'s/\x1f/\t/g; s/\\\\037/\t/g'
 }
 
 session_state() {

--- a/autotmux_test
+++ b/autotmux_test
@@ -27,17 +27,27 @@ cmd="$1"; shift
 case "$cmd" in
   list-sessions)
     # Real tmux can't put a TAB in -F output (a literal tab becomes '_'); the
-    # code separates columns with US (0x1f), which tmux emits as the escape
-    # '\037'. Mimic that here so the suite exercises the '\037'->TAB translation
-    # in list_tmux_sessions: the fixtures store real tabs, so rewrite them.
-    sed 's/\t/\\037/g' "$HOME/.tmux_sessions" 2>/dev/null
+    # code separates columns with US (0x1f). Different tmux versions emit a
+    # format-string 0x1f either as the 4-char escape '\037' (3.4) or as the raw
+    # byte. The fixtures store real tabs; rewrite them to whichever form this
+    # test wants (default: the '\037' escape) so the suite exercises both
+    # translations in list_tmux_sessions.
+    if test "${TMUX_FAKE_RAW_US:-0}" = 1; then
+      sed $'s/\t/\x1f/g' "$HOME/.tmux_sessions" 2>/dev/null
+    else
+      sed 's/\t/\\037/g' "$HOME/.tmux_sessions" 2>/dev/null
+    fi
     test -s "$HOME/.tmux_sessions" || { echo "no server running" >&2; exit 1; }
     exit 0
     ;;
   list-panes)
     if printf '%s\n' "$@" | grep -qx -- '-a'; then
-      # Same '\037' escaping as list-sessions (list_tmux_panes uses 0x1f too).
-      sed 's/\t/\\037/g' "$HOME/.tmux_panes" 2>/dev/null
+      # Same US-separator handling as list-sessions.
+      if test "${TMUX_FAKE_RAW_US:-0}" = 1; then
+        sed $'s/\t/\x1f/g' "$HOME/.tmux_panes" 2>/dev/null
+      else
+        sed 's/\t/\\037/g' "$HOME/.tmux_panes" 2>/dev/null
+      fi
     else
       # list-panes -t NAME -F '#{pane_current_command}': serve a generic list.
       cat "$HOME/.tmux_cmds" 2>/dev/null
@@ -243,6 +253,21 @@ test_skips_existing_sessions() {
   assert_status 0
   assert_called "tmux new-session -s 3"
   assert_output_contains "Creating tmux session 3"
+}
+
+test_attaches_disconnected_first_raw_us() {
+  # Some tmux builds emit a format-string 0x1f as a raw US byte rather than the
+  # '\037' escape. Without translating both forms back to TAB, session names
+  # end up concatenated with the attached count -- the picker would show
+  # session "1" with one client as "11" and session "2" detached as "20", and
+  # attach would target the mangled name. Cover the raw-byte case here.
+  export TMUX_FAKE_RAW_US=1
+  add_session 1 1   # attached
+  add_session 2 0   # disconnected
+  run_autotmux
+  assert_status 0
+  assert_called "tmux attach-session -t =2"
+  assert_output_contains "Attaching tmux session 2"
 }
 
 test_attaches_disconnected_with_space_in_name() {
@@ -709,6 +734,7 @@ run_test "passthrough preserves all arguments" test_passthrough_preserves_args
 run_test "creates session 1 when no sessions exist" test_creates_session_1
 run_test "attaches to disconnected session before creating new one" test_attaches_disconnected_first
 run_test "skips existing sessions when creating" test_skips_existing_sessions
+run_test "handles raw US byte from tmux without mangling names" test_attaches_disconnected_first_raw_us
 run_test "attaches to a disconnected session whose name has a space" test_attaches_disconnected_with_space_in_name
 run_test "creates the next number when a space-named session is attached" test_creates_next_number_with_space_in_name
 run_test "normalizes '.' and ':' in the project prefix" test_sanitizes_prefix_metacharacters

--- a/changetmux
+++ b/changetmux
@@ -30,12 +30,13 @@ active_pane_field() {
   # "session<TAB>path<TAB>command" for each session's active pane, so the picker
   # line can show a cwd and command without a vcs call. One list-panes covers
   # every session; keep the first active pane seen per session (active pane of
-  # the active window). See autotmux's list_tmux_sessions for the '\037'->TAB
-  # translation (tmux mangles a literal TAB in a -F format).
+  # the active window). See autotmux's list_tmux_sessions for why we translate
+  # both the raw 0x1f and the 4-char '\037' escape back to TAB (tmux mangles a
+  # literal TAB in -F, and different versions emit 0x1f either way).
   tmux list-panes -a \
     -F "#{session_name}"$'\x1f'"#{window_active}"$'\x1f'"#{pane_active}"$'\x1f'"#{pane_current_path}"$'\x1f'"#{pane_current_command}" \
     2>/dev/null \
-    | sed 's/\\037/\t/g' \
+    | sed $'s/\x1f/\t/g; s/\\\\037/\t/g' \
     | awk -F'\t' '$2 == 1 && $3 == 1 && !seen[$1]++ { print $1 "\t" $4 "\t" $5 }'
 }
 

--- a/changetmux_test
+++ b/changetmux_test
@@ -32,7 +32,14 @@ echo "tmux $*" >> "$HOME/.tmux_calls"
 cmd="$1"; shift
 case "$cmd" in
   list-sessions)
-    sed 's/\t/\\037/g' "$HOME/.tmux_sessions" 2>/dev/null
+    # Different tmux versions emit a format-string 0x1f as either the 4-char
+    # escape '\037' or the raw byte; the fixtures store real tabs. Default to
+    # the escape, switch to the raw byte under TMUX_FAKE_RAW_US=1.
+    if test "${TMUX_FAKE_RAW_US:-0}" = 1; then
+      sed $'s/\t/\x1f/g' "$HOME/.tmux_sessions" 2>/dev/null
+    else
+      sed 's/\t/\\037/g' "$HOME/.tmux_sessions" 2>/dev/null
+    fi
     test -s "$HOME/.tmux_sessions" || { echo "no server running" >&2; exit 1; }
     exit 0
     ;;
@@ -41,10 +48,18 @@ case "$cmd" in
     #   -a with a window_active field -> active pane of every session
     #   -s -t =NAME                   -> commands in one session
     if printf '%s\n' "$@" | grep -q 'window_active'; then
-      # 5 fields: name, window_active(1), pane_active(1), path, command.
+      # 5 fields: name, window_active(1), pane_active(1), path, command. Use
+      # the same US-separator form as list-sessions (raw byte or '\037' escape
+      # depending on TMUX_FAKE_RAW_US) so this fake matches whichever tmux
+      # behavior we're simulating.
       while IFS=$'\t' read -r name path command; do
-        printf '%s\037%s\037%s\037%s\037%s\n' "$name" 1 1 "$path" "$command"
-      done < "$HOME/.tmux_active" 2>/dev/null
+        printf '%s\t%s\t%s\t%s\t%s\n' "$name" 1 1 "$path" "$command"
+      done < "$HOME/.tmux_active" 2>/dev/null \
+        | { if test "${TMUX_FAKE_RAW_US:-0}" = 1; then
+              sed $'s/\t/\x1f/g'
+            else
+              sed 's/\t/\\037/g'
+            fi; }
     else
       # session_commands: -s -t =NAME -F '#{pane_current_command}'
       target=


### PR DESCRIPTION
## Summary

- The format strings embed a literal US (0x1f) byte as the field separator (tmux mangles a literal TAB). Some tmux builds emit it back as the raw byte, others (e.g. 3.4 in this container) as the 4-char escape `\037`.
- The `sed 's/\\037/\t/g'` only matched the escape, so on a tmux that emits the raw byte every row read as one field. In the picker, session `1` attached to one client showed as `11` and detached session `2` showed as `20`, because the US separator survived into the displayed name.
- Use ANSI-C quoting in the sed to mirror the format string's `$'\x1f'` and translate both forms back to TAB. Applied in `list_tmux_sessions`, `list_tmux_panes`, and `active_pane_field`.

## Test plan

- [x] `./autotmux_test` — 49 passing (includes new `handles raw US byte from tmux without mangling names`)
- [x] `./changetmux_test` — 13 passing (fake tmux now toggleable via `TMUX_FAKE_RAW_US`)
- [x] `make test` — all green
- [x] Reverted just the sed fix to confirm the new regression test fails cleanly

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEyBn76KtH7ZLnMr6z28uR)_