### PR TITLE
Fix setup/setup-kde bugs: bad Hyprland package names, fatal config steps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,4 +8,6 @@ test:
 	./detachsession_test
 	./makesession_test
 	./mdf_test
+	./setup_test
 	./setup-hypr_test
+	./setup-kde_test

--- a/setup
+++ b/setup
@@ -394,7 +394,7 @@ install_packages() {
                 # several hypr* tools may need a backport and shouldn't abort.
                 info "Installing Hyprland desktop packages"
                 sudo apt-get install -y --install-recommends \
-                    hyprland hyprland-idle hyprland-lock \
+                    hyprland hypridle hyprlock \
                     xdg-desktop-portal-gtk \
                     waybar fuzzel swaync kanshi \
                     power-profiles-daemon \
@@ -472,7 +472,7 @@ install_packages() {
                 info "Installing Hyprland desktop packages"
                 sudo dnf install -y \
                     hyprland hypridle hyprlock \
-                    hyprland-portal xdg-desktop-portal-gtk \
+                    xdg-desktop-portal-hyprland xdg-desktop-portal-gtk \
                     waybar fuzzel swaync swww kanshi \
                     power-profiles-daemon \
                     pipewire wireplumber pavucontrol \

--- a/setup-hypr
+++ b/setup-hypr
@@ -2,7 +2,7 @@
 # Configure a Hyprland-based Wayland desktop (KDE replacement).
 #
 # The dotfiles themselves live in the conf repo (config/hypr, config/waybar,
-# config/fuzzel, config/swaync, config/kanshi) and are installed by conf's
+# config/fuzzel, config/swaync) and are installed by conf's
 # `make install`. The Wayland desktop *packages* are installed by the top-level
 # `setup` (alongside the KDE packages). This script, like setup-kde, handles the
 # parts that are neither dotfiles nor packages:

--- a/setup-kde
+++ b/setup-kde
@@ -344,8 +344,14 @@ unbind_all_krohnkite_shortcuts() {
 
 add_app_shortcut() {
     name="$1"
-    command="$(type -p "$name")"
     shortcut="$2"
+    # type -p fails when the helper script isn't on PATH; without the guard
+    # that kills the whole script under set -e (or, with --ignore-errors,
+    # writes a broken .desktop file with an empty Exec=).
+    command="$(type -p "$name")" || {
+        warn "$name not found on PATH; skipping its launch shortcut"
+        return 0
+    }
     desktop_file="shortcut-$1.desktop"
 
     desktop_dir="$HOME/.local/share/applications"
@@ -459,10 +465,14 @@ configure_keybindings() {
 
 reload_kwin() {
     info "Reloading KWin configuration"
+    # || warn: KWin may not be running (e.g. bootstrapping before the first
+    # KDE login); a failed reload must not abort the script under set -e.
     if command -v qdbus6 >/dev/null 2>&1; then
-        qdbus6 org.kde.KWin /KWin reconfigure
+        qdbus6 org.kde.KWin /KWin reconfigure \
+            || warn "could not reload KWin; changes apply at next login"
     elif command -v qdbus >/dev/null 2>&1; then
-        qdbus org.kde.KWin /KWin reconfigure
+        qdbus org.kde.KWin /KWin reconfigure \
+            || warn "could not reload KWin; changes apply at next login"
     else
         warn "qdbus not found, please restart KWin manually or log out and back in"
     fi
@@ -527,8 +537,8 @@ reload_diminactive_effect
 reload_kglobalaccel
 
 if is_command setup-kde.local; then
-  source setup-kde.local
-  info "Sourcing setup-kde.local"
+    info "Sourcing setup-kde.local"
+    source setup-kde.local
 fi
 
 info "KDE configured successfully"

--- a/setup-kde_test
+++ b/setup-kde_test
@@ -1,0 +1,196 @@
+#!/bin/sh
+# Tests for setup-kde
+#
+# Runs setup-kde --no-install (so nothing is cloned or built) against a
+# throwaway HOME with the KDE CLI tools mocked, and checks the pure-config
+# steps: kwinrc/shortcut writes go through kwriteconfig6, and app-launch
+# shortcuts are created for helpers that exist on PATH and skipped (with a
+# warning, not a fatal error) for helpers that don't.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+setup() {
+    TEST_TMPDIR="$(mktemp -d)"
+    CALLS="$TEST_TMPDIR/calls"
+    rm -f "$CALLS"
+    mkdir -p "$TEST_TMPDIR/bin" "$TEST_TMPDIR/home"
+
+    # KDE CLI tools: record argv, touch nothing real.
+    for cmd in kwriteconfig6 qdbus6 qdbus kbuildsycoca6; do
+        cat > "$TEST_TMPDIR/bin/$cmd" <<MOCK
+#!/bin/sh
+echo "$cmd \$*" >> "$CALLS"
+exit 0
+MOCK
+    done
+
+    chmod +x "$TEST_TMPDIR"/bin/*
+}
+
+teardown() {
+    rm -rf "$TEST_TMPDIR"
+}
+
+# Add a fake launcher script (e.g. browser1) to the mock bin.
+add_launcher() {
+    cat > "$TEST_TMPDIR/bin/$1" <<'MOCK'
+#!/bin/sh
+exit 0
+MOCK
+    chmod +x "$TEST_TMPDIR/bin/$1"
+}
+
+# Run setup-kde in the sandbox: fresh HOME, and a PATH of just the mock bin
+# plus the system directories -- so the real ~/scripts (if it's on the
+# caller's PATH) can't satisfy the launcher lookups.
+run_kde() {
+    set +e
+    output="$(HOME="$TEST_TMPDIR/home" \
+        XDG_SESSION_TYPE=wayland \
+        PATH="$TEST_TMPDIR/bin:/usr/local/bin:/usr/bin:/bin" \
+        "$SCRIPT_DIR/setup-kde" "$@" 2>&1)"
+    status=$?
+    set -e
+}
+
+assert_status() {
+    if test "$status" -ne "$1"; then
+        echo "  FAIL: expected exit status $1, got $status"
+        echo "  output: $output"
+        TEST_FAILED=1
+        return 1
+    fi
+}
+
+assert_output_contains() {
+    case "$output" in
+        *"$1"*) ;;
+        *)
+            echo "  FAIL: output does not contain '$1'"
+            echo "  output: $output"
+            TEST_FAILED=1
+            return 1
+            ;;
+    esac
+}
+
+assert_called() {
+    if ! grep -q "$1" "$CALLS" 2>/dev/null; then
+        echo "  FAIL: expected call '$1' not found"
+        echo "  calls: $(cat "$CALLS" 2>/dev/null)"
+        TEST_FAILED=1
+        return 1
+    fi
+}
+
+assert_file_exists() {
+    if ! test -f "$1"; then
+        echo "  FAIL: expected file '$1' to exist"
+        TEST_FAILED=1
+        return 1
+    fi
+}
+
+assert_file_not_exists() {
+    if test -f "$1"; then
+        echo "  FAIL: unexpected file '$1' exists"
+        TEST_FAILED=1
+        return 1
+    fi
+}
+
+run_test() {
+    name="$1"
+    func="$2"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    setup
+    TEST_FAILED=
+    if "$func" && test -z "$TEST_FAILED"; then
+        echo "ok $TESTS_RUN $name"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        echo "not ok $TESTS_RUN $name"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+    teardown
+}
+
+# --- usage and help ---
+
+test_help_flag() {
+    run_kde --help
+    assert_status 0 &&
+    assert_output_contains "Usage: setup-kde"
+}
+
+test_unknown_option() {
+    run_kde --bogus
+    assert_status 1 &&
+    assert_output_contains "Unknown option"
+}
+
+# --- configuration (with --no-install so nothing is cloned/built) ---
+
+test_enables_and_configures_krohnkite() {
+    run_kde --no-install
+    assert_status 0 &&
+    assert_called "kwriteconfig6 --file kwinrc --group Plugins --key krohnkiteEnabled true" &&
+    assert_called "kwriteconfig6 --file kwinrc --group Script-krohnkite --key tileLayoutOrder 1"
+}
+
+test_configures_focus_follows_mouse() {
+    run_kde --no-install
+    assert_status 0 &&
+    assert_called "kwriteconfig6 --file kwinrc --group Windows --key FocusPolicy FocusFollowsMouse"
+}
+
+test_configures_nine_desktops() {
+    run_kde --no-install
+    assert_status 0 &&
+    assert_called "kwriteconfig6 --file kwinrc --group Desktops --key Number 9"
+}
+
+# A launcher that exists on PATH gets a .desktop file and a [services] _launch
+# shortcut pointing at its resolved path.
+test_app_shortcut_created_for_present_launcher() {
+    add_launcher browser1
+    run_kde --no-install
+    desktop="$TEST_TMPDIR/home/.local/share/applications/shortcut-browser1.desktop"
+    assert_status 0 &&
+    assert_file_exists "$desktop" &&
+    grep -q "Exec=$TEST_TMPDIR/bin/browser1" "$desktop" &&
+    grep -q "X-KDE-GlobalAccel-CommandShortcut=true" "$desktop" &&
+    assert_called "kwriteconfig6 --file kglobalshortcutsrc --group services --group shortcut-browser1.desktop --key _launch Meta+G"
+}
+
+# A launcher missing from PATH is skipped with a warning; it must not abort
+# the script (set -e) or leave a broken .desktop file with an empty Exec=.
+test_missing_launcher_skipped_not_fatal() {
+    add_launcher browser1
+    # browser2, terminal, terminal_on_workstation, music left missing.
+    run_kde --no-install
+    assert_status 0 &&
+    assert_output_contains "browser2 not found on PATH" &&
+    assert_output_contains "KDE configured successfully" &&
+    assert_file_not_exists "$TEST_TMPDIR/home/.local/share/applications/shortcut-browser2.desktop" &&
+    assert_file_exists "$TEST_TMPDIR/home/.local/share/applications/shortcut-browser1.desktop"
+}
+
+run_test "help flag" test_help_flag
+run_test "unknown option errors" test_unknown_option
+run_test "enables and configures Krohnkite" test_enables_and_configures_krohnkite
+run_test "configures focus follows mouse" test_configures_focus_follows_mouse
+run_test "configures nine desktops" test_configures_nine_desktops
+run_test "app shortcut created for present launcher" \
+    test_app_shortcut_created_for_present_launcher
+run_test "missing launcher is skipped, not fatal" \
+    test_missing_launcher_skipped_not_fatal
+
+echo
+echo "$TESTS_RUN tests, $TESTS_PASSED passed, $TESTS_FAILED failed"
+test "$TESTS_FAILED" -eq 0

--- a/setup_test
+++ b/setup_test
@@ -1,0 +1,125 @@
+#!/bin/sh
+# Tests for setup.
+#
+# The full bootstrap can't run in CI (it installs packages and edits system
+# config), so these are argument-parsing checks plus static checks on the
+# script source -- notably that the Hyprland package lists use real distro
+# package names: apt/dnf abort the whole transaction on one unknown name,
+# which would silently drop every other desktop package on the same line.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SETUP="$SCRIPT_DIR/setup"
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+run_setup() {
+    set +e
+    output="$("$SETUP" "$@" 2>&1)"
+    status=$?
+    set -e
+}
+
+assert_status() {
+    if test "$status" -ne "$1"; then
+        echo "  FAIL: expected exit status $1, got $status"
+        echo "  output: $output"
+        TEST_FAILED=1
+        return 1
+    fi
+}
+
+assert_output_contains() {
+    case "$output" in
+        *"$1"*) ;;
+        *)
+            echo "  FAIL: output does not contain '$1'"
+            echo "  output: $output"
+            TEST_FAILED=1
+            return 1
+            ;;
+    esac
+}
+
+assert_source_contains() {
+    if ! grep -q "$1" "$SETUP"; then
+        echo "  FAIL: setup does not contain '$1'"
+        TEST_FAILED=1
+        return 1
+    fi
+}
+
+assert_source_not_contains() {
+    if grep -q "$1" "$SETUP"; then
+        echo "  FAIL: setup contains '$1'"
+        TEST_FAILED=1
+        return 1
+    fi
+}
+
+run_test() {
+    name="$1"
+    func="$2"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TEST_FAILED=
+    if "$func" && test -z "$TEST_FAILED"; then
+        echo "ok $TESTS_RUN $name"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        echo "not ok $TESTS_RUN $name"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
+# --- usage and help ---
+
+test_help_flag() {
+    run_setup --help
+    assert_status 0 &&
+    assert_output_contains "Usage: setup"
+}
+
+test_h_flag() {
+    run_setup -h
+    assert_status 0 &&
+    assert_output_contains "Usage: setup"
+}
+
+test_unknown_option() {
+    run_setup --bogus
+    assert_status 1 &&
+    assert_output_contains "Unknown option"
+}
+
+# --- Hyprland package names ---
+
+# The idle/lock daemons are named after the upstream projects (hypridle,
+# hyprlock) on both Debian and Fedora; "hyprland-idle"/"hyprland-lock" don't
+# exist anywhere and make apt/dnf fail the whole install line.
+test_hypr_idle_lock_package_names() {
+    assert_source_contains "hypridle" &&
+    assert_source_contains "hyprlock" &&
+    assert_source_not_contains "hyprland-idle" &&
+    assert_source_not_contains "hyprland-lock"
+}
+
+# Fedora's Hyprland portal package is xdg-desktop-portal-hyprland (as the
+# conf repo's hypr README documents); "hyprland-portal" doesn't exist.
+test_hypr_portal_package_name() {
+    assert_source_contains "xdg-desktop-portal-hyprland" &&
+    assert_source_not_contains '[^-]hyprland-portal'
+}
+
+run_test "help flag" test_help_flag
+run_test "-h flag" test_h_flag
+run_test "unknown option errors" test_unknown_option
+run_test "hypridle/hyprlock package names are the upstream ones" \
+    test_hypr_idle_lock_package_names
+run_test "Hyprland portal package is xdg-desktop-portal-hyprland" \
+    test_hypr_portal_package_name
+
+echo
+echo "$TESTS_RUN tests, $TESTS_PASSED passed, $TESTS_FAILED failed"
+test "$TESTS_FAILED" -eq 0


### PR DESCRIPTION
Bug hunt over the setup scripts (`setup`, `setup-kde`, `setup-hypr`). Companion PR in `conf` fixes the Hyprland helper-script bugs: mikelward/conf#195 (merged).

## Bugs fixed

- **`setup` (Debian): nonexistent packages `hyprland-idle` / `hyprland-lock`.** The distro packages match the upstream project names `hypridle` / `hyprlock` — which the adjacent warning message already used. Because apt aborts the whole transaction on one unknown name, the typo silently skipped *every* package on that line (waybar, fuzzel, swaync, pipewire, brightnessctl, ...), leaving only the `|| warn` message.
- **`setup` (Fedora): nonexistent package `hyprland-portal`.** The real name is `xdg-desktop-portal-hyprland` (the name conf's `config/hypr/README.md` documents). Same all-or-nothing dnf failure mode as above.
- **`setup-kde`: a launcher missing from PATH killed the whole script.** `command="$(type -p "$name")"` fails when e.g. `browser1` isn't on PATH, which aborts under `set -e` with no message — or, under `--ignore-errors`, writes a broken `.desktop` file with an empty `Exec=`. Now warns and skips that shortcut.
- **`setup-kde`: unguarded `qdbus ... reconfigure`.** When KWin isn't running (bootstrapping before the first KDE login), the reload failed and `set -e` aborted the script before keybindings/app shortcuts were ever configured. Every other reload helper was already `|| true`-guarded; this one now warns instead.
- **`setup-kde`: "Sourcing setup-kde.local" was printed *after* sourcing it** (and never printed if the sourced file failed). Now printed first, matching `setup-hypr`.
- **`setup-hypr`: stale header comment** claiming conf ships `config/kanshi` (kanshi was dropped from the shipped configs).

## Tests

- New `setup_test`: arg parsing (`--help`, unknown option) plus static package-name checks guarding against the `hyprland-idle`/`hyprland-lock`/`hyprland-portal` typos regressing.
- New `setup-kde_test`: runs `setup-kde --no-install` against a throwaway `HOME` with the KDE CLI tools mocked; covers the kwinrc config writes, `.desktop` creation for launchers that exist, and the missing-launcher warn-and-skip path (which fails without the fix).
- Both wired into the `Makefile`; `make test` passes (all 12 test files, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WEvbv5iQpp4QGL3qS9RDzs