### PR TITLE
Use shpool attach -d/-f instead of pwd and steal workarounds

### DIFF
--- a/autoshpool
+++ b/autoshpool
@@ -155,9 +155,10 @@ create_and_attach_next() {
     if test -n "${sessions[$session]}"; then
       continue
     fi
-    export SHPOOL_INITIAL_PWD="$PWD"
     echo "Creating shpool session $session"
-    shpool attach "$session"
+    # -d . opens the new session in the directory this loop runs from (where the
+    # user started the shell), instead of shpool's daemon dir.
+    shpool attach -d . "$session"
     rc=$?
     # shpool exits 0 even when refusing because the session is already
     # attached elsewhere (libshpool BusyError -> AttachResult::Done), so a
@@ -451,14 +452,14 @@ autoshpool_loop() {
     if test -n "$switch_session"; then
       switch_pwd="$(get_switch_pwd)"
       clear_switch
-      # A recorded pwd (a prefix-mismatch switch) opens the session there; a
-      # bare switch keeps the target's own directory, so drop any stale value.
+      # A recorded pwd (a prefix-mismatch switch) opens a freshly created session
+      # there via -d; a bare switch omits -d so an existing target keeps its own
+      # directory.
       if test -n "$switch_pwd"; then
-        export SHPOOL_INITIAL_PWD="$switch_pwd"
+        shpool attach -d "$switch_pwd" "$switch_session"
       else
-        unset SHPOOL_INITIAL_PWD
+        shpool attach "$switch_session"
       fi
-      shpool attach "$switch_session"
     else
       # Pick the session first so a failed attach is reported as a failure
       # rather than falling through to create a brand-new session.

--- a/autoshpool_test
+++ b/autoshpool_test
@@ -89,7 +89,6 @@ TIMEOUT
   unset SHPOOL_SESSION_NAME
   unset SHPOOL_PREFIX
   unset SHPOOL_ATTACH_EXIT
-  unset SHPOOL_INITIAL_PWD
   rm -f "$TEST_TMPDIR/.autoshpool_switch"
   rm -f "$TEST_TMPDIR/.autoshpool_switch_pwd"
   rm -f "$TEST_TMPDIR/.shpool_calls"
@@ -347,42 +346,20 @@ test_plain_switch_records_no_pwd() {
   assert_no_switch_pwd
 }
 
-test_loop_switch_exports_recorded_pwd() {
-  # When the loop services a switch that carries a pwd, it exports
-  # SHPOOL_INITIAL_PWD so the freshly created session starts there.
-  cat > "$TEST_TMPDIR/bin/shpool" <<'SHPOOL'
-#!/bin/bash
-echo "shpool $*" >> "$HOME/.shpool_calls"
-case "$1" in
-  list)
-    echo "name                           started_at                         status"
-    cat "$HOME/.shpool_sessions" 2>/dev/null
-    exit 0
-    ;;
-  attach)
-    echo "INITIAL_PWD=$SHPOOL_INITIAL_PWD" >> "$HOME/.shpool_env"
-    exit 0
-    ;;
-esac
-SHPOOL
-  chmod +x "$TEST_TMPDIR/bin/shpool"
-
+test_loop_switch_passes_recorded_pwd_as_dir() {
+  # When the loop services a switch that carries a pwd, it passes it via
+  # `shpool attach -d` so the freshly created session starts there.
   echo "myproject:1" > "$HOME/.autoshpool_switch"
   echo "/home/u/proj" > "$HOME/.autoshpool_switch_pwd"
   run_autoshpool
   assert_status 0
-  assert_called "shpool attach myproject:1"
-  if ! grep -qx "INITIAL_PWD=/home/u/proj" "$HOME/.shpool_env"; then
-    echo "  FAIL: expected SHPOOL_INITIAL_PWD=/home/u/proj on attach"
-    echo "  env: $(cat "$HOME/.shpool_env" 2>/dev/null)"
-    return 1
-  fi
+  assert_called "shpool attach -d /home/u/proj myproject:1"
 }
 
 test_creates_session_1() {
   run_autoshpool
   assert_status 0
-  assert_called "shpool attach 1"
+  assert_called "shpool attach -d . 1"
   assert_output_contains "Creating shpool session 1"
 }
 
@@ -455,7 +432,7 @@ EOF
   run_autoshpool
   assert_status 7
   assert_called "shpool attach 3"
-  if grep -q "shpool attach 1" "$HOME/.shpool_calls" 2>/dev/null; then
+  if grep -q "shpool attach -d . 1" "$HOME/.shpool_calls" 2>/dev/null; then
     echo "  FAIL: created a new session after a failed attach"
     echo "  calls: $(cat "$HOME/.shpool_calls" 2>/dev/null)"
     return 1
@@ -497,7 +474,7 @@ SHPOOL
 
   run_autoshpool
   assert_status 0
-  assert_called "shpool attach 1"
+  assert_called "shpool attach -d . 1"
   assert_called "shpool attach other"
 }
 
@@ -534,9 +511,9 @@ SHPOOL
 
   run_autoshpool
   assert_status 0
-  assert_called "shpool attach 1"
+  assert_called "shpool attach -d . 1"
   assert_called "shpool attach target:9"
-  if grep -q "shpool attach 2" "$HOME/.shpool_calls" 2>/dev/null; then
+  if grep -q "shpool attach -d . 2" "$HOME/.shpool_calls" 2>/dev/null; then
     echo "  FAIL: created a new numbered session instead of servicing the switch"
     echo "  calls: $(cat "$HOME/.shpool_calls" 2>/dev/null)"
     return 1
@@ -582,8 +559,8 @@ SHPOOL
 
   run_autoshpool
   assert_status 0
-  assert_called "shpool attach 1"
-  if grep -q "shpool attach 2" "$HOME/.shpool_calls" 2>/dev/null; then
+  assert_called "shpool attach -d . 1"
+  if grep -q "shpool attach -d . 2" "$HOME/.shpool_calls" 2>/dev/null; then
     echo "  FAIL: created a new session despite the status settling to disconnected"
     echo "  calls: $(cat "$HOME/.shpool_calls" 2>/dev/null)"
     return 1
@@ -594,7 +571,7 @@ test_uses_prefix() {
   export SHPOOL_PREFIX="myproject:"
   run_autoshpool
   assert_status 0
-  assert_called "shpool attach myproject:1"
+  assert_called "shpool attach -d . myproject:1"
 }
 
 test_skips_existing_sessions() {
@@ -605,7 +582,7 @@ test_skips_existing_sessions() {
 EOF
   run_autoshpool
   assert_status 0
-  assert_called "shpool attach 3"
+  assert_called "shpool attach -d . 3"
   assert_output_contains "Creating shpool session 3"
 }
 
@@ -624,11 +601,13 @@ case "$1" in
     exit 0
     ;;
   attach)
-    if grep -Fxq "$2" "$HOME/.shpool_already_attached" 2>/dev/null; then
+    # The session name is the last argument (after any -d . options).
+    session="${@: -1}"
+    if grep -Fxq "$session" "$HOME/.shpool_already_attached" 2>/dev/null; then
       # Busy: print the upstream message and exit 0. The session shows as
       # attached in the listing because someone else owns it.
-      echo "session '$2' already has a terminal attached" >&2
-      printf '%s   2025-01-01T00:00:00Z   attached\n' "$2" >> "$HOME/.shpool_sessions"
+      echo "session '$session' already has a terminal attached" >&2
+      printf '%s   2025-01-01T00:00:00Z   attached\n' "$session" >> "$HOME/.shpool_sessions"
     fi
     exit 0
     ;;
@@ -638,8 +617,8 @@ SHPOOL
   echo "1" > "$HOME/.shpool_already_attached"
   run_autoshpool
   assert_status 0
-  assert_called "shpool attach 1"
-  assert_called "shpool attach 2"
+  assert_called "shpool attach -d . 1"
+  assert_called "shpool attach -d . 2"
   assert_output_contains "Creating shpool session 2"
   assert_output_contains "already has a terminal attached"
 }
@@ -674,7 +653,7 @@ SHPOOL
     echo "  output: $output"
     return 1
   fi
-  assert_called "shpool attach 1"
+  assert_called "shpool attach -d . 1"
   assert_output_contains "cannot confirm session state"
 }
 
@@ -684,8 +663,8 @@ test_propagates_real_attach_failure() {
   export SHPOOL_ATTACH_EXIT=7
   run_autoshpool
   assert_status 7
-  assert_called "shpool attach 1"
-  if grep -q "shpool attach 2" "$HOME/.shpool_calls" 2>/dev/null; then
+  assert_called "shpool attach -d . 1"
+  if grep -q "shpool attach -d . 2" "$HOME/.shpool_calls" 2>/dev/null; then
     echo "  FAIL: should not have retried with session 2"
     echo "  calls: $(cat "$HOME/.shpool_calls" 2>/dev/null)"
     return 1
@@ -894,7 +873,7 @@ run_test "switches to a new prefixed session on mismatch" test_attached_mismatch
 run_test "reuses a disconnected prefixed session on mismatch" test_attached_mismatch_reuses_disconnected
 run_test "records the current directory for a prefix-mismatch switch" test_attached_mismatch_records_pwd
 run_test "records no directory for a plain switch" test_plain_switch_records_no_pwd
-run_test "loop exports the recorded directory when servicing a switch" test_loop_switch_exports_recorded_pwd
+run_test "loop passes the recorded directory to shpool attach -d" test_loop_switch_passes_recorded_pwd_as_dir
 run_test "creates session 1 when no sessions exist" test_creates_session_1
 run_test "attaches to disconnected session before creating new one" test_attaches_disconnected_first
 run_test "reuses a disconnected separatorless session on startup" test_reuses_separatorless_session

--- a/changeshpool
+++ b/changeshpool
@@ -100,12 +100,15 @@ backend_perform_switch() {
     fi
     return 0   # request_switch exits; not reached
   fi
-  # A create opens a brand-new session in the current directory (-d .); an
-  # existing target is stolen from any other terminal with -f, which tells
-  # shpool to detach the current client before attaching us (no manual
-  # detach-then-poll around the daemon's settle lag).
+  # -f tells shpool to detach any client already attached before attaching us,
+  # so we no longer detach-then-poll around the daemon's settle lag by hand. It
+  # is needed on the create path too: another terminal can create and attach the
+  # same target between perform_switch_to classifying it as missing and this
+  # attach, and without -f shpool would report that Busy case as a silent no-op
+  # (exit 0 without switching). A create also opens the new session in the
+  # current directory with -d . (ignored when the session already exists).
   if test "$action" = create; then
-    shpool attach -d . "$target"
+    shpool attach -f -d . "$target"
   else
     shpool attach -f "$target"
   fi

--- a/changeshpool
+++ b/changeshpool
@@ -100,22 +100,15 @@ backend_perform_switch() {
     fi
     return 0   # request_switch exits; not reached
   fi
-  test "$action" = create && export SHPOOL_INITIAL_PWD="$PWD"
-  # shpool detach returns once the daemon has signalled the other client, but
-  # the client's tty hasn't released yet, so a back-to-back attach hits
-  # BusyError ("session 'X' already has a terminal attached"). Poll shpool
-  # list until the session leaves the "attached" state so attach lands
-  # cleanly. Bounded so a wedged client doesn't hang us forever -- if the
-  # target stays attached we still try attach (matches the old behaviour and
-  # surfaces the real error).
-  timeout 2 shpool detach "$target" 2>/dev/null
-  local i
-  for i in 1 2 3 4 5 6 7 8 9 10; do
-    test "$(session_status "$target" "$(shpool list 2>/dev/null)")" = attached \
-      || break
-    sleep 0.1
-  done
-  shpool attach "$target"
+  # A create opens a brand-new session in the current directory (-d .); an
+  # existing target is stolen from any other terminal with -f, which tells
+  # shpool to detach the current client before attaching us (no manual
+  # detach-then-poll around the daemon's settle lag).
+  if test "$action" = create; then
+    shpool attach -d . "$target"
+  else
+    shpool attach -f "$target"
+  fi
 }
 
 case "$1" in

--- a/changeshpool_test
+++ b/changeshpool_test
@@ -21,8 +21,8 @@ setup() {
 
   # Fake shpool: list serves the header plus .shpool_sessions rows; attach
   # records the call (and honours $SHPOOL_ATTACH_EXIT); detach records the call
-  # and rewrites the named session's row to "disconnected" so the steal-then-
-  # poll path in changeshpool sees the session leave the "attached" state.
+  # and rewrites the named session's row to "disconnected" (still used by the
+  # request_switch handoff, which detaches the current session).
   cat > "$TEST_TMPDIR/bin/shpool" <<'SHPOOL'
 #!/bin/bash
 echo "shpool $*" >> "$HOME/.shpool_calls"
@@ -79,7 +79,7 @@ VCS
 
   touch "$TEST_TMPDIR/.shrc.vcs"
 
-  unset SHPOOL_SESSION_NAME SHPOOL_PREFIX SHPOOL_ATTACH_EXIT SHPOOL_INITIAL_PWD
+  unset SHPOOL_SESSION_NAME SHPOOL_PREFIX SHPOOL_ATTACH_EXIT
   unset FZF_QUERY FZF_PICK FZF_EXIT
   rm -f "$TEST_TMPDIR"/.autoshpool_switch "$TEST_TMPDIR"/.autoshpool_switch_pwd
   rm -f "$TEST_TMPDIR"/.shpool_calls "$TEST_TMPDIR"/.shpool_sessions
@@ -312,19 +312,28 @@ test_typed_new_name_requests_switch() {
 test_outside_session_attaches_with_steal() {
   add_full target:1 disconnected
   FZF_PICK=$'^switch\ttarget:1\t' run_cs
-  assert_called 'shpool detach target:1'   # steal from any other terminal
-  assert_called 'shpool attach target:1'
-  assert_no_switch_file                     # no loop to service: attach directly
+  assert_called 'shpool attach -f target:1'   # -f steals from any other terminal
+  assert_not_called 'shpool detach'           # -f detaches for us, no manual step
+  assert_no_switch_file                        # no loop to service: attach directly
 }
 
 test_outside_session_steals_attached_target() {
   # When the target is currently attached elsewhere, the steal still lands:
-  # detach asks the other client to release, and the poll waits for the
-  # session to leave the "attached" state before attach runs.
+  # shpool attach -f detaches the other client before attaching us, so there is
+  # no manual detach-then-poll dance around the daemon's settle lag.
   add_full target:1 attached
   FZF_PICK=$'^switch\ttarget:1\t' run_cs
-  assert_called 'shpool detach target:1'
-  assert_called 'shpool attach target:1'
+  assert_called 'shpool attach -f target:1'
+  assert_not_called 'shpool detach'
+}
+
+test_outside_session_create_opens_in_current_dir() {
+  # Creating a session from outside any session attaches it directly with -d .
+  # so the new shell opens in the caller's directory, not shpool's daemon dir.
+  export SHPOOL_PREFIX="proj:"
+  FZF_PICK='^create' run_cs
+  assert_called 'shpool attach -d . proj:1'
+  assert_no_switch_file            # no loop to service: attach directly
 }
 
 test_esc_cancels_cleanly() {
@@ -418,6 +427,7 @@ run_test "pick: create entry requests the auto name with pwd" test_pick_create_e
 run_test "pick: typed new name requests a switch with pwd" test_typed_new_name_requests_switch
 run_test "pick: outside a session attaches with steal" test_outside_session_attaches_with_steal
 run_test "pick: outside a session steals an attached target" test_outside_session_steals_attached_target
+run_test "pick: outside a session creates in the current dir" test_outside_session_create_opens_in_current_dir
 run_test "pick: ESC cancels cleanly" test_esc_cancels_cleanly
 run_test "pick: fzf failure propagates as an error" test_picker_error_propagates
 run_test "choose: prints the chosen name without switching" test_choose_prints_name_only

--- a/changeshpool_test
+++ b/changeshpool_test
@@ -330,9 +330,11 @@ test_outside_session_steals_attached_target() {
 test_outside_session_create_opens_in_current_dir() {
   # Creating a session from outside any session attaches it directly with -d .
   # so the new shell opens in the caller's directory, not shpool's daemon dir.
+  # -f guards the classify->attach race (another terminal creating the same
+  # target first), matching the steal path, so the attach never no-ops silently.
   export SHPOOL_PREFIX="proj:"
   FZF_PICK='^create' run_cs
-  assert_called 'shpool attach -d . proj:1'
+  assert_called 'shpool attach -f -d . proj:1'
   assert_no_switch_file            # no loop to service: attach directly
 }
 

--- a/makesession_test
+++ b/makesession_test
@@ -9,7 +9,8 @@
 #     case without a real multiplexer.
 #   * backend behaviour - the real maketmux / makeshpool are run with a fake
 #     tmux / shpool, asserting the exact command each forwards and that
-#     makeshpool stamps SHPOOL_INITIAL_PWD with the caller's directory.
+#     makeshpool passes `shpool attach -d .` to open the session in the caller's
+#     directory.
 
 set -e
 
@@ -152,28 +153,15 @@ test_maketmux_inside_tmux_switches_client() {
   assert_called "tmux switch-client -t =work"
 }
 test_makeshpool_runs_shpool_attach() {
+  # makeshpool forwards to `shpool attach -d . <name>`: -d . opens the freshly
+  # created session in the caller's directory rather than shpool's daemon dir.
   install_script makeshpool; install_script autoshpool; install_script sessionlib
   fake shpool
   set +e
   output="$(env -i PATH="$BIN" HOME="$TEST_TMPDIR" "$BIN/makeshpool" work 2>&1)"
   status=$?
   set -e
-  assert_called "shpool attach work"
-}
-test_makeshpool_stamps_initial_pwd() {
-  install_script makeshpool; install_script autoshpool; install_script sessionlib
-  # record the stamped SHPOOL_INITIAL_PWD: a freshly created shpool session
-  # must open in the caller's dir, not the outer shell's startup dir.
-  cat > "$BIN/shpool" <<EOF
-#!/bin/bash
-echo "shpool \$* pwd=\$SHPOOL_INITIAL_PWD" >> "$CALLS"
-EOF
-  chmod +x "$BIN/shpool"
-  # run with the caller's cwd set to $TEST_TMPDIR so \$PWD is deterministic.
-  set +e
-  ( cd "$TEST_TMPDIR" && env -i PATH="$BIN" HOME="$TEST_TMPDIR" "$BIN/makeshpool" work )
-  set -e
-  assert_called "shpool attach work pwd=$TEST_TMPDIR"
+  assert_called "shpool attach -d . work"
 }
 test_makeshpool_inside_session_requests_switch() {
   # Inside a session, makeshpool can't attach a second session to this terminal
@@ -248,8 +236,7 @@ run_test "dispatch: no backend errors out" test_no_backend_errors
 run_test "dispatch: session name passes through" test_name_passes_through
 run_test "backend: maketmux outside tmux creates and attaches" test_maketmux_outside_tmux_creates_and_attaches
 run_test "backend: maketmux inside tmux switches client" test_maketmux_inside_tmux_switches_client
-run_test "backend: makeshpool runs shpool attach" test_makeshpool_runs_shpool_attach
-run_test "backend: makeshpool stamps SHPOOL_INITIAL_PWD" test_makeshpool_stamps_initial_pwd
+run_test "backend: makeshpool runs shpool attach -d ." test_makeshpool_runs_shpool_attach
 run_test "backend: makeshpool inside a session requests a switch" test_makeshpool_inside_session_requests_switch
 run_test "backend: makeshpool inside a session rejects extra args" test_makeshpool_inside_session_rejects_extra_args
 

--- a/makesession_test
+++ b/makesession_test
@@ -163,6 +163,17 @@ test_makeshpool_runs_shpool_attach() {
   set -e
   assert_called "shpool attach -d . work"
 }
+test_makeshpool_preserves_caller_dir() {
+  # shpool's --dir isn't repeatable, so a caller-supplied -d/--dir must be
+  # forwarded as-is rather than clobbered by the default -d .
+  install_script makeshpool; install_script autoshpool; install_script sessionlib
+  fake shpool
+  set +e
+  output="$(env -i PATH="$BIN" HOME="$TEST_TMPDIR" "$BIN/makeshpool" --dir /tmp work 2>&1)"
+  status=$?
+  set -e
+  assert_called "shpool attach --dir /tmp work"
+}
 test_makeshpool_inside_session_requests_switch() {
   # Inside a session, makeshpool can't attach a second session to this terminal
   # without nesting, so it hands the new session to autoshpool's loop via
@@ -237,6 +248,7 @@ run_test "dispatch: session name passes through" test_name_passes_through
 run_test "backend: maketmux outside tmux creates and attaches" test_maketmux_outside_tmux_creates_and_attaches
 run_test "backend: maketmux inside tmux switches client" test_maketmux_inside_tmux_switches_client
 run_test "backend: makeshpool runs shpool attach -d ." test_makeshpool_runs_shpool_attach
+run_test "backend: makeshpool preserves a caller-supplied --dir" test_makeshpool_preserves_caller_dir
 run_test "backend: makeshpool inside a session requests a switch" test_makeshpool_inside_session_requests_switch
 run_test "backend: makeshpool inside a session rejects extra args" test_makeshpool_inside_session_rejects_extra_args
 

--- a/makeshpool
+++ b/makeshpool
@@ -5,9 +5,8 @@
 # the session name.
 #
 # Outside any session, create-and-attach directly (shpool attach creates the
-# session when it doesn't exist yet). Stamp SHPOOL_INITIAL_PWD so the new
-# session's shell opens in the caller's directory rather than the outer shell's
-# startup dir -- the same reason the autoshpool wrapper stamps it. tmux needs no
+# session when it doesn't exist yet). Pass -d . so the new session's shell opens
+# in the caller's directory rather than shpool's daemon dir. tmux needs no
 # equivalent (see maketmux).
 #
 # Inside an existing session shpool can't attach a second session to this
@@ -35,5 +34,4 @@ if test -n "$SHPOOL_SESSION_NAME"; then
   request_switch "$1" "$PWD"   # records target, detaches us, and exits
 fi
 
-export SHPOOL_INITIAL_PWD="$PWD"
-exec shpool attach "$@"
+exec shpool attach -d . "$@"

--- a/makeshpool
+++ b/makeshpool
@@ -5,9 +5,11 @@
 # the session name.
 #
 # Outside any session, create-and-attach directly (shpool attach creates the
-# session when it doesn't exist yet). Pass -d . so the new session's shell opens
-# in the caller's directory rather than shpool's daemon dir. tmux needs no
-# equivalent (see maketmux).
+# session when it doesn't exist yet). Default -d . so the new session's shell
+# opens in the caller's directory rather than shpool's daemon dir, but only when
+# the caller didn't ask for a directory themselves -- shpool's --dir isn't
+# repeatable, so prepending ours would clobber a caller-supplied -d/--dir. tmux
+# needs no equivalent (see maketmux).
 #
 # Inside an existing session shpool can't attach a second session to this
 # terminal without nesting -- and exec'ing `shpool attach` over our shell would
@@ -34,4 +36,15 @@ if test -n "$SHPOOL_SESSION_NAME"; then
   request_switch "$1" "$PWD"   # records target, detaches us, and exits
 fi
 
-exec shpool attach -d . "$@"
+# Honour a caller-supplied directory; only default to -d . when none was given.
+_have_dir=
+for _arg in "$@"; do
+  case "$_arg" in
+    -d|-d?*|--dir|--dir=*) _have_dir=1; break ;;
+  esac
+done
+if test -n "$_have_dir"; then
+  exec shpool attach "$@"
+else
+  exec shpool attach -d . "$@"
+fi

--- a/maketmux
+++ b/maketmux
@@ -10,7 +10,8 @@
 # dance autotmux's do_switch uses). Target the switch with tmux's exact "=name"
 # form so a name that is a prefix of another session can't be matched instead.
 # Outside tmux there is no client to switch, so just create-and-attach. tmux
-# opens the session in the caller's PWD natively (no SHPOOL_INITIAL_PWD twin).
+# opens the session in the caller's PWD natively (makeshpool needs `shpool
+# attach -d .` for the same effect).
 if test -n "$TMUX"; then
   tmux new-session -d -s "$@" && exec tmux switch-client -t "=$1"
   exit $?


### PR DESCRIPTION
## Summary

shpool's `attach` subcommand supports two flags that our session helpers were reimplementing by hand:

- `-d/--dir <DIR>` — start the session's shell in a given directory (`.` = the invocation's pwd). Replaces stamping `SHPOOL_INITIAL_PWD` and having the login shell `cd` back on startup (the consuming side lives in mikelward/conf#188).
- `-f/--force` — detach any client already attached before attaching us. Replaces the manual `shpool detach` + poll-until-settled loop `changeshpool` used to steal a session.

## Changes

- **`autoshpool`**: create sessions with `shpool attach -d .`; the loop opens a prefix-mismatch switch's recorded pwd with `-d "$pwd"` (a bare switch still omits `-d`, so an existing target keeps its own directory).
- **`makeshpool`**: create-and-attach with `shpool attach -d .` — but only default `-d .` when the caller didn't supply their own `-d/--dir` (shpool's `--dir` isn't repeatable, so a caller-provided directory is forwarded verbatim).
- **`changeshpool`**: steal an existing target with `shpool attach -f`; create with `shpool attach -f -d .`. `-f` on the create path preserves the old detach-then-attach steal semantics, so a target another terminal races into existence between classification and attach isn't reported as a silent Busy no-op. The detach-then-poll dance around the daemon's settle lag is gone.
- **`maketmux`**: comment refresh (tmux already opens in the caller's pwd natively).

## Tests

- Updated `autoshpool_test`, `changeshpool_test`, and `makesession_test` to assert the new `-d`/`-f` invocations.
- Added cases: create-from-outside-a-session opens in the current directory with `-f -d .`; `makeshpool` forwards a caller-supplied `--dir` unchanged.
- `make test` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)