### PR TITLE
setup: add --minimal profile (auto on small disks) and fix macOS GUI message

### DIFF
--- a/setup
+++ b/setup
@@ -416,20 +416,27 @@ install_fonts() {
 start_services() {
     case "$OS" in
         debian|redhat)
-            # Enable shpool as a systemd user service
+            # Enable shpool as a systemd user service. Use the resolved
+            # shpool path in ExecStart rather than hard-coding
+            # %h/.cargo/bin/shpool: under --minimal we skip the cargo
+            # install, and shpool may instead come from a distro/Nix
+            # package elsewhere on PATH. Pointing the unit at a
+            # nonexistent ~/.cargo/bin/shpool would make `enable --now`
+            # fail and abort the whole bootstrap under set -e.
             if command -v shpool >/dev/null 2>&1 && command -v systemctl >/dev/null 2>&1; then
+                shpool_bin=$(command -v shpool)
                 shpool_service_dir="$HOME/.config/systemd/user"
                 shpool_service="$shpool_service_dir/shpool.service"
                 if ! test -f "$shpool_service"; then
                     info "Creating shpool systemd user service"
                     mkdir -p "$shpool_service_dir"
-                    cat > "$shpool_service" <<'SERVICE'
+                    cat > "$shpool_service" <<SERVICE
 [Unit]
 Description=shpool session manager
 Documentation=https://github.com/shell-pool/shpool
 
 [Service]
-ExecStart=%h/.cargo/bin/shpool daemon
+ExecStart=$shpool_bin daemon
 Restart=on-failure
 
 [Install]

--- a/setup
+++ b/setup
@@ -14,9 +14,13 @@
 #
 # Graphical components (KDE/Plasma, kitty, fonts, desktop config) are
 # installed only when a display server is detected. Pass --gui to force
-# them on, or --no-gui to skip them (e.g. on a headless server). To pass
-# flags through a pipe:
-#     curl -fsSL https://mikelward.com/setup | sh -s -- --no-gui
+# them on, or --no-gui to skip them (e.g. on a headless server).
+#
+# The heavyweight extras (Rust toolchain plus helix/jj/shpool/nushell,
+# all built from source) are skipped automatically when the disk is small
+# (see MIN_DISK_GB). Pass --minimal to force that lean profile, or --full
+# to install everything regardless. To pass flags through a pipe:
+#     curl -fsSL https://mikelward.com/setup | sh -s -- --no-gui --minimal
 
 set -e
 
@@ -35,19 +39,34 @@ ROOT_DIR="$SRC_DIR/root"
 #   no   - forced off via --no-gui
 GUI=auto
 
+# Install profile for the heavyweight source-built extras. One of:
+#   auto - decide based on available disk space (the default)
+#   yes  - forced lean via --minimal
+#   no   - forced full via --full
+MINIMAL=auto
+
+# Below this many GB free on $HOME's filesystem, auto mode picks --minimal.
+# Override by exporting MIN_DISK_GB before running.
+MIN_DISK_GB="${MIN_DISK_GB:-15}"
+
 usage() {
     cat <<'USAGE'
-Usage: setup [--gui | --no-gui] [-h | --help]
+Usage: setup [--gui | --no-gui] [--minimal | --full] [-h | --help]
 
 Bootstrap a new machine: install packages, fonts, tools, and dotfiles.
 
 Options:
   --gui       Force installation of graphical packages and desktop config
   --no-gui    Skip all graphical packages and desktop configuration
+  --minimal   Skip heavyweight extras (Rust toolchain, helix, jj, shpool,
+              nushell), installing only core packages, tools, and dotfiles
+  --full      Install everything, even when disk space looks tight
   -h, --help  Show this help and exit
 
 By default graphical components are installed only when a display server
-(X11 or Wayland) is detected, so this runs sensibly on headless machines.
+(X11 or Wayland) is detected, and the heavyweight source-built extras are
+skipped when free disk space is below MIN_DISK_GB (default 15GB), so this
+runs sensibly on headless and small-disk machines.
 USAGE
 }
 
@@ -72,6 +91,12 @@ while test $# -gt 0; do
             ;;
         --no-gui)
             GUI=no
+            ;;
+        --minimal)
+            MINIMAL=yes
+            ;;
+        --full)
+            MINIMAL=no
             ;;
         -h|--help)
             usage
@@ -149,12 +174,52 @@ resolve_gui() {
             info "Graphical setup: disabled (--no-gui)"
             ;;
         *)
-            if test "$OS" = "macos" || have_display; then
+            if test "$OS" = "macos"; then
+                # macOS has no DISPLAY variable; it's always graphical.
+                GUI_ENABLED=1
+                info "Graphical setup: enabled (macOS: display assumed)"
+            elif have_display; then
                 GUI_ENABLED=1
                 info "Graphical setup: enabled (display detected)"
             else
                 GUI_ENABLED=0
                 info "Graphical setup: disabled (no display detected; use --gui to override)"
+            fi
+            ;;
+    esac
+}
+
+# --- Detect available disk space ---
+
+# Available space, in whole GB, on the filesystem holding $HOME. Prints
+# nothing if df can't report it (caller treats that as "unknown").
+available_disk_gb() {
+    df -Pk "$HOME" 2>/dev/null | awk 'NR==2 {print int($4 / 1024 / 1024)}'
+}
+
+# Resolve $MINIMAL (auto/yes/no) into MINIMAL_ENABLED (1/0). In auto mode,
+# pick the lean profile when free disk space is below MIN_DISK_GB.
+resolve_minimal() {
+    case "$MINIMAL" in
+        yes)
+            MINIMAL_ENABLED=1
+            info "Install profile: minimal (--minimal)"
+            ;;
+        no)
+            MINIMAL_ENABLED=0
+            info "Install profile: full (--full)"
+            ;;
+        *)
+            avail=$(available_disk_gb)
+            if test -n "$avail" && test "$avail" -lt "$MIN_DISK_GB"; then
+                MINIMAL_ENABLED=1
+                info "Install profile: minimal (${avail}GB free < ${MIN_DISK_GB}GB; use --full to override)"
+            elif test -n "$avail"; then
+                MINIMAL_ENABLED=0
+                info "Install profile: full (${avail}GB free)"
+            else
+                MINIMAL_ENABLED=0
+                info "Install profile: full (could not determine free disk space)"
             fi
             ;;
     esac
@@ -600,6 +665,7 @@ KEYBOARD
 
 detect_os
 resolve_gui
+resolve_minimal
 install_packages
 if test "$GUI_ENABLED" -eq 1; then
     install_fonts
@@ -633,11 +699,15 @@ if test -f "$CONF_DIR/vcs/Makefile"; then
     make -C "$CONF_DIR/vcs" install
 fi
 
-install_rust
-install_helix
-install_jj
-install_shpool
-install_nushell
+if test "$MINIMAL_ENABLED" -eq 0; then
+    install_rust
+    install_helix
+    install_jj
+    install_shpool
+    install_nushell
+else
+    info "Skipping heavyweight extras (Rust, helix, jj, shpool, nushell); minimal profile"
+fi
 
 start_services
 


### PR DESCRIPTION
## Summary

A full `setup` run filled a 10GB VM disk. The main culprits are the source-built extras — the Rust toolchain plus `helix` (compiled from a git checkout), `jj`, `shpool`, and `nushell`. This adds a lean install profile that skips them, and makes it the automatic choice when the disk is small.

Also fixes a misleading log line: in auto mode on macOS we hard-code GUI on (there's no `DISPLAY` variable to detect), but the message claimed "display detected".

## Changes

- **`--minimal` / `--full` flags** plus an `auto` default. Minimal installs core packages, fonts (if GUI), go-task, uv, dotfiles, SSH key, and the desktop config — but skips `install_rust` / `install_helix` / `install_jj` / `install_shpool` / `install_nushell`.
- **Auto disk detection**: `available_disk_gb` reads free space on `$HOME`'s filesystem via `df -Pk`; `resolve_minimal` switches to minimal when it's below `MIN_DISK_GB` (default **15GB**, overridable by exporting `MIN_DISK_GB`). Unknown disk space falls back to full.
- **Clear log line** for the chosen profile, e.g. `Install profile: minimal (10GB free < 15GB; use --full to override)`.
- **macOS GUI message** now reads `enabled (macOS: display assumed)` instead of `display detected`.
- Updated header docs and `--help`.

## Testing

- `sh -n setup` passes; shellcheck clean on the new code.
- Unit-tested `resolve_minimal` across small/large/unknown disk and forced `--minimal`/`--full` — all resolve correctly, none trip `set -e`. The 10GB case correctly selects minimal.
- Verified `--help` lists the new flags and unknown-arg handling still errors (exit 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014UW7FpsRS1tD9SNDhzFntu)_