### PR TITLE
setup: stop installing go-task (drops ~1GB google.golang.org/api in Go cache)

### DIFF
--- a/setup
+++ b/setup
@@ -528,23 +528,6 @@ install_nushell() {
     cargo install --locked nu
 }
 
-# --- Install go-task ---
-
-install_go_task() {
-    if command -v task >/dev/null 2>&1; then
-        info "go-task already installed"
-        return
-    fi
-
-    if ! command -v go >/dev/null 2>&1; then
-        warn "go not found, skipping go-task installation"
-        return
-    fi
-
-    info "Installing go-task"
-    go install github.com/go-task/task/v3/cmd/task@latest
-}
-
 # --- Install uv (Python package manager) ---
 
 install_uv() {
@@ -677,7 +660,6 @@ install_packages
 if test "$GUI_ENABLED" -eq 1; then
     install_fonts
 fi
-install_go_task
 install_uv
 generate_ssh_key
 if test "$GUI_ENABLED" -eq 1; then

--- a/setup-kde
+++ b/setup-kde
@@ -55,10 +55,11 @@ install_krohnkite() {
 
     cd "$KROHNKITE_DIR"
 
-    # Build using go-task (preferred) or make (fallback). The binary is
-    # named "go-task" from Fedora's package, or "task" when installed via
-    # go install (see setup) -- but "task" can also be Taskwarrior, so
-    # check the version banner before trusting it.
+    # Build using go-task (preferred) or make (fallback). go-task is no
+    # longer installed by setup, but use it if it's present: the binary is
+    # named "go-task" from Fedora's package, or "task" when installed by
+    # hand -- but "task" can also be Taskwarrior, so check the version
+    # banner before trusting it. Otherwise fall back to make, then npm.
     if command -v go-task >/dev/null 2>&1; then
         info "Building Krohnkite with go-task"
         go-task package


### PR DESCRIPTION
## Summary

A full `setup` run was filling small disks, and the Go module cache turned out to be a big contributor — in particular `google.golang.org/api v0.271.0` (~1GB of generated client code). Tracing it: it's an **indirect** dependency of `go-task`, which is the only thing `setup` builds with `go install`.

go-task was only ever used as the *preferred* build tool for Krohnkite in `setup-kde`, and that step already falls back to `make`, then `npm`. So removing it costs nothing and saves significant disk.

## Changes

- Remove the `install_go_task` function and its call from `setup`. Nothing in `setup` runs `go install` anymore, so `google.golang.org/api` is no longer pulled into `~/go/pkg/mod` in any profile.
- Update the `setup-kde` comment to note go-task is no longer installed by `setup` but is still used if present (Fedora package or a hand-installed binary), before falling back to make/npm.

## Notes

- This is independent of `--minimal`: go-task is gone from every profile, not just minimal.
- To reclaim the space already on disk: `go clean -cache -modcache` (the module cache is fully re-downloadable).

## Testing

- `sh -n setup` and `bash -n setup-kde` pass.
- Confirmed no remaining `install_go_task` / `go install` references in `setup`; the only `go-task` mentions left are the opportunistic build-tool detection in `setup-kde`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014UW7FpsRS1tD9SNDhzFntu)_