### PR TITLE
Prefer shpool over tmux in the session dispatchers

### DIFF
--- a/autosession
+++ b/autosession
@@ -6,7 +6,7 @@
 #   * inside tmux  ($TMUX set)                 -> autotmux
 #   * inside shpool ($SHPOOL_SESSION_NAME set) -> autoshpool
 #   * outside both: honour $SESSION_BACKEND (tmux|shpool); otherwise use
-#     whichever of tmux/shpool is installed (tmux first).
+#     whichever of shpool/tmux is installed (shpool first).
 #
 # All arguments are passed through to the chosen script, so "autosession",
 # "autosession switch <target>", and pass-through commands all work. In shrc:
@@ -33,11 +33,11 @@ case "${SESSION_BACKEND:-}" in
   shpool) run autoshpool "$@" ;;
 esac
 
-if command -v tmux >/dev/null 2>&1; then
-  run autotmux "$@"
-fi
 if command -v shpool >/dev/null 2>&1; then
   run autoshpool "$@"
+fi
+if command -v tmux >/dev/null 2>&1; then
+  run autotmux "$@"
 fi
 
 echo "autosession: no tmux or shpool backend available" >&2

--- a/changesession
+++ b/changesession
@@ -5,7 +5,7 @@
 #   * inside tmux  ($TMUX set)                 -> changetmux
 #   * inside shpool ($SHPOOL_SESSION_NAME set) -> changeshpool
 #   * outside both: honour $SESSION_BACKEND (tmux|shpool); otherwise use
-#     whichever of tmux/shpool is installed (tmux first).
+#     whichever of shpool/tmux is installed (shpool first).
 #
 # All arguments are passed through to the chosen picker.
 
@@ -27,11 +27,11 @@ case "${SESSION_BACKEND:-}" in
   shpool) run changeshpool "$@" ;;
 esac
 
-if command -v tmux >/dev/null 2>&1; then
-  run changetmux "$@"
-fi
 if command -v shpool >/dev/null 2>&1; then
   run changeshpool "$@"
+fi
+if command -v tmux >/dev/null 2>&1; then
+  run changetmux "$@"
 fi
 
 echo "changesession: no tmux or shpool backend available" >&2

--- a/detachsession
+++ b/detachsession
@@ -6,7 +6,7 @@
 #   * inside tmux  ($TMUX set)                 -> detachtmux
 #   * inside shpool ($SHPOOL_SESSION_NAME set) -> detachshpool
 #   * outside both: honour $SESSION_BACKEND (tmux|shpool); otherwise use
-#     whichever of tmux/shpool is installed (tmux first).
+#     whichever of shpool/tmux is installed (shpool first).
 #
 # All arguments are passed through to the chosen script.
 #
@@ -31,11 +31,11 @@ case "${SESSION_BACKEND:-}" in
   shpool) run detachshpool "$@" ;;
 esac
 
-if command -v tmux >/dev/null 2>&1; then
-  run detachtmux "$@"
-fi
 if command -v shpool >/dev/null 2>&1; then
   run detachshpool "$@"
+fi
+if command -v tmux >/dev/null 2>&1; then
+  run detachtmux "$@"
 fi
 
 echo "detachsession: no tmux or shpool backend available" >&2

--- a/detachsession_test
+++ b/detachsession_test
@@ -122,6 +122,12 @@ test_fallback_shpool_installed() {
   run detachsession
   assert_called "detachshpool "
 }
+# Default preference when both are installed: shpool wins, tmux is the fallback.
+test_fallback_prefers_shpool_when_both_installed() {
+  install_script detachsession; fake detachtmux; fake detachshpool; fake tmux; fake shpool
+  run detachsession
+  assert_called "detachshpool "
+}
 test_no_backend_errors() {
   install_script detachsession; fake detachtmux; fake detachshpool
   run detachsession
@@ -156,6 +162,7 @@ run_test "dispatch: SESSION_BACKEND=tmux picks detachtmux" test_session_backend_
 run_test "dispatch: SESSION_BACKEND=shpool picks detachshpool" test_session_backend_shpool
 run_test "dispatch: falls back to installed tmux" test_fallback_tmux_installed
 run_test "dispatch: falls back to installed shpool" test_fallback_shpool_installed
+run_test "dispatch: prefers shpool when both installed" test_fallback_prefers_shpool_when_both_installed
 run_test "dispatch: no backend errors out" test_no_backend_errors
 run_test "dispatch: args pass through to backend" test_args_pass_through
 run_test "backend: detachtmux runs tmux detach" test_detachtmux_runs_tmux_detach

--- a/makesession
+++ b/makesession
@@ -6,7 +6,7 @@
 #   * inside tmux  ($TMUX set)                 -> maketmux
 #   * inside shpool ($SHPOOL_SESSION_NAME set) -> makeshpool
 #   * outside both: honour $SESSION_BACKEND (tmux|shpool); otherwise use
-#     whichever of tmux/shpool is installed (tmux first).
+#     whichever of shpool/tmux is installed (shpool first).
 #
 # All arguments (the session name, and any further pass-through) are forwarded.
 #
@@ -31,11 +31,11 @@ case "${SESSION_BACKEND:-}" in
   shpool) run makeshpool "$@" ;;
 esac
 
-if command -v tmux >/dev/null 2>&1; then
-  run maketmux "$@"
-fi
 if command -v shpool >/dev/null 2>&1; then
   run makeshpool "$@"
+fi
+if command -v tmux >/dev/null 2>&1; then
+  run maketmux "$@"
 fi
 
 echo "makesession: no tmux or shpool backend available" >&2

--- a/makesession_test
+++ b/makesession_test
@@ -115,6 +115,12 @@ test_fallback_shpool_installed() {
   run makesession
   assert_called "makeshpool "
 }
+# Default preference when both are installed: shpool wins, tmux is the fallback.
+test_fallback_prefers_shpool_when_both_installed() {
+  install_script makesession; fake maketmux; fake makeshpool; fake tmux; fake shpool
+  run makesession
+  assert_called "makeshpool "
+}
 test_no_backend_errors() {
   install_script makesession; fake maketmux; fake makeshpool
   run makesession
@@ -181,6 +187,7 @@ run_test "dispatch: SESSION_BACKEND=tmux picks maketmux" test_session_backend_tm
 run_test "dispatch: SESSION_BACKEND=shpool picks makeshpool" test_session_backend_shpool
 run_test "dispatch: falls back to installed tmux" test_fallback_tmux_installed
 run_test "dispatch: falls back to installed shpool" test_fallback_shpool_installed
+run_test "dispatch: prefers shpool when both installed" test_fallback_prefers_shpool_when_both_installed
 run_test "dispatch: no backend errors out" test_no_backend_errors
 run_test "dispatch: session name passes through" test_name_passes_through
 run_test "backend: maketmux outside tmux creates and attaches" test_maketmux_outside_tmux_creates_and_attaches


### PR DESCRIPTION
## Summary

- `autosession` / `changesession` / `detachsession` / `makesession` all fell back to **tmux first** when neither `$TMUX` nor `$SHPOOL_SESSION_NAME` nor `$SESSION_BACKEND` was set. Swap the order so **shpool wins by default** with tmux as the fallback.
- Matches the companion conf PR (mikelward/conf#182) that swaps the same default in `session_backend` across shrc / fish / nushell.
- Doc comments in each dispatcher updated to describe the new "shpool first" fallback.

## Test plan

- [x] `make test` passes locally: detachsession 11, makesession 13, mdf 14, autoshpool 46, autotmux 49.
- [x] Added a "prefers shpool when both installed" regression test to `detachsession_test` and `makesession_test` to lock in the new default.

https://claude.ai/code/session_0115sRHy9GUiMReXnHn38EaV

---
_Generated by [Claude Code](https://claude.ai/code/session_0115sRHy9GUiMReXnHn38EaV)_