### PR TITLE
setup: install fnm (Fast Node Manager)

### DIFF
--- a/setup
+++ b/setup
@@ -828,7 +828,13 @@ install_fnm() {
     info "Installing fnm"
     # The upstream installer edits shell rc files by default; --skip-shell
     # keeps it out of them since the shell config is managed by the conf repo.
-    curl -fsSL https://fnm.vercel.app/install | bash -s -- --skip-shell
+    # Download to a temp file rather than piping curl into bash: a piped curl
+    # failure (network/HTTP error) is masked because bash exits 0 on the empty
+    # stdin, so set -e wouldn't catch it and fnm would silently never install.
+    fnm_installer=$(mktemp)
+    curl -fsSL https://fnm.vercel.app/install -o "$fnm_installer"
+    bash "$fnm_installer" --skip-shell
+    rm -f "$fnm_installer"
 }
 
 # --- Generate SSH key ---

--- a/setup
+++ b/setup
@@ -818,6 +818,19 @@ install_uv() {
     fi
 }
 
+# --- Install fnm (Fast Node Manager) ---
+
+install_fnm() {
+    if command -v fnm >/dev/null 2>&1; then
+        info "fnm already installed"
+        return
+    fi
+    info "Installing fnm"
+    # The upstream installer edits shell rc files by default; --skip-shell
+    # keeps it out of them since the shell config is managed by the conf repo.
+    curl -fsSL https://fnm.vercel.app/install | bash -s -- --skip-shell
+}
+
 # --- Generate SSH key ---
 
 generate_ssh_key() {
@@ -1000,6 +1013,7 @@ if test "$INSTALL" = yes; then
         install_fonts
     fi
     install_uv
+    install_fnm
 else
     info "Skipping software installation (--no-install)"
 fi

--- a/setup_test
+++ b/setup_test
@@ -187,6 +187,17 @@ test_unzip_installed() {
     assert_source_contains "typescript unzip zsh"
 }
 
+# --- fnm ---
+
+# fnm (Fast Node Manager) is installed via its upstream installer during the
+# install phase, alongside uv. --skip-shell keeps the installer out of the
+# shell rc files, which are managed by the conf repo, not setup.
+test_fnm_installed() {
+    assert_source_contains "install_fnm" &&
+    assert_source_contains "https://fnm.vercel.app/install" &&
+    assert_source_contains "skip-shell"
+}
+
 # --- SSH key ---
 
 # The default Krohnkite clone is HTTPS, but other repos (conf, scripts) are
@@ -216,6 +227,8 @@ run_test "swaync installs under its distro package names, decoupled" \
     test_swaync_package_names
 run_test "tsc installs alongside npm on every platform" \
     test_typescript_installed_with_npm
+run_test "fnm installs via its upstream installer with --skip-shell" \
+    test_fnm_installed
 run_test "unzip installs on every platform" test_unzip_installed
 run_test "SSH key prompt points at GitHub and Codeberg" \
     test_ssh_key_prompt_covers_github_and_codeberg

--- a/setup_test
+++ b/setup_test
@@ -191,11 +191,14 @@ test_unzip_installed() {
 
 # fnm (Fast Node Manager) is installed via its upstream installer during the
 # install phase, alongside uv. --skip-shell keeps the installer out of the
-# shell rc files, which are managed by the conf repo, not setup.
+# shell rc files, which are managed by the conf repo, not setup. The installer
+# is downloaded to a temp file rather than piped into bash: a piped curl
+# failure is masked (bash exits 0 on empty stdin) so set -e wouldn't catch it.
 test_fnm_installed() {
     assert_source_contains "install_fnm" &&
-    assert_source_contains "https://fnm.vercel.app/install" &&
-    assert_source_contains "skip-shell"
+    assert_source_contains "https://fnm.vercel.app/install -o" &&
+    assert_source_contains "skip-shell" &&
+    assert_source_not_contains "fnm.vercel.app/install | bash"
 }
 
 # --- SSH key ---


### PR DESCRIPTION
## Summary

Adds fnm (Fast Node Manager) to the `setup` bootstrap script.

- New `install_fnm` step runs during the install phase, right after `install_uv`, mirroring how other standalone tools are installed via their upstream installer.
- Uses fnm's official installer with `--skip-shell` so it doesn't edit the shell rc files — those are managed by the `conf` repo, not `setup`.
- Skips re-installing when `fnm` is already on `PATH`.

fnm was already referenced in the `--no-npm` help text as one of the alternative ways Node can be provided; now `setup` installs it directly.

## Testing

- Added `test_fnm_installed` to `setup_test`, checking the source wires up `install_fnm`, the upstream installer URL, and `--skip-shell`.
- `./setup_test` — 14/14 pass.
- `make test` — full scripts suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kwky7MwdowgBTUQz9sg39n

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kwky7MwdowgBTUQz9sg39n)_