### PR TITLE
Fix five bugs: terminal_on host, gitbackup stdin drain, du status masking, setup-hypr lid parity, setup --ssh

### DIFF
--- a/functions
+++ b/functions
@@ -136,12 +136,15 @@ get_size_of_file_or_directory()
     local size
     local file
     file="$1"
-    size=$(du -ks "$file" | cut -f 1)
+    # don't pipe into cut here: $? would report cut's status, masking
+    # a du failure (empty size that fails open in callers' -lt checks)
+    size=$(du -ks "$file")
     if test $? -ne 0
     then
         error "Cannot determine disk usage of $file"
         return 1
     fi
+    size=${size%%[[:space:]]*}
     debug "$file uses $size kilobytes of disk space"
     echo "$size"
     return 0

--- a/gitbackup
+++ b/gitbackup
@@ -209,7 +209,10 @@ do
     # create the destination directory if it doesn't exist
     # (rsync won't create the whole tree because we're only syncing part of the tree on each pass)
     debug "Creating $dstdir on $dsthost"
-    run ssh $dsthost 'dstdir="'"$dstdir"'"; test -d "$dstdir" || mkdir -p "$dstdir"'
+    # -n: don't let ssh inherit the find pipe feeding this loop as stdin,
+    # or it drains the remaining repository paths and only the first repo
+    # gets backed up
+    run ssh -n $dsthost 'dstdir="'"$dstdir"'"; test -d "$dstdir" || mkdir -p "$dstdir"'
 
     flags=
     if test "$debug"

--- a/setup
+++ b/setup
@@ -856,15 +856,23 @@ generate_ssh_key() {
         return
     fi
 
-    for key in "$HOME"/.ssh/id_*; do
-        case "$key" in
-            *.pub) continue ;;
-        esac
-        if test -f "$key"; then
-            info "SSH key already exists: $key"
-            return
-        fi
-    done
+    # Only auto mode skips on existing key files: --ssh promises to
+    # generate anyway, so it pushes past this check too. It still never
+    # clobbers the file ssh-keygen would write.
+    if test "$SSH" = auto; then
+        for key in "$HOME"/.ssh/id_*; do
+            case "$key" in
+                *.pub) continue ;;
+            esac
+            if test -f "$key"; then
+                info "SSH key already exists: $key; pass --ssh to create one anyway"
+                return
+            fi
+        done
+    elif test -f "$HOME/.ssh/id_ed25519"; then
+        info "SSH key already exists: $HOME/.ssh/id_ed25519; not overwriting"
+        return
+    fi
 
     info "Generating SSH key"
     mkdir -p "$HOME/.ssh"

--- a/setup-hypr
+++ b/setup-hypr
@@ -31,6 +31,10 @@ INSTALL=yes
 # set -e; "yes" (via --ignore-errors) leaves it off and pushes through.
 IGNORE_ERRORS=no
 
+# Where logind drop-ins live. Overridable for tests (SETUP_LOGIND_DIR), which
+# can't mock the real /etc.
+LOGIND_DIR="${SETUP_LOGIND_DIR:-/etc/systemd/logind.conf.d}"
+
 info() {
     printf "%s\n" "$*"
 }
@@ -98,12 +102,19 @@ fi
 # Hand full lid control to Hyprland (config/hypr/scripts/lid.sh) so a docked
 # laptop with the lid shut doesn't suspend when an external display is active.
 # A drop-in is cleaner than editing /etc/systemd/logind.conf directly.
+# Shared with the Sway build: setup-sway installs a drop-in with the same
+# settings, so whichever ran first wins and the other skips.
 install_logind_lid_dropin() {
     is_command systemctl || { warn "systemd not detected; skipping logind lid drop-in"; return 0; }
-    dropin_dir=/etc/systemd/logind.conf.d
-    dropin="$dropin_dir/10-hypr-lid.conf"
+    # Anchored to an uncommented assignment: a drop-in carrying a commented
+    # example like "#HandleLidSwitch=ignore" must not count as configured.
+    if grep -qsE '^[[:space:]]*HandleLidSwitch=ignore' "$LOGIND_DIR"/*.conf 2>/dev/null; then
+        info "logind already ignores the lid (drop-in present); skipping"
+        return 0
+    fi
+    dropin="$LOGIND_DIR/10-hypr-lid.conf"
     info "Installing logind lid drop-in ($dropin)"
-    sudo mkdir -p "$dropin_dir"
+    sudo mkdir -p "$LOGIND_DIR"
     sudo tee "$dropin" >/dev/null <<'CONF'
 # Installed by setup-hypr. Let Hyprland's lid handler (lid.sh) manage the lid
 # so a docked laptop with the lid closed keeps running on its external display.

--- a/setup-hypr_test
+++ b/setup-hypr_test
@@ -21,6 +21,10 @@ setup() {
     export XDG_CONFIG_HOME="$TEST_TMPDIR/config"
     unset HYPRLAND_INSTANCE_SIGNATURE
 
+    # Point the logind drop-in dir into the sandbox so the already-configured
+    # check reads test fixtures, not the host's /etc.
+    export SETUP_LOGIND_DIR="$TEST_TMPDIR/logind.conf.d"
+
     # sudo records its argv and discards any heredoc stdin (e.g. the logind
     # drop-in piped to `sudo tee`) so nothing touches the real system.
     cat > "$TEST_TMPDIR/bin/sudo" <<MOCK
@@ -151,8 +155,29 @@ test_does_not_install_packages() {
 test_installs_logind_lid_dropin() {
     run_hypr
     assert_status 0 &&
-    assert_called "sudo mkdir -p /etc/systemd/logind.conf.d" &&
-    assert_called "sudo tee /etc/systemd/logind.conf.d/10-hypr-lid.conf"
+    assert_called "sudo mkdir -p $SETUP_LOGIND_DIR" &&
+    assert_called "sudo tee $SETUP_LOGIND_DIR/10-hypr-lid.conf"
+}
+
+# Shared with the Sway build: when a drop-in (e.g. setup-sway's) already
+# ignores the lid, nothing is written.
+test_skips_dropin_when_lid_already_ignored() {
+    mkdir -p "$SETUP_LOGIND_DIR"
+    printf '[Login]\nHandleLidSwitch=ignore\n' > "$SETUP_LOGIND_DIR/10-sway-lid.conf"
+    run_hypr
+    assert_status 0 &&
+    assert_output_contains "already ignores the lid" &&
+    assert_not_called "sudo tee"
+}
+
+# A commented example ("#HandleLidSwitch=ignore") is not configuration --
+# systemd ignores it, so the drop-in must still be installed.
+test_commented_lid_entry_does_not_skip_dropin() {
+    mkdir -p "$SETUP_LOGIND_DIR"
+    printf '[Login]\n#HandleLidSwitch=ignore\n' > "$SETUP_LOGIND_DIR/50-example.conf"
+    run_hypr
+    assert_status 0 &&
+    assert_called "sudo tee $SETUP_LOGIND_DIR/10-hypr-lid.conf"
 }
 
 test_reloads_logind() {
@@ -173,7 +198,7 @@ test_enables_power_profiles_daemon() {
 test_no_install_skips_system_changes() {
     run_hypr --no-install
     assert_status 0 &&
-    assert_not_called "sudo tee /etc/systemd/logind.conf.d" &&
+    assert_not_called "sudo tee $SETUP_LOGIND_DIR" &&
     assert_output_contains "Skipping logind"
 }
 
@@ -259,6 +284,10 @@ run_test "-h flag" test_h_flag
 run_test "unknown option errors" test_unknown_option
 run_test "does not install packages (setup does)" test_does_not_install_packages
 run_test "installs logind lid drop-in" test_installs_logind_lid_dropin
+run_test "skips drop-in when the lid is already ignored (shared with sway)" \
+    test_skips_dropin_when_lid_already_ignored
+run_test "commented lid entry does not skip the drop-in" \
+    test_commented_lid_entry_does_not_skip_dropin
 run_test "reloads logind" test_reloads_logind
 run_test "enables power-profiles-daemon" test_enables_power_profiles_daemon
 run_test "no-install skips system changes" test_no_install_skips_system_changes

--- a/setup_test
+++ b/setup_test
@@ -213,6 +213,15 @@ test_ssh_key_prompt_covers_github_and_codeberg() {
     assert_source_contains "add the key to GitHub and Codeberg"
 }
 
+# --ssh promises to generate a key even when one is already available, so
+# only auto mode may skip on existing on-disk keys; forced mode pushes past
+# that check and skips only to avoid clobbering the id_ed25519 it would write.
+test_ssh_flag_overrides_existing_key_check() {
+    assert_source_contains 'test "$SSH" = auto' &&
+    assert_source_contains "pass --ssh to create one anyway" &&
+    assert_source_contains "not overwriting"
+}
+
 # After cloning the repos, setup offers to flip their remotes to SSH via the
 # gittossh helper. The prompt must default to no so a non-interactive
 # "curl | sh" run doesn't rewrite remotes unasked.
@@ -235,6 +244,8 @@ run_test "fnm installs via its upstream installer with --skip-shell" \
 run_test "unzip installs on every platform" test_unzip_installed
 run_test "SSH key prompt points at GitHub and Codeberg" \
     test_ssh_key_prompt_covers_github_and_codeberg
+run_test "--ssh overrides the existing-key skip" \
+    test_ssh_flag_overrides_existing_key_check
 run_test "setup offers to switch repo remotes to SSH" \
     test_offers_ssh_remote_switch
 

--- a/terminal_on
+++ b/terminal_on
@@ -1,7 +1,7 @@
 #!/bin/bash
 . "$HOME"/.shrc
 set -eu
-destination="$1"
+destination="${1:-}"
 if test -z "$destination"; then
   echo "Usage: $0 hostname" >&2
   exit 2
@@ -14,5 +14,5 @@ fi
 if command -v rw >/dev/null 2>&1; then
   terminal rw -r "$destination"
 else
-  terminal bash -i -c 'need_auth && auth; ssh -n "$destination" true; ssh "$destination"'
+  terminal bash -i -c 'need_auth && auth; ssh -n "$1" true; ssh "$1"' bash "$destination"
 fi


### PR DESCRIPTION
Bug-hunt pass over the repo. Five fixes, one commit each; each was reproduced before fixing and verified after.

1. **terminal_on never passed the hostname to the spawned shell.** The single-quoted command left `$destination` for the child bash to expand, but it was never exported, so on machines without `rw` the terminal ran `ssh ""`. The host is now passed as a positional argument. Also, `set -eu` ran before the usage check, so invoking with no argument died on an unbound-variable error instead of printing usage — verified both paths with a stubbed `terminal`.

2. **gitbackup silently backed up only the first repository.** The `ssh` call that creates the remote directory inherited the `find` pipe feeding the `while read` loop and drained the remaining repo paths. `ssh -n` reads from /dev/null instead.

3. **`get_size_of_file_or_directory` masked `du` failures** by testing `$?` after a pipe into `cut` (which exits 0), returning success with an empty size — gitbackup's disk-space guard then failed open. It now checks `du`'s own status and strips the path field with parameter expansion.

4. **setup-hypr rewrote the logind lid drop-in on every run and duplicated setup-sway's.** setup-sway documents the skip-if-already-ignored behavior as mutual, but setup-hypr had no such check. Copied the guard and the `SETUP_LOGIND_DIR` test override over, with the same skip/commented-entry tests as setup-sway_test.

5. **`setup --ssh` was a no-op with any key file on disk**, contradicting its help text ("generate an SSH key even if one is already available"): only the ssh-agent check was gated on auto mode. The on-disk loop is now gated too; forced mode still refuses to clobber an existing `id_ed25519`.

`make test` green: all suites pass, including the two new setup-hypr lid tests (14 → was 12) and the new setup --ssh source assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZ2yuzkAp1syaGGQEfRC2y

---
_Generated by [Claude Code](https://claude.ai/code/session_01GZ2yuzkAp1syaGGQEfRC2y)_