### PR TITLE
setup: install yazi for the Hyprland desktop

### DIFF
--- a/setup
+++ b/setup
@@ -404,6 +404,10 @@ install_packages() {
                     policykit-1-gnome \
                     fonts-jetbrains-mono \
                     || warn "some Hyprland packages are unavailable; you may need a backport or manual build (hyprland, hypridle, hyprlock, swww, swaync)"
+                # yazi (terminal file manager) is often not in the default repos;
+                # install it separately so its absence doesn't block the rest.
+                sudo apt-get install -y --install-recommends yazi \
+                    || warn "yazi unavailable via apt; install with 'cargo install --locked yazi-fm yazi-cli'"
             fi
             ;;
         redhat)
@@ -460,6 +464,10 @@ install_packages() {
                     polkit-gnome \
                     jetbrains-mono-fonts \
                     || warn "some Hyprland packages are unavailable; you may need a COPR (e.g. solopasha/hyprland) or manual build"
+                # yazi (terminal file manager) may need a COPR; install it
+                # separately so its absence doesn't block the rest.
+                sudo dnf install -y yazi \
+                    || warn "yazi unavailable via dnf; install with 'cargo install --locked yazi-fm yazi-cli'"
             fi
             ;;
         macos)


### PR DESCRIPTION
## Summary

The Hyprland desktop binds `SUPER+E` to **yazi** (mikelward/conf#190). Install it as part of `setup`'s GUI branch.

## Changes

- `setup` installs `yazi` in the Debian and Fedora GUI branches, on its **own guarded line** (separate from the bundled Hyprland packages) so that yazi being absent from a distro's default repos doesn't fail the whole install command and block the rest. The warning points at `cargo install --locked yazi-fm yazi-cli`.

## Testing

- `make test` passes (setup-hypr_test 8/8, all suites green); `sh -n setup` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YAS9bjhpAB7541oX5MX5sy)_