### PR TITLE
makeshpool: hand off to autoshpool's loop instead of nesting inside a session

### DIFF
--- a/makesession_test
+++ b/makesession_test
@@ -152,7 +152,8 @@ test_maketmux_inside_tmux_switches_client() {
   assert_called "tmux switch-client -t =work"
 }
 test_makeshpool_runs_shpool_attach() {
-  install_script makeshpool; fake shpool
+  install_script makeshpool; install_script autoshpool; install_script sessionlib
+  fake shpool
   set +e
   output="$(env -i PATH="$BIN" HOME="$TEST_TMPDIR" "$BIN/makeshpool" work 2>&1)"
   status=$?
@@ -160,7 +161,7 @@ test_makeshpool_runs_shpool_attach() {
   assert_called "shpool attach work"
 }
 test_makeshpool_stamps_initial_pwd() {
-  install_script makeshpool
+  install_script makeshpool; install_script autoshpool; install_script sessionlib
   # record the stamped SHPOOL_INITIAL_PWD: a freshly created shpool session
   # must open in the caller's dir, not the outer shell's startup dir.
   cat > "$BIN/shpool" <<EOF
@@ -173,6 +174,40 @@ EOF
   ( cd "$TEST_TMPDIR" && env -i PATH="$BIN" HOME="$TEST_TMPDIR" "$BIN/makeshpool" work )
   set -e
   assert_called "shpool attach work pwd=$TEST_TMPDIR"
+}
+test_makeshpool_inside_session_requests_switch() {
+  # Inside a session, makeshpool can't attach a second session to this terminal
+  # without nesting, so it hands the new session to autoshpool's loop via
+  # request_switch (records the target + PWD and detaches us) rather than running
+  # shpool attach. Mirrors maketmux's switch-client dance for nested tmux.
+  install_script makeshpool; install_script autoshpool; install_script sessionlib
+  fake shpool
+  # request_switch bounds its detach with timeout; fake it to run the rest.
+  cat > "$BIN/timeout" <<'EOF'
+#!/bin/bash
+shift
+"$@"
+EOF
+  chmod +x "$BIN/timeout"
+  set +e
+  ( cd "$TEST_TMPDIR" && env -i PATH="$BIN" HOME="$TEST_TMPDIR" SHPOOL_SESSION_NAME=work "$BIN/makeshpool" newproj )
+  status=$?
+  set -e
+  assert_status 0
+  assert_called "shpool detach work"
+  if test "$(cat "$TEST_TMPDIR/.autoshpool_switch" 2>/dev/null)" != "newproj"; then
+    echo "  FAIL: switch file should record 'newproj', got '$(cat "$TEST_TMPDIR/.autoshpool_switch" 2>/dev/null)'"
+    TEST_FAILED=1
+  fi
+  if test "$(cat "$TEST_TMPDIR/.autoshpool_switch_pwd" 2>/dev/null)" != "$TEST_TMPDIR"; then
+    echo "  FAIL: switch pwd file should record '$TEST_TMPDIR', got '$(cat "$TEST_TMPDIR/.autoshpool_switch_pwd" 2>/dev/null)'"
+    TEST_FAILED=1
+  fi
+  if grep -q "shpool attach" "$CALLS" 2>/dev/null; then
+    echo "  FAIL: must not attach (would nest) when inside a session"
+    echo "  calls: $(cat "$CALLS" 2>/dev/null)"
+    TEST_FAILED=1
+  fi
 }
 
 run_test "dispatch: inside tmux picks maketmux" test_inside_tmux_picks_maketmux
@@ -187,6 +222,7 @@ run_test "backend: maketmux outside tmux creates and attaches" test_maketmux_out
 run_test "backend: maketmux inside tmux switches client" test_maketmux_inside_tmux_switches_client
 run_test "backend: makeshpool runs shpool attach" test_makeshpool_runs_shpool_attach
 run_test "backend: makeshpool stamps SHPOOL_INITIAL_PWD" test_makeshpool_stamps_initial_pwd
+run_test "backend: makeshpool inside a session requests a switch" test_makeshpool_inside_session_requests_switch
 
 echo "$TESTS_RUN tests, $TESTS_PASSED passed, $TESTS_FAILED failed"
 test "$TESTS_FAILED" -eq 0

--- a/makesession_test
+++ b/makesession_test
@@ -209,6 +209,34 @@ EOF
     TEST_FAILED=1
   fi
 }
+test_makeshpool_inside_session_rejects_extra_args() {
+  # The switch handoff carries only a name, so extra attach options can't be
+  # forwarded from inside a session: makeshpool must error rather than silently
+  # drop them (and must not record a switch or touch shpool).
+  install_script makeshpool; install_script autoshpool; install_script sessionlib
+  fake shpool
+  cat > "$BIN/timeout" <<'EOF'
+#!/bin/bash
+shift
+"$@"
+EOF
+  chmod +x "$BIN/timeout"
+  set +e
+  output="$(env -i PATH="$BIN" HOME="$TEST_TMPDIR" SHPOOL_SESSION_NAME=work "$BIN/makeshpool" newproj --ttl 1h 2>&1)"
+  status=$?
+  set -e
+  assert_status 2
+  assert_output_contains "can't forward options"
+  if test -e "$TEST_TMPDIR/.autoshpool_switch"; then
+    echo "  FAIL: must not record a switch when rejecting"
+    TEST_FAILED=1
+  fi
+  if grep -qE "shpool (attach|detach)" "$CALLS" 2>/dev/null; then
+    echo "  FAIL: must not touch shpool when rejecting"
+    echo "  calls: $(cat "$CALLS" 2>/dev/null)"
+    TEST_FAILED=1
+  fi
+}
 
 run_test "dispatch: inside tmux picks maketmux" test_inside_tmux_picks_maketmux
 run_test "dispatch: inside shpool picks makeshpool" test_inside_shpool_picks_makeshpool
@@ -223,6 +251,7 @@ run_test "backend: maketmux inside tmux switches client" test_maketmux_inside_tm
 run_test "backend: makeshpool runs shpool attach" test_makeshpool_runs_shpool_attach
 run_test "backend: makeshpool stamps SHPOOL_INITIAL_PWD" test_makeshpool_stamps_initial_pwd
 run_test "backend: makeshpool inside a session requests a switch" test_makeshpool_inside_session_requests_switch
+run_test "backend: makeshpool inside a session rejects extra args" test_makeshpool_inside_session_rejects_extra_args
 
 echo "$TESTS_RUN tests, $TESTS_PASSED passed, $TESTS_FAILED failed"
 test "$TESTS_FAILED" -eq 0

--- a/makeshpool
+++ b/makeshpool
@@ -23,6 +23,15 @@
 source "$(dirname "$0")/autoshpool"
 
 if test -n "$SHPOOL_SESSION_NAME"; then
+  # The switch handoff carries only a session name (the outer loop just runs
+  # `shpool attach "$name"`), so extra `shpool attach` options -- e.g. --ttl,
+  # --cmd -- have nowhere to go on this path. Refuse rather than silently drop
+  # them (the outside-session path below still forwards "$@"); detach first to
+  # create the session with options.
+  if test "$#" -gt 1; then
+    echo "makeshpool: can't forward options (${*:2}) when creating a session from inside another; detach first" >&2
+    exit 2
+  fi
   request_switch "$1" "$PWD"   # records target, detaches us, and exits
 fi
 

--- a/makeshpool
+++ b/makeshpool
@@ -1,12 +1,30 @@
 #!/bin/bash
 # makeshpool - create (and attach to) a named shpool session
 #
-# Thin wrapper over `shpool attach` (which creates the session when it doesn't
-# exist yet), the shpool twin of maketmux, dispatched by makesession. All
-# arguments pass through (the first is the session name).
+# The shpool twin of maketmux, dispatched by makesession. The first argument is
+# the session name.
 #
-# Stamp SHPOOL_INITIAL_PWD so the new session's shell cd's to the caller's
-# directory rather than the outer shell's startup dir -- the same reason the
-# autoshpool wrapper stamps it. tmux needs no equivalent (see maketmux).
+# Outside any session, create-and-attach directly (shpool attach creates the
+# session when it doesn't exist yet). Stamp SHPOOL_INITIAL_PWD so the new
+# session's shell opens in the caller's directory rather than the outer shell's
+# startup dir -- the same reason the autoshpool wrapper stamps it. tmux needs no
+# equivalent (see maketmux).
+#
+# Inside an existing session shpool can't attach a second session to this
+# terminal without nesting -- and exec'ing `shpool attach` over our shell would
+# tear down the current session. So hand the new session to autoshpool's outer
+# loop the way changeshpool/switchshpool do: request_switch records the target,
+# carries PWD so it opens here, detaches us, and exits; the loop then creates
+# and attaches it as a sibling. This mirrors maketmux's new-session -d /
+# switch-client dance for the nested-tmux case.
+
+# Pull in the shpool backend helpers for request_switch. autoshpool's is_sourced
+# guard makes sourcing it define functions without running the loop.
+source "$(dirname "$0")/autoshpool"
+
+if test -n "$SHPOOL_SESSION_NAME"; then
+  request_switch "$1" "$PWD"   # records target, detaches us, and exits
+fi
+
 export SHPOOL_INITIAL_PWD="$PWD"
 exec shpool attach "$@"


### PR DESCRIPTION
## Summary

Follow-up to the session-backend review (finding #3). `makeshpool` ran `exec shpool attach "$@"` unconditionally. **From inside an existing shpool session that nests a second client** — and, being an `exec`, tears down the current session's shell when the inner one exits. This is the analog of the nested `new-session` that `maketmux` deliberately avoids for tmux (where nesting is *refused* outright).

`changeshpool` already handles "create a session from inside a session" correctly: it hands the target to `autoshpool`'s outer loop via `request_switch` (records the target + PWD, detaches us, and exits), and the loop then creates and attaches it as a **sibling**.

This change makes `makeshpool` do the same:
- **Inside a session** (`$SHPOOL_SESSION_NAME` set): `request_switch "$1" "$PWD"` — hand off to the loop, no nesting.
- **Outside a session**: unchanged — stamp `SHPOOL_INITIAL_PWD` and `exec shpool attach`.

`makeshpool` now sources `autoshpool` (guarded by its `is_sourced` check, exactly as `changeshpool` does) to reuse `request_switch`.

## Companion shell-wrapper change

The `ms`/`msp` wrappers in `shrc` (bash/zsh), `config/fish/config.fish`, and `config/nushell/config.nu` are updated in the **conf** repo (separate PR) to add the `&& … && exit` parked-shell cleanup that `cs`/`csp` already carry — since `request_switch` detaches the calling shell. Unlike `cs`, `make` always names a session (no no-arg picker path), so there's no `$# -eq 0` gate; it exits whenever shpool was the backend that ran (in shpool, not tmux, where `maketmux` switches the client in place).

## Tests

Added `test_makeshpool_inside_session_requests_switch` to `makesession_test`: with `$SHPOOL_SESSION_NAME` set, `makeshpool newproj` must record the switch target + PWD and call `shpool detach`, and must **not** call `shpool attach`. Verified it fails against the old `exec shpool attach` and passes with the fix. Existing makeshpool tests updated to install the now-required `autoshpool`/`sessionlib` alongside it.

Full `make test` is green.

https://claude.ai/code/session_0175wgiQ6HtzKQeTSyMHka65

---
_Generated by [Claude Code](https://claude.ai/code/session_0175wgiQ6HtzKQeTSyMHka65)_