### PR TITLE
setup-hypr: seed hyprland-local.lua for Hyprland 0.55's Lua config

### DIFF
--- a/setup-hypr
+++ b/setup-hypr
@@ -12,11 +12,13 @@
 #   internal panel on close, and suspend only when no external display is
 #   connected.
 # - Enable power-profiles-daemon (used by the waybar power-profiles module).
-# - Seed ~/.config/hypr/hyprland.conf.local (per-machine overrides: pinned
-#   monitor rules, extra launchers, device tweaks) from the installed
-#   template. Never overwrites an existing one. hyprland.conf sources the
-#   file, and Hyprland reports an error when a sourced file is missing, so
-#   an (empty) file must exist on every machine.
+# - Seed the per-machine override files (pinned monitor rules, extra
+#   launchers, device tweaks) from the installed templates, never
+#   overwriting existing ones: ~/.config/hypr/hyprland.conf.local (hyprlang,
+#   Hyprland <= 0.54 -- hyprland.conf sources it, and Hyprland reports an
+#   error when a sourced file is missing, so an (empty) file must exist) and
+#   ~/.config/hypr/hyprland-local.lua (Lua, Hyprland 0.55+ -- hyprland.lua
+#   requires it via pcall, so it's optional but seeded for documentation).
 #
 # Usage:
 #     setup-hypr [--no-install] [--ignore-errors] [-h | --help]
@@ -130,30 +132,34 @@ enable_services() {
     fi
 }
 
-# --- Per-machine hyprland.conf.local ---
+# --- Per-machine hyprland.conf.local / hyprland-local.lua ---
 
-# Seed ~/.config/hypr/hyprland.conf.local from the template conf's
-# `make install` ships, mirroring setup-sway's config.local seeding. The
-# shared hyprland.conf sources it last so per-machine overrides win; it must
-# exist (even empty) or Hyprland reports a config error for the missing
-# sourced file. Never overwrite an existing one -- re-running setup-hypr
-# must be safe.
-seed_conf_local() {
-    cfgdir="${XDG_CONFIG_HOME:-$HOME/.config}/hypr"
-    local_file="$cfgdir/hyprland.conf.local"
-    template="$cfgdir/hyprland.conf.local.template"
+# Seed the per-machine override files from the templates conf's
+# `make install` ships, mirroring setup-sway's config.local seeding. Two
+# files, one per config generation:
+#   hyprland.conf.local -- hyprlang; hyprland.conf (Hyprland <= 0.54)
+#       sources it last, and it must exist (even empty) or Hyprland reports
+#       a config error for the missing sourced file.
+#   hyprland-local.lua  -- Lua; hyprland.lua (Hyprland 0.55+) requires it
+#       last via pcall, so it's optional -- but seed it anyway so the
+#       documented template (rebinding via hyprbinds, monitor rules) is at
+#       hand.
+# Never overwrite an existing one -- re-running setup-hypr must be safe.
+seed_one_local() {
+    local_file="$1"
+    template="$2"
+    comment="$3"    # comment prefix for the appended monitor hints
     if test -f "$local_file"; then
         info "Per-machine config already exists ($local_file); leaving it alone"
         return 0
     fi
-    mkdir -p "$cfgdir"
     if test -f "$template"; then
         cp "$template" "$local_file"
         info "Created $local_file from the template"
     else
-        warn "hyprland.conf.local.template not found ($template); run conf's 'make install' first"
-        # Create an empty file anyway so hyprland.conf's `source` line
-        # doesn't raise a config error at startup.
+        warn "${template##*/} not found ($template); run conf's 'make install' first"
+        # Create an empty file anyway: hyprland.conf's `source` line raises
+        # a config error at startup without it (harmless for the lua file).
         : > "$local_file"
         info "Created empty $local_file"
     fi
@@ -172,10 +178,19 @@ seed_conf_local() {
         fi
         {
             echo ""
-            echo "# Monitors detected on this machine ($(hostname)):"
-            printf '%s\n' "$monitors" | sed 's/^/#   /'
+            echo "$comment Monitors detected on this machine ($(hostname)):"
+            printf '%s\n' "$monitors" | sed "s/^/$comment   /"
         } >> "$local_file"
     fi
+}
+
+seed_conf_local() {
+    cfgdir="${XDG_CONFIG_HOME:-$HOME/.config}/hypr"
+    mkdir -p "$cfgdir"
+    seed_one_local "$cfgdir/hyprland.conf.local" \
+                   "$cfgdir/hyprland.conf.local.template" "#"
+    seed_one_local "$cfgdir/hyprland-local.lua" \
+                   "$cfgdir/hyprland-local.lua.template" "--"
 }
 
 # --- Main ---

--- a/setup-hypr_test
+++ b/setup-hypr_test
@@ -215,6 +215,33 @@ test_never_overwrites_existing_conf_local() {
     assert_file_contains "$XDG_CONFIG_HOME/hypr/hyprland.conf.local" "my precious overrides"
 }
 
+# --- per-machine hyprland-local.lua seeding (Hyprland 0.55+, Lua config) ---
+
+test_seeds_local_lua_from_template() {
+    mkdir -p "$XDG_CONFIG_HOME/hypr"
+    echo "-- lua template body" > "$XDG_CONFIG_HOME/hypr/hyprland-local.lua.template"
+    run_hypr
+    assert_status 0 &&
+    assert_file_contains "$XDG_CONFIG_HOME/hypr/hyprland-local.lua" "lua template body"
+}
+
+# hyprland.lua requires the file via pcall so it's optional there, but the
+# seeder still creates an empty one for consistency with the hyprlang path.
+test_creates_empty_local_lua_without_template() {
+    run_hypr
+    assert_status 0 &&
+    test -f "$XDG_CONFIG_HOME/hypr/hyprland-local.lua"
+}
+
+test_never_overwrites_existing_local_lua() {
+    mkdir -p "$XDG_CONFIG_HOME/hypr"
+    echo "-- lua template body" > "$XDG_CONFIG_HOME/hypr/hyprland-local.lua.template"
+    echo "-- my precious lua overrides" > "$XDG_CONFIG_HOME/hypr/hyprland-local.lua"
+    run_hypr
+    assert_status 0 &&
+    assert_file_contains "$XDG_CONFIG_HOME/hypr/hyprland-local.lua" "my precious lua overrides"
+}
+
 assert_file_not_contains_line() {
     if grep -q "^$2\$" "$1" 2>/dev/null; then
         echo "  FAIL: $1 contains unwanted line '$2'"
@@ -251,7 +278,11 @@ MOCK
     assert_file_contains "$XDG_CONFIG_HOME/hypr/hyprland.conf.local" "#   DP-3" &&
     assert_file_not_contains_line "$XDG_CONFIG_HOME/hypr/hyprland.conf.local" "#   1" &&
     assert_file_not_contains_line "$XDG_CONFIG_HOME/hypr/hyprland.conf.local" "#   2" &&
-    assert_file_not_contains_line "$XDG_CONFIG_HOME/hypr/hyprland.conf.local" "#   "
+    assert_file_not_contains_line "$XDG_CONFIG_HOME/hypr/hyprland.conf.local" "#   " &&
+    # The lua override file gets the same hints with lua comments.
+    assert_file_contains "$XDG_CONFIG_HOME/hypr/hyprland-local.lua" "Monitors detected" &&
+    assert_file_contains "$XDG_CONFIG_HOME/hypr/hyprland-local.lua" "\-\-   eDP-1" &&
+    assert_file_contains "$XDG_CONFIG_HOME/hypr/hyprland-local.lua" "\-\-   DP-3"
 }
 
 run_test "help flag" test_help_flag
@@ -268,6 +299,12 @@ run_test "creates an empty hyprland.conf.local without the template" \
     test_creates_empty_conf_local_without_template
 run_test "never overwrites an existing hyprland.conf.local" \
     test_never_overwrites_existing_conf_local
+run_test "seeds hyprland-local.lua from the template" \
+    test_seeds_local_lua_from_template
+run_test "creates an empty hyprland-local.lua without the template" \
+    test_creates_empty_local_lua_without_template
+run_test "never overwrites an existing hyprland-local.lua" \
+    test_never_overwrites_existing_local_lua
 run_test "appends detected monitors inside a hyprland session" \
     test_appends_detected_monitors_inside_hyprland
 


### PR DESCRIPTION
## Summary

Companion to the conf repo's Hyprland Lua migration (hyprlang is deprecated since Hyprland 0.55). The conf repo now ships `hyprland.lua` with per-machine overrides in `hyprland-local.lua`, alongside the frozen `hyprland.conf` + `hyprland.conf.local` pair for ≤ 0.54.

- Generalise the local-file seeding into `seed_one_local(file, template, comment_prefix)` and seed **both** override files: `hyprland.conf.local` (hyprlang, must exist even empty or ≤ 0.54 errors on the missing sourced file) and `hyprland-local.lua` (Lua, optional via `pcall` but seeded so the documented template is at hand).
- The detected-monitor hints appended inside a running session use the right comment prefix per file: `#` for hyprlang, `--` for Lua.
- Behaviour is otherwise unchanged: never overwrites an existing file, creates an empty file when the template is missing, safe to re-run.

## Testing

`setup-hypr_test` gains cases for seeding the Lua file from its template, the no-template path, the never-overwrite path, and Lua-commented monitor hints — **15 tests, 15 passed**. Full `make test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWnT45RXQjzV87Supe5PNF

---
_Generated by [Claude Code](https://claude.ai/code/session_01VWnT45RXQjzV87Supe5PNF)_