### PR TITLE
setup-kde: fall back to launchers beside the script when not on PATH

### DIFF
--- a/setup-kde
+++ b/setup-kde
@@ -20,6 +20,12 @@
 KROHNKITE_REPO="https://codeberg.org/anametologin/Krohnkite.git"
 KROHNKITE_DIR="${TMPDIR:-/tmp}/krohnkite-$$"
 
+# Directory containing this script, resolved up front while $0 still means
+# what the caller typed: install_krohnkite cds into the Krohnkite checkout,
+# after which a relative $0 (./setup-kde) would resolve against the wrong
+# directory. add_app_shortcut uses this to find launchers beside the script.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 # Whether to build and install Krohnkite. "no" (via --no-install) skips the
 # install and only (re)applies configuration.
 INSTALL=yes
@@ -354,11 +360,10 @@ add_app_shortcut() {
     # before treating the launcher as absent.
     command="$(type -p "$name")" || command=""
     if test -z "$command"; then
-        script_dir="$(cd "$(dirname "$0")" && pwd)"
-        if test -x "$script_dir/$name"; then
-            command="$script_dir/$name"
+        if test -x "$SCRIPT_DIR/$name"; then
+            command="$SCRIPT_DIR/$name"
         else
-            warn "$name not found on PATH or in $script_dir; skipping its launch shortcut"
+            warn "$name not found on PATH or in $SCRIPT_DIR; skipping its launch shortcut"
             return 0
         fi
     fi

--- a/setup-kde
+++ b/setup-kde
@@ -347,11 +347,21 @@ add_app_shortcut() {
     shortcut="$2"
     # type -p fails when the helper script isn't on PATH; without the guard
     # that kills the whole script under set -e (or, with --ignore-errors,
-    # writes a broken .desktop file with an empty Exec=).
-    command="$(type -p "$name")" || {
-        warn "$name not found on PATH; skipping its launch shortcut"
-        return 0
-    }
+    # writes a broken .desktop file with an empty Exec=). During a fresh
+    # bootstrap `setup` runs this script straight out of the just-cloned
+    # scripts repo, before any login shell has put ~/scripts on PATH -- the
+    # launchers exist beside this script, so fall back to a sibling file
+    # before treating the launcher as absent.
+    command="$(type -p "$name")" || command=""
+    if test -z "$command"; then
+        script_dir="$(cd "$(dirname "$0")" && pwd)"
+        if test -x "$script_dir/$name"; then
+            command="$script_dir/$name"
+        else
+            warn "$name not found on PATH or in $script_dir; skipping its launch shortcut"
+            return 0
+        fi
+    fi
     desktop_file="shortcut-$1.desktop"
 
     desktop_dir="$HOME/.local/share/applications"

--- a/setup-kde_test
+++ b/setup-kde_test
@@ -56,6 +56,31 @@ isolate_script() {
     KDE_SCRIPT="$TEST_TMPDIR/isolated/setup-kde"
 }
 
+# Mocks that let the full install path run: git "clones" by creating the
+# target directory with a fake .kwinscript, npm and kpackagetool6 just
+# record. This exercises install_krohnkite's cd into the checkout.
+add_install_mocks() {
+    cat > "$TEST_TMPDIR/bin/git" <<MOCK
+#!/bin/sh
+echo "git \$*" >> "$CALLS"
+if test "\$1" = clone; then
+    for arg in "\$@"; do dir="\$arg"; done
+    mkdir -p "\$dir"
+    touch "\$dir/fake.kwinscript"
+fi
+exit 0
+MOCK
+    for cmd in npm kpackagetool6; do
+        cat > "$TEST_TMPDIR/bin/$cmd" <<MOCK
+#!/bin/sh
+echo "$cmd \$*" >> "$CALLS"
+exit 0
+MOCK
+    done
+    chmod +x "$TEST_TMPDIR/bin/git" "$TEST_TMPDIR/bin/npm" \
+        "$TEST_TMPDIR/bin/kpackagetool6"
+}
+
 # Run setup-kde in the sandbox: fresh HOME, and a PATH of just the mock bin
 # plus the system directories -- so the real ~/scripts (if it's on the
 # caller's PATH) can't satisfy the launcher lookups.
@@ -65,6 +90,18 @@ run_kde() {
         XDG_SESSION_TYPE=wayland \
         PATH="$TEST_TMPDIR/bin:/usr/local/bin:/usr/bin:/bin" \
         "$KDE_SCRIPT" "$@" 2>&1)"
+    status=$?
+    set -e
+}
+
+# Like run_kde, but invoke the script by a RELATIVE path (./setup-kde) from
+# its own directory, the way a hands-on run does.
+run_kde_relative() {
+    set +e
+    output="$(cd "$(dirname "$KDE_SCRIPT")" && HOME="$TEST_TMPDIR/home" \
+        XDG_SESSION_TYPE=wayland \
+        PATH="$TEST_TMPDIR/bin:/usr/local/bin:/usr/bin:/bin" \
+        ./setup-kde "$@" 2>&1)"
     status=$?
     set -e
 }
@@ -213,6 +250,26 @@ MOCK
     grep -q "Exec=$TEST_TMPDIR/isolated/browser1" "$desktop"
 }
 
+# The sibling fallback must survive install_krohnkite's cd into the Krohnkite
+# checkout even when the script was invoked by a relative path: $0 is only
+# meaningful relative to the ORIGINAL cwd, so the script directory has to be
+# resolved before any cd.
+test_sibling_launcher_fallback_survives_install_cd() {
+    isolate_script
+    add_install_mocks
+    cat > "$TEST_TMPDIR/isolated/browser1" <<'MOCK'
+#!/bin/sh
+exit 0
+MOCK
+    chmod +x "$TEST_TMPDIR/isolated/browser1"
+    run_kde_relative
+    desktop="$TEST_TMPDIR/home/.local/share/applications/shortcut-browser1.desktop"
+    assert_status 0 &&
+    assert_called "kpackagetool6" &&
+    assert_file_exists "$desktop" &&
+    grep -q "Exec=$TEST_TMPDIR/isolated/browser1" "$desktop"
+}
+
 run_test "help flag" test_help_flag
 run_test "unknown option errors" test_unknown_option
 run_test "enables and configures Krohnkite" test_enables_and_configures_krohnkite
@@ -224,6 +281,8 @@ run_test "missing launcher is skipped, not fatal" \
     test_missing_launcher_skipped_not_fatal
 run_test "launcher beside the script is found without PATH" \
     test_sibling_launcher_fallback
+run_test "sibling fallback survives install's cd (relative \$0)" \
+    test_sibling_launcher_fallback_survives_install_cd
 
 echo
 echo "$TESTS_RUN tests, $TESTS_PASSED passed, $TESTS_FAILED failed"

--- a/setup-kde_test
+++ b/setup-kde_test
@@ -19,6 +19,7 @@ setup() {
     CALLS="$TEST_TMPDIR/calls"
     rm -f "$CALLS"
     mkdir -p "$TEST_TMPDIR/bin" "$TEST_TMPDIR/home"
+    KDE_SCRIPT="$SCRIPT_DIR/setup-kde"
 
     # KDE CLI tools: record argv, touch nothing real.
     for cmd in kwriteconfig6 qdbus6 qdbus kbuildsycoca6; do
@@ -45,6 +46,16 @@ MOCK
     chmod +x "$TEST_TMPDIR/bin/$1"
 }
 
+# Run a copy of setup-kde from a directory with no launcher siblings. In the
+# real repo the launchers live beside setup-kde, so the sibling-directory
+# fallback would find them; tests about genuinely-missing launchers need the
+# script isolated from its siblings.
+isolate_script() {
+    mkdir -p "$TEST_TMPDIR/isolated"
+    cp "$SCRIPT_DIR/setup-kde" "$TEST_TMPDIR/isolated/setup-kde"
+    KDE_SCRIPT="$TEST_TMPDIR/isolated/setup-kde"
+}
+
 # Run setup-kde in the sandbox: fresh HOME, and a PATH of just the mock bin
 # plus the system directories -- so the real ~/scripts (if it's on the
 # caller's PATH) can't satisfy the launcher lookups.
@@ -53,7 +64,7 @@ run_kde() {
     output="$(HOME="$TEST_TMPDIR/home" \
         XDG_SESSION_TYPE=wayland \
         PATH="$TEST_TMPDIR/bin:/usr/local/bin:/usr/bin:/bin" \
-        "$SCRIPT_DIR/setup-kde" "$@" 2>&1)"
+        "$KDE_SCRIPT" "$@" 2>&1)"
     status=$?
     set -e
 }
@@ -168,9 +179,12 @@ test_app_shortcut_created_for_present_launcher() {
     assert_called "kwriteconfig6 --file kglobalshortcutsrc --group services --group shortcut-browser1.desktop --key _launch Meta+G"
 }
 
-# A launcher missing from PATH is skipped with a warning; it must not abort
-# the script (set -e) or leave a broken .desktop file with an empty Exec=.
+# A launcher on neither PATH nor beside the script is skipped with a warning;
+# it must not abort the script (set -e) or leave a broken .desktop file with
+# an empty Exec=. Uses an isolated copy of setup-kde: in the repo the
+# launchers are siblings of the script, which the fallback would find.
 test_missing_launcher_skipped_not_fatal() {
+    isolate_script
     add_launcher browser1
     # browser2, terminal, terminal_on_workstation, music left missing.
     run_kde --no-install
@@ -179,6 +193,24 @@ test_missing_launcher_skipped_not_fatal() {
     assert_output_contains "KDE configured successfully" &&
     assert_file_not_exists "$TEST_TMPDIR/home/.local/share/applications/shortcut-browser2.desktop" &&
     assert_file_exists "$TEST_TMPDIR/home/.local/share/applications/shortcut-browser1.desktop"
+}
+
+# A launcher absent from PATH but sitting beside setup-kde (the fresh
+# bootstrap case: `setup` runs the just-cloned repo's setup-kde before any
+# login shell puts ~/scripts on PATH) is resolved via the script's own
+# directory.
+test_sibling_launcher_fallback() {
+    isolate_script
+    cat > "$TEST_TMPDIR/isolated/browser1" <<'MOCK'
+#!/bin/sh
+exit 0
+MOCK
+    chmod +x "$TEST_TMPDIR/isolated/browser1"
+    run_kde --no-install
+    desktop="$TEST_TMPDIR/home/.local/share/applications/shortcut-browser1.desktop"
+    assert_status 0 &&
+    assert_file_exists "$desktop" &&
+    grep -q "Exec=$TEST_TMPDIR/isolated/browser1" "$desktop"
 }
 
 run_test "help flag" test_help_flag
@@ -190,6 +222,8 @@ run_test "app shortcut created for present launcher" \
     test_app_shortcut_created_for_present_launcher
 run_test "missing launcher is skipped, not fatal" \
     test_missing_launcher_skipped_not_fatal
+run_test "launcher beside the script is found without PATH" \
+    test_sibling_launcher_fallback
 
 echo
 echo "$TESTS_RUN tests, $TESTS_PASSED passed, $TESTS_FAILED failed"


### PR DESCRIPTION
Follow-up to #117, addressing the review comment left on it (https://github.com/mikelward/scripts/pull/117#discussion_r3508865541).

During a fresh bootstrap, `setup` runs `$SCRIPTS_DIR/setup-kde` straight out of the just-cloned repo, before any login shell has put `~/scripts` on PATH — so #117's warn-and-skip guard would skip *every* launch shortcut even though `browser1`, `terminal`, etc. sit right next to `setup-kde`. `add_app_shortcut` now falls back to the script's own directory before treating a launcher as absent; PATH still wins when the launcher is found there.

Tests: the missing-launcher test now runs an isolated copy of `setup-kde` (in the repo, the launchers are siblings the fallback would otherwise find), and a new test covers the sibling-fallback path, asserting `Exec=` resolves to the sibling file. `make test` passes (12 files, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WEvbv5iQpp4QGL3qS9RDzs

---
_Generated by [Claude Code](https://claude.ai/code/session_01WEvbv5iQpp4QGL3qS9RDzs)_