### PR TITLE
autoshpool: fix picker switch creating a new numbered session

### DIFF
--- a/autoshpool
+++ b/autoshpool
@@ -154,10 +154,34 @@ create_and_attach_next() {
     # buffering) splattered escape sequences onto the user's terminal at
     # unpredictable moments.
     if test $rc -eq 0; then
+      # A switch queued while we held this session means the detach that ended
+      # the attach was deliberate (changeshpool/switchshpool detaches us to hand
+      # the switch to this loop). We owned the session, so hand straight back to
+      # the loop to service the switch instead of running the busy-race check
+      # below -- otherwise the not-yet-settled "attached" status (see the poll)
+      # is mistaken for a lost race and a brand-new numbered session is created.
+      if test -n "$(get_switch_session)"; then
+        return 0
+      fi
       if ! listing="$(timeout 2 shpool list 2>/dev/null)"; then
         echo "shpool list failed after attach; cannot confirm session state" >&2
         return 2
       fi
+      # A session we owned and just detached from still shows as "attached" for
+      # a moment before the daemon settles the status (the same lag changeshpool
+      # polls around when stealing). A session we genuinely lost the race for is
+      # owned by another live client and stays "attached". Poll briefly so the
+      # status can settle: ours leaves "attached" (we return to the loop), a lost
+      # race stays "attached" for the whole window (we try the next number).
+      local i
+      for i in 1 2 3 4 5 6 7 8 9 10; do
+        test "$(session_status "$session" "$listing")" = attached || break
+        sleep 0.1
+        if ! listing="$(timeout 2 shpool list 2>/dev/null)"; then
+          echo "shpool list failed after attach; cannot confirm session state" >&2
+          return 2
+        fi
+      done
       if test "$(session_status "$session" "$listing")" = "attached"; then
         sessions[$session]=1
         continue

--- a/autoshpool_test
+++ b/autoshpool_test
@@ -453,6 +453,95 @@ SHPOOL
   assert_called "shpool attach other"
 }
 
+test_create_path_services_queued_switch() {
+  # Regression: while the loop is still inside create_and_attach_next holding a
+  # freshly created session, switching via the picker writes a switch file and
+  # detaches us. The detach has not settled in `shpool list` yet, so the session
+  # still shows "attached" -- which must NOT be mistaken for a lost busy race and
+  # trigger creation of a brand-new numbered session. The queued switch must be
+  # serviced instead.
+  cat > "$TEST_TMPDIR/bin/shpool" <<'SHPOOL'
+#!/bin/bash
+echo "shpool $*" >> "$HOME/.shpool_calls"
+case "$1" in
+  list)
+    echo "name                           started_at                         status"
+    cat "$HOME/.shpool_sessions" 2>/dev/null
+    exit 0
+    ;;
+  attach)
+    call_count=$(grep -c "shpool attach" "$HOME/.shpool_calls" 2>/dev/null || echo 0)
+    if [ "$call_count" -le 1 ]; then
+      # First attach (session 1): the user picks a switch target while the
+      # daemon still reports our just-detached session as attached.
+      echo "target:9" > "$HOME/.autoshpool_switch"
+      printf '%-30s %-33s %s\n' "1" "2025-01-01T00:00:00Z" "attached" \
+        >> "$HOME/.shpool_sessions"
+    fi
+    exit 0
+    ;;
+esac
+SHPOOL
+  chmod +x "$TEST_TMPDIR/bin/shpool"
+
+  run_autoshpool
+  assert_status 0
+  assert_called "shpool attach 1"
+  assert_called "shpool attach target:9"
+  if grep -q "shpool attach 2" "$HOME/.shpool_calls" 2>/dev/null; then
+    echo "  FAIL: created a new numbered session instead of servicing the switch"
+    echo "  calls: $(cat "$HOME/.shpool_calls" 2>/dev/null)"
+    return 1
+  fi
+}
+
+test_create_path_waits_for_unsettled_status() {
+  # A session we owned and just detached can still show "attached" on the first
+  # post-attach listing before the daemon settles it to "disconnected". Even with
+  # no switch queued, the busy-race check must poll for the status to settle
+  # rather than immediately treating the stale "attached" as a lost race and
+  # creating the next numbered session.
+  cat > "$TEST_TMPDIR/bin/shpool" <<'SHPOOL'
+#!/bin/bash
+echo "shpool $*" >> "$HOME/.shpool_calls"
+case "$1" in
+  list)
+    echo "name                           started_at                         status"
+    if [ -f "$HOME/.shpool_sessions" ]; then
+      if [ -f "$HOME/.list_seen_attached" ]; then
+        # A later list: the status has now settled to disconnected.
+        awk '$1 == "1" && $NF == "attached" { $NF = "disconnected"; printf "%-30s %-33s %s\n", $1, $2, $NF; next } { print }' \
+          "$HOME/.shpool_sessions" > "$HOME/.shpool_sessions.new" \
+          && mv "$HOME/.shpool_sessions.new" "$HOME/.shpool_sessions"
+      elif awk '$1 == "1" && $NF == "attached" { f = 1 } END { exit !f }' "$HOME/.shpool_sessions"; then
+        touch "$HOME/.list_seen_attached"
+      fi
+      cat "$HOME/.shpool_sessions"
+    fi
+    exit 0
+    ;;
+  attach)
+    call_count=$(grep -c "shpool attach" "$HOME/.shpool_calls" 2>/dev/null || echo 0)
+    if [ "$call_count" -le 1 ]; then
+      printf '%-30s %-33s %s\n' "1" "2025-01-01T00:00:00Z" "attached" \
+        >> "$HOME/.shpool_sessions"
+    fi
+    exit 0
+    ;;
+esac
+SHPOOL
+  chmod +x "$TEST_TMPDIR/bin/shpool"
+
+  run_autoshpool
+  assert_status 0
+  assert_called "shpool attach 1"
+  if grep -q "shpool attach 2" "$HOME/.shpool_calls" 2>/dev/null; then
+    echo "  FAIL: created a new session despite the status settling to disconnected"
+    echo "  calls: $(cat "$HOME/.shpool_calls" 2>/dev/null)"
+    return 1
+  fi
+}
+
 test_uses_prefix() {
   export SHPOOL_PREFIX="myproject:"
   run_autoshpool
@@ -764,6 +853,8 @@ run_test "failed attach does not create a new session" test_failed_attach_does_n
 run_test "returns non-zero when shpool attach fails" test_returns_nonzero_on_failure
 run_test "preserves specific exit code from shpool attach" test_preserves_exit_code
 run_test "loop handles switch request after session ends" test_loop_handles_switch
+run_test "create path services a switch queued before the status settles" test_create_path_services_queued_switch
+run_test "create path waits for an unsettled attached status to settle" test_create_path_waits_for_unsettled_status
 run_test "uses SHPOOL_PREFIX for session names" test_uses_prefix
 run_test "skips existing sessions when creating" test_skips_existing_sessions
 run_test "retries with the next number when a session is already attached" test_retries_when_session_already_attached


### PR DESCRIPTION
## Problem

Picking a session in the `changeshpool`/`changesession` fzf picker and pressing Enter would **create a new numbered session** instead of switching to the chosen one.

## Root cause

The bug is in `create_and_attach_next` in `autoshpool`.

When you log in, the servicing loop creates the first session (e.g. `proj:1`) and blocks inside `shpool attach proj:1` — but that call lives *inside* `create_and_attach_next`, not the loop body. When you then pick a session in the picker, `changeshpool`'s `request_switch` writes the target to the switch file and **detaches your current session** to hand control back to the loop.

The detach makes `shpool attach` return, and control resumes inside `create_and_attach_next`, which runs its post-attach "did I lose a busy race?" check. Because the deliberate detach hasn't propagated to `shpool list` yet (the same not-yet-settled-status lag the code acknowledges elsewhere), the session still shows `attached`. The function mistakes this for a lost busy race, moves to the next number, and creates a brand-new session — instead of returning to the loop to service the queued switch.

This is why it only bites the common "log in, immediately switch to an existing session" flow.

## Fix

Two complementary changes in `create_and_attach_next`:

- **Queued switch ⇒ return.** If a switch is queued when our attach returns, the detach was deliberate and we owned the session, so return `0` and let the loop service the switch. A switch file can only appear if the attach genuinely succeeded (the user was inside the session), so this is precise and safe.
- **Poll for the status to settle.** For the residual race (e.g. a plain external detach with no switch queued), poll briefly for the session to leave `attached` before concluding it was a lost race — mirroring `changeshpool`'s steal-then-poll path. A session we owned leaves `attached`; one genuinely held by another client stays `attached` for the whole window and we correctly try the next number.

## Tests

Added two regression tests in `autoshpool_test` (both fail on the previous code, pass with the fix):

- `create path services a switch queued before the status settles`
- `create path waits for an unsettled attached status to settle`

Full suite green: `make test` (plus `changeshpool_test`).

https://claude.ai/code/session_01MH8GqyTyFkXzvhqbozcwUb

---
_Generated by [Claude Code](https://claude.ai/code/session_01MH8GqyTyFkXzvhqbozcwUb)_