### PR TITLE
Clone Krohnkite from Codeberg over HTTPS; prompt for Codeberg SSH key

### DIFF
--- a/setup
+++ b/setup
@@ -850,8 +850,9 @@ generate_ssh_key() {
     ssh-keygen -t ed25519 -f "$HOME/.ssh/id_ed25519" -N ""
 
     info ""
-    info "Add this SSH public key to GitHub before continuing:"
-    info "  https://github.com/settings/ssh/new"
+    info "Add this SSH public key to GitHub and Codeberg before continuing:"
+    info "  GitHub:   https://github.com/settings/ssh/new"
+    info "  Codeberg: https://codeberg.org/user/settings/keys"
     info ""
     cat "$HOME/.ssh/id_ed25519.pub"
     info ""
@@ -859,13 +860,13 @@ generate_ssh_key() {
     # When run via "curl | sh", stdin is the script itself, so we
     # can't read user input.  Open /dev/tty to read from the terminal.
     if test -t 0; then
-        printf "Press Enter after adding the key to GitHub..."
+        printf "Press Enter after adding the key to GitHub and Codeberg..."
         read _
     elif test -e /dev/tty; then
-        printf "Press Enter after adding the key to GitHub..."
+        printf "Press Enter after adding the key to GitHub and Codeberg..."
         read _ < /dev/tty
     else
-        warn "Cannot prompt for input; add the key to GitHub manually before cloning SSH repos"
+        warn "Cannot prompt for input; add the key to GitHub and Codeberg manually before cloning SSH repos"
     fi
 }
 

--- a/setup-kde
+++ b/setup-kde
@@ -24,7 +24,7 @@
 # committed to the repo installs as-is, and building from source uses the
 # local tsc via an npm shim.
 
-KROHNKITE_DEFAULT_REPO="git@codeberg.org:mikelward/Krohnkite.git"
+KROHNKITE_DEFAULT_REPO="https://codeberg.org/mikelward/Krohnkite.git"
 KROHNKITE_REPO="${KROHNKITE_REPO:-$KROHNKITE_DEFAULT_REPO}"
 # The mikel branch only exists on my fork, so it's only the default when
 # cloning the default repo: an overridden KROHNKITE_REPO clones its remote

--- a/setup-kde
+++ b/setup-kde
@@ -24,7 +24,7 @@
 # committed to the repo installs as-is, and building from source uses the
 # local tsc via an npm shim.
 
-KROHNKITE_DEFAULT_REPO="https://github.com/mikelward/Krohnkite-codeberg.git"
+KROHNKITE_DEFAULT_REPO="git@codeberg.org:mikelward/Krohnkite.git"
 KROHNKITE_REPO="${KROHNKITE_REPO:-$KROHNKITE_DEFAULT_REPO}"
 # The mikel branch only exists on my fork, so it's only the default when
 # cloning the default repo: an overridden KROHNKITE_REPO clones its remote

--- a/setup-kde_test
+++ b/setup-kde_test
@@ -234,7 +234,7 @@ test_clones_fork_by_default() {
     add_install_mocks
     run_kde
     assert_status 0 &&
-    assert_called "git clone --depth 1 --branch mikel git@codeberg.org:mikelward/Krohnkite.git"
+    assert_called "git clone --depth 1 --branch mikel https://codeberg.org/mikelward/Krohnkite.git"
 }
 
 # KROHNKITE_REPO and KROHNKITE_BRANCH override the clone source (any git

--- a/setup-kde_test
+++ b/setup-kde_test
@@ -229,12 +229,12 @@ test_unknown_option() {
 
 # --- installation (mocked git/kpackagetool6; npm is a never-called canary) ---
 
-# The clone must come from my fork's mikel branch, not upstream codeberg.
+# The clone must come from my Codeberg fork's mikel branch.
 test_clones_fork_by_default() {
     add_install_mocks
     run_kde
     assert_status 0 &&
-    assert_called "git clone --depth 1 --branch mikel https://github.com/mikelward/Krohnkite-codeberg.git"
+    assert_called "git clone --depth 1 --branch mikel git@codeberg.org:mikelward/Krohnkite.git"
 }
 
 # KROHNKITE_REPO and KROHNKITE_BRANCH override the clone source (any git

--- a/setup_test
+++ b/setup_test
@@ -178,6 +178,18 @@ test_typescript_installed_with_npm() {
     assert_source_contains "brew install typescript"
 }
 
+# --- SSH key ---
+
+# The default Krohnkite clone is HTTPS, but other repos (conf, scripts) are
+# cloned over SSH, and pushing anywhere needs a key. Codeberg hosts Krohnkite
+# now, so the key-generation prompt must point at both GitHub and Codeberg,
+# not GitHub alone.
+test_ssh_key_prompt_covers_github_and_codeberg() {
+    assert_source_contains "https://github.com/settings/ssh/new" &&
+    assert_source_contains "https://codeberg.org/user/settings/keys" &&
+    assert_source_contains "add the key to GitHub and Codeberg"
+}
+
 run_test "--sway flag dispatches to setup-sway" test_sway_flag_and_dispatch
 run_test "Sway package names are the upstream ones" test_sway_package_names
 run_test "shared Wayland stack installs independently of hyprland" \
@@ -186,6 +198,8 @@ run_test "swaync installs under its distro package names, decoupled" \
     test_swaync_package_names
 run_test "tsc installs alongside npm on every platform" \
     test_typescript_installed_with_npm
+run_test "SSH key prompt points at GitHub and Codeberg" \
+    test_ssh_key_prompt_covers_github_and_codeberg
 
 echo
 echo "$TESTS_RUN tests, $TESTS_PASSED passed, $TESTS_FAILED failed"


### PR DESCRIPTION
## Summary

Point the Krohnkite setup at its new Codeberg home and make the default install path work without an SSH key.

- **`setup-kde`**: default `KROHNKITE_DEFAULT_REPO` changes from the GitHub mirror (`https://github.com/mikelward/Krohnkite-codeberg.git`) to the canonical Codeberg repo over HTTPS (`https://codeberg.org/mikelward/Krohnkite.git`). HTTPS clones read-only for anyone, so the default `setup` → `setup-kde` path no longer depends on Codeberg SSH auth. The `mikel` branch stays the default; override with `KROHNKITE_REPO` (e.g. an SSH URL for pushing) / `KROHNKITE_BRANCH`.
- **`setup`**: `generate_ssh_key` now prompts users to add the new key to both GitHub and Codeberg (Krohnkite and other repos are pushed over SSH), instead of GitHub alone.

## Testing

- `make test` — all suites pass.
  - `setup-kde_test`: updated the clone assertion to expect the HTTPS Codeberg URL.
  - `setup_test`: added a static check asserting the SSH-key prompt lists both the GitHub and Codeberg key-upload URLs.

## Follow-up (not in this PR)

A standalone script to rewrite a repo's HTTPS remotes to SSH, and an end-of-`setup` prompt to switch cloned repos over, will be done separately.