### PR TITLE
setup-kde: harden Plasma against hotplug and resume crashes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,4 @@ test:
 	./setup-hypr_test
 	./setup-sway_test
 	./setup-kde_test
+	./kde-recover_test

--- a/kde-recover
+++ b/kde-recover
@@ -1,0 +1,148 @@
+#!/bin/bash
+# Recover a wedged KDE Plasma 6 session.
+#
+# For when plasmashell has crashed or hung (commonly after resume from
+# sleep or a monitor hotplug), or a hotplug left the session with no
+# enabled outputs. Steps, each best-effort:
+#
+# 1. Re-enable outputs when EVERY connected output ended up disabled (a
+#    single disabled output may be deliberate, e.g. a closed laptop lid on
+#    a dock; zero enabled outputs never is).
+# 2. Restart plasmashell -- via its systemd user unit when available
+#    (clearing any exhausted start-rate limit first), otherwise by
+#    quitting and relaunching it directly.
+# 3. Restart kded, which hosts the kscreen module that applies display
+#    profiles on hotplug.
+# 4. Ask KWin to reload its configuration.
+#
+# setup-kde binds this to Meta+Shift+R. kglobalaccel runs inside kwin, so
+# the shortcut works even when plasmashell is dead and there is no panel
+# left to click -- whenever this script can help, kwin is still alive.
+#
+# Usage:
+#     kde-recover [-h | --help]
+
+info() {
+    printf "%s\n" "$*"
+}
+
+warn() {
+    printf "Warning: %s\n" "$*" >&2
+}
+
+usage() {
+    cat <<'USAGE'
+Usage: kde-recover [-h | --help]
+
+Recover a wedged KDE Plasma session: re-enable outputs when all are
+disabled, restart plasmashell and kded, and reload KWin's configuration.
+USAGE
+}
+
+while test $# -gt 0; do
+    case "$1" in
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            warn "Unknown option: $1"
+            usage >&2
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+qdbus_cmd() {
+    if command -v qdbus6 >/dev/null 2>&1; then
+        qdbus6 "$@"
+    elif command -v qdbus >/dev/null 2>&1; then
+        qdbus "$@"
+    else
+        return 1
+    fi
+}
+
+# When no connected output is enabled, enable them all. kscreen-doctor -j
+# reports every output; filter in python3 rather than parsing the colored
+# human-readable output.
+reenable_outputs() {
+    command -v kscreen-doctor >/dev/null 2>&1 || return 0
+    json="$(kscreen-doctor -j 2>/dev/null)" || return 0
+    test -n "$json" || return 0
+    to_enable="$(printf '%s' "$json" | python3 -c '
+import json, sys
+try:
+    outputs = json.load(sys.stdin).get("outputs", [])
+except Exception:
+    sys.exit(0)
+connected = [o for o in outputs if o.get("connected")]
+if any(o.get("enabled") for o in connected):
+    sys.exit(0)
+for o in connected:
+    if o.get("name"):
+        print(o["name"])
+')"
+    test -n "$to_enable" || return 0
+    for name in $to_enable; do
+        info "No outputs enabled; re-enabling $name"
+        kscreen-doctor "output.$name.enable" \
+            || warn "could not enable output $name"
+    done
+}
+
+# True when the plasmashell systemd user unit exists (Plasma 6's default
+# systemd-managed session).
+have_plasmashell_unit() {
+    command -v systemctl >/dev/null 2>&1 \
+        && systemctl --user cat plasma-plasmashell.service >/dev/null 2>&1
+}
+
+restart_plasmashell() {
+    if have_plasmashell_unit; then
+        info "Restarting plasmashell via systemd"
+        # reset-failed clears an exhausted start-rate limit, without which
+        # the restart of a crash-looped unit is refused.
+        systemctl --user reset-failed plasma-plasmashell.service 2>/dev/null
+        systemctl --user restart plasma-plasmashell.service \
+            && return 0
+        warn "systemctl restart failed; falling back to a direct relaunch"
+    fi
+    info "Restarting plasmashell directly"
+    if command -v kquitapp6 >/dev/null 2>&1; then
+        kquitapp6 plasmashell >/dev/null 2>&1
+    else
+        pkill -x plasmashell 2>/dev/null
+    fi
+    # Give the old instance a moment to release its Wayland/X resources.
+    sleep 1
+    if command -v kstart >/dev/null 2>&1; then
+        kstart plasmashell >/dev/null 2>&1 \
+            || warn "kstart plasmashell failed"
+    else
+        (setsid plasmashell >/dev/null 2>&1 &)
+    fi
+}
+
+# kded hosts the kscreen module that applies saved display profiles on
+# hotplug; a dead or wedged kded is a common reason hotplug "does nothing".
+# try-restart only touches it if it's running. The unit has been named both
+# plasma-kded6 and plasma-kded across distros/releases; try both.
+restart_kded() {
+    command -v systemctl >/dev/null 2>&1 || return 0
+    systemctl --user try-restart plasma-kded6.service 2>/dev/null \
+        || systemctl --user try-restart plasma-kded.service 2>/dev/null \
+        || true
+}
+
+reload_kwin() {
+    qdbus_cmd org.kde.KWin /KWin reconfigure >/dev/null 2>&1 \
+        || warn "could not ask KWin to reconfigure"
+}
+
+reenable_outputs
+restart_plasmashell
+restart_kded
+reload_kwin
+info "Recovery steps complete"

--- a/kde-recover_test
+++ b/kde-recover_test
@@ -1,0 +1,224 @@
+#!/bin/sh
+# Tests for kde-recover
+#
+# Runs kde-recover against mocked KDE/systemd CLI tools and checks the
+# recovery steps: plasmashell restarts through systemd when its unit
+# exists (clearing the start-rate limit first) and falls back to
+# kquitapp6/kstart when it doesn't, KWin is asked to reconfigure, and
+# outputs are re-enabled only when kscreen-doctor reports that every
+# connected output is disabled.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+setup() {
+    TEST_TMPDIR="$(mktemp -d)"
+    CALLS="$TEST_TMPDIR/calls"
+    rm -f "$CALLS"
+    mkdir -p "$TEST_TMPDIR/bin" "$TEST_TMPDIR/home"
+    SCRIPT="$SCRIPT_DIR/kde-recover"
+
+    # Simple mocks: record argv, touch nothing real.
+    for cmd in qdbus6 kstart kquitapp6; do
+        cat > "$TEST_TMPDIR/bin/$cmd" <<MOCK
+#!/bin/sh
+echo "$cmd \$*" >> "$CALLS"
+exit 0
+MOCK
+    done
+
+    # systemctl: records and succeeds for every subcommand, so
+    # `systemctl --user cat plasma-plasmashell.service` reports the unit
+    # as present and the systemd restart path is taken.
+    cat > "$TEST_TMPDIR/bin/systemctl" <<MOCK
+#!/bin/sh
+echo "systemctl \$*" >> "$CALLS"
+exit 0
+MOCK
+
+    # kscreen-doctor: -j replays a canned JSON report (written per-test by
+    # set_outputs); every call is recorded.
+    cat > "$TEST_TMPDIR/bin/kscreen-doctor" <<MOCK
+#!/bin/sh
+echo "kscreen-doctor \$*" >> "$CALLS"
+if test "\$1" = -j; then
+    cat "$TEST_TMPDIR/kscreen.json" 2>/dev/null
+fi
+exit 0
+MOCK
+
+    chmod +x "$TEST_TMPDIR"/bin/*
+}
+
+teardown() {
+    rm -rf "$TEST_TMPDIR"
+}
+
+# Make `systemctl --user cat ...` fail, simulating a session where the
+# plasmashell unit doesn't exist (non-systemd Plasma startup).
+remove_plasmashell_unit() {
+    cat > "$TEST_TMPDIR/bin/systemctl" <<MOCK
+#!/bin/sh
+echo "systemctl \$*" >> "$CALLS"
+case "\$*" in
+    *" cat "*) exit 1 ;;
+esac
+exit 0
+MOCK
+    chmod +x "$TEST_TMPDIR/bin/systemctl"
+}
+
+# Write the JSON that the kscreen-doctor mock replays for -j.
+set_outputs() {
+    printf '%s' "$1" > "$TEST_TMPDIR/kscreen.json"
+}
+
+run_recover() {
+    set +e
+    output="$(HOME="$TEST_TMPDIR/home" \
+        PATH="$TEST_TMPDIR/bin:/usr/local/bin:/usr/bin:/bin" \
+        "$SCRIPT" "$@" 2>&1)"
+    status=$?
+    set -e
+}
+
+assert_status() {
+    if test "$status" -ne "$1"; then
+        echo "  FAIL: expected exit status $1, got $status"
+        echo "  output: $output"
+        TEST_FAILED=1
+        return 1
+    fi
+}
+
+assert_output_contains() {
+    case "$output" in
+        *"$1"*) ;;
+        *)
+            echo "  FAIL: output does not contain '$1'"
+            echo "  output: $output"
+            TEST_FAILED=1
+            return 1
+            ;;
+    esac
+}
+
+assert_called() {
+    if ! grep -q "$1" "$CALLS" 2>/dev/null; then
+        echo "  FAIL: expected call '$1' not found"
+        echo "  calls: $(cat "$CALLS" 2>/dev/null)"
+        TEST_FAILED=1
+        return 1
+    fi
+}
+
+assert_not_called() {
+    if grep -q "$1" "$CALLS" 2>/dev/null; then
+        echo "  FAIL: unexpected call '$1' found"
+        echo "  calls: $(cat "$CALLS" 2>/dev/null)"
+        TEST_FAILED=1
+        return 1
+    fi
+}
+
+run_test() {
+    name="$1"
+    func="$2"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    setup
+    TEST_FAILED=
+    if "$func" && test -z "$TEST_FAILED"; then
+        echo "ok $TESTS_RUN $name"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        echo "not ok $TESTS_RUN $name"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+    teardown
+}
+
+# --- usage and help ---
+
+test_help_flag() {
+    run_recover --help
+    assert_status 0 &&
+    assert_output_contains "Usage: kde-recover"
+}
+
+test_unknown_option() {
+    run_recover --bogus
+    assert_status 1 &&
+    assert_output_contains "Unknown option"
+}
+
+# --- plasmashell restart ---
+
+# With the systemd unit present, restart goes through systemctl, clearing
+# any exhausted start-rate limit first; no direct kill/relaunch happens.
+test_restarts_plasmashell_via_systemd() {
+    set_outputs '{"outputs":[{"name":"eDP-1","connected":true,"enabled":true}]}'
+    run_recover
+    assert_status 0 &&
+    assert_called "systemctl --user reset-failed plasma-plasmashell.service" &&
+    assert_called "systemctl --user restart plasma-plasmashell.service" &&
+    assert_not_called "kstart plasmashell" &&
+    assert_called "qdbus6 org.kde.KWin /KWin reconfigure"
+}
+
+# Without the unit, plasmashell is quit and relaunched directly.
+test_restarts_plasmashell_directly_without_unit() {
+    remove_plasmashell_unit
+    set_outputs '{"outputs":[{"name":"eDP-1","connected":true,"enabled":true}]}'
+    run_recover
+    assert_status 0 &&
+    assert_called "kquitapp6 plasmashell" &&
+    assert_called "kstart plasmashell" &&
+    assert_not_called "systemctl --user restart plasma-plasmashell.service"
+}
+
+# --- output re-enabling ---
+
+# All connected outputs disabled: every connected one is re-enabled, but
+# never a disconnected port.
+test_reenables_outputs_when_all_disabled() {
+    set_outputs '{"outputs":[
+        {"name":"eDP-1","connected":true,"enabled":false},
+        {"name":"DP-1","connected":true,"enabled":false},
+        {"name":"HDMI-A-1","connected":false,"enabled":false}]}'
+    run_recover
+    assert_status 0 &&
+    assert_called "kscreen-doctor output.eDP-1.enable" &&
+    assert_called "kscreen-doctor output.DP-1.enable" &&
+    assert_not_called "kscreen-doctor output.HDMI-A-1.enable"
+}
+
+# At least one output still enabled: a disabled output may be deliberate
+# (closed laptop lid on a dock), so nothing is touched.
+test_leaves_outputs_alone_when_one_enabled() {
+    set_outputs '{"outputs":[
+        {"name":"eDP-1","connected":true,"enabled":false},
+        {"name":"DP-1","connected":true,"enabled":true}]}'
+    run_recover
+    assert_status 0 &&
+    assert_not_called "kscreen-doctor output.eDP-1.enable" &&
+    assert_not_called "kscreen-doctor output.DP-1.enable"
+}
+
+run_test "help flag" test_help_flag
+run_test "unknown option errors" test_unknown_option
+run_test "restarts plasmashell via systemd" \
+    test_restarts_plasmashell_via_systemd
+run_test "restarts plasmashell directly without a systemd unit" \
+    test_restarts_plasmashell_directly_without_unit
+run_test "re-enables outputs when all are disabled" \
+    test_reenables_outputs_when_all_disabled
+run_test "leaves outputs alone when one is still enabled" \
+    test_leaves_outputs_alone_when_one_enabled
+
+echo
+echo "$TESTS_RUN tests, $TESTS_PASSED passed, $TESTS_FAILED failed"
+test "$TESTS_FAILED" -eq 0

--- a/setup-kde
+++ b/setup-kde
@@ -6,6 +6,9 @@
 # - Focus follows mouse (mouse precedence)
 # - Window management and desktop switching keybindings
 # - Application launch shortcuts (browser, terminal, music)
+# - Crash resilience: plasmashell/kwin_x11 auto-restart drop-ins, Xwayland
+#   crash policy, a kde-recover shortcut (Meta+Shift+R), and a warning when
+#   the NVIDIA driver isn't configured to survive suspend
 #
 # Requires: git, pnpm or npm, kpackagetool6, kwriteconfig6
 # Optional: go-task (preferred build tool), p7zip
@@ -289,6 +292,77 @@ configure_desktops() {
     kwriteconfig6 --file kwinrc --group Desktops --key Rows 1
 }
 
+# --- Harden Plasma session services ---
+
+# Plasma 6 starts the session via systemd (startkderc systemdBoot, the
+# default since 5.25), and the stock plasma-plasmashell.service already
+# restarts on failure -- but systemd's default start-rate limit (5 starts
+# in 10s) gives up during the crash loops that resume from sleep or
+# monitor hotplug can trigger, leaving the desktop with no shell until a
+# manual restart. Drop-ins lift the limit so the shell always comes back;
+# RestartSec throttles a truly persistent loop to one attempt every 2s.
+harden_plasma_services() {
+    info "Hardening Plasma session services (always restart after a crash)"
+    kwriteconfig6 --file startkderc --group General --key systemdBoot true
+
+    dropin_root="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+    # kwin_wayland is deliberately absent: on Wayland kwin IS the session,
+    # and every client dies with it, so an auto-restart can't save
+    # anything. kwin_x11 can be restarted in place.
+    for service in plasma-plasmashell plasma-kwin_x11; do
+        dropin_dir="$dropin_root/$service.service.d"
+        mkdir -p "$dropin_dir"
+        cat > "$dropin_dir/50-restart.conf" <<'DROPIN'
+# Written by setup-kde: keep restarting after crashes (e.g. after resume
+# from sleep or monitor hotplug) instead of giving up when systemd's
+# default start-rate limit (5 starts in 10s) is exceeded.
+[Unit]
+StartLimitIntervalSec=0
+
+[Service]
+Restart=on-failure
+RestartSec=2
+DROPIN
+    done
+    if command -v systemctl >/dev/null 2>&1; then
+        systemctl --user daemon-reload 2>/dev/null \
+            || warn "could not reload systemd user units; restart drop-ins apply at next login"
+    fi
+}
+
+# --- Xwayland crash policy ---
+
+# On Wayland an Xwayland crash takes every X11 app with it; with
+# XwaylandCrashPolicy=Stop it also ends X11 support for the whole session.
+# Restart (the upstream default) respawns it, but KWin stops trying after
+# XwaylandMaxCrashCount consecutive crashes (default 3), which a bad
+# resume/hotplug flurry can burn through. Be explicit and raise the budget.
+configure_xwayland_crash_policy() {
+    info "Configuring Xwayland to restart after crashes (up to 10 times)"
+    kwriteconfig6 --file kwinrc --group Wayland --key XwaylandCrashPolicy Restart
+    kwriteconfig6 --file kwinrc --group Wayland --key XwaylandMaxCrashCount 10
+}
+
+# --- Diagnose NVIDIA suspend configuration ---
+
+# The most common cause of Plasma/KWin crashing or resuming to a black or
+# corrupted desktop on NVIDIA is the driver discarding video memory across
+# suspend. The fix is system-level (a module option plus the driver's
+# suspend/resume services), so only detect and warn here rather than
+# touching system config from a user-scoped script.
+check_nvidia_suspend() {
+    test -r /proc/driver/nvidia/params || return 0
+    preserve=$(sed -n 's/^PreserveVideoMemoryAllocations: *//p' \
+        /proc/driver/nvidia/params 2>/dev/null)
+    if test "$preserve" != 1; then
+        warn "NVIDIA driver loaded without PreserveVideoMemoryAllocations=1;"
+        warn "Plasma/KWin crashes after resume from sleep are likely. To fix, as root:"
+        warn "  printf '%s\\n' 'options nvidia NVreg_PreserveAllVideoMemoryAllocations=1 NVreg_TemporaryFilePath=/var/tmp' > /etc/modprobe.d/nvidia-power.conf"
+        warn "  systemctl enable nvidia-suspend.service nvidia-resume.service nvidia-hibernate.service"
+        warn "  then regenerate the initramfs and reboot"
+    fi
+}
+
 # --- Configure keybindings ---
 
 # Third arg is the human-readable label written into the value's third
@@ -421,6 +495,12 @@ configure_app_shortcuts() {
     add_app_shortcut "terminal" "Meta+T"
     add_app_shortcut "terminal_on_workstation" "Meta+W"
     add_app_shortcut "music" "Meta+Y"
+
+    # Recovery: restart a crashed/wedged plasmashell, reload KWin, and
+    # re-enable outputs a bad hotplug left all-disabled. Bound via
+    # kglobalaccel, which lives inside kwin, so the shortcut still works
+    # when plasmashell is dead and there's no panel left to click.
+    add_app_shortcut "kde-recover" "Meta+Shift+R"
 }
 
 configure_keybindings() {
@@ -537,6 +617,9 @@ configure_krohnkite
 configure_focus_follows_mouse
 configure_dim_inactive
 configure_desktops
+harden_plasma_services
+configure_xwayland_crash_policy
+check_nvidia_suspend
 # Reload so Krohnkite registers its default shortcuts in kglobalshortcutsrc
 reload_kwin
 configure_keybindings

--- a/setup-kde_test
+++ b/setup-kde_test
@@ -21,8 +21,9 @@ setup() {
     mkdir -p "$TEST_TMPDIR/bin" "$TEST_TMPDIR/home"
     KDE_SCRIPT="$SCRIPT_DIR/setup-kde"
 
-    # KDE CLI tools: record argv, touch nothing real.
-    for cmd in kwriteconfig6 qdbus6 qdbus kbuildsycoca6; do
+    # KDE CLI tools (plus systemctl, which harden_plasma_services calls
+    # for daemon-reload): record argv, touch nothing real.
+    for cmd in kwriteconfig6 qdbus6 qdbus kbuildsycoca6 systemctl; do
         cat > "$TEST_TMPDIR/bin/$cmd" <<MOCK
 #!/bin/sh
 echo "$cmd \$*" >> "$CALLS"
@@ -87,6 +88,7 @@ MOCK
 run_kde() {
     set +e
     output="$(HOME="$TEST_TMPDIR/home" \
+        XDG_CONFIG_HOME="$TEST_TMPDIR/home/.config" \
         XDG_SESSION_TYPE=wayland \
         PATH="$TEST_TMPDIR/bin:/usr/local/bin:/usr/bin:/bin" \
         "$KDE_SCRIPT" "$@" 2>&1)"
@@ -99,6 +101,7 @@ run_kde() {
 run_kde_relative() {
     set +e
     output="$(cd "$(dirname "$KDE_SCRIPT")" && HOME="$TEST_TMPDIR/home" \
+        XDG_CONFIG_HOME="$TEST_TMPDIR/home/.config" \
         XDG_SESSION_TYPE=wayland \
         PATH="$TEST_TMPDIR/bin:/usr/local/bin:/usr/bin:/bin" \
         ./setup-kde "$@" 2>&1)"
@@ -203,6 +206,40 @@ test_configures_nine_desktops() {
     assert_called "kwriteconfig6 --file kwinrc --group Desktops --key Number 9"
 }
 
+# Crash hardening: systemd drop-ins that keep plasmashell/kwin_x11
+# restarting past the default start-rate limit, plus the explicit
+# systemdBoot so the units are used at all.
+test_hardens_plasma_services() {
+    run_kde --no-install
+    dropin_dir="$TEST_TMPDIR/home/.config/systemd/user"
+    shell_dropin="$dropin_dir/plasma-plasmashell.service.d/50-restart.conf"
+    kwin_dropin="$dropin_dir/plasma-kwin_x11.service.d/50-restart.conf"
+    assert_status 0 &&
+    assert_called "kwriteconfig6 --file startkderc --group General --key systemdBoot true" &&
+    assert_file_exists "$shell_dropin" &&
+    assert_file_exists "$kwin_dropin" &&
+    grep -q "Restart=on-failure" "$shell_dropin" &&
+    grep -q "StartLimitIntervalSec=0" "$shell_dropin" &&
+    assert_called "systemctl --user daemon-reload"
+}
+
+test_configures_xwayland_crash_policy() {
+    run_kde --no-install
+    assert_status 0 &&
+    assert_called "kwriteconfig6 --file kwinrc --group Wayland --key XwaylandCrashPolicy Restart" &&
+    assert_called "kwriteconfig6 --file kwinrc --group Wayland --key XwaylandMaxCrashCount 10"
+}
+
+# kde-recover lives beside setup-kde in the repo, so the sibling fallback
+# resolves it and the recovery shortcut is registered.
+test_kde_recover_shortcut() {
+    run_kde --no-install
+    desktop="$TEST_TMPDIR/home/.local/share/applications/shortcut-kde-recover.desktop"
+    assert_status 0 &&
+    assert_file_exists "$desktop" &&
+    assert_called "kwriteconfig6 --file kglobalshortcutsrc --group services --group shortcut-kde-recover.desktop --key _launch Meta+Shift+R"
+}
+
 # A launcher that exists on PATH gets a .desktop file and a [services] _launch
 # shortcut pointing at its resolved path.
 test_app_shortcut_created_for_present_launcher() {
@@ -275,6 +312,11 @@ run_test "unknown option errors" test_unknown_option
 run_test "enables and configures Krohnkite" test_enables_and_configures_krohnkite
 run_test "configures focus follows mouse" test_configures_focus_follows_mouse
 run_test "configures nine desktops" test_configures_nine_desktops
+run_test "hardens plasma services with restart drop-ins" \
+    test_hardens_plasma_services
+run_test "configures Xwayland crash policy" \
+    test_configures_xwayland_crash_policy
+run_test "registers the kde-recover shortcut" test_kde_recover_shortcut
 run_test "app shortcut created for present launcher" \
     test_app_shortcut_created_for_present_launcher
 run_test "missing launcher is skipped, not fatal" \


### PR DESCRIPTION
Monitor hotplug and resume from sleep regularly crash plasmashell, and when it crash-loops, systemd's default start-rate limit (5 starts in 10s) gives up and leaves the desktop with no shell. This hardens the KDE setup, all via `setup-kde` config steps plus one new recovery script.

## setup-kde

- **Auto-restart drop-ins**: writes systemd user drop-ins for `plasma-plasmashell.service` and `plasma-kwin_x11.service` that lift the start-rate limit (`StartLimitIntervalSec=0`) and throttle a persistent crash loop to one attempt every 2s, and sets `startkderc` `systemdBoot=true` explicitly so the units are used at all. `kwin_wayland` deliberately gets no drop-in: on Wayland kwin *is* the session, so a restart can't save anything.
- **Xwayland crash policy**: `XwaylandCrashPolicy=Restart` with `XwaylandMaxCrashCount=10`, so a resume/hotplug crash flurry doesn't permanently end X11 support for the session (KWin's default gives up after 3).
- **NVIDIA suspend check (warn-only)**: if the NVIDIA driver is loaded without `PreserveVideoMemoryAllocations=1` — the most common cause of Plasma/KWin crashing after resume — print the system-level fix (modprobe option + nvidia-suspend/resume services) rather than touching system config from a user-scoped script.
- **Recovery shortcut**: binds the new `kde-recover` to `Meta+Shift+R`. kglobalaccel runs inside kwin, so the shortcut still works when plasmashell is dead and there's no panel left to click.

## kde-recover (new)

Best-effort recovery for a wedged session:

1. Re-enables outputs when *every* connected output ended up disabled after a bad hotplug (one disabled output may be a deliberately closed lid; zero enabled outputs never is), via `kscreen-doctor`.
2. Restarts plasmashell through its systemd unit when present — clearing an exhausted start-rate limit with `reset-failed` first — otherwise quits and relaunches it directly.
3. Restarts kded (`try-restart`), whose kscreen module applies display profiles on hotplug.
4. Asks KWin to reload its configuration.

## Tests

- `setup-kde_test`: 3 new tests (drop-ins written with the right directives + daemon-reload, Xwayland keys, kde-recover shortcut registration); `systemctl` added to the mocks and `XDG_CONFIG_HOME` now sandboxed alongside `HOME`.
- `kde-recover_test` (new, wired into `make test`): systemd vs. direct restart paths, and output re-enabling only when all connected outputs are disabled.

All 18 tests pass; shellcheck is clean on the new and changed scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T7ozwVp5LcWJkBwFyEjR8M

---
_Generated by [Claude Code](https://claude.ai/code/session_01T7ozwVp5LcWJkBwFyEjR8M)_