### PR TITLE
shpool: use `attach --dir`/`--force` to drop the env-var handoff and steal-poll dance

### DIFF
--- a/autoshpool
+++ b/autoshpool
@@ -155,9 +155,11 @@ create_and_attach_next() {
     if test -n "${sessions[$session]}"; then
       continue
     fi
-    export SHPOOL_INITIAL_PWD="$PWD"
     echo "Creating shpool session $session"
-    shpool attach "$session"
+    # --dir opens the new session in the caller's directory rather than the
+    # outer shell's startup dir. It only takes effect when the session is
+    # created; shpool ignores it on a reattach (the shell already exists).
+    shpool attach "$session" --dir "$PWD"
     rc=$?
     # shpool exits 0 even when refusing because the session is already
     # attached elsewhere (libshpool BusyError -> AttachResult::Done), so a
@@ -451,14 +453,14 @@ autoshpool_loop() {
     if test -n "$switch_session"; then
       switch_pwd="$(get_switch_pwd)"
       clear_switch
-      # A recorded pwd (a prefix-mismatch switch) opens the session there; a
-      # bare switch keeps the target's own directory, so drop any stale value.
+      # A recorded pwd (a create/prefix-mismatch switch) opens the session there
+      # via --dir; a bare switch to an existing session omits --dir so it keeps
+      # its own directory (shpool ignores --dir on a reattach anyway).
       if test -n "$switch_pwd"; then
-        export SHPOOL_INITIAL_PWD="$switch_pwd"
+        shpool attach "$switch_session" --dir "$switch_pwd"
       else
-        unset SHPOOL_INITIAL_PWD
+        shpool attach "$switch_session"
       fi
-      shpool attach "$switch_session"
     else
       # Pick the session first so a failed attach is reported as a failure
       # rather than falling through to create a brand-new session.

--- a/autoshpool_test
+++ b/autoshpool_test
@@ -347,36 +347,14 @@ test_plain_switch_records_no_pwd() {
   assert_no_switch_pwd
 }
 
-test_loop_switch_exports_recorded_pwd() {
-  # When the loop services a switch that carries a pwd, it exports
-  # SHPOOL_INITIAL_PWD so the freshly created session starts there.
-  cat > "$TEST_TMPDIR/bin/shpool" <<'SHPOOL'
-#!/bin/bash
-echo "shpool $*" >> "$HOME/.shpool_calls"
-case "$1" in
-  list)
-    echo "name                           started_at                         status"
-    cat "$HOME/.shpool_sessions" 2>/dev/null
-    exit 0
-    ;;
-  attach)
-    echo "INITIAL_PWD=$SHPOOL_INITIAL_PWD" >> "$HOME/.shpool_env"
-    exit 0
-    ;;
-esac
-SHPOOL
-  chmod +x "$TEST_TMPDIR/bin/shpool"
-
+test_loop_switch_passes_recorded_dir() {
+  # When the loop services a switch that carries a pwd, it passes --dir so the
+  # freshly created session starts there.
   echo "myproject:1" > "$HOME/.autoshpool_switch"
   echo "/home/u/proj" > "$HOME/.autoshpool_switch_pwd"
   run_autoshpool
   assert_status 0
-  assert_called "shpool attach myproject:1"
-  if ! grep -qx "INITIAL_PWD=/home/u/proj" "$HOME/.shpool_env"; then
-    echo "  FAIL: expected SHPOOL_INITIAL_PWD=/home/u/proj on attach"
-    echo "  env: $(cat "$HOME/.shpool_env" 2>/dev/null)"
-    return 1
-  fi
+  assert_called "shpool attach myproject:1 --dir /home/u/proj"
 }
 
 test_creates_session_1() {
@@ -894,7 +872,7 @@ run_test "switches to a new prefixed session on mismatch" test_attached_mismatch
 run_test "reuses a disconnected prefixed session on mismatch" test_attached_mismatch_reuses_disconnected
 run_test "records the current directory for a prefix-mismatch switch" test_attached_mismatch_records_pwd
 run_test "records no directory for a plain switch" test_plain_switch_records_no_pwd
-run_test "loop exports the recorded directory when servicing a switch" test_loop_switch_exports_recorded_pwd
+run_test "loop passes the recorded directory via --dir when servicing a switch" test_loop_switch_passes_recorded_dir
 run_test "creates session 1 when no sessions exist" test_creates_session_1
 run_test "attaches to disconnected session before creating new one" test_attaches_disconnected_first
 run_test "reuses a disconnected separatorless session on startup" test_reuses_separatorless_session

--- a/changeshpool
+++ b/changeshpool
@@ -100,22 +100,16 @@ backend_perform_switch() {
     fi
     return 0   # request_switch exits; not reached
   fi
-  test "$action" = create && export SHPOOL_INITIAL_PWD="$PWD"
-  # shpool detach returns once the daemon has signalled the other client, but
-  # the client's tty hasn't released yet, so a back-to-back attach hits
-  # BusyError ("session 'X' already has a terminal attached"). Poll shpool
-  # list until the session leaves the "attached" state so attach lands
-  # cleanly. Bounded so a wedged client doesn't hang us forever -- if the
-  # target stays attached we still try attach (matches the old behaviour and
-  # surfaces the real error).
-  timeout 2 shpool detach "$target" 2>/dev/null
-  local i
-  for i in 1 2 3 4 5 6 7 8 9 10; do
-    test "$(session_status "$target" "$(shpool list 2>/dev/null)")" = attached \
-      || break
-    sleep 0.1
-  done
-  shpool attach "$target"
+  # From outside a session, attach directly. --force tells shpool to detach any
+  # tty already attached to the target first (stealing it from another
+  # terminal), which replaces the old detach-then-poll-until-released dance: no
+  # BusyError race to poll around, since shpool sequences the handover itself. A
+  # create carries --dir so the new session opens in the current directory.
+  if test "$action" = create; then
+    shpool attach --force --dir "$PWD" "$target"
+  else
+    shpool attach --force "$target"
+  fi
 }
 
 case "$1" in

--- a/changeshpool_test
+++ b/changeshpool_test
@@ -312,19 +312,19 @@ test_typed_new_name_requests_switch() {
 test_outside_session_attaches_with_steal() {
   add_full target:1 disconnected
   FZF_PICK=$'^switch\ttarget:1\t' run_cs
-  assert_called 'shpool detach target:1'   # steal from any other terminal
-  assert_called 'shpool attach target:1'
-  assert_no_switch_file                     # no loop to service: attach directly
+  assert_called 'shpool attach --force target:1'   # --force steals from any other terminal
+  assert_not_called 'shpool detach'                 # no separate detach/poll dance
+  assert_no_switch_file                             # no loop to service: attach directly
 }
 
 test_outside_session_steals_attached_target() {
-  # When the target is currently attached elsewhere, the steal still lands:
-  # detach asks the other client to release, and the poll waits for the
-  # session to leave the "attached" state before attach runs.
+  # When the target is currently attached elsewhere, --force still lands the
+  # attach: shpool detaches the other client and sequences the handover itself,
+  # so there is no manual detach-then-poll.
   add_full target:1 attached
   FZF_PICK=$'^switch\ttarget:1\t' run_cs
-  assert_called 'shpool detach target:1'
-  assert_called 'shpool attach target:1'
+  assert_called 'shpool attach --force target:1'
+  assert_not_called 'shpool detach'
 }
 
 test_esc_cancels_cleanly() {

--- a/makesession_test
+++ b/makesession_test
@@ -9,7 +9,7 @@
 #     case without a real multiplexer.
 #   * backend behaviour - the real maketmux / makeshpool are run with a fake
 #     tmux / shpool, asserting the exact command each forwards and that
-#     makeshpool stamps SHPOOL_INITIAL_PWD with the caller's directory.
+#     makeshpool passes --dir with the caller's directory.
 
 set -e
 
@@ -158,22 +158,24 @@ test_makeshpool_runs_shpool_attach() {
   output="$(env -i PATH="$BIN" HOME="$TEST_TMPDIR" "$BIN/makeshpool" work 2>&1)"
   status=$?
   set -e
-  assert_called "shpool attach work"
+  # makeshpool forwards `shpool attach <name>` (now with a trailing --dir; the
+  # passes-dir test pins that part). Match loosely so this stays about the
+  # forward itself and not the cwd.
+  if ! grep -q "shpool attach work" "$CALLS" 2>/dev/null; then
+    echo "  FAIL: expected 'shpool attach work' forward"; echo "  calls: $(cat "$CALLS" 2>/dev/null)"
+    TEST_FAILED=1
+  fi
 }
-test_makeshpool_stamps_initial_pwd() {
+test_makeshpool_passes_dir() {
   install_script makeshpool; install_script autoshpool; install_script sessionlib
-  # record the stamped SHPOOL_INITIAL_PWD: a freshly created shpool session
-  # must open in the caller's dir, not the outer shell's startup dir.
-  cat > "$BIN/shpool" <<EOF
-#!/bin/bash
-echo "shpool \$* pwd=\$SHPOOL_INITIAL_PWD" >> "$CALLS"
-EOF
-  chmod +x "$BIN/shpool"
-  # run with the caller's cwd set to $TEST_TMPDIR so \$PWD is deterministic.
+  # a freshly created shpool session must open in the caller's dir, passed via
+  # --dir, not the outer shell's startup dir.
+  fake shpool
+  # run with the caller's cwd set to $TEST_TMPDIR so $PWD is deterministic.
   set +e
   ( cd "$TEST_TMPDIR" && env -i PATH="$BIN" HOME="$TEST_TMPDIR" "$BIN/makeshpool" work )
   set -e
-  assert_called "shpool attach work pwd=$TEST_TMPDIR"
+  assert_called "shpool attach work --dir $TEST_TMPDIR"
 }
 test_makeshpool_inside_session_requests_switch() {
   # Inside a session, makeshpool can't attach a second session to this terminal
@@ -249,7 +251,7 @@ run_test "dispatch: session name passes through" test_name_passes_through
 run_test "backend: maketmux outside tmux creates and attaches" test_maketmux_outside_tmux_creates_and_attaches
 run_test "backend: maketmux inside tmux switches client" test_maketmux_inside_tmux_switches_client
 run_test "backend: makeshpool runs shpool attach" test_makeshpool_runs_shpool_attach
-run_test "backend: makeshpool stamps SHPOOL_INITIAL_PWD" test_makeshpool_stamps_initial_pwd
+run_test "backend: makeshpool passes --dir" test_makeshpool_passes_dir
 run_test "backend: makeshpool inside a session requests a switch" test_makeshpool_inside_session_requests_switch
 run_test "backend: makeshpool inside a session rejects extra args" test_makeshpool_inside_session_rejects_extra_args
 

--- a/makeshpool
+++ b/makeshpool
@@ -5,10 +5,11 @@
 # the session name.
 #
 # Outside any session, create-and-attach directly (shpool attach creates the
-# session when it doesn't exist yet). Stamp SHPOOL_INITIAL_PWD so the new
-# session's shell opens in the caller's directory rather than the outer shell's
-# startup dir -- the same reason the autoshpool wrapper stamps it. tmux needs no
-# equivalent (see maketmux).
+# session when it doesn't exist yet). Pass --dir "$PWD" so the new session's
+# shell opens in the caller's directory rather than the outer shell's startup
+# dir -- the same reason the autoshpool wrapper passes it. shpool ignores --dir
+# on a reattach (the shell already exists). tmux needs no equivalent (see
+# maketmux).
 #
 # Inside an existing session shpool can't attach a second session to this
 # terminal without nesting -- and exec'ing `shpool attach` over our shell would
@@ -35,5 +36,4 @@ if test -n "$SHPOOL_SESSION_NAME"; then
   request_switch "$1" "$PWD"   # records target, detaches us, and exits
 fi
 
-export SHPOOL_INITIAL_PWD="$PWD"
-exec shpool attach "$@"
+exec shpool attach "$@" --dir "$PWD"

--- a/maketmux
+++ b/maketmux
@@ -10,7 +10,8 @@
 # dance autotmux's do_switch uses). Target the switch with tmux's exact "=name"
 # form so a name that is a prefix of another session can't be matched instead.
 # Outside tmux there is no client to switch, so just create-and-attach. tmux
-# opens the session in the caller's PWD natively (no SHPOOL_INITIAL_PWD twin).
+# opens the session in the caller's PWD natively (no --dir twin needed, unlike
+# makeshpool's `shpool attach --dir`).
 if test -n "$TMUX"; then
   tmux new-session -d -s "$@" && exec tmux switch-client -t "=$1"
   exit $?


### PR DESCRIPTION
## What

Two low-risk simplifications to the shpool session scripts, using shpool `attach` flags that already exist in released versions (`--dir` since 0.9.3, `--force` older still). These are the first, safe step of the broader "can we lean on shpool's newer session features" investigation from shell-pool/shpool#338 — the template/`var`-based redesign is intentionally **not** part of this PR.

### 1. `SHPOOL_INITIAL_PWD` → `shpool attach --dir "$PWD"`

The scripts used to export a private `SHPOOL_INITIAL_PWD` env var so a newly created session's shell (via the user's shell rc) could `cd` into the caller's directory. shpool now starts the session's shell in a given directory itself, so the wrapper just passes `--dir` and the env-var handoff goes away entirely (no remaining producer or consumer in this repo).

- `makeshpool`: `exec shpool attach "$@" --dir "$PWD"`
- `autoshpool`: the create path (`create_and_attach_next`) and the switch-with-recorded-pwd path in the loop
- `changeshpool`: the outside-a-session create path

`--dir` only takes effect when the session is created; shpool ignores it on a reattach, which matches the old create-only semantics (a bare switch to an existing session still keeps its own directory).

### 2. changeshpool steal dance → `shpool attach --force`

From outside a session, `changeshpool` used to steal a target attached to another terminal by: `shpool detach` it, then poll `shpool list` until it left the `attached` state (to dodge a `BusyError` from a not-yet-released tty), then `shpool attach`. `--force` tells shpool to detach any attached tty first and sequence the handover in the daemon, so the whole detach-then-poll loop collapses to a single `shpool attach --force "$target"`.

## Testing

- Updated the affected assertions in `autoshpool_test`, `changeshpool_test`, and `makesession_test` to expect the new command forms (and refreshed a stale `maketmux` comment about the old env-var twin).
- Full suite passes: `make test` → all 9 suites green (195 tests).
- No new shellcheck findings on the changed scripts (existing SC1091/SC2155/SC2034 notes are pre-existing).

## Notes

- Requires shpool ≥ 0.9.3 for `--dir` — very safe to assume. (The template-based redesign, if pursued later, would need ≥ 0.10.2.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qt7tg1tA7N1Hg1JUbatL4m)_