### PR TITLE
Install unzip in setup script

### DIFF
--- a/setup
+++ b/setup
@@ -384,6 +384,7 @@ install_packages() {
                 python3-venv \
                 ripgrep \
                 shellcheck \
+                unzip \
                 vim \
                 zsh
             if test "$NPM" = yes; then
@@ -493,6 +494,7 @@ install_packages() {
                 python3-pip \
                 ripgrep \
                 ShellCheck \
+                unzip \
                 vim \
                 zsh
             if test "$NPM" = yes; then
@@ -607,6 +609,7 @@ install_packages() {
                 python3 \
                 ripgrep \
                 shellcheck \
+                unzip \
                 vim \
                 zsh
             if test "$NPM" = yes; then
@@ -635,7 +638,7 @@ install_packages() {
             ;;
         *)
             warn "Unsupported OS, skipping package installation"
-            warn "Please install manually: bat curl fd fzf git git-delta golang jq kitty make mercurial npm p7zip python3 ripgrep shellcheck typescript zsh"
+            warn "Please install manually: bat curl fd fzf git git-delta golang jq kitty make mercurial npm p7zip python3 ripgrep shellcheck typescript unzip zsh"
             ;;
     esac
 }

--- a/setup_test
+++ b/setup_test
@@ -178,6 +178,15 @@ test_typescript_installed_with_npm() {
     assert_source_contains "brew install typescript"
 }
 
+# --- unzip ---
+
+# unzip is a core package installed on every platform, and listed in the
+# manual-install hint for unsupported OSes.
+test_unzip_installed() {
+    assert_source_contains "unzip" &&
+    assert_source_contains "typescript unzip zsh"
+}
+
 # --- SSH key ---
 
 # The default Krohnkite clone is HTTPS, but other repos (conf, scripts) are
@@ -207,6 +216,7 @@ run_test "swaync installs under its distro package names, decoupled" \
     test_swaync_package_names
 run_test "tsc installs alongside npm on every platform" \
     test_typescript_installed_with_npm
+run_test "unzip installs on every platform" test_unzip_installed
 run_test "SSH key prompt points at GitHub and Codeberg" \
     test_ssh_key_prompt_covers_github_and_codeberg
 run_test "setup offers to switch repo remotes to SSH" \


### PR DESCRIPTION
## Summary

Adds `unzip` to the packages installed by the `setup` bootstrap script.

## Changes

- Added `unzip` to the core package list on all three platforms:
  - Debian/Ubuntu (`apt-get install`)
  - Fedora/RedHat (`dnf install`)
  - macOS (`brew install`)
- Added `unzip` to the manual-install hint printed for unsupported OSes.
- Added a `setup_test` case (`test_unzip_installed`) verifying `unzip` is present in the source and in the manual-install hint, wired into the test runner.

## Testing

- `./setup_test` — 13 tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TiF5QVAjtKURD9ijtc1Vac

---
_Generated by [Claude Code](https://claude.ai/code/session_01TiF5QVAjtKURD9ijtc1Vac)_