### PR TITLE
setup: enable the lionheartp/Hyprland COPR on Fedora

### DIFF
--- a/setup
+++ b/setup
@@ -457,7 +457,13 @@ install_packages() {
                 # Hyprland Wayland desktop packages, installed unconditionally
                 # alongside KDE so either desktop is available (--kde/--hypr
                 # only choose which one to *configure*). `|| warn` because
-                # several hypr* tools may need a COPR and shouldn't abort.
+                # several hypr* tools may need the COPR and shouldn't abort.
+                # Fedora doesn't ship Hyprland in its default repos, so enable
+                # the lionheartp/Hyprland COPR first (needs the copr dnf plugin).
+                info "Enabling the lionheartp/Hyprland COPR"
+                sudo dnf install -y dnf-plugins-core || true
+                sudo dnf copr enable -y lionheartp/Hyprland \
+                    || warn "could not enable the lionheartp/Hyprland COPR; hyprland may be unavailable"
                 info "Installing Hyprland desktop packages"
                 sudo dnf install -y \
                     hyprland hypridle hyprlock \
@@ -469,7 +475,7 @@ install_packages() {
                     network-manager-applet blueman \
                     polkit-gnome \
                     jetbrains-mono-fonts \
-                    || warn "some Hyprland packages are unavailable; you may need a COPR (e.g. solopasha/hyprland) or manual build"
+                    || warn "some Hyprland packages are unavailable; check the lionheartp/Hyprland COPR or build manually"
                 # In the default repos even where hyprland isn't, so install
                 # separately -- a missing hyprland above shouldn't take these
                 # down with it.


### PR DESCRIPTION
## Summary

Fedora doesn't ship Hyprland in its default repos, so `setup`'s `dnf` Hyprland install would just warn and skip. Enable the [`lionheartp/Hyprland` COPR](https://copr.fedorainfracloud.org/coprs/lionheartp/Hyprland) before the install so `dnf` can find `hyprland` & friends.

## Changes

- In `setup`'s `redhat` GUI branch, before the Hyprland `dnf install`: `sudo dnf install -y dnf-plugins-core` (for the `copr` subcommand) then `sudo dnf copr enable -y lionheartp/Hyprland`, both guarded so a failure warns rather than aborts. Updated the fallback warning to point at the COPR.

## Testing

- `sh -n setup` clean; `make test` passes (setup-hypr_test 8/8).

Companion: mikelward/conf#193 (README note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YAS9bjhpAB7541oX5MX5sy)_