### PR TITLE
autoshpool: drop tee/fifo stderr capture

### DIFF
--- a/autoshpool
+++ b/autoshpool
@@ -145,12 +145,19 @@ create_and_attach_next() {
     # Re-check the listing: if our session still shows as "attached", we lost
     # a race against another shell and should try the next number. A session
     # we just exited from is either gone or "disconnected" by now.
+    # Bound the list the way abort_if_hung does -- if it hangs or errors we
+    # cannot tell a real attach from a busy refusal, so report failure
+    # rather than letting `autoshpool && exit` silently exit the shell with
+    # no session attached.
     # Capturing stderr to disambiguate the busy message was tried and rolled
     # back because routing shpool's interactive stderr through a pipe (tee
     # buffering) splattered escape sequences onto the user's terminal at
     # unpredictable moments.
     if test $rc -eq 0; then
-      listing="$(shpool list 2>/dev/null)"
+      if ! listing="$(timeout 2 shpool list 2>/dev/null)"; then
+        echo "shpool list failed after attach; cannot confirm session state" >&2
+        return 2
+      fi
       if test "$(session_status "$session" "$listing")" = "attached"; then
         sessions[$session]=1
         continue

--- a/autoshpool
+++ b/autoshpool
@@ -130,15 +130,6 @@ create_and_attach_next() {
   for session in $(get_shpool_session_names); do
     sessions[$session]=1
   done
-  declare errfile fifo
-  errfile=$(mktemp) || return 2
-  fifo=$(mktemp -u) || { rm -f "$errfile"; return 2; }
-  if ! mkfifo -m 600 "$fifo"; then
-    rm -f "$errfile"
-    return 2
-  fi
-  # shellcheck disable=SC2064  # expand paths now, not on trap fire
-  trap "rm -f '$errfile' '$fifo'" RETURN
   for num in $(seq 1 100); do
     declare session="$SHPOOL_PREFIX$num"
     if test -n "${sessions[$session]}"; then
@@ -146,21 +137,25 @@ create_and_attach_next() {
     fi
     export SHPOOL_INITIAL_PWD="$PWD"
     echo "Creating shpool session $session"
-    : >"$errfile"
-    # Tee shpool's stderr so it stays visible to the user (live, like a normal
-    # attach) while a copy lands in $errfile for the busy-session check below.
-    # shpool exits 0 even when refusing because the session is already
-    # attached elsewhere (libshpool BusyError -> AttachResult::Done), so the
-    # message itself is the only reliable signal that we should try the next
-    # number instead of treating the attach as successful.
-    tee -a "$errfile" >&2 <"$fifo" &
-    declare tee_pid=$!
-    shpool attach "$session" 2>"$fifo"
+    shpool attach "$session"
     rc=$?
-    wait "$tee_pid" 2>/dev/null
-    if grep -q "already has a terminal attached" "$errfile"; then
-      sessions[$session]=1
-      continue
+    # shpool exits 0 even when refusing because the session is already
+    # attached elsewhere (libshpool BusyError -> AttachResult::Done), so a
+    # clean exit alone is not proof that we actually owned the session.
+    # Re-check the listing: if our session still shows as "attached", we lost
+    # a race against another shell and should try the next number. A session
+    # we just exited from is either gone or "disconnected" by now.
+    # Capturing stderr to disambiguate the busy message was tried and rolled
+    # back because routing shpool's interactive stderr through a pipe (tee
+    # buffering) splattered escape sequences onto the user's terminal at
+    # unpredictable moments.
+    if test $rc -eq 0; then
+      listing="$(shpool list 2>/dev/null)"
+      if test "$(session_status "$session" "$listing")" = "attached"; then
+        sessions[$session]=1
+        continue
+      fi
+      return 0
     fi
     return $rc
   done

--- a/autoshpool_test
+++ b/autoshpool_test
@@ -507,6 +507,40 @@ SHPOOL
   assert_output_contains "already has a terminal attached"
 }
 
+test_post_attach_list_failure_propagates() {
+  # If the post-attach `shpool list` fails or hangs, we cannot tell a real
+  # attach from a busy refusal. autoshpool must report failure rather than
+  # letting the .shrc pattern `autoshpool && exit` silently exit the shell
+  # with no session attached.
+  cat > "$TEST_TMPDIR/bin/shpool" <<'SHPOOL'
+#!/bin/bash
+echo "shpool $*" >> "$HOME/.shpool_calls"
+case "$1" in
+  list)
+    if [ -e "$HOME/.shpool_attached" ]; then
+      exit 1
+    fi
+    echo "name                           started_at                         status"
+    cat "$HOME/.shpool_sessions" 2>/dev/null
+    exit 0
+    ;;
+  attach)
+    touch "$HOME/.shpool_attached"
+    exit 0
+    ;;
+esac
+SHPOOL
+  chmod +x "$TEST_TMPDIR/bin/shpool"
+  run_autoshpool
+  if [ "$status" -eq 0 ]; then
+    echo "  FAIL: expected non-zero exit when post-attach list fails"
+    echo "  output: $output"
+    return 1
+  fi
+  assert_called "shpool attach 1"
+  assert_output_contains "cannot confirm session state"
+}
+
 test_propagates_real_attach_failure() {
   # A non-zero attach exit with no busy-session message must propagate the
   # error, not silently try the next number.
@@ -733,6 +767,7 @@ run_test "loop handles switch request after session ends" test_loop_handles_swit
 run_test "uses SHPOOL_PREFIX for session names" test_uses_prefix
 run_test "skips existing sessions when creating" test_skips_existing_sessions
 run_test "retries with the next number when a session is already attached" test_retries_when_session_already_attached
+run_test "reports failure when the post-attach list check fails" test_post_attach_list_failure_propagates
 run_test "propagates a real attach failure rather than trying the next number" test_propagates_real_attach_failure
 run_test "switch resolves a path segment to its session" test_switch_resolves_path_segment
 run_test "switch matches whole path segments only" test_switch_requires_whole_segment

--- a/autoshpool_test
+++ b/autoshpool_test
@@ -473,10 +473,10 @@ EOF
 }
 
 test_retries_when_session_already_attached() {
-  # shpool refuses a busy session by printing the message to stderr and
-  # exiting 0 (upstream BusyError -> AttachResult::Done). autoshpool must
-  # detect the message and try the next number rather than treating the
-  # zero exit as success.
+  # shpool exits 0 even when refusing because the session is already attached
+  # elsewhere (libshpool BusyError -> AttachResult::Done). autoshpool detects
+  # the race by re-listing after attach: if the session still shows as
+  # "attached" we lost a race and try the next number.
   cat > "$TEST_TMPDIR/bin/shpool" <<'SHPOOL'
 #!/bin/bash
 echo "shpool $*" >> "$HOME/.shpool_calls"
@@ -488,7 +488,10 @@ case "$1" in
     ;;
   attach)
     if grep -Fxq "$2" "$HOME/.shpool_already_attached" 2>/dev/null; then
+      # Busy: print the upstream message and exit 0. The session shows as
+      # attached in the listing because someone else owns it.
       echo "session '$2' already has a terminal attached" >&2
+      printf '%s   2025-01-01T00:00:00Z   attached\n' "$2" >> "$HOME/.shpool_sessions"
     fi
     exit 0
     ;;


### PR DESCRIPTION
## Summary
- Routing shpool's interactive stderr through a tee'd FIFO held escape sequences in tee's buffer and dumped them onto the terminal at unpredictable moments — appearing as random garbage and making the shell look hung during normal sessions.
- The capture only existed to spot shpool's "already has a terminal attached" message, since shpool exits 0 even when refusing a busy session.
- Replace it with a post-attach `shpool list` check: after a zero-exit attach, treat the session as taken only when it still shows as `attached`. A session we just exited from is gone or `disconnected` by then.

## Tradeoffs
Trades a narrow race (another shell attaching in the window between our detach and our re-list) for not corrupting the user's terminal on every session — the failure mode that motivated this change.

## Test plan
- [x] `./autoshpool_test` (40/40 pass), including `test_retries_when_session_already_attached` updated to reflect the new detection path.
- [x] `make test` across the repo, no regressions.
- [ ] Manual: run `autoshpool` in a fresh shell and confirm no stray escape output during/after a session.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XqnLd4JcjycMjvXiqKJudk)_