### PR TITLE
setup: add --no-install and --ignore-errors flags

### DIFF
--- a/setup
+++ b/setup
@@ -2,7 +2,8 @@
 # Bootstrap script for setting up a new machine.
 #
 # Usage:
-#     setup [--gui | --no-gui] [-h | --help]
+#     setup [--gui | --no-gui] [--minimal | --full] [--no-install] \
+#           [--ignore-errors] [-h | --help]
 #
 #  or, to bootstrap from scratch:
 #     curl -fsSL https://mikelward.com/setup | sh
@@ -21,8 +22,12 @@
 # (see MIN_DISK_GB). Pass --minimal to force that lean profile, or --full
 # to install everything regardless. To pass flags through a pipe:
 #     curl -fsSL https://mikelward.com/setup | sh -s -- --no-gui --minimal
-
-set -e
+#
+# Pass --no-install to skip all software installation (packages, fonts,
+# uv, and the heavyweight extras) and only (re)apply configuration --
+# handy when re-running on a machine that already has the tools. Pass
+# --ignore-errors to keep going past failures instead of aborting on the
+# first one. Both flags are forwarded to setup-kde / setup-macos.
 
 SCRIPTS_REPO="git@github.com:mikelward/scripts.git"
 CONF_REPO="git@github.com:mikelward/conf.git"
@@ -49,19 +54,34 @@ MINIMAL=auto
 # Override by exporting MIN_DISK_GB before running.
 MIN_DISK_GB="${MIN_DISK_GB:-15}"
 
+# Whether to install software at all. One of:
+#   yes - install packages, fonts, and tools (the default)
+#   no  - skip every install step and only (re)apply configuration (--no-install)
+INSTALL=yes
+
+# Whether to keep going after a command fails. One of:
+#   no  - abort on the first error, via set -e (the default)
+#   yes - keep going past failures (--ignore-errors)
+IGNORE_ERRORS=no
+
 usage() {
     cat <<'USAGE'
-Usage: setup [--gui | --no-gui] [--minimal | --full] [-h | --help]
+Usage: setup [--gui | --no-gui] [--minimal | --full] [--no-install]
+             [--ignore-errors] [-h | --help]
 
 Bootstrap a new machine: install packages, fonts, tools, and dotfiles.
 
 Options:
-  --gui       Force installation of graphical packages and desktop config
-  --no-gui    Skip all graphical packages and desktop configuration
-  --minimal   Skip heavyweight extras (Rust toolchain, helix, jj, shpool,
-              nushell), installing only core packages, tools, and dotfiles
-  --full      Install everything, even when disk space looks tight
-  -h, --help  Show this help and exit
+  --gui            Force installation of graphical packages and desktop config
+  --no-gui         Skip all graphical packages and desktop configuration
+  --minimal        Skip heavyweight extras (Rust toolchain, helix, jj, shpool,
+                   nushell), installing only core packages, tools, and dotfiles
+  --full           Install everything, even when disk space looks tight
+  --no-install     Skip every install step (packages, fonts, uv, extras) and
+                   only (re)apply configuration. Forwarded to setup-kde/macos
+  --ignore-errors  Keep going past failures instead of aborting on the first
+                   one. Forwarded to setup-kde/macos
+  -h, --help       Show this help and exit
 
 By default graphical components are installed only when a display server
 (X11 or Wayland) is detected, and the heavyweight source-built extras are
@@ -98,6 +118,15 @@ while test $# -gt 0; do
         --full)
             MINIMAL=no
             ;;
+        --install)
+            INSTALL=yes
+            ;;
+        --no-install)
+            INSTALL=no
+            ;;
+        --ignore-errors)
+            IGNORE_ERRORS=yes
+            ;;
         -h|--help)
             usage
             exit 0
@@ -110,6 +139,22 @@ while test $# -gt 0; do
     esac
     shift
 done
+
+# Abort on the first error by default. --ignore-errors leaves set -e off so
+# the bootstrap pushes through failing steps. We toggle this only after
+# parsing args, so an unknown option above still exits non-zero.
+if test "$IGNORE_ERRORS" = no; then
+    set -e
+fi
+
+# Flags to forward to the desktop setup helpers (setup-kde / setup-macos).
+DESKTOP_SETUP_FLAGS=""
+if test "$INSTALL" = no; then
+    DESKTOP_SETUP_FLAGS="$DESKTOP_SETUP_FLAGS --no-install"
+fi
+if test "$IGNORE_ERRORS" = yes; then
+    DESKTOP_SETUP_FLAGS="$DESKTOP_SETUP_FLAGS --ignore-errors"
+fi
 
 clone_or_pull() {
     repo="$1"
@@ -656,11 +701,15 @@ KEYBOARD
 detect_os
 resolve_gui
 resolve_minimal
-install_packages
-if test "$GUI_ENABLED" -eq 1; then
-    install_fonts
+if test "$INSTALL" = yes; then
+    install_packages
+    if test "$GUI_ENABLED" -eq 1; then
+        install_fonts
+    fi
+    install_uv
+else
+    info "Skipping software installation (--no-install)"
 fi
-install_uv
 generate_ssh_key
 if test "$GUI_ENABLED" -eq 1; then
     set_default_terminal
@@ -688,7 +737,9 @@ if test -f "$CONF_DIR/vcs/Makefile"; then
     make -C "$CONF_DIR/vcs" install
 fi
 
-if test "$MINIMAL_ENABLED" -eq 0; then
+if test "$INSTALL" = no; then
+    info "Skipping heavyweight extras (Rust, helix, jj, shpool, nushell); --no-install"
+elif test "$MINIMAL_ENABLED" -eq 0; then
     install_rust
     install_helix
     install_jj
@@ -703,10 +754,10 @@ start_services
 if test "$GUI_ENABLED" -eq 1; then
     if test "$OS" = "macos"; then
         info "Configuring macOS desktop environment"
-        "$SCRIPTS_DIR/setup-macos"
+        "$SCRIPTS_DIR/setup-macos" $DESKTOP_SETUP_FLAGS
     else
         info "Configuring KDE desktop environment"
-        "$SCRIPTS_DIR/setup-kde"
+        "$SCRIPTS_DIR/setup-kde" $DESKTOP_SETUP_FLAGS
     fi
 else
     info "Skipping desktop environment configuration (no GUI)"

--- a/setup
+++ b/setup
@@ -24,10 +24,11 @@
 #     curl -fsSL https://mikelward.com/setup | sh -s -- --no-gui --minimal
 #
 # Pass --no-install to skip all software installation (packages, fonts,
-# uv, and the heavyweight extras) and only (re)apply configuration --
-# handy when re-running on a machine that already has the tools. Pass
-# --ignore-errors to keep going past failures instead of aborting on the
-# first one. Both flags are forwarded to setup-kde / setup-macos.
+# uv, the heavyweight extras, and the root config build) and only
+# (re)apply configuration -- handy when re-running on a machine that
+# already has the tools. Pass --ignore-errors to keep going past failures
+# instead of aborting on the first one. Both flags are forwarded to
+# setup-kde / setup-macos.
 
 SCRIPTS_REPO="git@github.com:mikelward/scripts.git"
 CONF_REPO="git@github.com:mikelward/conf.git"
@@ -77,8 +78,8 @@ Options:
   --minimal        Skip heavyweight extras (Rust toolchain, helix, jj, shpool,
                    nushell), installing only core packages, tools, and dotfiles
   --full           Install everything, even when disk space looks tight
-  --no-install     Skip every install step (packages, fonts, uv, extras) and
-                   only (re)apply configuration. Forwarded to setup-kde/macos
+  --no-install     Skip every install step (packages, fonts, uv, extras, root
+                   config) and only (re)apply config. Forwarded to setup-kde/macos
   --ignore-errors  Keep going past failures instead of aborting on the first
                    one. Forwarded to setup-kde/macos
   -h, --help       Show this help and exit
@@ -765,23 +766,32 @@ fi
 
 # --- Install root config ---
 
-mkdir -p "$SRC_DIR"
-clone_or_pull "$ROOT_REPO" "$ROOT_DIR"
-# The default root config builds helper tools that require cargo. When
-# cargo isn't available (e.g. a --minimal run, or rustup was skipped),
-# install the legacy config from the repo's legacy/ subdirectory instead.
-# Source ~/.cargo/env first so a previously installed toolchain still
-# counts as available even on a run that skipped install_rust.
-if test -f "$HOME/.cargo/env"; then
-    . "$HOME/.cargo/env"
-fi
-if command -v cargo >/dev/null 2>&1; then
-    make -C "$ROOT_DIR"
-    sudo make -C "$ROOT_DIR" install
+# The root config builds helper tools and installs files via make, so it's
+# an install step too: skip it under --no-install.
+if test "$INSTALL" = yes; then
+    mkdir -p "$SRC_DIR"
+    clone_or_pull "$ROOT_REPO" "$ROOT_DIR"
+    # The default root config builds helper tools that require cargo. When
+    # cargo isn't available (e.g. a --minimal run, or rustup was skipped),
+    # install the legacy config from the repo's legacy/ subdirectory instead.
+    # Source ~/.cargo/env first so a previously installed toolchain still
+    # counts as available even on a run that skipped install_rust.
+    if test -f "$HOME/.cargo/env"; then
+        . "$HOME/.cargo/env"
+    fi
+    if command -v cargo >/dev/null 2>&1; then
+        make -C "$ROOT_DIR"
+        sudo make -C "$ROOT_DIR" install
+    else
+        info "cargo unavailable; installing legacy root config from $ROOT_DIR/legacy"
+        sudo make -C "$ROOT_DIR/legacy" install
+    fi
 else
-    info "cargo unavailable; installing legacy root config from $ROOT_DIR/legacy"
-    sudo make -C "$ROOT_DIR/legacy" install
+    info "Skipping root config installation (--no-install)"
 fi
+
+# Group membership is configuration, not an install, so apply it regardless
+# of --no-install.
 if test "$OS" = "macos"; then
     # macOS: the admin group (GID 80) already has sudo access; the wheel/admin
     # group membership is managed by Directory Services, not /etc/group.

--- a/setup-kde
+++ b/setup-kde
@@ -11,12 +11,22 @@
 # Optional: go-task (preferred build tool), p7zip
 #
 # Usage:
-#     setup-kde
-
-set -e
+#     setup-kde [--no-install] [--ignore-errors] [-h | --help]
+#
+# --no-install skips building/installing Krohnkite and only (re)applies the
+# KDE configuration. --ignore-errors keeps going past failures instead of
+# aborting on the first one. setup forwards both flags here.
 
 KROHNKITE_REPO="https://codeberg.org/anametologin/Krohnkite.git"
 KROHNKITE_DIR="${TMPDIR:-/tmp}/krohnkite-$$"
+
+# Whether to build and install Krohnkite. "no" (via --no-install) skips the
+# install and only (re)applies configuration.
+INSTALL=yes
+
+# Whether to keep going past failures. "no" aborts on the first error via
+# set -e; "yes" (via --ignore-errors) leaves it off and pushes through.
+IGNORE_ERRORS=no
 
 info() {
     printf "%s\n" "$*"
@@ -35,6 +45,51 @@ is_command() {
     test -x "$(command -v "$1")"
 }
 
+usage() {
+    cat <<'USAGE'
+Usage: setup-kde [--no-install] [--ignore-errors] [-h | --help]
+
+Configure the KDE Plasma 6 desktop environment.
+
+Options:
+  --no-install     Skip building/installing Krohnkite; only (re)apply config
+  --ignore-errors  Keep going past failures instead of aborting on the first
+  -h, --help       Show this help and exit
+USAGE
+}
+
+# --- Parse arguments ---
+
+while test $# -gt 0; do
+    case "$1" in
+        --install)
+            INSTALL=yes
+            ;;
+        --no-install)
+            INSTALL=no
+            ;;
+        --ignore-errors)
+            IGNORE_ERRORS=yes
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            warn "Unknown option: $1"
+            usage >&2
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+# Abort on the first error by default. --ignore-errors leaves set -e off so
+# the script pushes through failing steps.
+if test "$IGNORE_ERRORS" = no; then
+    set -e
+fi
+
 cleanup() {
     rm -rf "$KROHNKITE_DIR"
 }
@@ -42,10 +97,15 @@ trap cleanup EXIT
 
 # --- Check prerequisites ---
 
-command -v git >/dev/null 2>&1 || error "git is required"
-command -v npm >/dev/null 2>&1 || error "npm is required (to build Krohnkite)"
-command -v kpackagetool6 >/dev/null 2>&1 || error "kpackagetool6 is required (KDE Plasma 6)"
+# kwriteconfig6 is needed for every configuration step, so it's always
+# required. git/npm/kpackagetool6 are only used to build and install
+# Krohnkite, so they're only required when actually installing.
 command -v kwriteconfig6 >/dev/null 2>&1 || error "kwriteconfig6 is required (KDE Plasma 6)"
+if test "$INSTALL" = yes; then
+    command -v git >/dev/null 2>&1 || error "git is required"
+    command -v npm >/dev/null 2>&1 || error "npm is required (to build Krohnkite)"
+    command -v kpackagetool6 >/dev/null 2>&1 || error "kpackagetool6 is required (KDE Plasma 6)"
+fi
 
 # --- Install Krohnkite ---
 
@@ -399,7 +459,11 @@ reload_kglobalaccel() {
 
 # --- Main ---
 
-install_krohnkite
+if test "$INSTALL" = yes; then
+    install_krohnkite
+else
+    info "Skipping Krohnkite installation (--no-install)"
+fi
 enable_krohnkite
 configure_krohnkite
 configure_focus_follows_mouse

--- a/setup-macos
+++ b/setup-macos
@@ -18,9 +18,16 @@
 # Requires: defaults, hidutil
 #
 # Usage:
-#     setup-macos
+#     setup-macos [--no-install] [--ignore-errors] [-h | --help]
+#
+# setup forwards --no-install and --ignore-errors here. macOS configuration
+# installs no separate software (everything is `defaults`/Automator config),
+# so --no-install is accepted but has nothing to skip. --ignore-errors keeps
+# going past failures instead of aborting on the first one.
 
-set -e
+# Whether to keep going past failures. "no" aborts on the first error via
+# set -e; "yes" (via --ignore-errors) leaves it off and pushes through.
+IGNORE_ERRORS=no
 
 info() {
     printf "%s\n" "$*"
@@ -29,6 +36,50 @@ info() {
 warn() {
     printf "Warning: %s\n" "$*" >&2
 }
+
+usage() {
+    cat <<'USAGE'
+Usage: setup-macos [--no-install] [--ignore-errors] [-h | --help]
+
+Configure the macOS desktop environment.
+
+Options:
+  --no-install     Accepted for consistency with setup; macOS configuration
+                   installs no separate software, so there's nothing to skip
+  --ignore-errors  Keep going past failures instead of aborting on the first
+  -h, --help       Show this help and exit
+USAGE
+}
+
+# --- Parse arguments ---
+
+while test $# -gt 0; do
+    case "$1" in
+        --install|--no-install)
+            # No separate install step on macOS; accepted as a no-op so
+            # setup can forward the flag uniformly.
+            ;;
+        --ignore-errors)
+            IGNORE_ERRORS=yes
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            warn "Unknown option: $1"
+            usage >&2
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+# Abort on the first error by default. --ignore-errors leaves set -e off so
+# the script pushes through failing steps.
+if test "$IGNORE_ERRORS" = no; then
+    set -e
+fi
 
 # --- Configure keyboard ---
 


### PR DESCRIPTION
## Summary

Adds two flags to `setup`, both forwarded to `setup-kde` / `setup-macos`:

- **`--no-install`** — skip every software install step (system packages, fonts, `uv`, and the heavyweight Rust/helix/jj/shpool/nushell extras) and only (re)apply configuration. Useful when re-running on a machine that already has the tools.
- **`--ignore-errors`** — leave `set -e` off so the bootstrap pushes through failing steps instead of aborting on the first one.

## Details

**`setup`**
- New `INSTALL` / `IGNORE_ERRORS` state, parsed via `--no-install` (plus `--install` for symmetry) and `--ignore-errors`.
- `set -e` is now applied *after* argument parsing, gated on `IGNORE_ERRORS`, so an unknown option still exits non-zero.
- Install steps (`install_packages`, `install_fonts`, `install_uv`, and the extras block) are gated behind `INSTALL=yes`.
- Builds a `DESKTOP_SETUP_FLAGS` list and forwards `--no-install` / `--ignore-errors` to `setup-kde` / `setup-macos`.

**`setup-kde`**
- Gains the same flags and a `usage()`.
- `--no-install` skips building/installing Krohnkite; the `git` / `npm` / `kpackagetool6` prerequisite checks (only needed to build/install Krohnkite) are skipped too, while `kwriteconfig6` stays required for the configuration steps.
- `set -e` is conditional on `--ignore-errors`.

**`setup-macos`**
- Accepts both flags for uniform forwarding. It installs no separate software, so `--no-install` is a documented no-op there; `--ignore-errors` controls `set -e` as elsewhere.

## Testing

- `sh -n` / `bash -n` pass on all three scripts.
- Verified `-h` output and unknown-option handling (exit 1) for `setup`, `setup-kde`, and `setup-macos`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvjDPTM8aefXFDg6FstpNG)_