### PR TITLE
setup-hypr: only seed real monitor names into hyprland.conf.local

### DIFF
--- a/setup-hypr
+++ b/setup-hypr
@@ -158,14 +158,22 @@ seed_conf_local() {
         info "Created empty $local_file"
     fi
     # Inside a running Hyprland session, append this machine's monitor names
-    # as comments so filling in a pinned layout is copy-paste.
+    # as comments so filling in a pinned layout is copy-paste. Prefer jq
+    # (`setup` installs it): a bare grep for "name" would also pick up the
+    # nested activeWorkspace/specialWorkspace names in the monitor JSON.
+    # Without jq, parse the plain-text output's "Monitor <name> (ID n):"
+    # headers instead, which only exist at the monitor level.
     if test -n "$HYPRLAND_INSTANCE_SIGNATURE" && is_command hyprctl; then
+        if is_command jq; then
+            monitors=$(hyprctl monitors all -j 2>/dev/null | jq -r '.[].name')
+        else
+            monitors=$(hyprctl monitors all 2>/dev/null \
+                | sed -n 's/^Monitor \([^ ]*\).*/\1/p')
+        fi
         {
             echo ""
             echo "# Monitors detected on this machine ($(hostname)):"
-            hyprctl monitors all -j 2>/dev/null \
-                | grep -o '"name": *"[^"]*"' | cut -d'"' -f4 \
-                | sed 's/^/#   /'
+            printf '%s\n' "$monitors" | sed 's/^/#   /'
         } >> "$local_file"
     fi
 }

--- a/setup-hypr_test
+++ b/setup-hypr_test
@@ -215,14 +215,32 @@ test_never_overwrites_existing_conf_local() {
     assert_file_contains "$XDG_CONFIG_HOME/hypr/hyprland.conf.local" "my precious overrides"
 }
 
+assert_file_not_contains_line() {
+    if grep -q "^$2\$" "$1" 2>/dev/null; then
+        echo "  FAIL: $1 contains unwanted line '$2'"
+        TEST_FAILED=1
+        return 1
+    fi
+}
+
 # Inside a Hyprland session, the detected monitor names are appended as
-# comments.
+# comments -- and ONLY monitor names: the monitor JSON nests
+# activeWorkspace/specialWorkspace objects that also have "name" keys, which
+# must not leak in as bogus hints (jq path), and the plain-text fallback must
+# only take the "Monitor <name> (ID n):" headers. The mock serves both forms.
 test_appends_detected_monitors_inside_hyprland() {
     mkdir -p "$XDG_CONFIG_HOME/hypr"
     echo "# template body" > "$XDG_CONFIG_HOME/hypr/hyprland.conf.local.template"
     cat > "$TEST_TMPDIR/bin/hyprctl" <<'MOCK'
 #!/bin/sh
-printf '[ { "name": "eDP-1" }, { "name": "DP-3" } ]\n'
+case "$*" in
+    *-j*)
+        printf '[ { "name": "eDP-1", "activeWorkspace": { "id": 1, "name": "1" }, "specialWorkspace": { "id": 0, "name": "" } }, { "name": "DP-3", "activeWorkspace": { "id": 2, "name": "2" }, "specialWorkspace": { "id": 0, "name": "" } } ]\n'
+        ;;
+    *)
+        printf 'Monitor eDP-1 (ID 0):\n\tactive workspace: 1 (1)\nMonitor DP-3 (ID 1):\n\tactive workspace: 2 (2)\n'
+        ;;
+esac
 MOCK
     chmod +x "$TEST_TMPDIR/bin/hyprctl"
     export HYPRLAND_INSTANCE_SIGNATURE=fake-sig
@@ -230,7 +248,10 @@ MOCK
     assert_status 0 &&
     assert_file_contains "$XDG_CONFIG_HOME/hypr/hyprland.conf.local" "Monitors detected" &&
     assert_file_contains "$XDG_CONFIG_HOME/hypr/hyprland.conf.local" "#   eDP-1" &&
-    assert_file_contains "$XDG_CONFIG_HOME/hypr/hyprland.conf.local" "#   DP-3"
+    assert_file_contains "$XDG_CONFIG_HOME/hypr/hyprland.conf.local" "#   DP-3" &&
+    assert_file_not_contains_line "$XDG_CONFIG_HOME/hypr/hyprland.conf.local" "#   1" &&
+    assert_file_not_contains_line "$XDG_CONFIG_HOME/hypr/hyprland.conf.local" "#   2" &&
+    assert_file_not_contains_line "$XDG_CONFIG_HOME/hypr/hyprland.conf.local" "#   "
 }
 
 run_test "help flag" test_help_flag


### PR DESCRIPTION
Follow-up to #121, addressing the Codex review comment that landed after the merge: `hyprctl monitors all -j` nests `activeWorkspace`/`specialWorkspace` objects that also carry `"name"` keys, so the bare grep seeded workspace names (`1`, `2`, empty specials) into the detected-monitors comments alongside the real outputs, making the copy-paste hints wrong on any multi-monitor machine.

- The extraction now uses `jq -r '.[].name'` (jq is already in `setup`'s base package list on both distros), taking only the top-level monitor names.
- Fallback for jq-less machines: parse the plain-text `hyprctl monitors all` output's `Monitor <name> (ID n):` headers, which only exist at the monitor level.
- The test's `hyprctl` mock now serves both the JSON (with nested workspace names) and plain-text forms, and asserts the workspace names do **not** leak into the seeded file. 12/12 pass; full `make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M6EJsiAH9MbbxJV9Z1iCLG

---
_Generated by [Claude Code](https://claude.ai/code/session_01M6EJsiAH9MbbxJV9Z1iCLG)_