### PR TITLE
setup: fall back to legacy root config when cargo is unavailable

### DIFF
--- a/setup
+++ b/setup
@@ -716,8 +716,21 @@ fi
 
 mkdir -p "$SRC_DIR"
 clone_or_pull "$ROOT_REPO" "$ROOT_DIR"
-make -C "$ROOT_DIR"
-sudo make -C "$ROOT_DIR" install
+# The default root config builds helper tools that require cargo. When
+# cargo isn't available (e.g. a --minimal run, or rustup was skipped),
+# install the legacy config from the repo's legacy/ subdirectory instead.
+# Source ~/.cargo/env first so a previously installed toolchain still
+# counts as available even on a run that skipped install_rust.
+if test -f "$HOME/.cargo/env"; then
+    . "$HOME/.cargo/env"
+fi
+if command -v cargo >/dev/null 2>&1; then
+    make -C "$ROOT_DIR"
+    sudo make -C "$ROOT_DIR" install
+else
+    info "cargo unavailable; installing legacy root config from $ROOT_DIR/legacy"
+    sudo make -C "$ROOT_DIR/legacy" install
+fi
 if test "$OS" = "macos"; then
     # macOS: the admin group (GID 80) already has sudo access; the wheel/admin
     # group membership is managed by Directory Services, not /etc/group.


### PR DESCRIPTION
## Summary

The default `root` config builds helper tools that require cargo. On a `--minimal` run (or any machine without a Rust toolchain) the normal `make` / `sudo make install` against the repo root would fail. This adds a fallback: when cargo isn't available, install the legacy config from the root repo's `legacy/` subdirectory instead.

## Changes

In the root-config step of `setup`:
- Source `~/.cargo/env` (if present) before checking, so a previously installed toolchain still counts as available even on a run that skipped `install_rust` (e.g. `--minimal`).
- If `cargo` is on `PATH`: behavior unchanged — `make -C "$ROOT_DIR"` then `sudo make -C "$ROOT_DIR" install`.
- Otherwise: `sudo make -C "$ROOT_DIR/legacy" install`, with an info line noting the fallback.

## Testing

- `sh -n setup` passes; shellcheck clean apart from the pre-existing `SC1091` info note that already applies to the other `~/.cargo/env` sourcing lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014UW7FpsRS1tD9SNDhzFntu)_