### PR TITLE
Add setup-sway and a --sway option to setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,4 +11,5 @@ test:
 	./mdf_test
 	./setup_test
 	./setup-hypr_test
+	./setup-sway_test
 	./setup-kde_test

--- a/setup
+++ b/setup
@@ -394,13 +394,16 @@ install_packages() {
                     kwin-dev \
                     plasma-desktop \
                     plasma-sdk
-                # Hyprland Wayland desktop packages, installed unconditionally
-                # alongside KDE so either desktop is available (--kde/--hypr
-                # only choose which one to *configure*). `|| warn` because
-                # several hypr* tools may need a backport and shouldn't abort.
-                info "Installing Hyprland desktop packages"
+                # Shared Wayland desktop stack, used by BOTH the Hyprland and
+                # Sway builds (bar, launcher, notifications, portal, audio,
+                # applets, fonts). Installed unconditionally alongside KDE so
+                # any desktop is available (--kde/--hypr/--sway only choose
+                # which one to *configure*), and in its OWN transaction: apt
+                # aborts the whole install on one unavailable name, so a
+                # release without hyprland must not take the Sway/Hyprland
+                # shared pieces down with it.
+                info "Installing shared Wayland desktop packages"
                 sudo apt-get install -y --install-recommends \
-                    hyprland hypridle hyprlock \
                     xdg-desktop-portal-gtk \
                     waybar fuzzel swaync kanshi \
                     power-profiles-daemon \
@@ -409,7 +412,13 @@ install_packages() {
                     network-manager-gnome blueman \
                     policykit-1-gnome \
                     fonts-jetbrains-mono \
-                    || warn "some Hyprland packages are unavailable; you may need a backport or manual build (hyprland, hypridle, hyprlock, swww, swaync)"
+                    || warn "some shared Wayland desktop packages are unavailable via apt"
+                # Hyprland-only packages. `|| warn` because the hypr* tools
+                # may need a backport and shouldn't abort.
+                info "Installing Hyprland desktop packages"
+                sudo apt-get install -y --install-recommends \
+                    hyprland hypridle hyprlock \
+                    || warn "some Hyprland packages are unavailable; you may need a backport or manual build (hyprland, hypridle, hyprlock, swww)"
                 # These are in the default repos even where hyprland isn't, so
                 # install them separately -- otherwise a missing hyprland fails
                 # the whole command above and takes these down with it.
@@ -489,17 +498,27 @@ install_packages() {
                 sudo dnf install -y dnf-plugins-core || true
                 sudo dnf copr enable -y lionheartp/Hyprland \
                     || warn "could not enable the lionheartp/Hyprland COPR; hyprland may be unavailable"
-                info "Installing Hyprland desktop packages"
+                # Shared Wayland desktop stack, used by BOTH the Hyprland and
+                # Sway builds. Its own transaction, all default-repo, so a
+                # failed COPR / missing hyprland can't take the bar, launcher,
+                # and power pieces down with it.
+                info "Installing shared Wayland desktop packages"
                 sudo dnf install -y \
-                    hyprland hypridle hyprlock \
-                    xdg-desktop-portal-hyprland xdg-desktop-portal-gtk \
-                    waybar fuzzel swaync swww kanshi \
+                    xdg-desktop-portal-gtk \
+                    waybar fuzzel swaync kanshi \
                     power-profiles-daemon \
                     pipewire wireplumber pavucontrol \
                     brightnessctl \
                     network-manager-applet blueman \
                     polkit-gnome \
                     jetbrains-mono-fonts \
+                    || warn "some shared Wayland desktop packages are unavailable via dnf"
+                # Hyprland-only packages (these are the ones that need the
+                # COPR above).
+                info "Installing Hyprland desktop packages"
+                sudo dnf install -y \
+                    hyprland hypridle hyprlock \
+                    xdg-desktop-portal-hyprland swww \
                     || warn "some Hyprland packages are unavailable; check the lionheartp/Hyprland COPR or build manually"
                 # In the default repos even where hyprland isn't, so install
                 # separately -- a missing hyprland above shouldn't take these

--- a/setup
+++ b/setup
@@ -92,12 +92,14 @@ NPM=yes
 # Which Linux desktop to install and configure (ignored on macOS). One of:
 #   kde   - KDE Plasma + Krohnkite, via setup-kde (the default)
 #   hypr  - Hyprland Wayland desktop, via setup-hypr
-# Override with --kde / --hypr, or by exporting DESKTOP before running.
+#   sway  - Sway Wayland desktop, via setup-sway
+# Override with --kde / --hypr / --sway, or by exporting DESKTOP before
+# running.
 DESKTOP="${DESKTOP:-kde}"
 
 usage() {
     cat <<'USAGE'
-Usage: setup [--gui | --no-gui] [--kde | --hypr] [--minimal | --full]
+Usage: setup [--gui | --no-gui] [--kde | --hypr | --sway] [--minimal | --full]
              [--no-install] [--ignore-errors] [--ssh | --no-ssh] [--no-npm]
              [-h | --help]
 
@@ -108,6 +110,7 @@ Options:
   --no-gui         Skip all graphical packages and desktop configuration
   --kde            Install/configure KDE Plasma + Krohnkite (default; Linux)
   --hypr           Install/configure the Hyprland Wayland desktop (Linux)
+  --sway           Install/configure the Sway Wayland desktop (Linux)
   --minimal        Skip heavyweight extras (Rust toolchain, helix, jj, shpool,
                    nushell), installing only core packages, tools, and dotfiles
   --full           Install everything, even when disk space looks tight
@@ -156,6 +159,9 @@ while test $# -gt 0; do
             ;;
         --hypr)
             DESKTOP=hypr
+            ;;
+        --sway)
+            DESKTOP=sway
             ;;
         --minimal)
             MINIMAL=yes
@@ -410,6 +416,20 @@ install_packages() {
                 sudo apt-get install -y --install-recommends \
                     grim slurp wl-clipboard playerctl gnome-calculator \
                     || warn "screenshot/media/calculator tools unavailable via apt"
+                # Sway Wayland desktop packages, installed unconditionally
+                # alongside KDE/Hyprland for the same reason (--sway only
+                # chooses which desktop to *configure*). All are in the
+                # default repos; the bar/launcher/notification stack above
+                # (waybar, fuzzel, swaync, ...) is shared with Hyprland.
+                info "Installing Sway desktop packages"
+                sudo apt-get install -y --install-recommends \
+                    sway swaybg swayidle swaylock xdg-desktop-portal-wlr \
+                    || warn "some Sway packages are unavailable via apt"
+                # autotiling (dwindle-style dynamic tiling) is packaged
+                # separately and missing from some releases; its absence
+                # only costs the dynamic splits, not the desktop.
+                sudo apt-get install -y --install-recommends autotiling \
+                    || warn "autotiling unavailable via apt; install with 'pipx install autotiling'"
                 # yazi (terminal file manager) is often not in the default repos;
                 # install it separately so its absence doesn't block the rest.
                 sudo apt-get install -y --install-recommends yazi \
@@ -487,6 +507,21 @@ install_packages() {
                 sudo dnf install -y \
                     grim slurp wl-clipboard playerctl gnome-calculator \
                     || warn "screenshot/media/calculator tools unavailable via dnf"
+                # Sway Wayland desktop packages, installed unconditionally
+                # alongside KDE/Hyprland for the same reason (--sway only
+                # chooses which desktop to *configure*). All are in the
+                # default Fedora repos -- no COPR needed, unlike Hyprland.
+                # The bar/launcher/notification stack above (waybar, fuzzel,
+                # swaync, ...) is shared with Hyprland.
+                info "Installing Sway desktop packages"
+                sudo dnf install -y \
+                    sway swaybg swayidle swaylock xdg-desktop-portal-wlr \
+                    || warn "some Sway packages are unavailable via dnf"
+                # autotiling (dwindle-style dynamic tiling) is packaged
+                # separately; its absence only costs the dynamic splits,
+                # not the desktop.
+                sudo dnf install -y autotiling \
+                    || warn "autotiling unavailable via dnf; install with 'pipx install autotiling'"
                 # yazi (terminal file manager) may need a COPR; install it
                 # separately so its absence doesn't block the rest.
                 sudo dnf install -y yazi \
@@ -910,6 +945,9 @@ if test "$GUI_ENABLED" -eq 1; then
     elif test "$DESKTOP" = hypr; then
         info "Configuring Hyprland desktop environment"
         "$SCRIPTS_DIR/setup-hypr" $DESKTOP_SETUP_FLAGS
+    elif test "$DESKTOP" = sway; then
+        info "Configuring Sway desktop environment"
+        "$SCRIPTS_DIR/setup-sway" $DESKTOP_SETUP_FLAGS
     else
         info "Configuring KDE desktop environment"
         "$SCRIPTS_DIR/setup-kde" $DESKTOP_SETUP_FLAGS

--- a/setup
+++ b/setup
@@ -405,7 +405,7 @@ install_packages() {
                 info "Installing shared Wayland desktop packages"
                 sudo apt-get install -y --install-recommends \
                     xdg-desktop-portal-gtk \
-                    waybar fuzzel swaync kanshi \
+                    waybar fuzzel kanshi \
                     power-profiles-daemon \
                     pipewire wireplumber pavucontrol \
                     brightnessctl \
@@ -413,6 +413,13 @@ install_packages() {
                     policykit-1-gnome \
                     fonts-jetbrains-mono \
                     || warn "some shared Wayland desktop packages are unavailable via apt"
+                # swaync ships on apt as sway-notification-center (Ubuntu
+                # 24.04, Debian 13); try the upstream name for backports.
+                # Its own transaction so a missing name can't abort the
+                # shared stack above.
+                sudo apt-get install -y --install-recommends sway-notification-center \
+                    || sudo apt-get install -y --install-recommends swaync \
+                    || warn "swaync unavailable via apt (sway-notification-center); notifications need a manual build"
                 # Hyprland-only packages. `|| warn` because the hypr* tools
                 # may need a backport and shouldn't abort.
                 info "Installing Hyprland desktop packages"
@@ -505,7 +512,7 @@ install_packages() {
                 info "Installing shared Wayland desktop packages"
                 sudo dnf install -y \
                     xdg-desktop-portal-gtk \
-                    waybar fuzzel swaync kanshi \
+                    waybar fuzzel kanshi \
                     power-profiles-daemon \
                     pipewire wireplumber pavucontrol \
                     brightnessctl \
@@ -513,6 +520,13 @@ install_packages() {
                     polkit-gnome \
                     jetbrains-mono-fonts \
                     || warn "some shared Wayland desktop packages are unavailable via dnf"
+                # Fedora packages swaync as SwayNotificationCenter; try the
+                # upstream name too in case a COPR provides it. Its own
+                # transaction so a missing name can't abort the shared stack
+                # above.
+                sudo dnf install -y SwayNotificationCenter \
+                    || sudo dnf install -y swaync \
+                    || warn "swaync unavailable via dnf (SwayNotificationCenter); notifications need a manual build"
                 # Hyprland-only packages (these are the ones that need the
                 # COPR above).
                 info "Installing Hyprland desktop packages"

--- a/setup-sway
+++ b/setup-sway
@@ -110,7 +110,9 @@ fi
 # the same settings, so whichever ran first wins and the other skips.
 install_logind_lid_dropin() {
     is_command systemctl || { warn "systemd not detected; skipping logind lid drop-in"; return 0; }
-    if grep -qs 'HandleLidSwitch=ignore' "$LOGIND_DIR"/*.conf 2>/dev/null; then
+    # Anchored to an uncommented assignment: a drop-in carrying a commented
+    # example like "#HandleLidSwitch=ignore" must not count as configured.
+    if grep -qsE '^[[:space:]]*HandleLidSwitch=ignore' "$LOGIND_DIR"/*.conf 2>/dev/null; then
         info "logind already ignores the lid (drop-in present); skipping"
         return 0
     fi

--- a/setup-sway
+++ b/setup-sway
@@ -1,0 +1,207 @@
+#!/bin/sh
+# Configure a Sway-based Wayland desktop (KDE replacement).
+#
+# The dotfiles live in the conf repo (config/sway, config/swaylock, plus the
+# shared config/waybar, config/fuzzel, config/swaync, and the shared theme
+# scripts under config/hypr/scripts) and are installed by conf's
+# `make install`. The Wayland desktop *packages* are installed by the
+# top-level `setup`. This script, like setup-hypr and setup-kde, handles the
+# parts that are neither dotfiles nor packages:
+#
+# - Tell systemd-logind to ignore the laptop lid so Sway's own lid handler
+#   (config/sway/scripts/lid.sh, wired via bindswitch) is authoritative:
+#   disable the internal panel on close, and suspend only when no external
+#   display is active. The drop-in content is SHARED with the Hyprland build
+#   (setup-hypr installs the same settings), so if a drop-in already ignores
+#   the lid nothing is written.
+#   TODO: consider moving the lid suspend policy to logind instead
+#   (HandleLidSwitch=suspend + HandleLidSwitchDocked=ignore) and dropping
+#   the conditional suspend from both compositors' lid scripts; that is a
+#   shared system-level change, so change the Hyprland build at the same
+#   time.
+# - Enable power-profiles-daemon (used by the waybar power-profiles module).
+# - Seed ~/.config/sway/config.local (per-host overrides: output names, idle
+#   tweaks) from the installed template. Never overwrites an existing one.
+#
+# Usage:
+#     setup-sway [--no-install] [--ignore-errors] [-h | --help]
+#
+# --no-install skips the system-modifying steps (logind drop-in, enabling the
+# service). --ignore-errors keeps going past failures. setup forwards both.
+
+# Whether to install packages. "no" (via --no-install) skips the install.
+INSTALL=yes
+
+# Whether to keep going past failures. "no" aborts on the first error via
+# set -e; "yes" (via --ignore-errors) leaves it off and pushes through.
+IGNORE_ERRORS=no
+
+# Where logind drop-ins live. Overridable for tests (SETUP_LOGIND_DIR), which
+# can't mock the real /etc.
+LOGIND_DIR="${SETUP_LOGIND_DIR:-/etc/systemd/logind.conf.d}"
+
+info() {
+    printf "%s\n" "$*"
+}
+
+warn() {
+    printf "Warning: %s\n" "$*" >&2
+}
+
+error() {
+    printf "Error: %s\n" "$*" >&2
+    exit 1
+}
+
+is_command() {
+    test -x "$(command -v "$1")"
+}
+
+usage() {
+    cat <<'USAGE'
+Usage: setup-sway [--no-install] [--ignore-errors] [-h | --help]
+
+Configure a Sway-based Wayland desktop (packages come from `setup`).
+
+Options:
+  --no-install     Skip the system-modifying steps (logind drop-in, services)
+  --ignore-errors  Keep going past failures instead of aborting on the first
+  -h, --help       Show this help and exit
+USAGE
+}
+
+# --- Parse arguments ---
+
+while test $# -gt 0; do
+    case "$1" in
+        --install)
+            INSTALL=yes
+            ;;
+        --no-install)
+            INSTALL=no
+            ;;
+        --ignore-errors)
+            IGNORE_ERRORS=yes
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            warn "Unknown option: $1"
+            usage >&2
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+# Abort on the first error by default. --ignore-errors leaves set -e off so
+# the script pushes through failing steps.
+if test "$IGNORE_ERRORS" = no; then
+    set -e
+fi
+
+# --- systemd-logind: ignore the lid ---
+
+# Hand full lid control to Sway (config/sway/scripts/lid.sh) so a docked
+# laptop with the lid shut doesn't suspend when an external display is
+# active. Shared with the Hyprland build: setup-hypr installs a drop-in with
+# the same settings, so whichever ran first wins and the other skips.
+install_logind_lid_dropin() {
+    is_command systemctl || { warn "systemd not detected; skipping logind lid drop-in"; return 0; }
+    if grep -qs 'HandleLidSwitch=ignore' "$LOGIND_DIR"/*.conf 2>/dev/null; then
+        info "logind already ignores the lid (drop-in present); skipping"
+        return 0
+    fi
+    dropin="$LOGIND_DIR/10-sway-lid.conf"
+    info "Installing logind lid drop-in ($dropin)"
+    sudo mkdir -p "$LOGIND_DIR"
+    sudo tee "$dropin" >/dev/null <<'CONF'
+# Installed by setup-sway. Let the compositor's lid handler (Sway's lid.sh,
+# or Hyprland's -- they implement the same policy) manage the lid so a docked
+# laptop with the lid closed keeps running on its external display.
+[Login]
+HandleLidSwitch=ignore
+HandleLidSwitchExternalPower=ignore
+HandleLidSwitchDocked=ignore
+CONF
+    # Reload logind so the drop-in takes effect without a reboot.
+    sudo systemctl kill -s HUP systemd-logind 2>/dev/null \
+        || warn "could not reload systemd-logind; changes apply after reboot"
+}
+
+# --- Services ---
+
+enable_services() {
+    is_command systemctl || { warn "systemd not detected; enable power-profiles-daemon manually"; return 0; }
+    if systemctl list-unit-files power-profiles-daemon.service >/dev/null 2>&1; then
+        info "Enabling power-profiles-daemon"
+        sudo systemctl enable --now power-profiles-daemon.service \
+            || warn "could not enable power-profiles-daemon"
+    else
+        warn "power-profiles-daemon.service not found; install power-profiles-daemon"
+    fi
+}
+
+# --- Per-host config.local ---
+
+# Seed ~/.config/sway/config.local from the template conf's `make install`
+# ships. The base sway config is identical on every machine; config.local
+# holds only this machine's overrides (output names, idle tweaks). Never
+# overwrite an existing one -- re-running setup-sway must be safe.
+seed_config_local() {
+    cfgdir="${XDG_CONFIG_HOME:-$HOME/.config}/sway"
+    local_file="$cfgdir/config.local"
+    template="$cfgdir/config.local.template"
+    if test -f "$local_file"; then
+        info "Per-host config already exists ($local_file); leaving it alone"
+        return 0
+    fi
+    if ! test -f "$template"; then
+        warn "config.local.template not found ($template); run conf's 'make install' first"
+        return 0
+    fi
+    mkdir -p "$cfgdir"
+    cp "$template" "$local_file"
+    info "Created $local_file from the template"
+    # Inside a running Sway session, append this machine's output names as
+    # comments so filling in the per-host values is copy-paste.
+    if test -n "$SWAYSOCK" && is_command swaymsg; then
+        {
+            echo ""
+            echo "# Outputs detected on this machine ($(hostname)):"
+            swaymsg -t get_outputs 2>/dev/null \
+                | grep -o '"name": *"[^"]*"' | cut -d'"' -f4 \
+                | sed 's/^/#   /'
+        } >> "$local_file"
+    fi
+}
+
+# --- Main ---
+
+# The Wayland desktop packages are installed by the top-level `setup`. Here we
+# only apply the system-modifying config; --no-install skips it (e.g. a dry run
+# or when re-running just to reseed config.local / source setup-sway.local).
+if test "$INSTALL" = yes; then
+    install_logind_lid_dropin
+    enable_services
+else
+    info "Skipping logind drop-in and service enablement (--no-install)"
+fi
+
+# Per-host overrides are user-level config, not a system change: seed them
+# even under --no-install.
+seed_config_local
+
+# Local overrides, mirroring setup-kde's setup-kde.local hook.
+if is_command setup-sway.local; then
+    info "Sourcing setup-sway.local"
+    # shellcheck source=/dev/null
+    . setup-sway.local
+fi
+
+info "Sway desktop configured."
+info "Per-host values (output names, idle tweaks) live in"
+info "~/.config/sway/config.local -- see conf/config/sway/README.md."
+info "Log in and pick the Sway session (or run 'sway' from a TTY)."

--- a/setup-sway_test
+++ b/setup-sway_test
@@ -180,6 +180,16 @@ test_skips_dropin_when_lid_already_ignored() {
     assert_not_called "sudo tee"
 }
 
+# A commented example ("#HandleLidSwitch=ignore") is not configuration --
+# systemd ignores it, so the drop-in must still be installed.
+test_commented_lid_entry_does_not_skip_dropin() {
+    mkdir -p "$SETUP_LOGIND_DIR"
+    printf '[Login]\n#HandleLidSwitch=ignore\n' > "$SETUP_LOGIND_DIR/50-example.conf"
+    run_sway
+    assert_status 0 &&
+    assert_called "sudo tee $SETUP_LOGIND_DIR/10-sway-lid.conf"
+}
+
 # --- services ---
 
 test_enables_power_profiles_daemon() {
@@ -258,6 +268,8 @@ run_test "installs logind lid drop-in" test_installs_logind_lid_dropin
 run_test "reloads logind" test_reloads_logind
 run_test "skips drop-in when the lid is already ignored (shared with hypr)" \
     test_skips_dropin_when_lid_already_ignored
+run_test "commented lid entry does not skip the drop-in" \
+    test_commented_lid_entry_does_not_skip_dropin
 run_test "enables power-profiles-daemon" test_enables_power_profiles_daemon
 run_test "no-install skips system changes" test_no_install_skips_system_changes
 run_test "seeds config.local from the template" test_seeds_config_local_from_template

--- a/setup-sway_test
+++ b/setup-sway_test
@@ -1,0 +1,273 @@
+#!/bin/sh
+# Tests for setup-sway
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+setup() {
+    TEST_TMPDIR="$(mktemp -d)"
+    # Put mocks first on PATH so they shadow real commands.
+    export PATH="$TEST_TMPDIR/bin:$PATH"
+    mkdir -p "$TEST_TMPDIR/bin"
+    CALLS="$TEST_TMPDIR/calls"
+    rm -f "$CALLS"
+
+    # Isolate the user-level config seeding from the real $HOME, and the
+    # logind drop-in detection from the real /etc.
+    export XDG_CONFIG_HOME="$TEST_TMPDIR/config"
+    export SETUP_LOGIND_DIR="$TEST_TMPDIR/logind.conf.d"
+    unset SWAYSOCK
+
+    # sudo records its argv and discards any heredoc stdin (e.g. the logind
+    # drop-in piped to `sudo tee`) so nothing touches the real system.
+    cat > "$TEST_TMPDIR/bin/sudo" <<MOCK
+#!/bin/sh
+echo "sudo \$*" >> "$CALLS"
+exit 0
+MOCK
+
+    # systemctl: record, and make list-unit-files succeed so enable_services
+    # believes power-profiles-daemon exists.
+    cat > "$TEST_TMPDIR/bin/systemctl" <<MOCK
+#!/bin/sh
+echo "systemctl \$*" >> "$CALLS"
+exit 0
+MOCK
+
+    # Package managers: record calls, to prove setup-sway installs nothing.
+    for cmd in pacman apt-get dnf; do
+        cat > "$TEST_TMPDIR/bin/$cmd" <<MOCK
+#!/bin/sh
+echo "$cmd \$*" >> "$CALLS"
+exit 0
+MOCK
+    done
+
+    chmod +x "$TEST_TMPDIR"/bin/*
+}
+
+teardown() {
+    rm -rf "$TEST_TMPDIR"
+}
+
+run_sway() {
+    set +e
+    output="$("$SCRIPT_DIR/setup-sway" "$@" 2>&1)"
+    status=$?
+    set -e
+}
+
+assert_status() {
+    if test "$status" -ne "$1"; then
+        echo "  FAIL: expected exit status $1, got $status"
+        echo "  output: $output"
+        TEST_FAILED=1
+        return 1
+    fi
+}
+
+assert_output_contains() {
+    case "$output" in
+        *"$1"*) ;;
+        *)
+            echo "  FAIL: output does not contain '$1'"
+            echo "  output: $output"
+            TEST_FAILED=1
+            return 1
+            ;;
+    esac
+}
+
+assert_called() {
+    if ! grep -q "$1" "$CALLS" 2>/dev/null; then
+        echo "  FAIL: expected call '$1' not found"
+        echo "  calls: $(cat "$CALLS" 2>/dev/null)"
+        TEST_FAILED=1
+        return 1
+    fi
+}
+
+assert_not_called() {
+    if grep -q "$1" "$CALLS" 2>/dev/null; then
+        echo "  FAIL: unexpected call '$1' found"
+        echo "  calls: $(cat "$CALLS" 2>/dev/null)"
+        TEST_FAILED=1
+        return 1
+    fi
+}
+
+assert_file_contains() {
+    if ! grep -q "$2" "$1" 2>/dev/null; then
+        echo "  FAIL: $1 does not contain '$2'"
+        TEST_FAILED=1
+        return 1
+    fi
+}
+
+run_test() {
+    name="$1"
+    func="$2"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    setup
+    TEST_FAILED=
+    if "$func" && test -z "$TEST_FAILED"; then
+        echo "ok $TESTS_RUN $name"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        echo "not ok $TESTS_RUN $name"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+    teardown
+}
+
+# --- usage and help ---
+
+test_help_flag() {
+    run_sway --help
+    assert_status 0 &&
+    assert_output_contains "Usage: setup-sway"
+}
+
+test_h_flag() {
+    run_sway -h
+    assert_status 0 &&
+    assert_output_contains "Usage: setup-sway"
+}
+
+test_unknown_option() {
+    run_sway --bogus
+    assert_status 1 &&
+    assert_output_contains "Unknown option"
+}
+
+# --- packages are NOT installed here (the top-level `setup` does that) ---
+
+test_does_not_install_packages() {
+    run_sway
+    assert_status 0 &&
+    assert_not_called "pacman -S" &&
+    assert_not_called "apt-get install" &&
+    assert_not_called "dnf install"
+}
+
+# --- logind lid drop-in ---
+
+test_installs_logind_lid_dropin() {
+    run_sway
+    assert_status 0 &&
+    assert_called "sudo mkdir -p $SETUP_LOGIND_DIR" &&
+    assert_called "sudo tee $SETUP_LOGIND_DIR/10-sway-lid.conf"
+}
+
+test_reloads_logind() {
+    run_sway
+    assert_status 0 &&
+    assert_called "sudo systemctl kill -s HUP systemd-logind"
+}
+
+# Shared with the Hyprland build: when a drop-in (e.g. setup-hypr's) already
+# ignores the lid, nothing is written.
+test_skips_dropin_when_lid_already_ignored() {
+    mkdir -p "$SETUP_LOGIND_DIR"
+    printf '[Login]\nHandleLidSwitch=ignore\n' > "$SETUP_LOGIND_DIR/10-hypr-lid.conf"
+    run_sway
+    assert_status 0 &&
+    assert_output_contains "already ignores the lid" &&
+    assert_not_called "sudo tee"
+}
+
+# --- services ---
+
+test_enables_power_profiles_daemon() {
+    run_sway
+    assert_status 0 &&
+    assert_called "sudo systemctl enable --now power-profiles-daemon"
+}
+
+# --no-install skips the system-modifying steps.
+test_no_install_skips_system_changes() {
+    run_sway --no-install
+    assert_status 0 &&
+    assert_not_called "sudo tee" &&
+    assert_output_contains "Skipping logind"
+}
+
+# --- per-host config.local seeding ---
+
+test_seeds_config_local_from_template() {
+    mkdir -p "$XDG_CONFIG_HOME/sway"
+    echo "# template body" > "$XDG_CONFIG_HOME/sway/config.local.template"
+    run_sway
+    assert_status 0 &&
+    assert_output_contains "Created" &&
+    assert_file_contains "$XDG_CONFIG_HOME/sway/config.local" "template body"
+}
+
+test_never_overwrites_existing_config_local() {
+    mkdir -p "$XDG_CONFIG_HOME/sway"
+    echo "# template body" > "$XDG_CONFIG_HOME/sway/config.local.template"
+    echo "# my precious overrides" > "$XDG_CONFIG_HOME/sway/config.local"
+    run_sway
+    assert_status 0 &&
+    assert_output_contains "leaving it alone" &&
+    assert_file_contains "$XDG_CONFIG_HOME/sway/config.local" "my precious overrides"
+}
+
+test_warns_when_template_missing() {
+    run_sway
+    assert_status 0 &&
+    assert_output_contains "config.local.template not found"
+}
+
+# Seeding is user-level config, not a system change: it happens even under
+# --no-install.
+test_no_install_still_seeds_config_local() {
+    mkdir -p "$XDG_CONFIG_HOME/sway"
+    echo "# template body" > "$XDG_CONFIG_HOME/sway/config.local.template"
+    run_sway --no-install
+    assert_status 0 &&
+    assert_file_contains "$XDG_CONFIG_HOME/sway/config.local" "template body"
+}
+
+# Inside a Sway session, the detected output names are appended as comments.
+test_appends_detected_outputs_inside_sway() {
+    mkdir -p "$XDG_CONFIG_HOME/sway"
+    echo "# template body" > "$XDG_CONFIG_HOME/sway/config.local.template"
+    cat > "$TEST_TMPDIR/bin/swaymsg" <<'MOCK'
+#!/bin/sh
+printf '[ { "name": "eDP-1", "active": true }, { "name": "DP-3", "active": true } ]\n'
+MOCK
+    chmod +x "$TEST_TMPDIR/bin/swaymsg"
+    export SWAYSOCK=/tmp/fake-sock
+    run_sway
+    assert_status 0 &&
+    assert_file_contains "$XDG_CONFIG_HOME/sway/config.local" "Outputs detected" &&
+    assert_file_contains "$XDG_CONFIG_HOME/sway/config.local" "#   eDP-1" &&
+    assert_file_contains "$XDG_CONFIG_HOME/sway/config.local" "#   DP-3"
+}
+
+run_test "help flag" test_help_flag
+run_test "-h flag" test_h_flag
+run_test "unknown option errors" test_unknown_option
+run_test "does not install packages (setup does)" test_does_not_install_packages
+run_test "installs logind lid drop-in" test_installs_logind_lid_dropin
+run_test "reloads logind" test_reloads_logind
+run_test "skips drop-in when the lid is already ignored (shared with hypr)" \
+    test_skips_dropin_when_lid_already_ignored
+run_test "enables power-profiles-daemon" test_enables_power_profiles_daemon
+run_test "no-install skips system changes" test_no_install_skips_system_changes
+run_test "seeds config.local from the template" test_seeds_config_local_from_template
+run_test "never overwrites an existing config.local" \
+    test_never_overwrites_existing_config_local
+run_test "warns when the template is missing" test_warns_when_template_missing
+run_test "no-install still seeds config.local" test_no_install_still_seeds_config_local
+run_test "appends detected outputs inside a sway session" \
+    test_appends_detected_outputs_inside_sway
+
+echo
+echo "$TESTS_RUN tests, $TESTS_PASSED passed, $TESTS_FAILED failed"
+test "$TESTS_FAILED" -eq 0

--- a/setup_test
+++ b/setup_test
@@ -131,6 +131,22 @@ test_sway_package_names() {
     assert_source_not_contains "xdg-desktop-portal-sway"
 }
 
+# The shared Wayland stack (waybar/fuzzel/swaync/power-profiles-daemon/...,
+# used by BOTH the Hyprland and Sway builds) must install in its own
+# transaction: apt/dnf abort a transaction on one unavailable package, so a
+# release without hyprland must not take the shared pieces down with it.
+# Join the backslash-continued lines first so each install command is one
+# line, then make sure no install command mixes hyprland with waybar.
+test_shared_wayland_stack_decoupled() {
+    joined=$(sed -e ':a' -e '/\\$/N; s/\\\n//; ta' "$SETUP")
+    if printf '%s\n' "$joined" | grep 'install' | grep 'hyprland' | grep -q 'waybar'; then
+        echo "  FAIL: hyprland and waybar share an install transaction"
+        TEST_FAILED=1
+        return 1
+    fi
+    assert_source_contains "Installing shared Wayland desktop packages"
+}
+
 run_test "help flag" test_help_flag
 run_test "-h flag" test_h_flag
 run_test "unknown option errors" test_unknown_option
@@ -140,6 +156,8 @@ run_test "Hyprland portal package is xdg-desktop-portal-hyprland" \
     test_hypr_portal_package_name
 run_test "--sway flag dispatches to setup-sway" test_sway_flag_and_dispatch
 run_test "Sway package names are the upstream ones" test_sway_package_names
+run_test "shared Wayland stack installs independently of hyprland" \
+    test_shared_wayland_stack_decoupled
 
 echo
 echo "$TESTS_RUN tests, $TESTS_PASSED passed, $TESTS_FAILED failed"

--- a/setup_test
+++ b/setup_test
@@ -112,6 +112,25 @@ test_hypr_portal_package_name() {
     assert_source_not_contains '[^-]hyprland-portal'
 }
 
+# --- Sway desktop ---
+
+# --sway selects the Sway desktop and dispatches to setup-sway, mirroring
+# --kde/--hypr.
+test_sway_flag_and_dispatch() {
+    assert_source_contains '[-]-sway)' &&
+    assert_source_contains "DESKTOP=sway" &&
+    assert_source_contains "setup-sway"
+}
+
+# The Sway stack packages ship under their upstream names in the default
+# Debian and Fedora repos; wlroots' portal is xdg-desktop-portal-wlr (not
+# "-sway"). One bad name would abort the whole apt/dnf line.
+test_sway_package_names() {
+    assert_source_contains "sway swaybg swayidle swaylock xdg-desktop-portal-wlr" &&
+    assert_source_contains "autotiling" &&
+    assert_source_not_contains "xdg-desktop-portal-sway"
+}
+
 run_test "help flag" test_help_flag
 run_test "-h flag" test_h_flag
 run_test "unknown option errors" test_unknown_option
@@ -119,6 +138,8 @@ run_test "hypridle/hyprlock package names are the upstream ones" \
     test_hypr_idle_lock_package_names
 run_test "Hyprland portal package is xdg-desktop-portal-hyprland" \
     test_hypr_portal_package_name
+run_test "--sway flag dispatches to setup-sway" test_sway_flag_and_dispatch
+run_test "Sway package names are the upstream ones" test_sway_package_names
 
 echo
 echo "$TESTS_RUN tests, $TESTS_PASSED passed, $TESTS_FAILED failed"

--- a/setup_test
+++ b/setup_test
@@ -154,10 +154,23 @@ run_test "hypridle/hyprlock package names are the upstream ones" \
     test_hypr_idle_lock_package_names
 run_test "Hyprland portal package is xdg-desktop-portal-hyprland" \
     test_hypr_portal_package_name
+# swaync's distro package names differ from the upstream project name --
+# apt has sway-notification-center (Ubuntu 24.04 / Debian 13), Fedora has
+# SwayNotificationCenter -- and one wrong name in a multi-package apt/dnf
+# transaction aborts the rest. It must be installed in its own transaction
+# under the distro name (upstream name as the fallback).
+test_swaync_package_names() {
+    assert_source_contains "sway-notification-center" &&
+    assert_source_contains "SwayNotificationCenter" &&
+    assert_source_not_contains "fuzzel swaync"
+}
+
 run_test "--sway flag dispatches to setup-sway" test_sway_flag_and_dispatch
 run_test "Sway package names are the upstream ones" test_sway_package_names
 run_test "shared Wayland stack installs independently of hyprland" \
     test_shared_wayland_stack_decoupled
+run_test "swaync installs under its distro package names, decoupled" \
+    test_swaync_package_names
 
 echo
 echo "$TESTS_RUN tests, $TESTS_PASSED passed, $TESTS_FAILED failed"


### PR DESCRIPTION
Companion to conf#198 (the Sway Wayland desktop in `config/sway`). Like `setup-hypr`, **`setup-sway` is config-only** — packages come from the top-level `setup`:

- Installs the **systemd-logind lid drop-in** (`HandleLidSwitch=ignore` + variants) so Sway's `lid.sh` is the sole lid handler. The policy is **shared with the Hyprland build**: if any drop-in already ignores the lid (e.g. setup-hypr's `10-hypr-lid.conf`), nothing is written. Includes the agreed TODO about maybe flipping to logind-owned suspend (`HandleLidSwitch=suspend` + `HandleLidSwitchDocked=ignore`) for both builds together.
- Enables **power-profiles-daemon** (waybar's power-profile module).
- **Seeds `~/.config/sway/config.local`** from the template conf installs (never overwrites — idempotent and safe to re-run), appending the machine's detected output names as comments when run inside a Sway session. This is the only genuinely runtime-discovery step; everything else stays in static shared config.
- Sources `setup-sway.local`, mirroring the setup-kde/setup-hypr hook.

`setup` gains `--sway` (`DESKTOP=sway` → dispatch to setup-sway) and installs the Sway packages (`sway swaybg swayidle swaylock xdg-desktop-portal-wlr`, plus `autotiling` separately with a pipx fallback warning) unconditionally alongside the KDE/Hyprland ones on both Debian and Fedora — all default-repo, no COPR needed.

Tests: `setup-sway_test` (14 cases, mirroring `setup-hypr_test`, plus the drop-in-sharing and config.local seeding behaviours; the logind dir is overridable via `SETUP_LOGIND_DIR` so tests never read the real /etc), two new `setup_test` cases (`--sway` dispatch, Sway package names), and Makefile wiring. Full `make test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M6EJsiAH9MbbxJV9Z1iCLG

---
_Generated by [Claude Code](https://claude.ai/code/session_01M6EJsiAH9MbbxJV9Z1iCLG)_