### PR TITLE
setup-kde: clone my krohnkite fork, never touch the npm registry

### DIFF
--- a/setup
+++ b/setup
@@ -36,9 +36,12 @@
 # agent) or a key file already exists. Pass --ssh to generate one anyway,
 # or --no-ssh to skip it entirely.
 #
-# The distro npm/Node.js package is installed by default. Pass --no-npm to
-# skip it on machines where that package fails to install or where Node is
-# provided some other way (nvm, fnm, corepack, a standalone pnpm, etc.).
+# The distro npm/Node.js package is installed by default, along with the
+# TypeScript compiler (tsc), which setup-kde needs to build Krohnkite from
+# source without fetching from the npm registry at build time. Pass
+# --no-npm to skip both on machines where the npm package fails to install
+# or where Node is provided some other way (nvm, fnm, corepack, a
+# standalone pnpm, etc.) -- then provide tsc yourself.
 
 SCRIPTS_REPO="git@github.com:mikelward/scripts.git"
 CONF_REPO="git@github.com:mikelward/conf.git"
@@ -82,9 +85,10 @@ IGNORE_ERRORS=no
 #   no   - never generate (--no-ssh)
 SSH=auto
 
-# Whether to install the npm/Node.js package. One of:
-#   yes - install it along with the other system packages (the default)
-#   no  - skip it (--no-npm), for machines where the distro npm package
+# Whether to install the npm/Node.js package and the TypeScript compiler
+# (tsc, needed by setup-kde to build Krohnkite). One of:
+#   yes - install them along with the other system packages (the default)
+#   no  - skip them (--no-npm), for machines where the distro npm package
 #         fails to install or where Node is provided some other way
 #         (nvm, fnm, corepack, a standalone pnpm, etc.)
 NPM=yes
@@ -120,8 +124,9 @@ Options:
                    one. Forwarded to setup-kde/macos
   --ssh            Generate an SSH key even if one is already available
   --no-ssh         Skip SSH key generation
-  --no-npm         Skip the distro npm/Node.js package (for machines where it
-                   fails to install or Node is provided another way)
+  --no-npm         Skip the distro npm/Node.js package and the TypeScript
+                   compiler (for machines where npm fails to install or Node
+                   is provided another way; provide tsc yourself)
   -h, --help       Show this help and exit
 
 By default graphical components are installed only when a display server
@@ -384,6 +389,14 @@ install_packages() {
             if test "$NPM" = yes; then
                 info "Installing npm"
                 sudo apt-get install -y --install-recommends npm
+                # tsc lets setup-kde build Krohnkite from source without
+                # fetching typescript from the npm registry at build time.
+                # Debian/Ubuntu package it as node-typescript; fall back to
+                # a one-time global npm install where that's unavailable.
+                info "Installing TypeScript (tsc)"
+                sudo apt-get install -y --install-recommends node-typescript \
+                    || sudo npm install -g typescript \
+                    || warn "could not install tsc; setup-kde needs it to build Krohnkite"
             fi
             if test "$GUI_ENABLED" -eq 1; then
                 info "Installing kitty"
@@ -485,6 +498,13 @@ install_packages() {
             if test "$NPM" = yes; then
                 info "Installing npm"
                 sudo dnf install -y npm
+                # tsc lets setup-kde build Krohnkite from source without
+                # fetching typescript from the npm registry at build time.
+                # Fedora ships no typescript rpm, so this is a one-time
+                # global npm install during bootstrap.
+                info "Installing TypeScript (tsc)"
+                sudo npm install -g typescript \
+                    || warn "could not install tsc; setup-kde needs it to build Krohnkite"
             fi
             if test "$GUI_ENABLED" -eq 1; then
                 info "Installing kitty"
@@ -592,6 +612,12 @@ install_packages() {
             if test "$NPM" = yes; then
                 info "Installing Node.js (npm)"
                 brew install node
+                # tsc lets setup-kde build Krohnkite from source without
+                # fetching typescript from the npm registry at build time.
+                # Installed on macOS too so the toolchain matches Linux.
+                info "Installing TypeScript (tsc)"
+                brew install typescript \
+                    || warn "could not install tsc; setup-kde needs it to build Krohnkite"
             fi
             # adb/fastboot are CLI tools (used by pidcat and friends), not
             # graphical -- install them regardless of --no-gui, matching the
@@ -609,7 +635,7 @@ install_packages() {
             ;;
         *)
             warn "Unsupported OS, skipping package installation"
-            warn "Please install manually: bat curl fd fzf git git-delta golang jq kitty make mercurial npm p7zip python3 ripgrep shellcheck zsh"
+            warn "Please install manually: bat curl fd fzf git git-delta golang jq kitty make mercurial npm p7zip python3 ripgrep shellcheck typescript zsh"
             ;;
     esac
 }

--- a/setup-kde
+++ b/setup-kde
@@ -118,6 +118,11 @@ command -v kwriteconfig6 >/dev/null 2>&1 || error "kwriteconfig6 is required (KD
 if test "$INSTALL" = yes; then
     command -v git >/dev/null 2>&1 || error "git is required"
     command -v kpackagetool6 >/dev/null 2>&1 || error "kpackagetool6 is required (KDE Plasma 6)"
+    # Not fatal here: a checkout that ships a prebuilt .kwinscript installs
+    # without any compiler. But if a build turns out to be needed it will
+    # fail on this, so say so before spending time on the clone.
+    command -v tsc >/dev/null 2>&1 \
+        || warn "tsc not found; the install will fail unless $KROHNKITE_REPO ships a prebuilt .kwinscript"
 fi
 
 # --- Install Krohnkite ---

--- a/setup-kde
+++ b/setup-kde
@@ -18,12 +18,14 @@
 # KDE configuration. --ignore-errors keeps going past failures instead of
 # aborting on the first one. setup forwards both flags here.
 #
-# Krohnkite comes from my fork by default; set KROHNKITE_REPO to clone from
-# somewhere else (any git URL or local path). The build never talks to the
-# npm registry: a prebuilt .kwinscript committed to the repo installs as-is,
-# and building from source uses the local tsc via an npm shim.
+# Krohnkite comes from my fork's mikel branch by default; set KROHNKITE_REPO
+# (any git URL or local path) and/or KROHNKITE_BRANCH to clone something
+# else. The build never talks to the npm registry: a prebuilt .kwinscript
+# committed to the repo installs as-is, and building from source uses the
+# local tsc via an npm shim.
 
-KROHNKITE_REPO="${KROHNKITE_REPO:-https://github.com/mikelward/krohnkite.git}"
+KROHNKITE_REPO="${KROHNKITE_REPO:-https://github.com/mikelward/Krohnkite-codeberg.git}"
+KROHNKITE_BRANCH="${KROHNKITE_BRANCH:-mikel}"
 KROHNKITE_DIR="${TMPDIR:-/tmp}/krohnkite-$$"
 
 # Directory containing this script, resolved up front while $0 still means
@@ -195,8 +197,8 @@ SHIM
 }
 
 install_krohnkite() {
-    info "Cloning Krohnkite from $KROHNKITE_REPO"
-    git clone --depth 1 "$KROHNKITE_REPO" "$KROHNKITE_DIR"
+    info "Cloning Krohnkite from $KROHNKITE_REPO ($KROHNKITE_BRANCH)"
+    git clone --depth 1 --branch "$KROHNKITE_BRANCH" "$KROHNKITE_REPO" "$KROHNKITE_DIR"
 
     cd "$KROHNKITE_DIR"
 

--- a/setup-kde
+++ b/setup-kde
@@ -7,8 +7,9 @@
 # - Window management and desktop switching keybindings
 # - Application launch shortcuts (browser, terminal, music)
 #
-# Requires: git, pnpm or npm, kpackagetool6, kwriteconfig6
-# Optional: go-task (preferred build tool), p7zip
+# Requires: git, kpackagetool6, kwriteconfig6
+# Optional: tsc (only to build Krohnkite when the checkout has no prebuilt
+#           .kwinscript), go-task (preferred build tool), p7zip
 #
 # Usage:
 #     setup-kde [--no-install] [--ignore-errors] [-h | --help]
@@ -16,8 +17,13 @@
 # --no-install skips building/installing Krohnkite and only (re)applies the
 # KDE configuration. --ignore-errors keeps going past failures instead of
 # aborting on the first one. setup forwards both flags here.
+#
+# Krohnkite comes from my fork by default; set KROHNKITE_REPO to clone from
+# somewhere else (any git URL or local path). The build never talks to the
+# npm registry: a prebuilt .kwinscript committed to the repo installs as-is,
+# and building from source uses the local tsc via an npm shim.
 
-KROHNKITE_REPO="https://codeberg.org/anametologin/Krohnkite.git"
+KROHNKITE_REPO="${KROHNKITE_REPO:-https://github.com/mikelward/krohnkite.git}"
 KROHNKITE_DIR="${TMPDIR:-/tmp}/krohnkite-$$"
 
 # Directory containing this script, resolved up front while $0 still means
@@ -104,23 +110,59 @@ trap cleanup EXIT
 # --- Check prerequisites ---
 
 # kwriteconfig6 is needed for every configuration step, so it's always
-# required. git/pnpm/npm/kpackagetool6 are only used to build and install
-# Krohnkite, so they're only required when actually installing.
+# required. git/kpackagetool6 are only used to fetch and install Krohnkite,
+# so they're only required when actually installing. tsc is checked in
+# build_krohnkite: whether a build is needed at all depends on the checkout
+# (a committed prebuilt .kwinscript installs without one).
 command -v kwriteconfig6 >/dev/null 2>&1 || error "kwriteconfig6 is required (KDE Plasma 6)"
 if test "$INSTALL" = yes; then
     command -v git >/dev/null 2>&1 || error "git is required"
-    command -v pnpm >/dev/null 2>&1 || command -v npm >/dev/null 2>&1 \
-        || error "pnpm or npm is required (to build Krohnkite)"
     command -v kpackagetool6 >/dev/null 2>&1 || error "kpackagetool6 is required (KDE Plasma 6)"
 fi
 
 # --- Install Krohnkite ---
 
-install_krohnkite() {
-    info "Cloning Krohnkite"
-    git clone --depth 1 "$KROHNKITE_REPO" "$KROHNKITE_DIR"
+# Build the .kwinscript package from source without touching the npm
+# registry. Krohnkite's build (the Makefile, or the Taskfile via
+# go-task/task) shells out to npm for exactly two things: "npm install
+# --save-dev" to fetch typescript, and "npm run tsc --" to compile. A
+# local tsc covers both, so prepend an npm shim to PATH that turns install
+# into a no-op and run tsc into the local compiler. Anything else the
+# build asks npm for would be a remote fetch, so the shim fails on it.
+build_krohnkite() {
+    command -v tsc >/dev/null 2>&1 \
+        || error "tsc is required to build Krohnkite without remote npm; install typescript, or commit a prebuilt .kwinscript to $KROHNKITE_REPO"
 
-    cd "$KROHNKITE_DIR"
+    shimdir="$KROHNKITE_DIR/.npm-shim"
+    mkdir -p "$shimdir"
+    cat > "$shimdir/npm" <<'SHIM'
+#!/bin/sh
+case "$1" in
+    install|i|ci)
+        # Krohnkite's only build dependency is typescript; the local tsc
+        # stands in for it, so there is nothing to install.
+        exit 0
+        ;;
+    run)
+        # "npm run tsc -- <args>" -> "tsc <args>": strip npm's "--"
+        # separator, which tsc would reject (TS5023).
+        shift
+        script=${1:-}
+        [ "$#" -gt 0 ] && shift
+        [ "${1:-}" = "--" ] && shift
+        if [ "$script" = tsc ]; then
+            exec tsc "$@"
+        fi
+        echo "npm shim: refusing 'npm run $script' (no remote npm)" >&2
+        exit 1
+        ;;
+    *)
+        echo "npm shim: refusing 'npm $1' (no remote npm)" >&2
+        exit 1
+        ;;
+esac
+SHIM
+    chmod +x "$shimdir/npm"
 
     # Build using go-task (preferred), then make. go-task is no longer
     # installed by setup, but use it if it's present: the binary is named
@@ -130,62 +172,36 @@ install_krohnkite() {
     #
     # Krohnkite's Makefile is the real build: it compiles the TypeScript and
     # assembles the installable .kwinscript package. package.json defines no
-    # "build" script, so there is no pnpm/npm-only build to fall back on --
-    # the Makefile is it. The Makefile shells out to npm, though, so on a
-    # host that has pnpm but not npm we prepend a tiny npm->pnpm shim to
-    # PATH and run make as usual.
+    # "build" script, so there is no npm-only build to fall back on -- the
+    # Makefile is it.
     if command -v go-task >/dev/null 2>&1; then
         info "Building Krohnkite with go-task"
-        go-task package
+        PATH="$shimdir:$PATH" go-task package
     elif command -v task >/dev/null 2>&1 \
             && task --version 2>/dev/null | grep -q '^Task version'; then
         info "Building Krohnkite with task"
-        task package
+        PATH="$shimdir:$PATH" task package
     elif test -f Makefile; then
-        if command -v npm >/dev/null 2>&1; then
-            info "Building Krohnkite with make"
-            make
-        elif command -v pnpm >/dev/null 2>&1; then
-            info "Building Krohnkite with make (npm shimmed to pnpm)"
-            # Krohnkite's Makefile runs "npm install --save-dev" and
-            # "npm run tsc --". Write a small npm->pnpm shim: map install
-            # to "pnpm install" (which pulls dev deps too) and, for run,
-            # drop npm's "--" separator -- pnpm would forward a bare "--"
-            # to the script and break tsc (TS5023).
-            shimdir="$KROHNKITE_DIR/.npm-shim"
-            mkdir -p "$shimdir"
-            cat > "$shimdir/npm" <<'SHIM'
-#!/bin/sh
-case "$1" in
-    install|i|ci)
-        exec pnpm install
-        ;;
-    run)
-        # "npm run <s> -- <args>" -> "pnpm run <s> <args>": strip npm's
-        # "--" separator so pnpm does not pass it on to the script.
-        shift
-        script=${1:-}
-        [ "$#" -gt 0 ] && shift
-        [ "${1:-}" = "--" ] && shift
-        exec pnpm run "$script" "$@"
-        ;;
-    *)
-        exec pnpm "$@"
-        ;;
-esac
-SHIM
-            chmod +x "$shimdir/npm"
-            PATH="$shimdir:$PATH" make
-        else
-            error "npm or pnpm is required (to build Krohnkite)"
-        fi
+        info "Building Krohnkite with make"
+        PATH="$shimdir:$PATH" make
     else
-        info "Building Krohnkite with npm"
-        npm install && npm run build
+        error "Krohnkite checkout has no Taskfile or Makefile to build with"
     fi
+}
 
-    # Find the built .kwinscript file, or a directory containing metadata.json
+install_krohnkite() {
+    info "Cloning Krohnkite from $KROHNKITE_REPO"
+    git clone --depth 1 "$KROHNKITE_REPO" "$KROHNKITE_DIR"
+
+    cd "$KROHNKITE_DIR"
+
+    # A prebuilt .kwinscript committed to the repo installs as-is -- no
+    # build, no npm. Only build from source when there isn't one.
     kwinscript=$(find . -name '*.kwinscript' -print -quit)
+    if test -z "$kwinscript"; then
+        build_krohnkite
+        kwinscript=$(find . -name '*.kwinscript' -print -quit)
+    fi
     if test -n "$kwinscript"; then
         info "Installing Krohnkite from $kwinscript"
         kpackagetool6 -t KWin/Script -u "$kwinscript" 2>/dev/null ||

--- a/setup-kde
+++ b/setup-kde
@@ -24,8 +24,14 @@
 # committed to the repo installs as-is, and building from source uses the
 # local tsc via an npm shim.
 
-KROHNKITE_REPO="${KROHNKITE_REPO:-https://github.com/mikelward/Krohnkite-codeberg.git}"
-KROHNKITE_BRANCH="${KROHNKITE_BRANCH:-mikel}"
+KROHNKITE_DEFAULT_REPO="https://github.com/mikelward/Krohnkite-codeberg.git"
+KROHNKITE_REPO="${KROHNKITE_REPO:-$KROHNKITE_DEFAULT_REPO}"
+# The mikel branch only exists on my fork, so it's only the default when
+# cloning the default repo: an overridden KROHNKITE_REPO clones its remote
+# HEAD unless KROHNKITE_BRANCH says otherwise.
+if test -z "${KROHNKITE_BRANCH:-}" && test "$KROHNKITE_REPO" = "$KROHNKITE_DEFAULT_REPO"; then
+    KROHNKITE_BRANCH=mikel
+fi
 KROHNKITE_DIR="${TMPDIR:-/tmp}/krohnkite-$$"
 
 # Directory containing this script, resolved up front while $0 still means
@@ -197,8 +203,13 @@ SHIM
 }
 
 install_krohnkite() {
-    info "Cloning Krohnkite from $KROHNKITE_REPO ($KROHNKITE_BRANCH)"
-    git clone --depth 1 --branch "$KROHNKITE_BRANCH" "$KROHNKITE_REPO" "$KROHNKITE_DIR"
+    if test -n "${KROHNKITE_BRANCH:-}"; then
+        info "Cloning Krohnkite from $KROHNKITE_REPO ($KROHNKITE_BRANCH)"
+        git clone --depth 1 --branch "$KROHNKITE_BRANCH" "$KROHNKITE_REPO" "$KROHNKITE_DIR"
+    else
+        info "Cloning Krohnkite from $KROHNKITE_REPO"
+        git clone --depth 1 "$KROHNKITE_REPO" "$KROHNKITE_DIR"
+    fi
 
     cd "$KROHNKITE_DIR"
 

--- a/setup-kde_test
+++ b/setup-kde_test
@@ -229,22 +229,24 @@ test_unknown_option() {
 
 # --- installation (mocked git/kpackagetool6; npm is a never-called canary) ---
 
-# The clone must come from my fork, not upstream codeberg.
+# The clone must come from my fork's mikel branch, not upstream codeberg.
 test_clones_fork_by_default() {
     add_install_mocks
     run_kde
     assert_status 0 &&
-    assert_called "git clone --depth 1 https://github.com/mikelward/krohnkite.git"
+    assert_called "git clone --depth 1 --branch mikel https://github.com/mikelward/Krohnkite-codeberg.git"
 }
 
-# KROHNKITE_REPO overrides the clone source (any git URL or local path).
+# KROHNKITE_REPO and KROHNKITE_BRANCH override the clone source (any git
+# URL or local path) and branch.
 test_krohnkite_repo_env_overrides_clone_source() {
     add_install_mocks
     export KROHNKITE_REPO="https://example.test/me/krohnkite.git"
+    export KROHNKITE_BRANCH="mybranch"
     run_kde
-    unset KROHNKITE_REPO
+    unset KROHNKITE_REPO KROHNKITE_BRANCH
     assert_status 0 &&
-    assert_called "git clone --depth 1 https://example.test/me/krohnkite.git"
+    assert_called "git clone --depth 1 --branch mybranch https://example.test/me/krohnkite.git"
 }
 
 # A prebuilt .kwinscript committed to the fork installs directly: no build

--- a/setup-kde_test
+++ b/setup-kde_test
@@ -271,6 +271,23 @@ test_source_build_uses_local_tsc_not_remote_npm() {
     assert_not_called "npm"
 }
 
+# Missing tsc is a prerequisite *warning*, not an error: a checkout that
+# ships a prebuilt .kwinscript installs without any compiler, so the
+# install must still succeed. Skipped when the host itself has tsc on the
+# test PATH -- the script would legitimately find it and not warn.
+test_missing_tsc_warns_but_prebuilt_still_installs() {
+    if PATH="$TEST_TMPDIR/bin:/usr/local/bin:/usr/bin:/bin" \
+            command -v tsc >/dev/null 2>&1; then
+        echo "  skip: tsc present on test PATH"
+        return 0
+    fi
+    add_install_mocks
+    run_kde
+    assert_status 0 &&
+    assert_output_contains "tsc not found" &&
+    assert_called "kpackagetool6 -t KWin/Script"
+}
+
 # Without a prebuilt package or a local tsc, the build refuses rather than
 # falling back to a registry fetch. Skipped when the host itself has tsc on
 # the test PATH -- the script would legitimately find it and not error.
@@ -384,6 +401,8 @@ run_test "prebuilt package installs without npm" \
     test_prebuilt_package_installs_without_npm
 run_test "source build uses local tsc, never remote npm" \
     test_source_build_uses_local_tsc_not_remote_npm
+run_test "missing tsc warns up front but prebuilt still installs" \
+    test_missing_tsc_warns_but_prebuilt_still_installs
 run_test "source build without tsc errors instead of remote npm" \
     test_source_build_without_tsc_errors
 run_test "enables and configures Krohnkite" test_enables_and_configures_krohnkite

--- a/setup-kde_test
+++ b/setup-kde_test
@@ -57,8 +57,10 @@ isolate_script() {
 }
 
 # Mocks that let the full install path run: git "clones" by creating the
-# target directory with a fake .kwinscript, npm and kpackagetool6 just
-# record. This exercises install_krohnkite's cd into the checkout.
+# target directory with a fake prebuilt .kwinscript (the expected shape of
+# the fork), kpackagetool6 just records. npm is mocked purely as a canary:
+# nothing in the install may ever reach it. This exercises
+# install_krohnkite's cd into the checkout.
 add_install_mocks() {
     cat > "$TEST_TMPDIR/bin/git" <<MOCK
 #!/bin/sh
@@ -79,6 +81,40 @@ MOCK
     done
     chmod +x "$TEST_TMPDIR/bin/git" "$TEST_TMPDIR/bin/npm" \
         "$TEST_TMPDIR/bin/kpackagetool6"
+}
+
+# Like add_install_mocks, but the clone is source-only (no prebuilt
+# .kwinscript), forcing the build path. The mock go-task stands in for
+# Krohnkite's real build and invokes npm exactly the way the Makefile and
+# Taskfile do; setup-kde's shim must intercept both calls -- install
+# becomes a no-op and "run tsc" execs the (mocked) local tsc -- so the
+# canary npm in the mock bin is never reached.
+add_source_build_mocks() {
+    add_install_mocks
+    cat > "$TEST_TMPDIR/bin/git" <<MOCK
+#!/bin/sh
+echo "git \$*" >> "$CALLS"
+if test "\$1" = clone; then
+    for arg in "\$@"; do dir="\$arg"; done
+    mkdir -p "\$dir"
+fi
+exit 0
+MOCK
+    cat > "$TEST_TMPDIR/bin/go-task" <<MOCK
+#!/bin/sh
+echo "go-task \$*" >> "$CALLS"
+npm install --save-dev || exit 1
+npm run tsc -- --strict || exit 1
+touch krohnkite.kwinscript
+exit 0
+MOCK
+    cat > "$TEST_TMPDIR/bin/tsc" <<MOCK
+#!/bin/sh
+echo "tsc \$*" >> "$CALLS"
+exit 0
+MOCK
+    chmod +x "$TEST_TMPDIR/bin/git" "$TEST_TMPDIR/bin/go-task" \
+        "$TEST_TMPDIR/bin/tsc"
 }
 
 # Run setup-kde in the sandbox: fresh HOME, and a PATH of just the mock bin
@@ -136,6 +172,15 @@ assert_called() {
     fi
 }
 
+assert_not_called() {
+    if grep -q "$1" "$CALLS" 2>/dev/null; then
+        echo "  FAIL: unexpected call '$1' found"
+        echo "  calls: $(cat "$CALLS" 2>/dev/null)"
+        TEST_FAILED=1
+        return 1
+    fi
+}
+
 assert_file_exists() {
     if ! test -f "$1"; then
         echo "  FAIL: expected file '$1' to exist"
@@ -180,6 +225,66 @@ test_unknown_option() {
     run_kde --bogus
     assert_status 1 &&
     assert_output_contains "Unknown option"
+}
+
+# --- installation (mocked git/kpackagetool6; npm is a never-called canary) ---
+
+# The clone must come from my fork, not upstream codeberg.
+test_clones_fork_by_default() {
+    add_install_mocks
+    run_kde
+    assert_status 0 &&
+    assert_called "git clone --depth 1 https://github.com/mikelward/krohnkite.git"
+}
+
+# KROHNKITE_REPO overrides the clone source (any git URL or local path).
+test_krohnkite_repo_env_overrides_clone_source() {
+    add_install_mocks
+    export KROHNKITE_REPO="https://example.test/me/krohnkite.git"
+    run_kde
+    unset KROHNKITE_REPO
+    assert_status 0 &&
+    assert_called "git clone --depth 1 https://example.test/me/krohnkite.git"
+}
+
+# A prebuilt .kwinscript committed to the fork installs directly: no build
+# tool runs and npm is never touched.
+test_prebuilt_package_installs_without_npm() {
+    add_install_mocks
+    run_kde
+    assert_status 0 &&
+    assert_called "kpackagetool6 -t KWin/Script" &&
+    assert_not_called "npm" &&
+    assert_not_called "go-task"
+}
+
+# A source-only checkout builds via the npm shim: install is swallowed,
+# "npm run tsc" execs the local tsc, and the real npm (the canary mock on
+# PATH) is never reached.
+test_source_build_uses_local_tsc_not_remote_npm() {
+    add_source_build_mocks
+    run_kde
+    assert_status 0 &&
+    assert_called "go-task package" &&
+    assert_called "tsc --strict" &&
+    assert_called "kpackagetool6 -t KWin/Script" &&
+    assert_not_called "npm"
+}
+
+# Without a prebuilt package or a local tsc, the build refuses rather than
+# falling back to a registry fetch. Skipped when the host itself has tsc on
+# the test PATH -- the script would legitimately find it and not error.
+test_source_build_without_tsc_errors() {
+    if PATH="$TEST_TMPDIR/bin:/usr/local/bin:/usr/bin:/bin" \
+            command -v tsc >/dev/null 2>&1; then
+        echo "  skip: tsc present on test PATH"
+        return 0
+    fi
+    add_source_build_mocks
+    rm "$TEST_TMPDIR/bin/tsc"
+    run_kde
+    assert_status 1 &&
+    assert_output_contains "tsc is required to build Krohnkite without remote npm"
 }
 
 # --- configuration (with --no-install so nothing is cloned/built) ---
@@ -272,6 +377,15 @@ MOCK
 
 run_test "help flag" test_help_flag
 run_test "unknown option errors" test_unknown_option
+run_test "clones my krohnkite fork by default" test_clones_fork_by_default
+run_test "KROHNKITE_REPO overrides the clone source" \
+    test_krohnkite_repo_env_overrides_clone_source
+run_test "prebuilt package installs without npm" \
+    test_prebuilt_package_installs_without_npm
+run_test "source build uses local tsc, never remote npm" \
+    test_source_build_uses_local_tsc_not_remote_npm
+run_test "source build without tsc errors instead of remote npm" \
+    test_source_build_without_tsc_errors
 run_test "enables and configures Krohnkite" test_enables_and_configures_krohnkite
 run_test "configures focus follows mouse" test_configures_focus_follows_mouse
 run_test "configures nine desktops" test_configures_nine_desktops

--- a/setup-kde_test
+++ b/setup-kde_test
@@ -164,7 +164,7 @@ assert_output_contains() {
 }
 
 assert_called() {
-    if ! grep -q "$1" "$CALLS" 2>/dev/null; then
+    if ! grep -q -- "$1" "$CALLS" 2>/dev/null; then
         echo "  FAIL: expected call '$1' not found"
         echo "  calls: $(cat "$CALLS" 2>/dev/null)"
         TEST_FAILED=1
@@ -173,7 +173,7 @@ assert_called() {
 }
 
 assert_not_called() {
-    if grep -q "$1" "$CALLS" 2>/dev/null; then
+    if grep -q -- "$1" "$CALLS" 2>/dev/null; then
         echo "  FAIL: unexpected call '$1' found"
         echo "  calls: $(cat "$CALLS" 2>/dev/null)"
         TEST_FAILED=1
@@ -247,6 +247,19 @@ test_krohnkite_repo_env_overrides_clone_source() {
     unset KROHNKITE_REPO KROHNKITE_BRANCH
     assert_status 0 &&
     assert_called "git clone --depth 1 --branch mybranch https://example.test/me/krohnkite.git"
+}
+
+# The mikel branch only exists on my fork: overriding KROHNKITE_REPO alone
+# must clone that repo's remote HEAD, not force --branch mikel onto a repo
+# that may not have it.
+test_repo_override_does_not_force_mikel_branch() {
+    add_install_mocks
+    export KROHNKITE_REPO="https://example.test/me/krohnkite.git"
+    run_kde
+    unset KROHNKITE_REPO
+    assert_status 0 &&
+    assert_called "git clone --depth 1 https://example.test/me/krohnkite.git" &&
+    assert_not_called "--branch"
 }
 
 # A prebuilt .kwinscript committed to the fork installs directly: no build
@@ -399,6 +412,8 @@ run_test "unknown option errors" test_unknown_option
 run_test "clones my krohnkite fork by default" test_clones_fork_by_default
 run_test "KROHNKITE_REPO overrides the clone source" \
     test_krohnkite_repo_env_overrides_clone_source
+run_test "repo override alone doesn't force the mikel branch" \
+    test_repo_override_does_not_force_mikel_branch
 run_test "prebuilt package installs without npm" \
     test_prebuilt_package_installs_without_npm
 run_test "source build uses local tsc, never remote npm" \

--- a/setup_test
+++ b/setup_test
@@ -165,12 +165,27 @@ test_swaync_package_names() {
     assert_source_not_contains "fuzzel swaync"
 }
 
+# --- TypeScript compiler ---
+
+# setup-kde builds Krohnkite from source without fetching from the npm
+# registry at build time, which needs a local tsc -- so setup installs it
+# alongside npm: Debian/Ubuntu package it as node-typescript, Homebrew as
+# typescript, and Fedora ships no rpm so it's a one-time global npm
+# install during bootstrap.
+test_typescript_installed_with_npm() {
+    assert_source_contains "node-typescript" &&
+    assert_source_contains "npm install -g typescript" &&
+    assert_source_contains "brew install typescript"
+}
+
 run_test "--sway flag dispatches to setup-sway" test_sway_flag_and_dispatch
 run_test "Sway package names are the upstream ones" test_sway_package_names
 run_test "shared Wayland stack installs independently of hyprland" \
     test_shared_wayland_stack_decoupled
 run_test "swaync installs under its distro package names, decoupled" \
     test_swaync_package_names
+run_test "tsc installs alongside npm on every platform" \
+    test_typescript_installed_with_npm
 
 echo
 echo "$TESTS_RUN tests, $TESTS_PASSED passed, $TESTS_FAILED failed"


### PR DESCRIPTION
## Summary

- `setup-kde` now clones Krohnkite from **my fork's branch** — default `https://github.com/mikelward/Krohnkite-codeberg.git`, branch `mikel` — overridable via the `KROHNKITE_REPO` (any git URL or a local path) and `KROHNKITE_BRANCH` environment variables.
- The Krohnkite build **never fetches from the npm registry** any more:
  - If the checkout contains a prebuilt `.kwinscript` (committed to the fork), it installs as-is with no build step.
  - Building from source uses the local `tsc` via an npm shim on `PATH`: `npm install --save-dev` becomes a no-op, `npm run tsc --` execs the local compiler, and any other npm invocation fails loudly. This replaces the old npm→pnpm shim, which still fetched from the registry.
  - With neither a prebuilt package nor a local `tsc`, the build errors with guidance instead of falling back to a registry fetch; a missing `tsc` is also warned about up front in the prerequisite check, before the clone.
- `pnpm`/`npm` dropped from `setup-kde`'s prerequisites; header docs updated.
- `setup` now installs the TypeScript compiler alongside npm so default bootstraps have `tsc` before `setup-kde` runs: `node-typescript` on apt (npm -g fallback), `typescript` via brew, and a one-time global npm install on Fedora, which ships no typescript rpm. `--no-npm` skips it along with npm.

## Testing

- `setup-kde_test`: default clone URL/branch point at the fork's `mikel` branch, `KROHNKITE_REPO`/`KROHNKITE_BRANCH` override them, a prebuilt package installs without invoking npm or a build tool, a source build goes through the shim to local `tsc` with a canary npm mock asserting the registry path is never reached, a missing `tsc` warns up front but a prebuilt install still succeeds, and a source build without `tsc` errors instead of fetching.
- `setup_test`: static checks that all three platforms install the TypeScript compiler alongside npm.
- `make test` passes (all suites); shellcheck reports only pre-existing findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K72gQSnttFCExUaX8CX9Zv