### PR TITLE
Fix session-management bugs: busy no-op attaches, switch races, make* name handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 test:
 	./autoshpool_test
 	./autotmux_test
+	./autosession_test
 	./sessionlib_test
 	./changeshpool_test
 	./changetmux_test

--- a/autosession
+++ b/autosession
@@ -6,7 +6,8 @@
 #   * inside tmux  ($TMUX set)                 -> autotmux
 #   * inside shpool ($SHPOOL_SESSION_NAME set) -> autoshpool
 #   * outside both: honour $SESSION_BACKEND (tmux|shpool); otherwise use
-#     whichever of tmux/shpool is installed (tmux first).
+#     whichever of tmux/shpool is installed (shpool first, the
+#     family default -- matching the shell session_backend helper).
 #
 # All arguments are passed through to the chosen script, so "autosession",
 # "autosession switch <target>", and pass-through commands all work. In shrc:
@@ -33,11 +34,11 @@ case "${SESSION_BACKEND:-}" in
   shpool) run autoshpool "$@" ;;
 esac
 
-if command -v tmux >/dev/null 2>&1; then
-  run autotmux "$@"
-fi
 if command -v shpool >/dev/null 2>&1; then
   run autoshpool "$@"
+fi
+if command -v tmux >/dev/null 2>&1; then
+  run autotmux "$@"
 fi
 
 echo "autosession: no tmux or shpool backend available" >&2

--- a/autosession_test
+++ b/autosession_test
@@ -1,0 +1,140 @@
+#!/bin/bash
+# Tests for the autosession dispatcher: which backend it picks for each
+# ($TMUX / $SHPOOL_SESSION_NAME / $SESSION_BACKEND / installed) case. Runs the
+# real autosession with fake autotmux/autoshpool backends in an isolated PATH,
+# following the detachsession_test / makesession_test conventions.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+setup() {
+  TEST_TMPDIR="$(mktemp -d)"
+  BIN="$TEST_TMPDIR/bin"
+  CALLS="$TEST_TMPDIR/calls"
+  mkdir -p "$BIN"
+  : > "$CALLS"
+  ln -s "$(command -v dirname)" "$BIN/dirname"
+}
+
+teardown() { rm -rf "$TEST_TMPDIR"; }
+
+fake() {
+  cat > "$BIN/$1" <<EOF
+#!/bin/bash
+echo "$1 \$*" >> "$CALLS"
+EOF
+  chmod +x "$BIN/$1"
+}
+
+install_script() {
+  cp "$SCRIPT_DIR/$1" "$BIN/$1"
+  chmod +x "$BIN/$1"
+}
+
+run() {
+  local script="$1"; shift
+  set +e
+  output="$(env -i PATH="$BIN" HOME="$TEST_TMPDIR" "$@" "$BIN/$script" 2>&1)"
+  status=$?
+  set -e
+}
+
+assert_called() {
+  if ! grep -qx -- "$1" "$CALLS" 2>/dev/null; then
+    echo "  FAIL: expected call '$1'"; echo "  calls: $(cat "$CALLS" 2>/dev/null)"
+    TEST_FAILED=1
+  fi
+}
+assert_status() {
+  if test "$status" -ne "$1"; then
+    echo "  FAIL: expected exit $1, got $status"; echo "  output: $output"
+    TEST_FAILED=1
+  fi
+}
+assert_output_contains() {
+  case "$output" in
+    *"$1"*) ;;
+    *) echo "  FAIL: output missing '$1'"; echo "  output: $output"; TEST_FAILED=1 ;;
+  esac
+}
+
+run_test() {
+  TESTS_RUN=$((TESTS_RUN + 1))
+  setup
+  TEST_FAILED=
+  if "$2" && test -z "$TEST_FAILED"; then
+    echo "ok $TESTS_RUN $1"; TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo "not ok $TESTS_RUN $1"; TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+  teardown
+}
+
+test_inside_tmux_picks_autotmux() {
+  install_script autosession; fake autotmux; fake autoshpool; fake tmux; fake shpool
+  run autosession TMUX=/tmp/sock
+  assert_called "autotmux "
+}
+test_inside_shpool_picks_autoshpool() {
+  install_script autosession; fake autotmux; fake autoshpool; fake tmux; fake shpool
+  run autosession SHPOOL_SESSION_NAME=work
+  assert_called "autoshpool "
+}
+test_session_backend_tmux() {
+  install_script autosession; fake autotmux; fake autoshpool
+  run autosession SESSION_BACKEND=tmux
+  assert_called "autotmux "
+}
+test_session_backend_shpool() {
+  install_script autosession; fake autotmux; fake autoshpool
+  run autosession SESSION_BACKEND=shpool
+  assert_called "autoshpool "
+}
+test_fallback_tmux_installed() {
+  install_script autosession; fake autotmux; fake autoshpool; fake tmux
+  run autosession
+  assert_called "autotmux "
+}
+test_fallback_shpool_installed() {
+  install_script autosession; fake autotmux; fake autoshpool; fake shpool
+  run autosession
+  assert_called "autoshpool "
+}
+test_fallback_prefers_shpool() {
+  # With both installed and no $SESSION_BACKEND, the fallback prefers shpool --
+  # the family default, matching the shell session_backend helper.
+  install_script autosession; fake autotmux; fake autoshpool; fake tmux; fake shpool
+  run autosession
+  assert_called "autoshpool "
+}
+test_no_backend_errors() {
+  install_script autosession; fake autotmux; fake autoshpool
+  run autosession
+  assert_status 1
+  assert_output_contains "no tmux or shpool backend available"
+}
+test_args_pass_through() {
+  install_script autosession; fake autotmux; fake autoshpool
+  set +e
+  output="$(env -i PATH="$BIN" HOME="$TEST_TMPDIR" SESSION_BACKEND=tmux "$BIN/autosession" switch work 2>&1)"
+  status=$?
+  set -e
+  assert_called "autotmux switch work"
+}
+
+run_test "dispatch: inside tmux picks autotmux" test_inside_tmux_picks_autotmux
+run_test "dispatch: inside shpool picks autoshpool" test_inside_shpool_picks_autoshpool
+run_test "dispatch: SESSION_BACKEND=tmux picks autotmux" test_session_backend_tmux
+run_test "dispatch: SESSION_BACKEND=shpool picks autoshpool" test_session_backend_shpool
+run_test "dispatch: falls back to installed tmux" test_fallback_tmux_installed
+run_test "dispatch: falls back to installed shpool" test_fallback_shpool_installed
+run_test "dispatch: prefers shpool when both are installed" test_fallback_prefers_shpool
+run_test "dispatch: no backend errors out" test_no_backend_errors
+run_test "dispatch: args pass through to backend" test_args_pass_through
+
+echo "$TESTS_RUN tests, $TESTS_PASSED passed, $TESTS_FAILED failed"
+test "$TESTS_FAILED" -eq 0

--- a/autoshpool
+++ b/autoshpool
@@ -25,9 +25,26 @@
 # after moving into another project. Keep the `&& exit` in switchshpool/shrc
 # anyway: it cleanly exits the now-detached shell instead of leaving it parked
 # in a disconnected session.
+#
+# A request made from inside a session is keyed to that session's name (the
+# file gets a ".<session>" suffix), so it is serviced only by the loop that
+# holds that session -- with several terminals each running their own loop, a
+# concurrently woken loop in another terminal can neither consume this
+# terminal's switch nor have its own session-creation derailed by it. A request
+# made outside any session has no owning loop, so it stays unkeyed and is
+# serviced by the next loop that wakes (or starts).
 
 switch_session_file="$HOME/.autoshpool_switch"
 switch_pwd_file="$HOME/.autoshpool_switch_pwd"
+
+# The switch-file suffix for a request made from inside session $1: ".<name>"
+# with '/' (the one character a filename can't hold) mapped to '_'. Empty when
+# $1 is empty (a request made outside any session), naming the shared unkeyed
+# files above.
+switch_file_suffix() {
+  test -n "$1" || return 0
+  printf '.%s' "${1//\//_}"
+}
 
 # Shared helpers and the fzf picker engine. SESSION_SEP tells the library which
 # separator this backend uses (for session_matches_prefix).
@@ -105,7 +122,9 @@ abort_if_hung() {
 
 get_prefix() {
   # Use the current project name with a colon at the end, or empty string.
-  local prefix="$(basename "$(rootdir)")"
+  # Silence rootdir like autotmux's get_prefix: without ~/.shrc.vcs it doesn't
+  # exist, and "command not found" noise on stderr isn't an error here.
+  local prefix="$(basename "$(rootdir 2>/dev/null)")"
   test -n "$prefix" && echo "$prefix:"
 }
 
@@ -160,59 +179,67 @@ create_and_attach_next() {
     # user started the shell), instead of shpool's daemon dir.
     shpool attach -d . "$session"
     rc=$?
-    # shpool exits 0 even when refusing because the session is already
-    # attached elsewhere (libshpool BusyError -> AttachResult::Done), so a
-    # clean exit alone is not proof that we actually owned the session.
-    # Re-check the listing: if our session still shows as "attached", we lost
-    # a race against another shell and should try the next number. A session
-    # we just exited from is either gone or "disconnected" by now.
-    # Bound the list the way abort_if_hung does -- if it hangs or errors we
-    # cannot tell a real attach from a busy refusal, so report failure
-    # rather than letting `autoshpool && exit` silently exit the shell with
-    # no session attached.
+    # A clean exit alone is not proof that we actually owned the session: see
+    # wait_attach_settled for the busy race it re-checks the listing for. If we
+    # lost the race, try the next number.
     # Capturing stderr to disambiguate the busy message was tried and rolled
     # back because routing shpool's interactive stderr through a pipe (tee
     # buffering) splattered escape sequences onto the user's terminal at
     # unpredictable moments.
     if test $rc -eq 0; then
+      current_session="$session"
       # A switch queued while we held this session means the detach that ended
       # the attach was deliberate (changeshpool/switchshpool detaches us to hand
       # the switch to this loop). We owned the session, so hand straight back to
       # the loop to service the switch instead of running the busy-race check
       # below -- otherwise the not-yet-settled "attached" status (see the poll)
       # is mistaken for a lost race and a brand-new numbered session is created.
-      if test -n "$(get_switch_session)"; then
+      if pending_switch_key "$session" >/dev/null; then
         return 0
       fi
-      if ! listing="$(timeout 2 shpool list 2>/dev/null)"; then
-        echo "shpool list failed after attach; cannot confirm session state" >&2
-        return 2
-      fi
-      # A session we owned and just detached from still shows as "attached" for
-      # a moment before the daemon settles the status (the same lag changeshpool
-      # polls around when stealing). A session we genuinely lost the race for is
-      # owned by another live client and stays "attached". Poll briefly so the
-      # status can settle: ours leaves "attached" (we return to the loop), a lost
-      # race stays "attached" for the whole window (we try the next number).
-      local i
-      for i in 1 2 3 4 5 6 7 8 9 10; do
-        test "$(session_status "$session" "$listing")" = attached || break
-        sleep 0.1
-        if ! listing="$(timeout 2 shpool list 2>/dev/null)"; then
-          echo "shpool list failed after attach; cannot confirm session state" >&2
-          return 2
-        fi
-      done
-      if test "$(session_status "$session" "$listing")" = "attached"; then
-        sessions[$session]=1
-        continue
-      fi
+      wait_attach_settled "$session"
+      case $? in
+        1)
+          sessions[$session]=1
+          continue
+          ;;
+        2) return 2 ;;
+      esac
       return 0
     fi
     return $rc
   done
   echo "You already have more than 100 sessions??" >&2
   return 2
+}
+
+# Wait briefly for a just-released session's status to settle after an attach
+# that exited 0. A session we owned and just detached from still shows as
+# "attached" for a moment before the daemon settles the status (the same lag
+# changeshpool used to poll around when stealing); a session we never owned --
+# shpool exits 0 without attaching when the target is busy (libshpool
+# BusyError -> AttachResult::Done) -- is held by another live client and stays
+# "attached" for the whole window. Returns:
+#   0 - the session left "attached": the attach was real and cleanly released
+#   1 - still "attached" after the window: we lost a busy race, never attached
+#   2 - shpool list failed or hung: cannot tell (bounded like abort_if_hung so
+#       a wedged daemon doesn't hang shell startup; the caller reports failure
+#       rather than letting `autoshpool && exit` silently exit the shell)
+wait_attach_settled() {
+  local session="$1" listing i
+  if ! listing="$(timeout 2 shpool list 2>/dev/null)"; then
+    echo "shpool list failed after attach; cannot confirm session state" >&2
+    return 2
+  fi
+  for i in 1 2 3 4 5 6 7 8 9 10; do
+    test "$(session_status "$session" "$listing")" = attached || return 0
+    sleep 0.1
+    if ! listing="$(timeout 2 shpool list 2>/dev/null)"; then
+      echo "shpool list failed after attach; cannot confirm session state" >&2
+      return 2
+    fi
+  done
+  test "$(session_status "$session" "$listing")" != attached
 }
 
 proc_dir() {
@@ -394,22 +421,48 @@ resolve_switch_target() {
 }
 
 get_switch_session() {
-  cat "$switch_session_file" 2>/dev/null
+  # The queued switch target for the request keyed to session $1 (or the
+  # unkeyed request, with $1 empty). Empty when there is none.
+  cat "$switch_session_file$(switch_file_suffix "$1")" 2>/dev/null
 }
 
 get_switch_pwd() {
-  cat "$switch_pwd_file" 2>/dev/null
+  cat "$switch_pwd_file$(switch_file_suffix "$1")" 2>/dev/null
+}
+
+# Print the key of the pending switch request this loop should service while
+# holding session $1 (empty at startup): a request keyed to that session wins,
+# else an unkeyed request (made outside any session, first loop to wake takes
+# it). Prints nothing and fails when neither is pending. The key -- not the
+# target -- is printed so the caller reads the target and pwd from, and later
+# clears, the same request.
+pending_switch_key() {
+  local key
+  for key in "$1" ""; do
+    if test -n "$(get_switch_session "$key")"; then
+      printf '%s\n' "$key"
+      return 0
+    fi
+    # With $1 empty both iterations name the unkeyed file; stop after one.
+    test -n "$key" || break
+  done
+  return 1
 }
 
 request_switch() {
   # Record the target session and, optionally, the directory to open it in. A
   # bare request (e.g. switchshpool to an existing session) leaves the pwd file
-  # absent so the target keeps its own working directory.
-  echo "$1" > "$switch_session_file"
+  # absent so the target keeps its own working directory. The request is keyed
+  # to the session we're inside (see switch_file_suffix) so only the loop
+  # holding it -- the one whose attach returns when we detach below -- picks it
+  # up.
+  local suffix
+  suffix="$(switch_file_suffix "${SHPOOL_SESSION_NAME:-}")"
+  echo "$1" > "$switch_session_file$suffix"
   if test -n "$2"; then
-    echo "$2" > "$switch_pwd_file"
+    echo "$2" > "$switch_pwd_file$suffix"
   else
-    rm -f "$switch_pwd_file"
+    rm -f "$switch_pwd_file$suffix"
   fi
   # Hand the terminal back to the outer loop so the switch lands even when the
   # caller isn't a shell that will `exit` afterwards (a bare `autoshpool`, or a
@@ -429,7 +482,10 @@ request_switch() {
 }
 
 clear_switch() {
-  rm -f "$switch_session_file" "$switch_pwd_file"
+  # Remove the request keyed to session $1 (or the unkeyed request, $1 empty).
+  local suffix
+  suffix="$(switch_file_suffix "$1")"
+  rm -f "$switch_session_file$suffix" "$switch_pwd_file$suffix"
 }
 
 # Start an shpool session with a useful session name.
@@ -447,19 +503,31 @@ autoshpool_loop() {
 
   abort_if_hung
 
+  # The session this loop most recently held, so switch requests keyed to it
+  # (see request_switch) are serviced here and not by another terminal's loop.
+  # local, but bash's dynamic scoping shares it with create_and_attach_next.
+  local current_session=""
   while true; do
-    switch_session="$(get_switch_session)"
-    if test -n "$switch_session"; then
-      switch_pwd="$(get_switch_pwd)"
-      clear_switch
+    if switch_key="$(pending_switch_key "$current_session")"; then
+      switch_session="$(get_switch_session "$switch_key")"
+      switch_pwd="$(get_switch_pwd "$switch_key")"
+      clear_switch "$switch_key"
       # A recorded pwd (a prefix-mismatch switch) opens a freshly created session
       # there via -d; a bare switch omits -d so an existing target keeps its own
-      # directory.
+      # directory. -f detaches any client already attached to the target before
+      # attaching us: a switch to a session that's attached in another terminal
+      # is an explicit request to bring it here (changeshpool steals the same
+      # way from outside a session), and without -f shpool reports that busy
+      # case as a silent no-op (exit 0 without attaching) -- the loop would
+      # return 0 and the caller's `&& exit` would close this terminal with
+      # nothing attached.
       if test -n "$switch_pwd"; then
-        shpool attach -d "$switch_pwd" "$switch_session"
+        shpool attach -f -d "$switch_pwd" "$switch_session"
       else
-        shpool attach "$switch_session"
+        shpool attach -f "$switch_session"
       fi
+      rc=$?
+      current_session="$switch_session"
     else
       # Pick the session first so a failed attach is reported as a failure
       # rather than falling through to create a brand-new session.
@@ -467,11 +535,27 @@ autoshpool_loop() {
       if test -n "$session"; then
         echo "Attaching shpool session $session"
         shpool attach "$session"
+        rc=$?
+        current_session="$session"
+        # The same busy race create_and_attach_next checks for: another shell
+        # can attach this session between the listing and our attach, and
+        # shpool exits 0 without attaching (BusyError -> Done). Returning 0
+        # would let the caller's `&& exit` close the terminal with nothing
+        # attached; re-run the loop instead to pick another disconnected
+        # session (or create one). A queued switch means the detach was
+        # deliberate -- skip straight to servicing it.
+        if test $rc -eq 0 && ! pending_switch_key "$session" >/dev/null; then
+          wait_attach_settled "$session"
+          case $? in
+            1) continue ;;
+            2) rc=2 ;;
+          esac
+        fi
       else
         create_and_attach_next
+        rc=$?
       fi
     fi
-    rc=$?
 
     if test $rc -ne 0; then
       # Maybe .shrc failed or something.
@@ -480,8 +564,7 @@ autoshpool_loop() {
       return $rc
     fi
 
-    switch_session="$(get_switch_session)"
-    if test -n "$switch_session"; then
+    if pending_switch_key "$current_session" >/dev/null; then
       continue
     fi
 

--- a/autoshpool_test
+++ b/autoshpool_test
@@ -89,8 +89,7 @@ TIMEOUT
   unset SHPOOL_SESSION_NAME
   unset SHPOOL_PREFIX
   unset SHPOOL_ATTACH_EXIT
-  rm -f "$TEST_TMPDIR/.autoshpool_switch"
-  rm -f "$TEST_TMPDIR/.autoshpool_switch_pwd"
+  rm -f "$TEST_TMPDIR"/.autoshpool_switch*
   rm -f "$TEST_TMPDIR/.shpool_calls"
   rm -f "$TEST_TMPDIR/.shpool_sessions"
   rm -f "$TEST_TMPDIR/.fake_shpool_pids"
@@ -348,12 +347,13 @@ test_plain_switch_records_no_pwd() {
 
 test_loop_switch_passes_recorded_pwd_as_dir() {
   # When the loop services a switch that carries a pwd, it passes it via
-  # `shpool attach -d` so the freshly created session starts there.
+  # `shpool attach -d` so the freshly created session starts there (and -f so
+  # an attached target is stolen rather than silently skipped).
   echo "myproject:1" > "$HOME/.autoshpool_switch"
   echo "/home/u/proj" > "$HOME/.autoshpool_switch_pwd"
   run_autoshpool
   assert_status 0
-  assert_called "shpool attach -d /home/u/proj myproject:1"
+  assert_called "shpool attach -f -d /home/u/proj myproject:1"
 }
 
 test_creates_session_1() {
@@ -475,7 +475,9 @@ SHPOOL
   run_autoshpool
   assert_status 0
   assert_called "shpool attach -d . 1"
-  assert_called "shpool attach other"
+  # -f: a switch target attached in another terminal is stolen, not silently
+  # skipped (shpool exits 0 without attaching on a busy target).
+  assert_called "shpool attach -f other"
 }
 
 test_create_path_services_queued_switch() {
@@ -512,7 +514,7 @@ SHPOOL
   run_autoshpool
   assert_status 0
   assert_called "shpool attach -d . 1"
-  assert_called "shpool attach target:9"
+  assert_called "shpool attach -f target:9"
   if grep -q "shpool attach -d . 2" "$HOME/.shpool_calls" 2>/dev/null; then
     echo "  FAIL: created a new numbered session instead of servicing the switch"
     echo "  calls: $(cat "$HOME/.shpool_calls" 2>/dev/null)"
@@ -563,6 +565,108 @@ SHPOOL
   if grep -q "shpool attach -d . 2" "$HOME/.shpool_calls" 2>/dev/null; then
     echo "  FAIL: created a new session despite the status settling to disconnected"
     echo "  calls: $(cat "$HOME/.shpool_calls" 2>/dev/null)"
+    return 1
+  fi
+}
+
+test_reattach_busy_noop_retries() {
+  # The plain reattach path (attach a listed-disconnected session) can lose the
+  # same race the create path retries around: another shell attaches the
+  # session between our listing and our attach, and shpool exits 0 without
+  # attaching. Returning 0 would let `autoshpool && exit` close the terminal
+  # with nothing attached; the loop must re-run and pick/create another session.
+  cat > "$TEST_TMPDIR/bin/shpool" <<'SHPOOL'
+#!/bin/bash
+echo "shpool $*" >> "$HOME/.shpool_calls"
+case "$1" in
+  list)
+    echo "name                           started_at                         status"
+    cat "$HOME/.shpool_sessions" 2>/dev/null
+    exit 0
+    ;;
+  attach)
+    session="${@: -1}"
+    if [ "$session" = "3" ]; then
+      # Busy no-op: another shell won the race; the session shows attached and
+      # shpool exits 0 without attaching us.
+      sed -i 's/^3\(.*\)disconnected$/3\1attached/' "$HOME/.shpool_sessions"
+    fi
+    exit 0
+    ;;
+esac
+SHPOOL
+  chmod +x "$TEST_TMPDIR/bin/shpool"
+  cat > "$HOME/.shpool_sessions" <<EOF
+3      2025-01-01T00:00:00Z   disconnected
+EOF
+  run_autoshpool
+  assert_status 0
+  assert_called "shpool attach 3"
+  assert_called "shpool attach -d . 1"
+  assert_output_contains "Creating shpool session 1"
+}
+
+test_switch_request_keyed_to_current_session() {
+  # A request made from inside a session is keyed to that session's name, so
+  # only the loop holding it services the switch.
+  export SHPOOL_SESSION_NAME="other:1"
+  run_autoshpool switch foo
+  assert_status 0
+  assert_switch_file foo   # reads the keyed file (see switch_suffix)
+  if [ -e "$HOME/.autoshpool_switch" ]; then
+    echo "  FAIL: request from inside a session must not use the unkeyed file"
+    return 1
+  fi
+}
+
+test_foreign_keyed_switch_not_consumed() {
+  # A switch request keyed to another terminal's session is left for the loop
+  # that actually holds that session; this loop attaches/creates as normal.
+  echo "stolen" > "$HOME/.autoshpool_switch.foreign:1"
+  run_autoshpool
+  assert_status 0
+  assert_called "shpool attach -d . 1"
+  if grep -q -- "-f stolen" "$HOME/.shpool_calls" 2>/dev/null; then
+    echo "  FAIL: serviced a switch keyed to another session"
+    echo "  calls: $(cat "$HOME/.shpool_calls" 2>/dev/null)"
+    return 1
+  fi
+  if [ "$(cat "$HOME/.autoshpool_switch.foreign:1" 2>/dev/null)" != "stolen" ]; then
+    echo "  FAIL: the foreign request should still be queued"
+    return 1
+  fi
+}
+
+test_loop_services_switch_keyed_to_its_session() {
+  # A request keyed to the session this loop holds (written by switchshpool
+  # from inside it) is serviced when the attach returns, and cleared.
+  cat > "$TEST_TMPDIR/bin/shpool" <<'SHPOOL'
+#!/bin/bash
+echo "shpool $*" >> "$HOME/.shpool_calls"
+case "$1" in
+  list)
+    echo "name                           started_at                         status"
+    cat "$HOME/.shpool_sessions" 2>/dev/null
+    exit 0
+    ;;
+  attach)
+    call_count=$(grep -c "shpool attach" "$HOME/.shpool_calls" 2>/dev/null || echo 0)
+    if [ "$call_count" -le 1 ]; then
+      # The shell inside the just-created session "1" requests a switch.
+      echo "other" > "$HOME/.autoshpool_switch.1"
+    fi
+    exit 0
+    ;;
+esac
+SHPOOL
+  chmod +x "$TEST_TMPDIR/bin/shpool"
+
+  run_autoshpool
+  assert_status 0
+  assert_called "shpool attach -d . 1"
+  assert_called "shpool attach -f other"
+  if [ -e "$HOME/.autoshpool_switch.1" ]; then
+    echo "  FAIL: the serviced request should have been cleared"
     return 1
   fi
 }
@@ -671,10 +775,18 @@ test_propagates_real_attach_failure() {
   fi
 }
 
+# The switch-file suffix for a request made by a test that exported
+# SHPOOL_SESSION_NAME: requests from inside a session are keyed to that
+# session (see autoshpool's switch_file_suffix), unkeyed otherwise.
+switch_suffix() {
+  test -n "${SHPOOL_SESSION_NAME:-}" || return 0
+  printf '.%s' "${SHPOOL_SESSION_NAME//\//_}"
+}
+
 assert_switch_file() {
   local expected="$1"
   local actual
-  actual="$(cat "$HOME/.autoshpool_switch" 2>/dev/null)"
+  actual="$(cat "$HOME/.autoshpool_switch$(switch_suffix)" 2>/dev/null)"
   if [ "$actual" != "$expected" ]; then
     echo "  FAIL: expected switch file '$expected', got '$actual'"
     echo "  output: $output"
@@ -684,17 +796,22 @@ assert_switch_file() {
 }
 
 assert_no_switch_file() {
-  if [ -e "$HOME/.autoshpool_switch" ]; then
-    echo "  FAIL: expected no switch file, but it exists: $(cat "$HOME/.autoshpool_switch")"
-    TEST_FAILED=1
-    return 1
-  fi
+  # No request may exist at all -- keyed or unkeyed.
+  local f
+  for f in "$HOME"/.autoshpool_switch*; do
+    if [ -e "$f" ] && [[ "$f" != *_pwd* ]]; then
+      echo "  FAIL: expected no switch file, but $f exists: $(cat "$f")"
+      TEST_FAILED=1
+      return 1
+    fi
+  done
+  return 0
 }
 
 assert_switch_pwd() {
   local expected="$1"
   local actual
-  actual="$(cat "$HOME/.autoshpool_switch_pwd" 2>/dev/null)"
+  actual="$(cat "$HOME/.autoshpool_switch_pwd$(switch_suffix)" 2>/dev/null)"
   if [ "$actual" != "$expected" ]; then
     echo "  FAIL: expected switch pwd '$expected', got '$actual'"
     echo "  output: $output"
@@ -704,11 +821,15 @@ assert_switch_pwd() {
 }
 
 assert_no_switch_pwd() {
-  if [ -e "$HOME/.autoshpool_switch_pwd" ]; then
-    echo "  FAIL: expected no switch pwd file, but it exists: $(cat "$HOME/.autoshpool_switch_pwd")"
-    TEST_FAILED=1
-    return 1
-  fi
+  local f
+  for f in "$HOME"/.autoshpool_switch_pwd*; do
+    if [ -e "$f" ]; then
+      echo "  FAIL: expected no switch pwd file, but $f exists: $(cat "$f")"
+      TEST_FAILED=1
+      return 1
+    fi
+  done
+  return 0
 }
 
 test_switch_resolves_path_segment() {
@@ -885,6 +1006,10 @@ run_test "preserves specific exit code from shpool attach" test_preserves_exit_c
 run_test "loop handles switch request after session ends" test_loop_handles_switch
 run_test "create path services a switch queued before the status settles" test_create_path_services_queued_switch
 run_test "create path waits for an unsettled attached status to settle" test_create_path_waits_for_unsettled_status
+run_test "reattach path retries when the disconnected session was stolen" test_reattach_busy_noop_retries
+run_test "switch request from inside a session is keyed to that session" test_switch_request_keyed_to_current_session
+run_test "a switch keyed to another session is left for its own loop" test_foreign_keyed_switch_not_consumed
+run_test "loop services a switch keyed to the session it holds" test_loop_services_switch_keyed_to_its_session
 run_test "uses SHPOOL_PREFIX for session names" test_uses_prefix
 run_test "skips existing sessions when creating" test_skips_existing_sessions
 run_test "retries with the next number when a session is already attached" test_retries_when_session_already_attached

--- a/changesession
+++ b/changesession
@@ -18,7 +18,8 @@
 #   * inside tmux  ($TMUX set)                 -> changetmux
 #   * inside shpool ($SHPOOL_SESSION_NAME set) -> changeshpool
 #   * outside both: honour $SESSION_BACKEND (tmux|shpool); otherwise use
-#     whichever of tmux/shpool is installed (tmux first).
+#     whichever of tmux/shpool is installed (shpool first, the
+#     family default -- matching the shell session_backend helper).
 
 dir="$(cd "$(dirname "$0")" && pwd)"
 
@@ -32,8 +33,8 @@ resolve_backend() {
     tmux)   echo changetmux; return ;;
     shpool) echo changeshpool; return ;;
   esac
-  if command -v tmux >/dev/null 2>&1; then echo changetmux; return; fi
   if command -v shpool >/dev/null 2>&1; then echo changeshpool; return; fi
+  if command -v tmux >/dev/null 2>&1; then echo changetmux; return; fi
 }
 
 backend="$(resolve_backend)"

--- a/changesession_test
+++ b/changesession_test
@@ -133,6 +133,19 @@ test_choose_fallback_shpool_installed() {
   run choosesession
   assert_called "changeshpool --choose"
 }
+test_choose_fallback_prefers_shpool() {
+  # With both installed and no $SESSION_BACKEND, the fallback prefers shpool --
+  # the family default, matching the shell session_backend helper.
+  install_script choosesession; fake changetmux; fake changeshpool; fake tmux; fake shpool
+  run choosesession
+  assert_called "changeshpool --choose"
+}
+test_change_fallback_prefers_shpool() {
+  install_script changesession; fake_choosesession "work" 0
+  fake changetmux; fake changeshpool; fake tmux; fake shpool
+  run changesession
+  assert_called "changeshpool --switch work"
+}
 test_choose_no_backend_errors() {
   install_script choosesession; fake changetmux; fake changeshpool
   run choosesession
@@ -216,6 +229,8 @@ run_test "choose: SESSION_BACKEND=tmux picks changetmux" test_choose_session_bac
 run_test "choose: SESSION_BACKEND=shpool picks changeshpool" test_choose_session_backend_shpool
 run_test "choose: falls back to installed tmux" test_choose_fallback_tmux_installed
 run_test "choose: falls back to installed shpool" test_choose_fallback_shpool_installed
+run_test "choose: prefers shpool when both are installed" test_choose_fallback_prefers_shpool
+run_test "change: prefers shpool when both are installed" test_change_fallback_prefers_shpool
 run_test "choose: no backend errors out" test_choose_no_backend_errors
 run_test "choose: args pass through to the backend" test_choose_args_pass_through
 run_test "change: switches to the chosen name" test_change_switches_to_chosen_name

--- a/changeshpool
+++ b/changeshpool
@@ -52,7 +52,10 @@ backend_sanitize_name()  { printf '%s' "$1"; }   # shpool keeps names verbatim
 
 backend_session_rows() {
   # "name<TAB>state<TAB>cwd<TAB>command" per session: one shpool list for the
-  # statuses, one /proc walk for the live shells' cwd/command.
+  # statuses, one /proc walk for the live shells' cwd/command. NF == 3 matches
+  # get_shpool_sessions: a session with an empty name lists with only 2
+  # columns, and $1 would be its start time -- a bogus picker row for a
+  # session that can't be targeted by name anyway.
   local listing
   listing="$(shpool list 2>/dev/null)"
   declare -A spid scwd
@@ -68,7 +71,7 @@ backend_session_rows() {
     state="$(session_status "$s" "$listing")"
     cmd="$(session_command "${spid[$s]}")"
     printf '%s\t%s\t%s\t%s\n' "$s" "$state" "${scwd[$s]}" "$cmd"
-  done < <(awk 'NR > 1 && NF >= 2 { print $1 }' <<<"$listing")
+  done < <(awk 'NR > 1 && NF == 3 { print $1 }' <<<"$listing")
 }
 
 backend_describe() {

--- a/changeshpool_test
+++ b/changeshpool_test
@@ -81,7 +81,7 @@ VCS
 
   unset SHPOOL_SESSION_NAME SHPOOL_PREFIX SHPOOL_ATTACH_EXIT
   unset FZF_QUERY FZF_PICK FZF_EXIT
-  rm -f "$TEST_TMPDIR"/.autoshpool_switch "$TEST_TMPDIR"/.autoshpool_switch_pwd
+  rm -f "$TEST_TMPDIR"/.autoshpool_switch*
   rm -f "$TEST_TMPDIR"/.shpool_calls "$TEST_TMPDIR"/.shpool_sessions
   rm -f "$TEST_TMPDIR"/.fake_shpool_pids "$TEST_TMPDIR"/.fake_shells
 
@@ -168,27 +168,41 @@ assert_not_called() {
     TEST_FAILED=1; return 1
   fi
 }
+# Requests made from inside a session are keyed to that session's name (see
+# autoshpool's switch_file_suffix); tests export SHPOOL_SESSION_NAME to match.
+switch_suffix() {
+  test -n "${SHPOOL_SESSION_NAME:-}" || return 0
+  printf '.%s' "${SHPOOL_SESSION_NAME//\//_}"
+}
 assert_switch_file() {
-  local got; got="$(cat "$HOME/.autoshpool_switch" 2>/dev/null)"
+  local got; got="$(cat "$HOME/.autoshpool_switch$(switch_suffix)" 2>/dev/null)"
   if [ "$got" != "$1" ]; then
     echo "  FAIL: switch file is '$got', expected '$1'"; TEST_FAILED=1; return 1
   fi
 }
 assert_no_switch_file() {
-  if [ -f "$HOME/.autoshpool_switch" ]; then
-    echo "  FAIL: switch file unexpectedly exists"; TEST_FAILED=1; return 1
-  fi
+  local f
+  for f in "$HOME"/.autoshpool_switch*; do
+    if [ -e "$f" ] && [[ "$f" != *_pwd* ]]; then
+      echo "  FAIL: switch file $f unexpectedly exists"; TEST_FAILED=1; return 1
+    fi
+  done
+  return 0
 }
 assert_switch_pwd() {
-  local got; got="$(cat "$HOME/.autoshpool_switch_pwd" 2>/dev/null)"
+  local got; got="$(cat "$HOME/.autoshpool_switch_pwd$(switch_suffix)" 2>/dev/null)"
   if [ "$got" != "$1" ]; then
     echo "  FAIL: switch pwd is '$got', expected '$1'"; TEST_FAILED=1; return 1
   fi
 }
 assert_no_switch_pwd() {
-  if [ -f "$HOME/.autoshpool_switch_pwd" ]; then
-    echo "  FAIL: switch pwd unexpectedly exists"; TEST_FAILED=1; return 1
-  fi
+  local f
+  for f in "$HOME"/.autoshpool_switch_pwd*; do
+    if [ -e "$f" ]; then
+      echo "  FAIL: switch pwd $f unexpectedly exists"; TEST_FAILED=1; return 1
+    fi
+  done
+  return 0
 }
 
 list_action()  { run_cs --list; printf '%s\n' "$output" | sed -n "${1}p" | cut -f1; }
@@ -240,6 +254,19 @@ test_existing_auto_session_not_listed_twice() {
   fi
   if [ "$r1" != proj:2 ] || [ "$r2" != proj:1 ]; then
     echo "  FAIL: auto target not pinned first (r1=$r1 r2=$r2)"; echo "$output"; TEST_FAILED=1
+  fi
+}
+
+test_list_skips_empty_name_row() {
+  # A session with an empty name lists with only 2 columns (started_at,
+  # status). Its $1 is the start time, which must not surface as a bogus
+  # picker row (matching get_shpool_sessions' NF == 3 guard).
+  add_full proj:1 disconnected
+  printf '%-30s %s\n' "2024-12-31T00:00:00Z" "disconnected" >> "$HOME/.shpool_sessions"
+  run_cs --list
+  if printf '%s\n' "$output" | cut -f2 | grep -q "2024-12-31"; then
+    echo "  FAIL: empty-name row leaked its start time as a session name"
+    echo "  output: $output"; TEST_FAILED=1
   fi
 }
 
@@ -419,6 +446,7 @@ test_switch_missing_name_inside_requests_with_pwd() {
 
 run_test "list: create entry is first" test_list_create_entry_first
 run_test "list: existing auto session is not listed twice" test_existing_auto_session_not_listed_twice
+run_test "list: an empty-name session row is skipped" test_list_skips_empty_name_row
 run_test "list: attached session shows filled icon" test_list_attached_icon
 run_test "list: detached session shows empty icon" test_list_disconnected_icon
 run_test "list: prefix group sorts under the create entry" test_list_prefix_group_first

--- a/choosesession
+++ b/choosesession
@@ -7,7 +7,8 @@
 #   * inside tmux  ($TMUX set)                 -> changetmux --choose
 #   * inside shpool ($SHPOOL_SESSION_NAME set) -> changeshpool --choose
 #   * outside both: honour $SESSION_BACKEND (tmux|shpool); otherwise use
-#     whichever of tmux/shpool is installed (tmux first).
+#     whichever of tmux/shpool is installed (shpool first, the
+#     family default -- matching the shell session_backend helper).
 #
 # Prints the chosen session name and exits 0 when something was picked; prints
 # nothing and exits non-zero on an empty list, a cancel, or a picker error, so
@@ -34,11 +35,11 @@ case "${SESSION_BACKEND:-}" in
   shpool) run changeshpool "$@" ;;
 esac
 
-if command -v tmux >/dev/null 2>&1; then
-  run changetmux "$@"
-fi
 if command -v shpool >/dev/null 2>&1; then
   run changeshpool "$@"
+fi
+if command -v tmux >/dev/null 2>&1; then
+  run changetmux "$@"
 fi
 
 echo "choosesession: no tmux or shpool backend available" >&2

--- a/detachsession
+++ b/detachsession
@@ -6,7 +6,8 @@
 #   * inside tmux  ($TMUX set)                 -> detachtmux
 #   * inside shpool ($SHPOOL_SESSION_NAME set) -> detachshpool
 #   * outside both: honour $SESSION_BACKEND (tmux|shpool); otherwise use
-#     whichever of tmux/shpool is installed (tmux first).
+#     whichever of tmux/shpool is installed (shpool first, the
+#     family default -- matching the shell session_backend helper).
 #
 # All arguments are passed through to the chosen script.
 #
@@ -31,11 +32,11 @@ case "${SESSION_BACKEND:-}" in
   shpool) run detachshpool "$@" ;;
 esac
 
-if command -v tmux >/dev/null 2>&1; then
-  run detachtmux "$@"
-fi
 if command -v shpool >/dev/null 2>&1; then
   run detachshpool "$@"
+fi
+if command -v tmux >/dev/null 2>&1; then
+  run detachtmux "$@"
 fi
 
 echo "detachsession: no tmux or shpool backend available" >&2

--- a/detachsession_test
+++ b/detachsession_test
@@ -122,6 +122,13 @@ test_fallback_shpool_installed() {
   run detachsession
   assert_called "detachshpool "
 }
+test_fallback_prefers_shpool() {
+  # With both installed and no $SESSION_BACKEND, the fallback prefers shpool --
+  # the family default, matching the shell session_backend helper.
+  install_script detachsession; fake detachtmux; fake detachshpool; fake tmux; fake shpool
+  run detachsession
+  assert_called "detachshpool "
+}
 test_no_backend_errors() {
   install_script detachsession; fake detachtmux; fake detachshpool
   run detachsession
@@ -156,6 +163,7 @@ run_test "dispatch: SESSION_BACKEND=tmux picks detachtmux" test_session_backend_
 run_test "dispatch: SESSION_BACKEND=shpool picks detachshpool" test_session_backend_shpool
 run_test "dispatch: falls back to installed tmux" test_fallback_tmux_installed
 run_test "dispatch: falls back to installed shpool" test_fallback_shpool_installed
+run_test "dispatch: prefers shpool when both are installed" test_fallback_prefers_shpool
 run_test "dispatch: no backend errors out" test_no_backend_errors
 run_test "dispatch: args pass through to backend" test_args_pass_through
 run_test "backend: detachtmux runs tmux detach" test_detachtmux_runs_tmux_detach

--- a/makesession
+++ b/makesession
@@ -6,7 +6,8 @@
 #   * inside tmux  ($TMUX set)                 -> maketmux
 #   * inside shpool ($SHPOOL_SESSION_NAME set) -> makeshpool
 #   * outside both: honour $SESSION_BACKEND (tmux|shpool); otherwise use
-#     whichever of tmux/shpool is installed (tmux first).
+#     whichever of tmux/shpool is installed (shpool first, the
+#     family default -- matching the shell session_backend helper).
 #
 # All arguments (the session name, and any further pass-through) are forwarded.
 #
@@ -31,11 +32,11 @@ case "${SESSION_BACKEND:-}" in
   shpool) run makeshpool "$@" ;;
 esac
 
-if command -v tmux >/dev/null 2>&1; then
-  run maketmux "$@"
-fi
 if command -v shpool >/dev/null 2>&1; then
   run makeshpool "$@"
+fi
+if command -v tmux >/dev/null 2>&1; then
+  run maketmux "$@"
 fi
 
 echo "makesession: no tmux or shpool backend available" >&2

--- a/makesession_test
+++ b/makesession_test
@@ -228,6 +228,25 @@ test_maketmux_existing_session_attaches_outside() {
     TEST_FAILED=1
   fi
 }
+test_maketmux_existing_literal_name_wins() {
+  # A session that exists verbatim under a name sanitize_session_name would
+  # rewrite (names can legally contain '#', which tmux keeps on some paths) is
+  # targeted as-is -- existing-first, sanitize-only-when-generating, like
+  # sessionlib's perform_switch_to. Without that order, maketmux 'foo#bar'
+  # would miss the existing session and create a "foo_bar" twin.
+  install_maketmux; fake_tmux_with_list
+  printf 'foo#bar\x1f1\n' > "$TEST_TMPDIR/.tmux_sessions"
+  set +e
+  output="$(env -i PATH="$BIN" HOME="$TEST_TMPDIR" TMUX=/tmp/sock,1,0 "$BIN/maketmux" 'foo#bar' 2>&1)"
+  status=$?
+  set -e
+  assert_called "tmux switch-client -t =foo#bar"
+  if grep -q "new-session" "$CALLS" 2>/dev/null; then
+    echo "  FAIL: must not create a twin of an existing literal name"
+    echo "  calls: $(cat "$CALLS" 2>/dev/null)"
+    TEST_FAILED=1
+  fi
+}
 test_maketmux_existing_session_rejects_command() {
   # A command argument has nowhere to go when the session already exists, so
   # refuse rather than silently drop it.
@@ -382,6 +401,7 @@ run_test "backend: maketmux inside tmux switches client" test_maketmux_inside_tm
 run_test "backend: maketmux sanitizes the session name" test_maketmux_sanitizes_name
 run_test "backend: maketmux switches to an existing session" test_maketmux_existing_session_switches
 run_test "backend: maketmux attaches an existing session from outside" test_maketmux_existing_session_attaches_outside
+run_test "backend: maketmux targets an existing literal name unsanitized" test_maketmux_existing_literal_name_wins
 run_test "backend: maketmux rejects a command for an existing session" test_maketmux_existing_session_rejects_command
 run_test "backend: maketmux requires a session name" test_maketmux_requires_name
 run_test "backend: makeshpool runs shpool attach -d ." test_makeshpool_runs_shpool_attach

--- a/makesession_test
+++ b/makesession_test
@@ -25,7 +25,13 @@ setup() {
   CALLS="$TEST_TMPDIR/calls"
   mkdir -p "$BIN"
   : > "$CALLS"
-  ln -s "$(command -v dirname)" "$BIN/dirname"
+  # dirname for the dispatchers; sed/cut/grep for maketmux's session_exists
+  # lookup (via autotmux's list_tmux_sessions); cat for the fake tmux's
+  # list-sessions fixture.
+  local tool
+  for tool in dirname sed cut grep cat; do
+    ln -s "$(command -v $tool)" "$BIN/$tool"
+  done
 }
 
 teardown() {
@@ -116,6 +122,13 @@ test_fallback_shpool_installed() {
   run makesession
   assert_called "makeshpool "
 }
+test_fallback_prefers_shpool() {
+  # With both installed and no $SESSION_BACKEND, the fallback prefers shpool --
+  # the family default, matching the shell session_backend helper.
+  install_script makesession; fake maketmux; fake makeshpool; fake tmux; fake shpool
+  run makesession
+  assert_called "makeshpool "
+}
 test_no_backend_errors() {
   install_script makesession; fake maketmux; fake makeshpool
   run makesession
@@ -133,8 +146,28 @@ test_name_passes_through() {
 
 # --- backend behaviour ---
 
+install_maketmux() {
+  # maketmux sources autotmux (for sanitize_session_name / session_exists),
+  # which sources sessionlib.
+  install_script maketmux; install_script autotmux; install_script sessionlib
+}
+
+# A fake tmux that records its calls and answers list-sessions with the rows in
+# $TEST_TMPDIR/.tmux_sessions ("name<US>attached" per line, see autotmux's
+# list_tmux_sessions format).
+fake_tmux_with_list() {
+  cat > "$BIN/tmux" <<EOF
+#!/bin/bash
+echo "tmux \$*" >> "$CALLS"
+if [ "\$1" = list-sessions ]; then
+  cat "$TEST_TMPDIR/.tmux_sessions" 2>/dev/null
+fi
+EOF
+  chmod +x "$BIN/tmux"
+}
+
 test_maketmux_outside_tmux_creates_and_attaches() {
-  install_script maketmux; fake tmux
+  install_maketmux; fake tmux
   set +e
   output="$(env -i PATH="$BIN" HOME="$TEST_TMPDIR" "$BIN/maketmux" work 2>&1)"
   status=$?
@@ -144,13 +177,81 @@ test_maketmux_outside_tmux_creates_and_attaches() {
 test_maketmux_inside_tmux_switches_client() {
   # Inside tmux, new-session can't attach to the current terminal, so maketmux
   # creates the session detached and switches the existing client to it.
-  install_script maketmux; fake tmux
+  install_maketmux; fake tmux
   set +e
   output="$(env -i PATH="$BIN" HOME="$TEST_TMPDIR" TMUX=/tmp/sock,1,0 "$BIN/maketmux" work 2>&1)"
   status=$?
   set -e
   assert_called "tmux new-session -d -s work"
   assert_called "tmux switch-client -t =work"
+}
+test_maketmux_sanitizes_name() {
+  # tmux rewrites '.' out of names at creation ("foo.bar" stores "foo_bar"), so
+  # maketmux must create and target the sanitized name -- otherwise the
+  # switch-client to "=foo.bar" fails against the stored "foo_bar".
+  install_maketmux; fake tmux
+  set +e
+  output="$(env -i PATH="$BIN" HOME="$TEST_TMPDIR" TMUX=/tmp/sock,1,0 "$BIN/maketmux" foo.bar 2>&1)"
+  status=$?
+  set -e
+  assert_called "tmux new-session -d -s foo_bar"
+  assert_called "tmux switch-client -t =foo_bar"
+}
+test_maketmux_existing_session_switches() {
+  # An existing session is moved to, not re-created (tmux would fail with
+  # "duplicate session") -- mirroring makeshpool, where shpool attach
+  # attaches-or-creates.
+  install_maketmux; fake_tmux_with_list
+  printf 'work\x1f1\n' > "$TEST_TMPDIR/.tmux_sessions"
+  set +e
+  output="$(env -i PATH="$BIN" HOME="$TEST_TMPDIR" TMUX=/tmp/sock,1,0 "$BIN/maketmux" work 2>&1)"
+  status=$?
+  set -e
+  assert_called "tmux switch-client -t =work"
+  if grep -q "new-session" "$CALLS" 2>/dev/null; then
+    echo "  FAIL: must not create a session that already exists"
+    echo "  calls: $(cat "$CALLS" 2>/dev/null)"
+    TEST_FAILED=1
+  fi
+}
+test_maketmux_existing_session_attaches_outside() {
+  install_maketmux; fake_tmux_with_list
+  printf 'work\x1f0\n' > "$TEST_TMPDIR/.tmux_sessions"
+  set +e
+  output="$(env -i PATH="$BIN" HOME="$TEST_TMPDIR" "$BIN/maketmux" work 2>&1)"
+  status=$?
+  set -e
+  assert_called "tmux attach-session -t =work"
+  if grep -q "new-session" "$CALLS" 2>/dev/null; then
+    echo "  FAIL: must not create a session that already exists"
+    echo "  calls: $(cat "$CALLS" 2>/dev/null)"
+    TEST_FAILED=1
+  fi
+}
+test_maketmux_existing_session_rejects_command() {
+  # A command argument has nowhere to go when the session already exists, so
+  # refuse rather than silently drop it.
+  install_maketmux; fake_tmux_with_list
+  printf 'work\x1f0\n' > "$TEST_TMPDIR/.tmux_sessions"
+  set +e
+  output="$(env -i PATH="$BIN" HOME="$TEST_TMPDIR" "$BIN/maketmux" work vim 2>&1)"
+  status=$?
+  set -e
+  assert_status 2
+  assert_output_contains "already exists"
+}
+test_maketmux_requires_name() {
+  install_maketmux; fake tmux
+  set +e
+  output="$(env -i PATH="$BIN" HOME="$TEST_TMPDIR" "$BIN/maketmux" 2>&1)"
+  status=$?
+  set -e
+  assert_status 2
+  assert_output_contains "session name required"
+  if grep -q "tmux" "$CALLS" 2>/dev/null; then
+    echo "  FAIL: must not touch tmux without a name"
+    TEST_FAILED=1
+  fi
 }
 test_makeshpool_runs_shpool_attach() {
   # makeshpool forwards to `shpool attach -d . <name>`: -d . opens the freshly
@@ -194,12 +295,14 @@ EOF
   set -e
   assert_status 0
   assert_called "shpool detach work"
-  if test "$(cat "$TEST_TMPDIR/.autoshpool_switch" 2>/dev/null)" != "newproj"; then
-    echo "  FAIL: switch file should record 'newproj', got '$(cat "$TEST_TMPDIR/.autoshpool_switch" 2>/dev/null)'"
+  # The request is keyed to the session it was made from (".work"), so only
+  # the loop holding that session services it.
+  if test "$(cat "$TEST_TMPDIR/.autoshpool_switch.work" 2>/dev/null)" != "newproj"; then
+    echo "  FAIL: switch file should record 'newproj', got '$(cat "$TEST_TMPDIR/.autoshpool_switch.work" 2>/dev/null)'"
     TEST_FAILED=1
   fi
-  if test "$(cat "$TEST_TMPDIR/.autoshpool_switch_pwd" 2>/dev/null)" != "$TEST_TMPDIR"; then
-    echo "  FAIL: switch pwd file should record '$TEST_TMPDIR', got '$(cat "$TEST_TMPDIR/.autoshpool_switch_pwd" 2>/dev/null)'"
+  if test "$(cat "$TEST_TMPDIR/.autoshpool_switch_pwd.work" 2>/dev/null)" != "$TEST_TMPDIR"; then
+    echo "  FAIL: switch pwd file should record '$TEST_TMPDIR', got '$(cat "$TEST_TMPDIR/.autoshpool_switch_pwd.work" 2>/dev/null)'"
     TEST_FAILED=1
   fi
   if grep -q "shpool attach" "$CALLS" 2>/dev/null; then
@@ -226,12 +329,40 @@ EOF
   set -e
   assert_status 2
   assert_output_contains "can't forward options"
-  if test -e "$TEST_TMPDIR/.autoshpool_switch"; then
+  if compgen -G "$TEST_TMPDIR/.autoshpool_switch*" >/dev/null; then
     echo "  FAIL: must not record a switch when rejecting"
     TEST_FAILED=1
   fi
   if grep -qE "shpool (attach|detach)" "$CALLS" 2>/dev/null; then
     echo "  FAIL: must not touch shpool when rejecting"
+    echo "  calls: $(cat "$CALLS" 2>/dev/null)"
+    TEST_FAILED=1
+  fi
+}
+test_makeshpool_requires_name() {
+  # With no name, the inside-session path would request_switch to "" -- an
+  # empty request the loop reads as "no switch" -- detaching the user into
+  # nothing while the ms/msp wrappers exit the shell. Refuse up front.
+  install_script makeshpool; install_script autoshpool; install_script sessionlib
+  fake shpool
+  cat > "$BIN/timeout" <<'EOF'
+#!/bin/bash
+shift
+"$@"
+EOF
+  chmod +x "$BIN/timeout"
+  set +e
+  output="$(env -i PATH="$BIN" HOME="$TEST_TMPDIR" SHPOOL_SESSION_NAME=work "$BIN/makeshpool" 2>&1)"
+  status=$?
+  set -e
+  assert_status 2
+  assert_output_contains "session name required"
+  if compgen -G "$TEST_TMPDIR/.autoshpool_switch*" >/dev/null; then
+    echo "  FAIL: must not record a switch without a name"
+    TEST_FAILED=1
+  fi
+  if grep -qE "shpool (attach|detach)" "$CALLS" 2>/dev/null; then
+    echo "  FAIL: must not touch shpool without a name"
     echo "  calls: $(cat "$CALLS" 2>/dev/null)"
     TEST_FAILED=1
   fi
@@ -243,14 +374,21 @@ run_test "dispatch: SESSION_BACKEND=tmux picks maketmux" test_session_backend_tm
 run_test "dispatch: SESSION_BACKEND=shpool picks makeshpool" test_session_backend_shpool
 run_test "dispatch: falls back to installed tmux" test_fallback_tmux_installed
 run_test "dispatch: falls back to installed shpool" test_fallback_shpool_installed
+run_test "dispatch: prefers shpool when both are installed" test_fallback_prefers_shpool
 run_test "dispatch: no backend errors out" test_no_backend_errors
 run_test "dispatch: session name passes through" test_name_passes_through
 run_test "backend: maketmux outside tmux creates and attaches" test_maketmux_outside_tmux_creates_and_attaches
 run_test "backend: maketmux inside tmux switches client" test_maketmux_inside_tmux_switches_client
+run_test "backend: maketmux sanitizes the session name" test_maketmux_sanitizes_name
+run_test "backend: maketmux switches to an existing session" test_maketmux_existing_session_switches
+run_test "backend: maketmux attaches an existing session from outside" test_maketmux_existing_session_attaches_outside
+run_test "backend: maketmux rejects a command for an existing session" test_maketmux_existing_session_rejects_command
+run_test "backend: maketmux requires a session name" test_maketmux_requires_name
 run_test "backend: makeshpool runs shpool attach -d ." test_makeshpool_runs_shpool_attach
 run_test "backend: makeshpool preserves a caller-supplied --dir" test_makeshpool_preserves_caller_dir
 run_test "backend: makeshpool inside a session requests a switch" test_makeshpool_inside_session_requests_switch
 run_test "backend: makeshpool inside a session rejects extra args" test_makeshpool_inside_session_rejects_extra_args
+run_test "backend: makeshpool requires a session name" test_makeshpool_requires_name
 
 echo "$TESTS_RUN tests, $TESTS_PASSED passed, $TESTS_FAILED failed"
 test "$TESTS_FAILED" -eq 0

--- a/makeshpool
+++ b/makeshpool
@@ -23,6 +23,16 @@
 # guard makes sourcing it define functions without running the loop.
 source "$(dirname "$0")/autoshpool"
 
+# A name is required. Refusing here matters most inside a session: with no
+# name, request_switch below would record an empty target and detach us into
+# nothing -- the loop reads the empty request as "no switch" and the ms/msp
+# wrappers exit the now-detached shell. Same guard as sessionlib's
+# perform_switch_to.
+if test -z "$1"; then
+  echo "makeshpool: session name required" >&2
+  exit 2
+fi
+
 if test -n "$SHPOOL_SESSION_NAME"; then
   # The switch handoff carries only a session name (the outer loop just runs
   # `shpool attach "$name"`), so extra `shpool attach` options -- e.g. --ttl,

--- a/maketmux
+++ b/maketmux
@@ -4,7 +4,13 @@
 # The tmux twin of makeshpool, dispatched by makesession. The first argument
 # is the session name; any further arguments are the command to run in it.
 #
-# The name is normalized like autotmux's generated names: tmux rewrites '#',
+# An exact existing name always wins, taken as-is: names can legally contain
+# characters sanitize_session_name rewrites (e.g. '#', which tmux keeps on
+# some paths), so classifying the raw name first keeps `maketmux foo#bar`
+# targeting that session instead of creating a "foo_bar" twin -- the same
+# existing-first, sanitize-only-when-generating order as sessionlib's
+# perform_switch_to and autotmux's resolve_switch_target. A name we do end up
+# creating is normalized like autotmux's generated names: tmux rewrites '#',
 # ':' and '.' out of names at creation (`new-session -s foo.bar` stores
 # "foo_bar"), and a leading '$' '%' '=' is id/exact-match syntax, so an
 # unsanitized name would be created under a different name than the one the
@@ -33,8 +39,15 @@ if test -z "$1"; then
   exit 2
 fi
 
-name="$(sanitize_session_name "$1")"
+name="$1"
 shift
+
+# Only a name that doesn't exist verbatim is a *generated* name; sanitize it
+# so creation and targeting agree (and so an already-created "foo_bar" is
+# found when "foo.bar" is asked for again).
+if ! session_exists "$name"; then
+  name="$(sanitize_session_name "$name")"
+fi
 
 if session_exists "$name"; then
   if test "$#" -gt 0; then

--- a/maketmux
+++ b/maketmux
@@ -1,19 +1,54 @@
 #!/bin/bash
 # maketmux - create (and attach to) a named tmux session
 #
-# Thin tmux twin of makeshpool, dispatched by makesession. The first argument
+# The tmux twin of makeshpool, dispatched by makesession. The first argument
 # is the session name; any further arguments are the command to run in it.
+#
+# The name is normalized like autotmux's generated names: tmux rewrites '#',
+# ':' and '.' out of names at creation (`new-session -s foo.bar` stores
+# "foo_bar"), and a leading '$' '%' '=' is id/exact-match syntax, so an
+# unsanitized name would be created under a different name than the one the
+# switch below targets. Targets use tmux's exact "=name" form so a name that
+# is a prefix of another session can't be matched instead.
+#
+# When the session already exists, move to it instead of failing with tmux's
+# "duplicate session" -- mirroring makeshpool, where `shpool attach`
+# attaches-or-creates. A command argument has nowhere to go in that case (the
+# session is already running its own commands), so refuse rather than silently
+# drop it, like makeshpool's inside-session option refusal.
 #
 # Inside tmux ($TMUX set) `new-session` can't attach to the current terminal --
 # it would hit tmux's nested-session refusal -- so create the session detached
 # and switch this client to it instead (the new-session -d / switch-client
-# dance autotmux's do_switch uses). Target the switch with tmux's exact "=name"
-# form so a name that is a prefix of another session can't be matched instead.
-# Outside tmux there is no client to switch, so just create-and-attach. tmux
-# opens the session in the caller's PWD natively (makeshpool needs `shpool
-# attach -d .` for the same effect).
+# dance autotmux's do_switch uses). Outside tmux there is no client to switch,
+# so just create-and-attach. tmux opens the session in the caller's PWD
+# natively (makeshpool needs `shpool attach -d .` for the same effect).
+
+# Pull in sanitize_session_name/session_exists from the tmux backend module.
+# autotmux's is_sourced guard makes sourcing it define functions only.
+source "$(dirname "$0")/autotmux"
+
+if test -z "$1"; then
+  echo "maketmux: session name required" >&2
+  exit 2
+fi
+
+name="$(sanitize_session_name "$1")"
+shift
+
+if session_exists "$name"; then
+  if test "$#" -gt 0; then
+    echo "maketmux: session '$name' already exists; can't run a command ($*) in it" >&2
+    exit 2
+  fi
+  if test -n "$TMUX"; then
+    exec tmux switch-client -t "=$name"
+  fi
+  exec tmux attach-session -t "=$name"
+fi
+
 if test -n "$TMUX"; then
-  tmux new-session -d -s "$@" && exec tmux switch-client -t "=$1"
+  tmux new-session -d -s "$name" "$@" && exec tmux switch-client -t "=$name"
   exit $?
 fi
-exec tmux new-session -s "$@"
+exec tmux new-session -s "$name" "$@"


### PR DESCRIPTION
Fixes several bugs found in a review of the tmux/shpool session-management scripts. Companion PR in `conf` gates the shell configs' shpool arms on `autoshpool` and updates the dispatcher-default comments.

## autoshpool loop (`autoshpool`)

* **Switching to a session attached in another terminal silently closed your terminal.** `shpool attach` exits 0 without attaching when the target is busy (libshpool BusyError → `AttachResult::Done`, already documented in this file), so the loop's switch-servicing attach was a silent no-op: the loop returned 0 and the caller's `autoshpool && exit` exited the shell with nothing attached. The loop now attaches with `-f` (steal), matching what `changeshpool` already does from outside a session.
* **The plain reattach path had the same blind spot on a lost race.** If another shell attached a listed-disconnected session between our listing and our attach, the exit-0 no-op again closed the terminal. The reattach path now re-checks the session status (the settle-poll the create path already did, extracted into a shared `wait_attach_settled`) and re-runs the loop to pick or create another session.
* **Switch requests are now keyed to the session they were made from** (`~/.autoshpool_switch.<session>`). The single global file meant any terminal's loop could consume any request: a concurrently woken loop in another terminal could steal a switch, and `create_and_attach_next` early-returned on a *foreign* queued switch, derailing that terminal's session creation. Requests made outside any session stay unkeyed (no owning loop; the next loop to wake services them, as before).
* `get_prefix` silences `rootdir` like autotmux's, so machines without `~/.shrc.vcs` don't print "command not found" at startup.

## maketmux / makeshpool

* `maketmux foo.bar` created `foo_bar` (tmux rewrites `#`/`:`/`.` at creation) and then failed `switch-client -t "=foo.bar"`, stranding the user with a stray detached session. maketmux now sources autotmux and creates/targets the sanitized name.
* maketmux now switches/attaches to an existing session instead of failing with "duplicate session", mirroring makeshpool's attach-or-create; a command argument for an existing session is refused rather than silently dropped.
* `makeshpool` with no argument, inside a session, recorded an **empty** switch target and detached — the loop read it as "no switch" and the `ms`/`msp` wrappers exited the now-detached shell, closing the terminal into nothing. Both scripts now require a session name up front (the guard `sessionlib`'s `perform_switch_to` already had).

## changeshpool

* The picker listed rows with `NF >= 2`, so a session with an empty name leaked its start time as a bogus session name. Now `NF == 3`, matching `get_shpool_sessions`.

## Dispatchers

* `autosession`/`changesession`/`choosesession`/`detachsession`/`makesession` fell back to **tmux first** when run outside any session with `SESSION_BACKEND` unset — opposite to the family default everywhere else (shpool preferred, tmux fallback). Flipped to shpool first, so direct invocations (keybindings, shells without the `cs`/`ds`/`ms` wrappers) agree with the shell `session_backend` helper.

## Tests

`make test`: 237 tests, all passing. New coverage: busy-steal on switch servicing, reattach lost-race retry, keyed switch files (written, serviced by the owning loop, ignored by foreign loops), maketmux sanitization/existing-session/no-name, makeshpool no-name, dispatcher shpool-first preference, and a new `autosession_test` (the dispatcher previously had no coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015vUwuWVaHspDxk1AVhfU5x

---
_Generated by [Claude Code](https://claude.ai/code/session_015vUwuWVaHspDxk1AVhfU5x)_