### PR TITLE
autoshpool: reuse separatorless sessions and harden name handling

### DIFF
--- a/autoshpool
+++ b/autoshpool
@@ -42,17 +42,23 @@ pick_prefixed_session() {
   # Print the session to switch to for the current SHPOOL_PREFIX: reuse the
   # first disconnected session that already matches, otherwise the next free
   # numbered name. Mirrors the selection the main loop makes for a new shell.
-  declare -a disconnected=( $(get_disconnected_shpool_sessions) )
-  if test "${#disconnected[@]}" -gt 0; then
-    printf '%s\n' "${disconnected[0]}"
+  # Read line by line rather than splitting an unquoted command substitution:
+  # the prefix comes from the project basename, which can contain glob
+  # metacharacters (e.g. "a*b"), and an unquoted $() would glob-expand or
+  # IFS-split such a name instead of passing it through whole.
+  local first
+  IFS= read -r first < <(get_disconnected_shpool_sessions) || true
+  if test -n "$first"; then
+    printf '%s\n' "$first"
     return
   fi
   declare -A sessions
-  for session in $(get_shpool_session_names); do
-    sessions[$session]=1
-  done
+  local session num
+  while IFS= read -r session; do
+    test -n "$session" && sessions[$session]=1
+  done < <(get_shpool_session_names)
   for num in $(seq 1 100); do
-    declare session="$SHPOOL_PREFIX$num"
+    session="$SHPOOL_PREFIX$num"
     if test -z "${sessions[$session]}"; then
       printf '%s\n' "$session"
       return
@@ -106,9 +112,14 @@ get_prefix() {
 get_shpool_sessions() {
   # Session names can be empty, so need handle rows with only 2 columns specially.
   # The prefix is compared as a literal string, not a regex, since project names
-  # can contain regex metacharacters (e.g. "my.proj").
-  shpool list | awk -v prefix="$SHPOOL_PREFIX" \
-    'NR > 1 && NF == 3 && (prefix == "" || index($1, prefix) == 1) { print }'
+  # can contain regex metacharacters (e.g. "my.proj"). A session named exactly
+  # like the prefix with its separator stripped (e.g. "myproject" for
+  # "myproject:") also belongs to the project -- matching session_matches_prefix
+  # and autotmux's get_disconnected_sessions -- so it stays reusable instead of
+  # being stranded in favour of a fresh "myproject:1".
+  local bare="${SHPOOL_PREFIX%"$SESSION_SEP"}"
+  shpool list | awk -v prefix="$SHPOOL_PREFIX" -v bare="$bare" \
+    'NR > 1 && NF == 3 && (prefix == "" || index($1, prefix) == 1 || $1 == bare) { print }'
 }
 
 get_shpool_session_names() {
@@ -120,16 +131,25 @@ get_disconnected_shpool_sessions() {
 }
 
 first_disconnected_session() {
-  declare -a disconnected=( $(get_disconnected_shpool_sessions) )
-  test "${#disconnected[@]}" -gt 0 || return 1
-  printf '%s\n' "${disconnected[0]}"
+  # Read the first row rather than splitting an unquoted command substitution
+  # into an array: the prefix comes from the project basename, which can contain
+  # glob metacharacters (e.g. "a*b"), and an unquoted $() would glob-expand or
+  # IFS-split such a name instead of passing it through whole.
+  local first
+  IFS= read -r first < <(get_disconnected_shpool_sessions) || true
+  test -n "$first" || return 1
+  printf '%s\n' "$first"
 }
 
 create_and_attach_next() {
   declare -A sessions
-  for session in $(get_shpool_session_names); do
-    sessions[$session]=1
-  done
+  local session
+  # Read line by line so existing names are matched whole: the prefix comes from
+  # the project basename, which can contain glob metacharacters (e.g. "a*b"),
+  # and an unquoted $() would glob-expand or IFS-split such a name.
+  while IFS= read -r session; do
+    test -n "$session" && sessions[$session]=1
+  done < <(get_shpool_session_names)
   for num in $(seq 1 100); do
     declare session="$SHPOOL_PREFIX$num"
     if test -n "${sessions[$session]}"; then

--- a/autoshpool_test
+++ b/autoshpool_test
@@ -397,6 +397,54 @@ EOF
   assert_output_contains "Attaching shpool session 3"
 }
 
+test_reuses_separatorless_session() {
+  # A disconnected session named exactly like the bare prefix (no separator)
+  # belongs to the project, so startup reuses it instead of creating
+  # "myproject:1". Mirrors autotmux's separatorless reuse and the bare-name
+  # case in the shared session_matches_prefix.
+  export SHPOOL_PREFIX="myproject:"
+  cat > "$HOME/.shpool_sessions" <<EOF
+myproject   2025-01-01T00:00:00Z   disconnected
+EOF
+  run_autoshpool
+  assert_status 0
+  assert_called "shpool attach myproject"
+  assert_output_contains "Attaching shpool session myproject"
+}
+
+test_mismatch_switch_reuses_separatorless_session() {
+  # The prefix-mismatch switch path (pick_prefixed_session) reuses the
+  # separatorless session too, rather than queueing a fresh "myproject:1".
+  export SHPOOL_PREFIX="myproject:"
+  export SHPOOL_SESSION_NAME="other:1"
+  cat > "$HOME/.shpool_sessions" <<EOF
+myproject   2025-01-01T00:00:00Z   disconnected
+EOF
+  run_autoshpool
+  assert_status 0
+  assert_output_contains "does not match prefix"
+  assert_switch_file "myproject"
+}
+
+test_reuses_glob_metachar_session() {
+  # A session name containing a glob metacharacter (the project basename can
+  # contain one, e.g. "a*b") must round-trip whole. An unquoted command
+  # substitution would glob-expand it against the cwd; reading line by line
+  # passes it through verbatim. Run from a dir holding a decoy file the glob
+  # would match so the old breakage would be deterministic.
+  export SHPOOL_PREFIX="a*b:"
+  cat > "$HOME/.shpool_sessions" <<EOF
+a*b:3   2025-01-01T00:00:00Z   disconnected
+EOF
+  local oldpwd="$PWD"
+  cd "$TEST_TMPDIR"
+  : > 'aXb:3'
+  run_autoshpool
+  cd "$oldpwd"
+  assert_status 0
+  assert_output_contains "Attaching shpool session a*b:3"
+}
+
 test_failed_attach_does_not_create_new_session() {
   # A failed attach to an existing disconnected session must report the error,
   # not fall through and silently create a brand-new session.
@@ -849,6 +897,9 @@ run_test "records no directory for a plain switch" test_plain_switch_records_no_
 run_test "loop exports the recorded directory when servicing a switch" test_loop_switch_exports_recorded_pwd
 run_test "creates session 1 when no sessions exist" test_creates_session_1
 run_test "attaches to disconnected session before creating new one" test_attaches_disconnected_first
+run_test "reuses a disconnected separatorless session on startup" test_reuses_separatorless_session
+run_test "reuses a separatorless session on a prefix-mismatch switch" test_mismatch_switch_reuses_separatorless_session
+run_test "round-trips a session name containing a glob metacharacter" test_reuses_glob_metachar_session
 run_test "failed attach does not create a new session" test_failed_attach_does_not_create_new_session
 run_test "returns non-zero when shpool attach fails" test_returns_nonzero_on_failure
 run_test "preserves specific exit code from shpool attach" test_preserves_exit_code


### PR DESCRIPTION
## Summary

While reviewing the `{auto,change,make,*}{session,shpool,tmux}` family for bugs and inconsistencies, I found two places where the **shpool** backend diverged from the **tmux** backend. Both are fixed here in `autoshpool`, with the tmux side as the reference behavior.

### 1. Reuse a disconnected *separatorless* session
`autotmux:get_disconnected_sessions` reuses a session named exactly like the bare prefix (separator stripped) — e.g. `myproject` for prefix `myproject:` — and has tests for it. The shared `session_matches_prefix` in `sessionlib` treats that bare name as matching too, so `handle_already_attached` stays put on it.

But `autoshpool:get_shpool_sessions` filtered on the prefix only (`index($1, prefix) == 1`), so a disconnected session named `myproject` was **stranded** — startup created a fresh `myproject:1` instead of reusing it. This was also an internal contradiction: `handle_already_attached` considered the bare session a match while `get_disconnected_*` did not.

Fix: add the bare-name arm (`$1 == bare`) to the `awk` filter, mirroring `autotmux`.

### 2. Harden session-list parsing against glob metacharacters
`autoshpool` read session lists by splitting unquoted command substitutions into arrays (`declare -a x=( $(...) )`, `for s in $(...)`). A project basename can contain glob metacharacters (e.g. `a*b`), and these survive the columnar `awk` parse of `shpool list` (single token, no whitespace) but are then **glob-expanded / IFS-split** by the unquoted `$()` — yielding the wrong (or empty) session name.

`autotmux` already avoids this by reading line by line. Fix: convert `pick_prefixed_session`, `first_disconnected_session`, and `create_and_attach_next` to `IFS= read -r` loops.

## Tests

Added to `autoshpool_test`:
- `test_reuses_separatorless_session` — startup reuses a disconnected bare-prefix session
- `test_mismatch_switch_reuses_separatorless_session` — the prefix-mismatch switch path reuses it too
- `test_reuses_glob_metachar_session` — a name containing `*` round-trips whole (decoy file in cwd makes the old breakage deterministic)

All three fail without the corresponding fix and pass with it. Full suite: `make test` → all green (46 autoshpool tests, plus changeshpool/maketmux/etc. unaffected).

https://claude.ai/code/session_0175wgiQ6HtzKQeTSyMHka65

---
_Generated by [Claude Code](https://claude.ai/code/session_0175wgiQ6HtzKQeTSyMHka65)_