### PR TITLE
Add setup-hypr; install KDE + Hyprland packages together in setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,4 @@ test:
 	./detachsession_test
 	./makesession_test
 	./mdf_test
+	./setup-hypr_test

--- a/setup
+++ b/setup
@@ -2,8 +2,9 @@
 # Bootstrap script for setting up a new machine.
 #
 # Usage:
-#     setup [--gui | --no-gui] [--minimal | --full] [--no-install] \
-#           [--ignore-errors] [--ssh | --no-ssh] [--no-npm] [-h | --help]
+#     setup [--gui | --no-gui] [--kde | --hypr] [--minimal | --full] \
+#           [--no-install] [--ignore-errors] [--ssh | --no-ssh] [--no-npm] \
+#           [-h | --help]
 #
 #  or, to bootstrap from scratch:
 #     curl -fsSL https://mikelward.com/setup | sh
@@ -88,16 +89,25 @@ SSH=auto
 #         (nvm, fnm, corepack, a standalone pnpm, etc.)
 NPM=yes
 
+# Which Linux desktop to install and configure (ignored on macOS). One of:
+#   kde   - KDE Plasma + Krohnkite, via setup-kde (the default)
+#   hypr  - Hyprland Wayland desktop, via setup-hypr
+# Override with --kde / --hypr, or by exporting DESKTOP before running.
+DESKTOP="${DESKTOP:-kde}"
+
 usage() {
     cat <<'USAGE'
-Usage: setup [--gui | --no-gui] [--minimal | --full] [--no-install]
-             [--ignore-errors] [--ssh | --no-ssh] [--no-npm] [-h | --help]
+Usage: setup [--gui | --no-gui] [--kde | --hypr] [--minimal | --full]
+             [--no-install] [--ignore-errors] [--ssh | --no-ssh] [--no-npm]
+             [-h | --help]
 
 Bootstrap a new machine: install packages, fonts, tools, and dotfiles.
 
 Options:
   --gui            Force installation of graphical packages and desktop config
   --no-gui         Skip all graphical packages and desktop configuration
+  --kde            Install/configure KDE Plasma + Krohnkite (default; Linux)
+  --hypr           Install/configure the Hyprland Wayland desktop (Linux)
   --minimal        Skip heavyweight extras (Rust toolchain, helix, jj, shpool,
                    nushell), installing only core packages, tools, and dotfiles
   --full           Install everything, even when disk space looks tight
@@ -140,6 +150,12 @@ while test $# -gt 0; do
             ;;
         --no-gui)
             GUI=no
+            ;;
+        --kde)
+            DESKTOP=kde
+            ;;
+        --hypr)
+            DESKTOP=hypr
             ;;
         --minimal)
             MINIMAL=yes
@@ -364,13 +380,18 @@ install_packages() {
                 sudo apt-get install -y --install-recommends npm
             fi
             if test "$GUI_ENABLED" -eq 1; then
-                info "Installing graphical packages"
-                sudo apt-get install -y --install-recommends \
-                    kde-standard \
-                    kitty \
-                    kwin-dev \
-                    plasma-desktop \
-                    plasma-sdk
+                info "Installing kitty"
+                sudo apt-get install -y --install-recommends kitty
+                if test "$DESKTOP" = kde; then
+                    info "Installing KDE graphical packages"
+                    sudo apt-get install -y --install-recommends \
+                        kde-standard \
+                        kwin-dev \
+                        plasma-desktop \
+                        plasma-sdk
+                else
+                    info "Hyprland desktop selected; setup-hypr installs its packages"
+                fi
             fi
             ;;
         redhat)
@@ -403,13 +424,18 @@ install_packages() {
                 sudo dnf install -y npm
             fi
             if test "$GUI_ENABLED" -eq 1; then
-                info "Installing graphical packages"
-                sudo dnf install -y \
-                    '@kde-desktop-environment' \
-                    kitty \
-                    kwin-devel \
-                    plasma-desktop \
-                    plasma-sdk
+                info "Installing kitty"
+                sudo dnf install -y kitty
+                if test "$DESKTOP" = kde; then
+                    info "Installing KDE graphical packages"
+                    sudo dnf install -y \
+                        '@kde-desktop-environment' \
+                        kwin-devel \
+                        plasma-desktop \
+                        plasma-sdk
+                else
+                    info "Hyprland desktop selected; setup-hypr installs its packages"
+                fi
             fi
             ;;
         macos)
@@ -821,6 +847,9 @@ if test "$GUI_ENABLED" -eq 1; then
     if test "$OS" = "macos"; then
         info "Configuring macOS desktop environment"
         "$SCRIPTS_DIR/setup-macos" $DESKTOP_SETUP_FLAGS
+    elif test "$DESKTOP" = hypr; then
+        info "Configuring Hyprland desktop environment"
+        "$SCRIPTS_DIR/setup-hypr" $DESKTOP_SETUP_FLAGS
     else
         info "Configuring KDE desktop environment"
         "$SCRIPTS_DIR/setup-kde" $DESKTOP_SETUP_FLAGS

--- a/setup
+++ b/setup
@@ -382,16 +382,28 @@ install_packages() {
             if test "$GUI_ENABLED" -eq 1; then
                 info "Installing kitty"
                 sudo apt-get install -y --install-recommends kitty
-                if test "$DESKTOP" = kde; then
-                    info "Installing KDE graphical packages"
-                    sudo apt-get install -y --install-recommends \
-                        kde-standard \
-                        kwin-dev \
-                        plasma-desktop \
-                        plasma-sdk
-                else
-                    info "Hyprland desktop selected; setup-hypr installs its packages"
-                fi
+                info "Installing KDE graphical packages"
+                sudo apt-get install -y --install-recommends \
+                    kde-standard \
+                    kwin-dev \
+                    plasma-desktop \
+                    plasma-sdk
+                # Hyprland Wayland desktop packages, installed unconditionally
+                # alongside KDE so either desktop is available (--kde/--hypr
+                # only choose which one to *configure*). `|| warn` because
+                # several hypr* tools may need a backport and shouldn't abort.
+                info "Installing Hyprland desktop packages"
+                sudo apt-get install -y --install-recommends \
+                    hyprland hyprland-idle hyprland-lock \
+                    xdg-desktop-portal-gtk \
+                    waybar fuzzel swaync kanshi \
+                    power-profiles-daemon \
+                    pipewire wireplumber pavucontrol \
+                    brightnessctl \
+                    network-manager-gnome blueman \
+                    policykit-1-gnome \
+                    fonts-jetbrains-mono \
+                    || warn "some Hyprland packages are unavailable; you may need a backport or manual build (hyprland, hypridle, hyprlock, swww, swaync)"
             fi
             ;;
         redhat)
@@ -426,16 +438,28 @@ install_packages() {
             if test "$GUI_ENABLED" -eq 1; then
                 info "Installing kitty"
                 sudo dnf install -y kitty
-                if test "$DESKTOP" = kde; then
-                    info "Installing KDE graphical packages"
-                    sudo dnf install -y \
-                        '@kde-desktop-environment' \
-                        kwin-devel \
-                        plasma-desktop \
-                        plasma-sdk
-                else
-                    info "Hyprland desktop selected; setup-hypr installs its packages"
-                fi
+                info "Installing KDE graphical packages"
+                sudo dnf install -y \
+                    '@kde-desktop-environment' \
+                    kwin-devel \
+                    plasma-desktop \
+                    plasma-sdk
+                # Hyprland Wayland desktop packages, installed unconditionally
+                # alongside KDE so either desktop is available (--kde/--hypr
+                # only choose which one to *configure*). `|| warn` because
+                # several hypr* tools may need a COPR and shouldn't abort.
+                info "Installing Hyprland desktop packages"
+                sudo dnf install -y \
+                    hyprland hypridle hyprlock \
+                    hyprland-portal xdg-desktop-portal-gtk \
+                    waybar fuzzel swaync swww kanshi \
+                    power-profiles-daemon \
+                    pipewire wireplumber pavucontrol \
+                    brightnessctl \
+                    network-manager-applet blueman \
+                    polkit-gnome \
+                    jetbrains-mono-fonts \
+                    || warn "some Hyprland packages are unavailable; you may need a COPR (e.g. solopasha/hyprland) or manual build"
             fi
             ;;
         macos)

--- a/setup-hypr
+++ b/setup-hypr
@@ -122,7 +122,7 @@ install_packages() {
             # All first-class in Arch's repos.
             sudo pacman -S --needed --noconfirm \
                 hyprland hypridle hyprlock \
-                xdg-desktop-portal-hyprland \
+                xdg-desktop-portal-hyprland xdg-desktop-portal-gtk \
                 waybar fuzzel swaync swww kanshi \
                 power-profiles-daemon \
                 pipewire wireplumber pavucontrol \
@@ -140,6 +140,7 @@ install_packages() {
             # on the rest.
             sudo apt-get install -y --install-recommends \
                 hyprland hyprland-idle hyprland-lock \
+                xdg-desktop-portal-gtk \
                 waybar fuzzel swaync kanshi \
                 power-profiles-daemon \
                 pipewire wireplumber pavucontrol \
@@ -153,7 +154,7 @@ install_packages() {
             info "Installing Wayland desktop packages (dnf)"
             sudo dnf install -y \
                 hyprland hypridle hyprlock \
-                hyprland-portal \
+                hyprland-portal xdg-desktop-portal-gtk \
                 waybar fuzzel swaync swww kanshi \
                 power-profiles-daemon \
                 pipewire wireplumber pavucontrol \

--- a/setup-hypr
+++ b/setup-hypr
@@ -1,0 +1,234 @@
+#!/bin/sh
+# Configure a Hyprland-based Wayland desktop (KDE replacement).
+#
+# The dotfiles themselves live in the conf repo (config/hypr, config/waybar,
+# config/fuzzel, config/swaync, config/kanshi) and are installed by conf's
+# `make install`. This script handles the parts that aren't dotfiles:
+#
+# - Install the Wayland desktop packages (compositor, bar, launcher,
+#   notifications, wallpaper, display hotplug, idle/lock, power management).
+# - Tell systemd-logind to ignore the laptop lid so Hyprland's own lid
+#   handler (config/hypr/scripts/lid.sh) is authoritative: disable the
+#   internal panel on close, and suspend only when no external display is
+#   connected.
+# - Enable power-profiles-daemon (used by the waybar power-profiles module).
+#
+# Package availability varies by distro -- Hyprland is first-class on Arch,
+# and may need a backport / COPR / manual build on Debian and Fedora. Missing
+# packages are warned about, not fatal, so the rest still applies.
+#
+# Usage:
+#     setup-hypr [--no-install] [--ignore-errors] [-h | --help]
+#
+# --no-install skips package installation and only (re)applies the logind
+# drop-in and service enablement. --ignore-errors keeps going past failures.
+# setup forwards both flags here.
+
+# Whether to install packages. "no" (via --no-install) skips the install.
+INSTALL=yes
+
+# Whether to keep going past failures. "no" aborts on the first error via
+# set -e; "yes" (via --ignore-errors) leaves it off and pushes through.
+IGNORE_ERRORS=no
+
+info() {
+    printf "%s\n" "$*"
+}
+
+warn() {
+    printf "Warning: %s\n" "$*" >&2
+}
+
+error() {
+    printf "Error: %s\n" "$*" >&2
+    exit 1
+}
+
+is_command() {
+    test -x "$(command -v "$1")"
+}
+
+usage() {
+    cat <<'USAGE'
+Usage: setup-hypr [--no-install] [--ignore-errors] [-h | --help]
+
+Configure a Hyprland-based Wayland desktop.
+
+Options:
+  --no-install     Skip package installation; only (re)apply logind + services
+  --ignore-errors  Keep going past failures instead of aborting on the first
+  -h, --help       Show this help and exit
+USAGE
+}
+
+# --- Parse arguments ---
+
+while test $# -gt 0; do
+    case "$1" in
+        --install)
+            INSTALL=yes
+            ;;
+        --no-install)
+            INSTALL=no
+            ;;
+        --ignore-errors)
+            IGNORE_ERRORS=yes
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            warn "Unknown option: $1"
+            usage >&2
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+# Abort on the first error by default. --ignore-errors leaves set -e off so
+# the script pushes through failing steps.
+if test "$IGNORE_ERRORS" = no; then
+    set -e
+fi
+
+# --- Detect package backend ---
+
+# Unlike the top-level `setup`, detect pacman too: Hyprland is first-class on
+# Arch. Prefer the native package manager of the running distro.
+detect_backend() {
+    if command -v pacman >/dev/null 2>&1; then
+        BACKEND=pacman
+    elif command -v apt-get >/dev/null 2>&1; then
+        BACKEND=apt
+    elif command -v dnf >/dev/null 2>&1; then
+        BACKEND=dnf
+    else
+        BACKEND=unknown
+    fi
+}
+
+# --- Install packages ---
+
+# Package sets per backend. Names differ across distros; where a package isn't
+# in the default repos (common on Debian/Fedora for the hypr* tools), the
+# install warns and continues rather than aborting.
+install_packages() {
+    detect_backend
+    case "$BACKEND" in
+        pacman)
+            info "Installing Wayland desktop packages (pacman)"
+            # All first-class in Arch's repos.
+            sudo pacman -S --needed --noconfirm \
+                hyprland hypridle hyprlock \
+                xdg-desktop-portal-hyprland \
+                waybar fuzzel swaync swww kanshi \
+                power-profiles-daemon \
+                pipewire wireplumber pavucontrol \
+                brightnessctl \
+                network-manager-applet blueman \
+                polkit-gnome \
+                ttf-jetbrains-mono-nerd \
+                || warn "some pacman packages failed to install"
+            ;;
+        apt)
+            info "Installing Wayland desktop packages (apt)"
+            sudo apt-get update -qq || true
+            # hyprland/hypridle/hyprlock/swww/swaync often need a recent
+            # Debian/Ubuntu or a backport; install what's available and warn
+            # on the rest.
+            sudo apt-get install -y --install-recommends \
+                hyprland hyprland-idle hyprland-lock \
+                waybar fuzzel swaync kanshi \
+                power-profiles-daemon \
+                pipewire wireplumber pavucontrol \
+                brightnessctl \
+                network-manager-gnome blueman \
+                policykit-1-gnome \
+                fonts-jetbrains-mono \
+                || warn "some apt packages are unavailable; you may need a backport or manual build (hyprland, hypridle, hyprlock, swww, swaync)"
+            ;;
+        dnf)
+            info "Installing Wayland desktop packages (dnf)"
+            sudo dnf install -y \
+                hyprland hypridle hyprlock \
+                hyprland-portal \
+                waybar fuzzel swaync swww kanshi \
+                power-profiles-daemon \
+                pipewire wireplumber pavucontrol \
+                brightnessctl \
+                network-manager-applet blueman \
+                polkit-gnome \
+                jetbrains-mono-fonts \
+                || warn "some dnf packages are unavailable; you may need a COPR (e.g. solopasha/hyprland) or manual build"
+            ;;
+        *)
+            warn "Unsupported package backend; install manually:"
+            warn "  hyprland hypridle hyprlock xdg-desktop-portal-hyprland"
+            warn "  waybar fuzzel swaync swww kanshi power-profiles-daemon"
+            warn "  pipewire wireplumber pavucontrol brightnessctl"
+            warn "  network-manager-applet blueman polkit-gnome"
+            warn "  a JetBrains Mono Nerd Font"
+            ;;
+    esac
+}
+
+# --- systemd-logind: ignore the lid ---
+
+# Hand full lid control to Hyprland (config/hypr/scripts/lid.sh) so a docked
+# laptop with the lid shut doesn't suspend when an external display is active.
+# A drop-in is cleaner than editing /etc/systemd/logind.conf directly.
+install_logind_lid_dropin() {
+    is_command systemctl || { warn "systemd not detected; skipping logind lid drop-in"; return 0; }
+    dropin_dir=/etc/systemd/logind.conf.d
+    dropin="$dropin_dir/10-hypr-lid.conf"
+    info "Installing logind lid drop-in ($dropin)"
+    sudo mkdir -p "$dropin_dir"
+    sudo tee "$dropin" >/dev/null <<'CONF'
+# Installed by setup-hypr. Let Hyprland's lid handler (lid.sh) manage the lid
+# so a docked laptop with the lid closed keeps running on its external display.
+[Login]
+HandleLidSwitch=ignore
+HandleLidSwitchExternalPower=ignore
+HandleLidSwitchDocked=ignore
+CONF
+    # Reload logind so the drop-in takes effect without a reboot.
+    sudo systemctl kill -s HUP systemd-logind 2>/dev/null \
+        || warn "could not reload systemd-logind; changes apply after reboot"
+}
+
+# --- Services ---
+
+enable_services() {
+    is_command systemctl || { warn "systemd not detected; enable power-profiles-daemon manually"; return 0; }
+    if systemctl list-unit-files power-profiles-daemon.service >/dev/null 2>&1; then
+        info "Enabling power-profiles-daemon"
+        sudo systemctl enable --now power-profiles-daemon.service \
+            || warn "could not enable power-profiles-daemon"
+    else
+        warn "power-profiles-daemon.service not found; install power-profiles-daemon"
+    fi
+}
+
+# --- Main ---
+
+if test "$INSTALL" = yes; then
+    install_packages
+else
+    info "Skipping package installation (--no-install)"
+fi
+install_logind_lid_dropin
+enable_services
+
+# Local overrides, mirroring setup-kde's setup-kde.local hook.
+if is_command setup-hypr.local; then
+    info "Sourcing setup-hypr.local"
+    # shellcheck source=/dev/null
+    . setup-hypr.local
+fi
+
+info "Hyprland desktop configured."
+info "Fill in the placeholders (pointer/monitor names, wallpaper) noted in"
+info "conf/config/hypr/README.md, then log in and pick the Hyprland session"
+info "(or run 'Hyprland' from a TTY)."

--- a/setup-hypr
+++ b/setup-hypr
@@ -3,26 +3,21 @@
 #
 # The dotfiles themselves live in the conf repo (config/hypr, config/waybar,
 # config/fuzzel, config/swaync, config/kanshi) and are installed by conf's
-# `make install`. This script handles the parts that aren't dotfiles:
+# `make install`. The Wayland desktop *packages* are installed by the top-level
+# `setup` (alongside the KDE packages). This script, like setup-kde, handles the
+# parts that are neither dotfiles nor packages:
 #
-# - Install the Wayland desktop packages (compositor, bar, launcher,
-#   notifications, wallpaper, display hotplug, idle/lock, power management).
 # - Tell systemd-logind to ignore the laptop lid so Hyprland's own lid
 #   handler (config/hypr/scripts/lid.sh) is authoritative: disable the
 #   internal panel on close, and suspend only when no external display is
 #   connected.
 # - Enable power-profiles-daemon (used by the waybar power-profiles module).
 #
-# Package availability varies by distro -- Hyprland is first-class on Arch,
-# and may need a backport / COPR / manual build on Debian and Fedora. Missing
-# packages are warned about, not fatal, so the rest still applies.
-#
 # Usage:
 #     setup-hypr [--no-install] [--ignore-errors] [-h | --help]
 #
-# --no-install skips package installation and only (re)applies the logind
-# drop-in and service enablement. --ignore-errors keeps going past failures.
-# setup forwards both flags here.
+# --no-install skips the system-modifying steps (logind drop-in, enabling the
+# service). --ignore-errors keeps going past failures. setup forwards both.
 
 # Whether to install packages. "no" (via --no-install) skips the install.
 INSTALL=yes
@@ -52,10 +47,10 @@ usage() {
     cat <<'USAGE'
 Usage: setup-hypr [--no-install] [--ignore-errors] [-h | --help]
 
-Configure a Hyprland-based Wayland desktop.
+Configure a Hyprland-based Wayland desktop (packages come from `setup`).
 
 Options:
-  --no-install     Skip package installation; only (re)apply logind + services
+  --no-install     Skip the system-modifying steps (logind drop-in, services)
   --ignore-errors  Keep going past failures instead of aborting on the first
   -h, --help       Show this help and exit
 USAGE
@@ -92,88 +87,6 @@ done
 if test "$IGNORE_ERRORS" = no; then
     set -e
 fi
-
-# --- Detect package backend ---
-
-# Unlike the top-level `setup`, detect pacman too: Hyprland is first-class on
-# Arch. Prefer the native package manager of the running distro.
-detect_backend() {
-    if command -v pacman >/dev/null 2>&1; then
-        BACKEND=pacman
-    elif command -v apt-get >/dev/null 2>&1; then
-        BACKEND=apt
-    elif command -v dnf >/dev/null 2>&1; then
-        BACKEND=dnf
-    else
-        BACKEND=unknown
-    fi
-}
-
-# --- Install packages ---
-
-# Package sets per backend. Names differ across distros; where a package isn't
-# in the default repos (common on Debian/Fedora for the hypr* tools), the
-# install warns and continues rather than aborting.
-install_packages() {
-    detect_backend
-    case "$BACKEND" in
-        pacman)
-            info "Installing Wayland desktop packages (pacman)"
-            # All first-class in Arch's repos.
-            sudo pacman -S --needed --noconfirm \
-                hyprland hypridle hyprlock \
-                xdg-desktop-portal-hyprland xdg-desktop-portal-gtk \
-                waybar fuzzel swaync swww kanshi \
-                power-profiles-daemon \
-                pipewire wireplumber pavucontrol \
-                brightnessctl \
-                network-manager-applet blueman \
-                polkit-gnome \
-                ttf-jetbrains-mono-nerd \
-                || warn "some pacman packages failed to install"
-            ;;
-        apt)
-            info "Installing Wayland desktop packages (apt)"
-            sudo apt-get update -qq || true
-            # hyprland/hypridle/hyprlock/swww/swaync often need a recent
-            # Debian/Ubuntu or a backport; install what's available and warn
-            # on the rest.
-            sudo apt-get install -y --install-recommends \
-                hyprland hyprland-idle hyprland-lock \
-                xdg-desktop-portal-gtk \
-                waybar fuzzel swaync kanshi \
-                power-profiles-daemon \
-                pipewire wireplumber pavucontrol \
-                brightnessctl \
-                network-manager-gnome blueman \
-                policykit-1-gnome \
-                fonts-jetbrains-mono \
-                || warn "some apt packages are unavailable; you may need a backport or manual build (hyprland, hypridle, hyprlock, swww, swaync)"
-            ;;
-        dnf)
-            info "Installing Wayland desktop packages (dnf)"
-            sudo dnf install -y \
-                hyprland hypridle hyprlock \
-                hyprland-portal xdg-desktop-portal-gtk \
-                waybar fuzzel swaync swww kanshi \
-                power-profiles-daemon \
-                pipewire wireplumber pavucontrol \
-                brightnessctl \
-                network-manager-applet blueman \
-                polkit-gnome \
-                jetbrains-mono-fonts \
-                || warn "some dnf packages are unavailable; you may need a COPR (e.g. solopasha/hyprland) or manual build"
-            ;;
-        *)
-            warn "Unsupported package backend; install manually:"
-            warn "  hyprland hypridle hyprlock xdg-desktop-portal-hyprland"
-            warn "  waybar fuzzel swaync swww kanshi power-profiles-daemon"
-            warn "  pipewire wireplumber pavucontrol brightnessctl"
-            warn "  network-manager-applet blueman polkit-gnome"
-            warn "  a JetBrains Mono Nerd Font"
-            ;;
-    esac
-}
 
 # --- systemd-logind: ignore the lid ---
 
@@ -214,13 +127,15 @@ enable_services() {
 
 # --- Main ---
 
+# The Wayland desktop packages are installed by the top-level `setup`. Here we
+# only apply the system-modifying config; --no-install skips it (e.g. a dry run
+# or when re-running just to source setup-hypr.local).
 if test "$INSTALL" = yes; then
-    install_packages
+    install_logind_lid_dropin
+    enable_services
 else
-    info "Skipping package installation (--no-install)"
+    info "Skipping logind drop-in and service enablement (--no-install)"
 fi
-install_logind_lid_dropin
-enable_services
 
 # Local overrides, mirroring setup-kde's setup-kde.local hook.
 if is_command setup-hypr.local; then

--- a/setup-hypr_test
+++ b/setup-hypr_test
@@ -1,0 +1,197 @@
+#!/bin/sh
+# Tests for setup-hypr
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+setup() {
+    TEST_TMPDIR="$(mktemp -d)"
+    # Put mocks first on PATH so they shadow real commands.
+    export PATH="$TEST_TMPDIR/bin:$PATH"
+    mkdir -p "$TEST_TMPDIR/bin"
+    CALLS="$TEST_TMPDIR/calls"
+    rm -f "$CALLS"
+
+    # sudo records its argv and discards any heredoc stdin (e.g. the logind
+    # drop-in piped to `sudo tee`) so nothing touches the real system.
+    cat > "$TEST_TMPDIR/bin/sudo" <<MOCK
+#!/bin/sh
+echo "sudo \$*" >> "$CALLS"
+exit 0
+MOCK
+
+    # systemctl: record, and make list-unit-files succeed so enable_services
+    # believes power-profiles-daemon exists.
+    cat > "$TEST_TMPDIR/bin/systemctl" <<MOCK
+#!/bin/sh
+echo "systemctl \$*" >> "$CALLS"
+exit 0
+MOCK
+
+    # Package managers: record calls. Which one exists on PATH selects the
+    # backend (detect_backend prefers pacman, then apt-get, then dnf).
+    for cmd in pacman apt-get dnf; do
+        cat > "$TEST_TMPDIR/bin/$cmd" <<MOCK
+#!/bin/sh
+echo "$cmd \$*" >> "$CALLS"
+exit 0
+MOCK
+    done
+
+    chmod +x "$TEST_TMPDIR"/bin/*
+}
+
+teardown() {
+    rm -rf "$TEST_TMPDIR"
+}
+
+run_hypr() {
+    set +e
+    output="$("$SCRIPT_DIR/setup-hypr" "$@" 2>&1)"
+    status=$?
+    set -e
+}
+
+assert_status() {
+    if test "$status" -ne "$1"; then
+        echo "  FAIL: expected exit status $1, got $status"
+        echo "  output: $output"
+        TEST_FAILED=1
+        return 1
+    fi
+}
+
+assert_output_contains() {
+    case "$output" in
+        *"$1"*) ;;
+        *)
+            echo "  FAIL: output does not contain '$1'"
+            echo "  output: $output"
+            TEST_FAILED=1
+            return 1
+            ;;
+    esac
+}
+
+assert_called() {
+    if ! grep -q "$1" "$CALLS" 2>/dev/null; then
+        echo "  FAIL: expected call '$1' not found"
+        echo "  calls: $(cat "$CALLS" 2>/dev/null)"
+        TEST_FAILED=1
+        return 1
+    fi
+}
+
+assert_not_called() {
+    if grep -q "$1" "$CALLS" 2>/dev/null; then
+        echo "  FAIL: unexpected call '$1' found"
+        echo "  calls: $(cat "$CALLS" 2>/dev/null)"
+        TEST_FAILED=1
+        return 1
+    fi
+}
+
+run_test() {
+    name="$1"
+    func="$2"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    setup
+    TEST_FAILED=
+    if "$func" && test -z "$TEST_FAILED"; then
+        echo "ok $TESTS_RUN $name"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        echo "not ok $TESTS_RUN $name"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+    teardown
+}
+
+# --- usage and help ---
+
+test_help_flag() {
+    run_hypr --help
+    assert_status 0 &&
+    assert_output_contains "Usage: setup-hypr"
+}
+
+test_h_flag() {
+    run_hypr -h
+    assert_status 0 &&
+    assert_output_contains "Usage: setup-hypr"
+}
+
+test_unknown_option() {
+    run_hypr --bogus
+    assert_status 1 &&
+    assert_output_contains "Unknown option"
+}
+
+# --- package installation ---
+
+test_installs_packages_via_pacman() {
+    run_hypr
+    assert_status 0 &&
+    assert_called "sudo pacman -S" &&
+    assert_output_contains "pacman"
+}
+
+test_installs_core_desktop_packages() {
+    run_hypr
+    # A representative slice of the required desktop stack must be requested.
+    assert_status 0 &&
+    assert_called "hyprland" &&
+    assert_called "waybar" &&
+    assert_called "fuzzel" &&
+    assert_called "swaync" &&
+    assert_called "kanshi" &&
+    assert_called "power-profiles-daemon"
+}
+
+test_no_install_skips_packages() {
+    run_hypr --no-install
+    assert_status 0 &&
+    assert_not_called "pacman -S" &&
+    assert_output_contains "Skipping package installation"
+}
+
+# --- logind lid drop-in ---
+
+test_installs_logind_lid_dropin() {
+    run_hypr --no-install
+    assert_status 0 &&
+    assert_called "sudo mkdir -p /etc/systemd/logind.conf.d" &&
+    assert_called "sudo tee /etc/systemd/logind.conf.d/10-hypr-lid.conf"
+}
+
+test_reloads_logind() {
+    run_hypr --no-install
+    assert_status 0 &&
+    assert_called "sudo systemctl kill -s HUP systemd-logind"
+}
+
+# --- services ---
+
+test_enables_power_profiles_daemon() {
+    run_hypr --no-install
+    assert_status 0 &&
+    assert_called "sudo systemctl enable --now power-profiles-daemon"
+}
+
+run_test "help flag" test_help_flag
+run_test "-h flag" test_h_flag
+run_test "unknown option errors" test_unknown_option
+run_test "installs packages via pacman" test_installs_packages_via_pacman
+run_test "requests core desktop packages" test_installs_core_desktop_packages
+run_test "no-install skips packages" test_no_install_skips_packages
+run_test "installs logind lid drop-in" test_installs_logind_lid_dropin
+run_test "reloads logind" test_reloads_logind
+run_test "enables power-profiles-daemon" test_enables_power_profiles_daemon
+
+echo
+echo "$TESTS_RUN tests, $TESTS_PASSED passed, $TESTS_FAILED failed"
+test "$TESTS_FAILED" -eq 0

--- a/setup-hypr_test
+++ b/setup-hypr_test
@@ -131,45 +131,27 @@ test_unknown_option() {
     assert_output_contains "Unknown option"
 }
 
-# --- package installation ---
+# --- packages are NOT installed here (the top-level `setup` does that) ---
 
-test_installs_packages_via_pacman() {
+test_does_not_install_packages() {
     run_hypr
-    assert_status 0 &&
-    assert_called "sudo pacman -S" &&
-    assert_output_contains "pacman"
-}
-
-test_installs_core_desktop_packages() {
-    run_hypr
-    # A representative slice of the required desktop stack must be requested.
-    assert_status 0 &&
-    assert_called "hyprland" &&
-    assert_called "waybar" &&
-    assert_called "fuzzel" &&
-    assert_called "swaync" &&
-    assert_called "kanshi" &&
-    assert_called "power-profiles-daemon"
-}
-
-test_no_install_skips_packages() {
-    run_hypr --no-install
     assert_status 0 &&
     assert_not_called "pacman -S" &&
-    assert_output_contains "Skipping package installation"
+    assert_not_called "apt-get install" &&
+    assert_not_called "dnf install"
 }
 
 # --- logind lid drop-in ---
 
 test_installs_logind_lid_dropin() {
-    run_hypr --no-install
+    run_hypr
     assert_status 0 &&
     assert_called "sudo mkdir -p /etc/systemd/logind.conf.d" &&
     assert_called "sudo tee /etc/systemd/logind.conf.d/10-hypr-lid.conf"
 }
 
 test_reloads_logind() {
-    run_hypr --no-install
+    run_hypr
     assert_status 0 &&
     assert_called "sudo systemctl kill -s HUP systemd-logind"
 }
@@ -177,20 +159,27 @@ test_reloads_logind() {
 # --- services ---
 
 test_enables_power_profiles_daemon() {
-    run_hypr --no-install
+    run_hypr
     assert_status 0 &&
     assert_called "sudo systemctl enable --now power-profiles-daemon"
+}
+
+# --no-install skips the system-modifying steps.
+test_no_install_skips_system_changes() {
+    run_hypr --no-install
+    assert_status 0 &&
+    assert_not_called "sudo tee /etc/systemd/logind.conf.d" &&
+    assert_output_contains "Skipping logind"
 }
 
 run_test "help flag" test_help_flag
 run_test "-h flag" test_h_flag
 run_test "unknown option errors" test_unknown_option
-run_test "installs packages via pacman" test_installs_packages_via_pacman
-run_test "requests core desktop packages" test_installs_core_desktop_packages
-run_test "no-install skips packages" test_no_install_skips_packages
+run_test "does not install packages (setup does)" test_does_not_install_packages
 run_test "installs logind lid drop-in" test_installs_logind_lid_dropin
 run_test "reloads logind" test_reloads_logind
 run_test "enables power-profiles-daemon" test_enables_power_profiles_daemon
+run_test "no-install skips system changes" test_no_install_skips_system_changes
 
 echo
 echo "$TESTS_RUN tests, $TESTS_PASSED passed, $TESTS_FAILED failed"


### PR DESCRIPTION
## Summary

Adds `setup-hypr` — the Hyprland/Wayland counterpart to `setup-kde` — and makes `setup` install both desktops' packages, so a machine can be bootstrapped with the new Hyprland desktop (companion to the Hyprland dotfiles in mikelward/conf#189).

## Changes

- **`setup`**
  - Its GUI branch now installs the **Hyprland/Wayland desktop packages unconditionally alongside the KDE packages** (compositor, waybar, fuzzel, swaync, kanshi, power-profiles-daemon, pipewire/wireplumber/pavucontrol, brightnessctl, network + bluetooth applets, a polkit agent, `xdg-desktop-portal-gtk`, a Nerd Font). `|| warn` so a missing hypr\* backport/COPR doesn't abort the run. Applies to the Debian and Fedora branches.
  - New `--kde` / `--hypr` flags (default `kde`, or `export DESKTOP`) select which desktop to **configure**; `kitty` and both package sets are installed regardless.
  - Desktop dispatch routes to `setup-hypr` when selected.
- **`setup-hypr`** (new): config-only, mirroring `setup-kde` (which relies on `setup` for packages).
  - Installs a **systemd-logind drop-in** (`HandleLidSwitch=ignore`) so Hyprland's own lid handler is authoritative (disable the internal panel on close; suspend only when no external display is connected).
  - Enables `power-profiles-daemon`.
  - `--no-install` skips those system-modifying steps; supports `--ignore-errors` / `-h` and a `setup-hypr.local` hook.
- **`Makefile`**: `setup-hypr_test` added to the `test` target.

## Testing

- `setup-hypr_test` (8 mock-based cases like `package_test`): help/`-h`, unknown-option error, that it does **not** install packages (setup does), the logind lid drop-in is written, logind is reloaded, `power-profiles-daemon` is enabled, and `--no-install` skips the system changes.
- `make test` passes (all suites green).

> Note: `setup` targets Debian/Fedora/macOS (no pacman), so the Hyprland packages install on Debian/Fedora — matching where the KDE/Krohnkite setup already runs. An Arch/pacman path can be added if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)