### PR TITLE
setup-hypr: seed a per-machine hyprland.conf.local

### DIFF
--- a/setup-hypr
+++ b/setup-hypr
@@ -12,6 +12,11 @@
 #   internal panel on close, and suspend only when no external display is
 #   connected.
 # - Enable power-profiles-daemon (used by the waybar power-profiles module).
+# - Seed ~/.config/hypr/hyprland.conf.local (per-machine overrides: pinned
+#   monitor rules, extra launchers, device tweaks) from the installed
+#   template. Never overwrites an existing one. hyprland.conf sources the
+#   file, and Hyprland reports an error when a sourced file is missing, so
+#   an (empty) file must exist on every machine.
 #
 # Usage:
 #     setup-hypr [--no-install] [--ignore-errors] [-h | --help]
@@ -125,6 +130,46 @@ enable_services() {
     fi
 }
 
+# --- Per-machine hyprland.conf.local ---
+
+# Seed ~/.config/hypr/hyprland.conf.local from the template conf's
+# `make install` ships, mirroring setup-sway's config.local seeding. The
+# shared hyprland.conf sources it last so per-machine overrides win; it must
+# exist (even empty) or Hyprland reports a config error for the missing
+# sourced file. Never overwrite an existing one -- re-running setup-hypr
+# must be safe.
+seed_conf_local() {
+    cfgdir="${XDG_CONFIG_HOME:-$HOME/.config}/hypr"
+    local_file="$cfgdir/hyprland.conf.local"
+    template="$cfgdir/hyprland.conf.local.template"
+    if test -f "$local_file"; then
+        info "Per-machine config already exists ($local_file); leaving it alone"
+        return 0
+    fi
+    mkdir -p "$cfgdir"
+    if test -f "$template"; then
+        cp "$template" "$local_file"
+        info "Created $local_file from the template"
+    else
+        warn "hyprland.conf.local.template not found ($template); run conf's 'make install' first"
+        # Create an empty file anyway so hyprland.conf's `source` line
+        # doesn't raise a config error at startup.
+        : > "$local_file"
+        info "Created empty $local_file"
+    fi
+    # Inside a running Hyprland session, append this machine's monitor names
+    # as comments so filling in a pinned layout is copy-paste.
+    if test -n "$HYPRLAND_INSTANCE_SIGNATURE" && is_command hyprctl; then
+        {
+            echo ""
+            echo "# Monitors detected on this machine ($(hostname)):"
+            hyprctl monitors all -j 2>/dev/null \
+                | grep -o '"name": *"[^"]*"' | cut -d'"' -f4 \
+                | sed 's/^/#   /'
+        } >> "$local_file"
+    fi
+}
+
 # --- Main ---
 
 # The Wayland desktop packages are installed by the top-level `setup`. Here we
@@ -136,6 +181,10 @@ if test "$INSTALL" = yes; then
 else
     info "Skipping logind drop-in and service enablement (--no-install)"
 fi
+
+# Per-machine overrides are user-level config, not a system change: seed them
+# even under --no-install.
+seed_conf_local
 
 # Local overrides, mirroring setup-kde's setup-kde.local hook.
 if is_command setup-hypr.local; then

--- a/setup-hypr_test
+++ b/setup-hypr_test
@@ -16,6 +16,11 @@ setup() {
     CALLS="$TEST_TMPDIR/calls"
     rm -f "$CALLS"
 
+    # Isolate the hyprland.conf.local seeding from the real $HOME, and keep a
+    # host Hyprland session from leaking into the monitor-detection path.
+    export XDG_CONFIG_HOME="$TEST_TMPDIR/config"
+    unset HYPRLAND_INSTANCE_SIGNATURE
+
     # sudo records its argv and discards any heredoc stdin (e.g. the logind
     # drop-in piped to `sudo tee`) so nothing touches the real system.
     cat > "$TEST_TMPDIR/bin/sudo" <<MOCK
@@ -172,6 +177,62 @@ test_no_install_skips_system_changes() {
     assert_output_contains "Skipping logind"
 }
 
+# --- per-machine hyprland.conf.local seeding ---
+
+assert_file_contains() {
+    if ! grep -q "$2" "$1" 2>/dev/null; then
+        echo "  FAIL: $1 does not contain '$2'"
+        TEST_FAILED=1
+        return 1
+    fi
+}
+
+test_seeds_conf_local_from_template() {
+    mkdir -p "$XDG_CONFIG_HOME/hypr"
+    echo "# template body" > "$XDG_CONFIG_HOME/hypr/hyprland.conf.local.template"
+    run_hypr
+    assert_status 0 &&
+    assert_output_contains "Created" &&
+    assert_file_contains "$XDG_CONFIG_HOME/hypr/hyprland.conf.local" "template body"
+}
+
+# hyprland.conf sources the file, and Hyprland errors on a missing sourced
+# file, so even without the template an empty file must be created.
+test_creates_empty_conf_local_without_template() {
+    run_hypr
+    assert_status 0 &&
+    assert_output_contains "template not found" &&
+    test -f "$XDG_CONFIG_HOME/hypr/hyprland.conf.local"
+}
+
+test_never_overwrites_existing_conf_local() {
+    mkdir -p "$XDG_CONFIG_HOME/hypr"
+    echo "# template body" > "$XDG_CONFIG_HOME/hypr/hyprland.conf.local.template"
+    echo "# my precious overrides" > "$XDG_CONFIG_HOME/hypr/hyprland.conf.local"
+    run_hypr
+    assert_status 0 &&
+    assert_output_contains "leaving it alone" &&
+    assert_file_contains "$XDG_CONFIG_HOME/hypr/hyprland.conf.local" "my precious overrides"
+}
+
+# Inside a Hyprland session, the detected monitor names are appended as
+# comments.
+test_appends_detected_monitors_inside_hyprland() {
+    mkdir -p "$XDG_CONFIG_HOME/hypr"
+    echo "# template body" > "$XDG_CONFIG_HOME/hypr/hyprland.conf.local.template"
+    cat > "$TEST_TMPDIR/bin/hyprctl" <<'MOCK'
+#!/bin/sh
+printf '[ { "name": "eDP-1" }, { "name": "DP-3" } ]\n'
+MOCK
+    chmod +x "$TEST_TMPDIR/bin/hyprctl"
+    export HYPRLAND_INSTANCE_SIGNATURE=fake-sig
+    run_hypr
+    assert_status 0 &&
+    assert_file_contains "$XDG_CONFIG_HOME/hypr/hyprland.conf.local" "Monitors detected" &&
+    assert_file_contains "$XDG_CONFIG_HOME/hypr/hyprland.conf.local" "#   eDP-1" &&
+    assert_file_contains "$XDG_CONFIG_HOME/hypr/hyprland.conf.local" "#   DP-3"
+}
+
 run_test "help flag" test_help_flag
 run_test "-h flag" test_h_flag
 run_test "unknown option errors" test_unknown_option
@@ -180,6 +241,14 @@ run_test "installs logind lid drop-in" test_installs_logind_lid_dropin
 run_test "reloads logind" test_reloads_logind
 run_test "enables power-profiles-daemon" test_enables_power_profiles_daemon
 run_test "no-install skips system changes" test_no_install_skips_system_changes
+run_test "seeds hyprland.conf.local from the template" \
+    test_seeds_conf_local_from_template
+run_test "creates an empty hyprland.conf.local without the template" \
+    test_creates_empty_conf_local_without_template
+run_test "never overwrites an existing hyprland.conf.local" \
+    test_never_overwrites_existing_conf_local
+run_test "appends detected monitors inside a hyprland session" \
+    test_appends_detected_monitors_inside_hyprland
 
 echo
 echo "$TESTS_RUN tests, $TESTS_PASSED passed, $TESTS_FAILED failed"


### PR DESCRIPTION
Companion to conf#199, which makes `hyprland.conf` source **`~/.config/hypr/hyprland.conf.local`** (same file name plus a `.local` suffix, like Sway's `config.local`) for per-machine overrides. Hyprland raises a config-error notice when a sourced file is missing, so the file must exist on every machine — `setup-hypr` now seeds it, mirroring `setup-sway`'s `config.local` seeding:

- Copies the installed `hyprland.conf.local.template` to `~/.config/hypr/hyprland.conf.local` if it doesn't exist; **never overwrites** an existing one (idempotent, safe to re-run).
- Falls back to creating an **empty** file (with a warning) when the template isn't installed yet, so the `source` line stays error-free either way.
- When run inside a Hyprland session, appends the machine's detected monitor names as comments (via `hyprctl monitors all -j`) so filling in a pinned layout is copy-paste.
- Runs even under `--no-install` — it's user-level config, not a system change, matching setup-sway.

Tests: 4 new `setup-hypr_test` cases (seed-from-template, empty-file fallback, never-overwrite, monitor-name append with a mocked `hyprctl`), plus `XDG_CONFIG_HOME` isolation in the test harness so nothing touches the real `$HOME`. 12/12 pass; full `make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M6EJsiAH9MbbxJV9Z1iCLG

---
_Generated by [Claude Code](https://claude.ai/code/session_01M6EJsiAH9MbbxJV9Z1iCLG)_