### PR TITLE
setup: install uwsm (opt-in Wayland session manager)

### DIFF
--- a/setup
+++ b/setup
@@ -414,6 +414,11 @@ install_packages() {
                 # install it separately so its absence doesn't block the rest.
                 sudo apt-get install -y --install-recommends yazi \
                     || warn "yazi unavailable via apt; install with 'cargo install --locked yazi-fm yazi-cli'"
+                # uwsm (opt-in Universal Wayland Session Manager). Installed so
+                # it's available; it does NOT change how you log in unless you
+                # pick the uwsm session -- see conf/config/hypr/README.md.
+                sudo apt-get install -y --install-recommends uwsm \
+                    || warn "uwsm unavailable via apt (optional; skip)"
             fi
             ;;
         redhat)
@@ -480,6 +485,11 @@ install_packages() {
                 # separately so its absence doesn't block the rest.
                 sudo dnf install -y yazi \
                     || warn "yazi unavailable via dnf; install with 'cargo install --locked yazi-fm yazi-cli'"
+                # uwsm (opt-in Universal Wayland Session Manager). Installed so
+                # it's available; it does NOT change how you log in unless you
+                # pick the uwsm session -- see conf/config/hypr/README.md.
+                sudo dnf install -y uwsm \
+                    || warn "uwsm unavailable via dnf (optional; skip)"
             fi
             ;;
         macos)


### PR DESCRIPTION
## Summary

Install [uwsm](https://github.com/Vladimir-csp/uwsm) (Universal Wayland Session Manager) as part of a Hyprland GUI install, so it's *available* to opt into. Companion: mikelward/conf#194.

**This does not change how any machine logs in.** uwsm only takes effect if you select the uwsm session (documented in conf's README). Kept deliberately opt-in because gdm3 + PAM can be fussy about the session/auth wiring.

## Changes

- `setup` installs `uwsm` in the Debian and Fedora GUI branches, on its **own guarded line** (isolated from the Hyprland/COPR package block) so its absence just warns.

## Testing

- `sh -n setup` clean; `make test` passes (setup-hypr_test 8/8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YAS9bjhpAB7541oX5MX5sy)_