### PR TITLE
setup-kde: prefer pnpm over npm when available

### DIFF
--- a/setup-kde
+++ b/setup-kde
@@ -7,7 +7,7 @@
 # - Window management and desktop switching keybindings
 # - Application launch shortcuts (browser, terminal, music)
 #
-# Requires: git, npm, kpackagetool6, kwriteconfig6
+# Requires: git, pnpm or npm, kpackagetool6, kwriteconfig6
 # Optional: go-task (preferred build tool), p7zip
 #
 # Usage:
@@ -98,12 +98,13 @@ trap cleanup EXIT
 # --- Check prerequisites ---
 
 # kwriteconfig6 is needed for every configuration step, so it's always
-# required. git/npm/kpackagetool6 are only used to build and install
+# required. git/pnpm/npm/kpackagetool6 are only used to build and install
 # Krohnkite, so they're only required when actually installing.
 command -v kwriteconfig6 >/dev/null 2>&1 || error "kwriteconfig6 is required (KDE Plasma 6)"
 if test "$INSTALL" = yes; then
     command -v git >/dev/null 2>&1 || error "git is required"
-    command -v npm >/dev/null 2>&1 || error "npm is required (to build Krohnkite)"
+    command -v pnpm >/dev/null 2>&1 || command -v npm >/dev/null 2>&1 \
+        || error "pnpm or npm is required (to build Krohnkite)"
     command -v kpackagetool6 >/dev/null 2>&1 || error "kpackagetool6 is required (KDE Plasma 6)"
 fi
 
@@ -119,7 +120,8 @@ install_krohnkite() {
     # longer installed by setup, but use it if it's present: the binary is
     # named "go-task" from Fedora's package, or "task" when installed by
     # hand -- but "task" can also be Taskwarrior, so check the version
-    # banner before trusting it. Otherwise fall back to make, then npm.
+    # banner before trusting it. Otherwise fall back to make, then pnpm
+    # (preferred over npm when available), then npm.
     if command -v go-task >/dev/null 2>&1; then
         info "Building Krohnkite with go-task"
         go-task package
@@ -130,6 +132,9 @@ install_krohnkite() {
     elif test -f Makefile; then
         info "Building Krohnkite with make"
         make
+    elif command -v pnpm >/dev/null 2>&1; then
+        info "Building Krohnkite with pnpm"
+        pnpm install && pnpm run build
     else
         info "Building Krohnkite with npm"
         npm install && npm run build


### PR DESCRIPTION
## Summary

Answers "is it possible to use pnpm if available instead of npm?" — yes, and this wires it up in `setup-kde`, the only script that actually invokes a Node package manager to build (the `npm` in `setup` is just the Debian/Fedora package name being installed).

## Changes

- Build fallback for Krohnkite now prefers `pnpm` when it's on `PATH` (`pnpm install && pnpm run build`), falling back to `npm` otherwise. This only affects the path taken when `go-task`/`task`/`make` aren't available.
- Prerequisite check now accepts **either** `pnpm` or `npm` instead of requiring `npm`.
- Updated the header requirements comment and the build-order comment to match.

## Notes

The `go-task` / `task` / `make` build paths are unchanged and still take priority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXFQmik5JR6jxdeNr29Ca3)_