### PR TITLE
Fix changesession ESC exiting the shell; de-dup the auto session entry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 test:
 	./autoshpool_test
 	./autotmux_test
+	./sessionlib_test
+	./changeshpool_test
+	./changetmux_test
 	./detachsession_test
 	./makesession_test
 	./mdf_test

--- a/changeshpool_test
+++ b/changeshpool_test
@@ -215,18 +215,26 @@ test_list_create_entry_first() {
 
 test_existing_auto_session_not_listed_twice() {
   # When the auto name reuses an existing (disconnected) session, that session
-  # must appear once -- as a normal switch row -- never also as a "+" entry.
+  # must appear once -- as a normal switch row -- never also as a "+" entry, and
+  # stay the first (default) row even though an attached sibling is listed first
+  # by the backend. proj:1 is attached so the picker reuses disconnected proj:2.
   export SHPOOL_PREFIX="proj:"
-  add_full proj:1 disconnected
+  add_full proj:1 attached
+  add_full proj:2 disconnected
   run_cs --list
-  local creates rows
+  local creates rows r1 r2
   creates="$(printf '%s\n' "$output" | cut -f1 | grep -c '^create' || true)"
-  rows="$(printf '%s\n' "$output" | grep -c 'proj:1' || true)"
+  rows="$(printf '%s\n' "$output" | cut -f2 | grep -cxF 'proj:2' || true)"
+  r1="$(printf '%s\n' "$output" | sed -n '1p' | cut -f2)"
+  r2="$(printf '%s\n' "$output" | sed -n '2p' | cut -f2)"
   if [ "$creates" -ne 0 ]; then
     echo "  FAIL: create entry emitted for an existing auto session"; echo "$output"; TEST_FAILED=1
   fi
   if [ "$rows" -ne 1 ]; then
-    echo "  FAIL: proj:1 listed $rows times, expected 1"; echo "$output"; TEST_FAILED=1
+    echo "  FAIL: proj:2 listed $rows times, expected 1"; echo "$output"; TEST_FAILED=1
+  fi
+  if [ "$r1" != proj:2 ] || [ "$r2" != proj:1 ]; then
+    echo "  FAIL: auto target not pinned first (r1=$r1 r2=$r2)"; echo "$output"; TEST_FAILED=1
   fi
 }
 

--- a/changeshpool_test
+++ b/changeshpool_test
@@ -204,9 +204,29 @@ run_test() {
 # --- --list ---
 
 test_list_create_entry_first() {
-  add_full a disconnected
+  # An attached session for the prefix is skipped by the auto-name picker, so the
+  # auto name is a fresh (non-existent) "proj:1" and the create entry is shown.
+  export SHPOOL_PREFIX="proj:"
+  add_full proj:9 attached
   if [ "$(list_action 1)" != create ]; then
     echo "  FAIL: first row is not the create entry"; echo "  output: $output"; TEST_FAILED=1
+  fi
+}
+
+test_existing_auto_session_not_listed_twice() {
+  # When the auto name reuses an existing (disconnected) session, that session
+  # must appear once -- as a normal switch row -- never also as a "+" entry.
+  export SHPOOL_PREFIX="proj:"
+  add_full proj:1 disconnected
+  run_cs --list
+  local creates rows
+  creates="$(printf '%s\n' "$output" | cut -f1 | grep -c '^create' || true)"
+  rows="$(printf '%s\n' "$output" | grep -c 'proj:1' || true)"
+  if [ "$creates" -ne 0 ]; then
+    echo "  FAIL: create entry emitted for an existing auto session"; echo "$output"; TEST_FAILED=1
+  fi
+  if [ "$rows" -ne 1 ]; then
+    echo "  FAIL: proj:1 listed $rows times, expected 1"; echo "$output"; TEST_FAILED=1
   fi
 }
 
@@ -295,9 +315,11 @@ test_outside_session_steals_attached_target() {
 }
 
 test_esc_cancels_cleanly() {
+  # ESC must return non-zero (not 0) so the cs/csp shell wrappers don't mistake a
+  # cancel for a performed switch and exit the shell -- it should stay put.
   add_full a disconnected
   FZF_EXIT=130 run_cs
-  assert_status 0
+  assert_status 130
   assert_no_switch_file
   assert_not_called 'shpool attach'
 }
@@ -313,6 +335,7 @@ test_picker_error_propagates() {
 }
 
 run_test "list: create entry is first" test_list_create_entry_first
+run_test "list: existing auto session is not listed twice" test_existing_auto_session_not_listed_twice
 run_test "list: attached session shows filled icon" test_list_attached_icon
 run_test "list: detached session shows empty icon" test_list_disconnected_icon
 run_test "list: prefix group sorts under the create entry" test_list_prefix_group_first

--- a/changetmux_test
+++ b/changetmux_test
@@ -201,18 +201,26 @@ test_list_create_entry_first() {
 
 test_existing_auto_session_not_listed_twice() {
   # When the auto name reuses an existing (disconnected) session, that session
-  # must appear once -- as a normal switch row -- never also as a "+" entry.
+  # must appear once -- as a normal switch row -- never also as a "+" entry, and
+  # stay the first (default) row even though an attached sibling is listed first
+  # by the backend. proj/1 is attached so the picker reuses disconnected proj/2.
   export TMUX_PREFIX="proj/"
-  add_session proj/1 0; add_active proj/1 /tmp/proj
+  add_session proj/1 1; add_active proj/1 /tmp/proj
+  add_session proj/2 0; add_active proj/2 /tmp/proj
   run_ct --list
-  local creates rows
+  local creates rows r1 r2
   creates="$(printf '%s\n' "$output" | cut -f1 | grep -c '^create' || true)"
-  rows="$(printf '%s\n' "$output" | grep -c 'proj/1' || true)"
+  rows="$(printf '%s\n' "$output" | cut -f2 | grep -cxF 'proj/2' || true)"
+  r1="$(printf '%s\n' "$output" | sed -n '1p' | cut -f2)"
+  r2="$(printf '%s\n' "$output" | sed -n '2p' | cut -f2)"
   if [ "$creates" -ne 0 ]; then
     echo "  FAIL: create entry emitted for an existing auto session"; echo "$output"; TEST_FAILED=1
   fi
   if [ "$rows" -ne 1 ]; then
-    echo "  FAIL: proj/1 listed $rows times, expected 1"; echo "$output"; TEST_FAILED=1
+    echo "  FAIL: proj/2 listed $rows times, expected 1"; echo "$output"; TEST_FAILED=1
+  fi
+  if [ "$r1" != proj/2 ] || [ "$r2" != proj/1 ]; then
+    echo "  FAIL: auto target not pinned first (r1=$r1 r2=$r2)"; echo "$output"; TEST_FAILED=1
   fi
 }
 

--- a/changetmux_test
+++ b/changetmux_test
@@ -190,9 +190,29 @@ run_test() {
 # --- --list ordering and content ---
 
 test_list_create_entry_first() {
-  add_session a 0; add_active a /tmp/a
+  # An attached session for the prefix is skipped by the auto-name picker, so the
+  # auto name is a fresh (non-existent) "proj/1" and the create entry is shown.
+  export TMUX_PREFIX="proj/"
+  add_session proj/9 1; add_active proj/9 /tmp/proj
   if [ "$(list_action 1)" != create ]; then
     echo "  FAIL: first row is not the create entry"; echo "  output: $output"; TEST_FAILED=1
+  fi
+}
+
+test_existing_auto_session_not_listed_twice() {
+  # When the auto name reuses an existing (disconnected) session, that session
+  # must appear once -- as a normal switch row -- never also as a "+" entry.
+  export TMUX_PREFIX="proj/"
+  add_session proj/1 0; add_active proj/1 /tmp/proj
+  run_ct --list
+  local creates rows
+  creates="$(printf '%s\n' "$output" | cut -f1 | grep -c '^create' || true)"
+  rows="$(printf '%s\n' "$output" | grep -c 'proj/1' || true)"
+  if [ "$creates" -ne 0 ]; then
+    echo "  FAIL: create entry emitted for an existing auto session"; echo "$output"; TEST_FAILED=1
+  fi
+  if [ "$rows" -ne 1 ]; then
+    echo "  FAIL: proj/1 listed $rows times, expected 1"; echo "$output"; TEST_FAILED=1
   fi
 }
 
@@ -222,7 +242,9 @@ test_list_prefix_group_first() {
   # create entry.
   export TMUX_PREFIX="proj/"
   add_session other 0;  add_active other /tmp/other
-  add_session proj/2 0; add_active proj/2 /tmp/proj
+  # proj/2 is attached so the auto-name picker skips it (auto name stays a fresh
+  # proj/1) and the create entry is still shown first.
+  add_session proj/2 1; add_active proj/2 /tmp/proj
   # Row 1 = create, row 2 = the prefixed session, row 3 = the unrelated one.
   run_ct --list
   local r2 r3
@@ -284,9 +306,11 @@ test_outside_tmux_attaches_with_steal() {
 }
 
 test_esc_cancels_cleanly() {
+  # ESC must return non-zero (not 0) so the cs/csp shell wrappers don't mistake a
+  # cancel for a performed switch and exit the shell -- it should stay put.
   add_session a 0; add_active a /tmp/a
   FZF_EXIT=130 run_ct
-  assert_status 0
+  assert_status 130
   assert_not_called 'switch-client'
   assert_not_called 'attach-session'
 }
@@ -304,6 +328,7 @@ test_picker_error_propagates() {
 # --- runner ---
 
 run_test "list: create entry is first" test_list_create_entry_first
+run_test "list: existing auto session is not listed twice" test_existing_auto_session_not_listed_twice
 run_test "list: session names survive tmux tab mangling" test_list_session_names_survive_tab_mangle
 run_test "list: attached session shows filled icon" test_list_attached_icon
 run_test "list: detached session shows empty icon" test_list_disconnected_icon

--- a/sessionlib
+++ b/sessionlib
@@ -99,36 +99,50 @@ emit_line() {
 }
 
 build_list() {
-  # Print the picker rows in display order: the create entry, then sessions for
-  # this project's prefix, then the rest.
+  # Print the picker rows in display order: the auto session first (so Enter's
+  # default is this directory's auto session), then the rest of this project's
+  # prefix group, then everything else.
   local prefix autoname
   prefix="$(backend_prefix)"
   autoname="$(backend_autoname)" || autoname=""
 
-  # The create entry, shown only when the auto session doesn't exist yet. When it
-  # already exists (e.g. backend_autoname reused a disconnected session), it shows
-  # up below as a normal switch row; emitting a "+" entry for it too would list
-  # the same session twice -- once with a "+", once with its status icon.
-  if test -n "$autoname" && ! backend_session_exists "$autoname"; then
-    emit_line create "$autoname" \
-      "$(printf '+  %-20s  %s' "$autoname" "(create auto session for this directory)")"
+  # When the auto session doesn't exist yet, lead with a "+" create entry. When
+  # it already exists (e.g. backend_autoname reused a disconnected session), it
+  # is listed below as a normal switch row, so we pin THAT row to the top (see
+  # the partition loop) instead: emitting a "+" entry too would list it twice,
+  # and simply dropping it would hand the default row to an unrelated session.
+  local auto_exists=""
+  if test -n "$autoname"; then
+    if backend_session_exists "$autoname"; then
+      auto_exists=1
+    else
+      emit_line create "$autoname" \
+        "$(printf '+  %-20s  %s' "$autoname" "(create auto session for this directory)")"
+    fi
   fi
 
   # Partition sessions into this project's prefix group and everything else,
-  # preserving the backend's listing order within each group.
-  local s state cwd cmd line
-  local -a group_rest=()
+  # preserving the backend's listing order within each group. An existing auto
+  # session is held aside and emitted first, in place of the "+" entry.
+  local s state cwd cmd line auto_line=""
+  local -a group_prefix=() group_rest=()
   while IFS=$'\t' read -r s state cwd cmd; do
     test -n "$s" || continue
     line="$(emit_line switch "$s" "$(compact_line "$s" "$cwd" "$cmd" "$state")")"
-    if session_matches_prefix "$s" "$prefix"; then
-      printf '%s\n' "$line"
+    if test -n "$auto_exists" && test "$s" = "$autoname"; then
+      auto_line="$line"
+    elif session_matches_prefix "$s" "$prefix"; then
+      group_prefix+=("$line")
     else
       group_rest+=("$line")
     fi
   done < <(backend_session_rows)
 
   local r
+  test -n "$auto_line" && printf '%s\n' "$auto_line"
+  for r in "${group_prefix[@]}"; do
+    printf '%s\n' "$r"
+  done
   for r in "${group_rest[@]}"; do
     printf '%s\n' "$r"
   done

--- a/sessionlib
+++ b/sessionlib
@@ -105,13 +105,13 @@ build_list() {
   prefix="$(backend_prefix)"
   autoname="$(backend_autoname)" || autoname=""
 
-  # The create entry. Showing the auto name (and whether it's new vs a reused
-  # detached session) makes the default action obvious.
-  if test -n "$autoname"; then
-    local verb="create"
-    backend_session_exists "$autoname" && verb="attach"
+  # The create entry, shown only when the auto session doesn't exist yet. When it
+  # already exists (e.g. backend_autoname reused a disconnected session), it shows
+  # up below as a normal switch row; emitting a "+" entry for it too would list
+  # the same session twice -- once with a "+", once with its status icon.
+  if test -n "$autoname" && ! backend_session_exists "$autoname"; then
     emit_line create "$autoname" \
-      "$(printf '+  %-20s  %s' "$autoname" "($verb auto session for this directory)")"
+      "$(printf '+  %-20s  %s' "$autoname" "(create auto session for this directory)")"
   fi
 
   # Partition sessions into this project's prefix group and everything else,
@@ -154,6 +154,14 @@ preview_entry() {
 }
 
 run_picker() {
+  # Exit-status contract (the cs/csp wrappers rely on it to decide whether to
+  # exit a parked shell): a zero status means a switch was actually performed or
+  # queued, and the ONLY way to return zero is to fall through
+  # backend_perform_switch (which itself exits via request_switch on the
+  # shpool-inside case, or returns its attach/switch status otherwise). Every
+  # other path -- empty list, ESC/cancel, picker error, nothing selected -- must
+  # return non-zero. Keep that invariant when adding paths here: a no-op that
+  # returns zero would make the wrapper exit the shell without a switch.
   local list
   list="$(build_list)"
   if test -z "$list"; then
@@ -174,12 +182,14 @@ run_picker() {
   local rc=$?
   # fzf exit codes: 0 selected, 1 no match, 130 ESC/Ctrl-C. 0 and 1 are normal
   # (1 is the typed-new-name/empty case, handled below via --print-query); 130
-  # is a clean cancel. Anything else -- 2 (fzf error), 127 (fzf not installed),
-  # etc. -- is a real picker failure: propagate it so callers and keybindings
-  # can tell the picker never ran, instead of silently returning success.
+  # is a clean cancel -- propagate it (non-zero) so the cs/csp wrappers don't
+  # mistake a cancel for a performed switch and exit the shell (a real switch
+  # exits via the backend's request_switch/attach, never through this return).
+  # Anything else -- 2 (fzf error), 127 (fzf not installed), etc. -- is a real
+  # picker failure: propagate it too so callers can tell the picker never ran.
   case $rc in
     0|1) ;;
-    130) return 0 ;;
+    130) return 130 ;;
     *)
       echo "picker failed: ${CHANGESESSION_FZF:-fzf} exited $rc" >&2
       return "$rc"
@@ -205,5 +215,7 @@ run_picker() {
     return $?
   fi
 
-  return 0
+  # Nothing selected and nothing typed: like a cancel, no switch happened, so
+  # return non-zero to keep the cs/csp wrappers from exiting the shell.
+  return 130
 }

--- a/sessionlib_test
+++ b/sessionlib_test
@@ -1,0 +1,104 @@
+#!/bin/bash
+# Tests for sessionlib's shared picker engine (build_list / run_picker).
+#
+# These drive sessionlib directly with stub backend_* hooks, so they can cover
+# cases the per-backend scripts can't easily reach -- in particular an auto-name
+# that already exists as an *attached* session (changeshpool/changetmux only
+# ever auto-name a disconnected reuse or a fresh number, so a sessionlib-level
+# stub is the only way to prove the de-dup is status-agnostic).
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# --- harness ---------------------------------------------------------------
+
+setup() {
+  SESSION_SEP="/"
+  # Defaults the stubs read; each test overrides what it needs.
+  STUB_PREFIX="proj/"
+  STUB_AUTONAME="proj/1"
+  STUB_EXISTS=""          # space-separated list of "existing" session names
+  STUB_ROWS=""            # name<TAB>state<TAB>cwd<TAB>command lines
+  # Pull in the engine under test (idempotent guard means a fresh shell per test
+  # is unnecessary, but we re-source for clarity/isolation of the stubs above).
+  unset _SESSIONLIB_SOURCED
+  source "$SCRIPT_DIR/sessionlib"
+}
+
+# Backend hooks the engine calls, backed by the STUB_* fixtures.
+backend_prefix()         { printf '%s' "$STUB_PREFIX"; }
+backend_autoname()       { printf '%s' "$STUB_AUTONAME"; }
+backend_session_exists() { case " $STUB_EXISTS " in *" $1 "*) return 0 ;; *) return 1 ;; esac; }
+backend_session_rows()   { test -n "$STUB_ROWS" && printf '%s\n' "$STUB_ROWS"; }
+
+run_test() {
+  TESTS_RUN=$((TESTS_RUN + 1))
+  setup
+  TEST_FAILED=
+  if "$1" && test -z "$TEST_FAILED"; then
+    echo "ok $TESTS_RUN $2"; TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo "not ok $TESTS_RUN $2"; TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+}
+
+# Count how many --list rows name $1 in the session (field 2) column.
+count_session_rows() {
+  build_list | cut -f2 | grep -cxF -- "$1" || true
+}
+# Count create ("+") rows.
+count_create_rows() { build_list | cut -f1 | grep -cxF create || true; }
+
+# --- de-dup: an existing auto session must appear once, as a switch row ------
+
+test_existing_attached_auto_session_listed_once() {
+  # The case actually observed: the auto name is a live, *attached* session. It
+  # must show up once (its switch row with the attached icon), never also as a
+  # separate "+" create entry.
+  STUB_AUTONAME="proj/1"
+  STUB_EXISTS="proj/1"
+  STUB_ROWS="$(printf 'proj/1\tattached\t/home/u/proj\tvim\n')"
+  local rows creates
+  rows="$(count_session_rows proj/1)"
+  creates="$(count_create_rows)"
+  test "$rows" -eq 1   || { echo "  FAIL: proj/1 listed $rows times, expected 1"; TEST_FAILED=1; }
+  test "$creates" -eq 0 || { echo "  FAIL: a create entry was emitted for an existing session"; TEST_FAILED=1; }
+}
+
+test_existing_disconnected_auto_session_listed_once() {
+  STUB_AUTONAME="proj/1"
+  STUB_EXISTS="proj/1"
+  STUB_ROWS="$(printf 'proj/1\tdisconnected\t/home/u/proj\tbash\n')"
+  local rows creates
+  rows="$(count_session_rows proj/1)"
+  creates="$(count_create_rows)"
+  test "$rows" -eq 1   || { echo "  FAIL: proj/1 listed $rows times, expected 1"; TEST_FAILED=1; }
+  test "$creates" -eq 0 || { echo "  FAIL: a create entry was emitted for an existing session"; TEST_FAILED=1; }
+}
+
+test_fresh_auto_name_shows_create_entry() {
+  # When the auto name doesn't exist yet, the "+" create entry is shown, first.
+  STUB_AUTONAME="proj/2"
+  STUB_EXISTS="proj/1"
+  STUB_ROWS="$(printf 'proj/1\tattached\t/home/u/proj\tvim\n')"
+  local first creates
+  first="$(build_list | sed -n '1p' | cut -f1)"
+  creates="$(count_create_rows)"
+  test "$first" = create || { echo "  FAIL: first row is '$first', expected create"; TEST_FAILED=1; }
+  test "$creates" -eq 1  || { echo "  FAIL: expected exactly one create entry, got $creates"; TEST_FAILED=1; }
+}
+
+run_test test_existing_attached_auto_session_listed_once \
+  "build_list: an attached auto session is not listed twice"
+run_test test_existing_disconnected_auto_session_listed_once \
+  "build_list: a disconnected auto session is not listed twice"
+run_test test_fresh_auto_name_shows_create_entry \
+  "build_list: a fresh auto name still shows the create entry first"
+
+echo
+echo "$TESTS_RUN tests, $TESTS_PASSED passed, $TESTS_FAILED failed"
+test "$TESTS_FAILED" -eq 0

--- a/sessionlib_test
+++ b/sessionlib_test
@@ -55,10 +55,13 @@ count_create_rows() { build_list | cut -f1 | grep -cxF create || true; }
 
 # --- de-dup: an existing auto session must appear once, as a switch row ------
 
+# The session name (field 2) of the Nth --list row.
+nth_session() { build_list | sed -n "${1}p" | cut -f2; }
+
 test_existing_attached_auto_session_listed_once() {
   # The case actually observed: the auto name is a live, *attached* session. It
   # must show up once (its switch row with the attached icon), never also as a
-  # separate "+" create entry.
+  # separate "+" create entry, and stay the first (default) row.
   STUB_AUTONAME="proj/1"
   STUB_EXISTS="proj/1"
   STUB_ROWS="$(printf 'proj/1\tattached\t/home/u/proj\tvim\n')"
@@ -67,6 +70,7 @@ test_existing_attached_auto_session_listed_once() {
   creates="$(count_create_rows)"
   test "$rows" -eq 1   || { echo "  FAIL: proj/1 listed $rows times, expected 1"; TEST_FAILED=1; }
   test "$creates" -eq 0 || { echo "  FAIL: a create entry was emitted for an existing session"; TEST_FAILED=1; }
+  test "$(nth_session 1)" = proj/1 || { echo "  FAIL: existing auto session is not the first row"; TEST_FAILED=1; }
 }
 
 test_existing_disconnected_auto_session_listed_once() {
@@ -78,6 +82,23 @@ test_existing_disconnected_auto_session_listed_once() {
   creates="$(count_create_rows)"
   test "$rows" -eq 1   || { echo "  FAIL: proj/1 listed $rows times, expected 1"; TEST_FAILED=1; }
   test "$creates" -eq 0 || { echo "  FAIL: a create entry was emitted for an existing session"; TEST_FAILED=1; }
+  test "$(nth_session 1)" = proj/1 || { echo "  FAIL: existing auto session is not the first row"; TEST_FAILED=1; }
+}
+
+test_reused_auto_target_stays_default_row() {
+  # Codex's scenario: an older attached proj/1 plus a reusable disconnected
+  # proj/2 that the picker auto-targets. proj/2 must be the first (default) row
+  # so Enter reuses the detached auto session rather than stealing attached
+  # proj/1 -- even though the backend lists proj/1 first.
+  STUB_AUTONAME="proj/2"
+  STUB_EXISTS="proj/1 proj/2"
+  STUB_ROWS="$(printf 'proj/1\tattached\t/home/u/proj\tvim\nproj/2\tdisconnected\t/home/u/proj\tbash\n')"
+  local creates
+  creates="$(count_create_rows)"
+  test "$creates" -eq 0 || { echo "  FAIL: a create entry was emitted for an existing session"; TEST_FAILED=1; }
+  test "$(nth_session 1)" = proj/2 || { echo "  FAIL: row 1 is '$(nth_session 1)', expected the auto target proj/2"; TEST_FAILED=1; }
+  test "$(nth_session 2)" = proj/1 || { echo "  FAIL: row 2 is '$(nth_session 2)', expected proj/1"; TEST_FAILED=1; }
+  test "$(count_session_rows proj/2)" -eq 1 || { echo "  FAIL: proj/2 not listed exactly once"; TEST_FAILED=1; }
 }
 
 test_fresh_auto_name_shows_create_entry() {
@@ -96,6 +117,8 @@ run_test test_existing_attached_auto_session_listed_once \
   "build_list: an attached auto session is not listed twice"
 run_test test_existing_disconnected_auto_session_listed_once \
   "build_list: a disconnected auto session is not listed twice"
+run_test test_reused_auto_target_stays_default_row \
+  "build_list: a reused auto target stays the first/default row"
 run_test test_fresh_auto_name_shows_create_entry \
   "build_list: a fresh auto name still shows the create entry first"
 


### PR DESCRIPTION
Two fixes in the shared `sessionlib` picker engine (so both the shpool and tmux backends get them):

## 1. ESC no longer exits the shell

Cancelling the picker (ESC) returned `0`, which the `cs`/`csp` shell wrappers read as "a switch happened" — so they ran `&& exit` and dropped you out of the shell instead of leaving you in the current session.

`run_picker` now returns non-zero on cancel (and on the nothing-selected fall-through). A zero status now means a switch was actually performed/queued — the only way to return zero is to fall through `backend_perform_switch` (which exits via `request_switch` in the shpool-inside case, or returns its attach/switch status otherwise). That invariant is documented in `run_picker` so new paths don't reintroduce the bug.

## 2. The auto session is no longer listed twice

`build_list` emitted a `+ create/attach` entry for the auto session name even when that session already existed, so it appeared twice — once as the `+` entry and once as its normal switch row. The `+` entry is now shown only when the auto session doesn't exist yet. This keys off `backend_session_exists`, which ignores status, so it covers **attached and disconnected** sessions alike.

## Tests

- New `sessionlib_test` drives `build_list` with stub backends, covering the attached/disconnected de-dup and the fresh-name create entry (the attached case can't be reached through the real scripts, since the auto-name picker only ever reuses a disconnected session or a fresh number).
- Updated the ESC tests in `changeshpool_test`/`changetmux_test` to expect non-zero, plus a de-dup test in each.
- Wired the previously-unrun `changeshpool_test`/`changetmux_test` (and `sessionlib_test`) into `make test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdRfinpzr8vaDkP5dmtepj

---
_Generated by [Claude Code](https://claude.ai/code/session_01TdRfinpzr8vaDkP5dmtepj)_