### PR TITLE
Bug hunt: session-picker filtering, unrun package_test, pa.py robustness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ test:
 	./detachsession_test
 	./makesession_test
 	./mdf_test
+	./pa_test
+	./package_test
 	./gittossh_test
 	./runenv_test
 	./setup_test

--- a/pa.py
+++ b/pa.py
@@ -4,6 +4,7 @@
 
 import re
 import subprocess
+import sys
 
 
 def get_active_port(output):
@@ -30,12 +31,22 @@ def get_active_port(output):
           port_names[m[1]] = m[2]
 
 
+def format_ports(ports):
+  # Drop missing ports (no default sink/source, PulseAudio not running)
+  # instead of rendering the literal string "None" in the status bar.
+  return ' '.join(p for p in ports if p)
+
+
 def main():
-  ports = [get_active_port(result.stdout)
-           for subcommand in ['list-sinks', 'list-sources']
-           for result in [subprocess.run(['pacmd', subcommand], capture_output=True)]]
-  print(' '.join('%s' % p for p in ports))
+  try:
+    results = [subprocess.run(['pacmd', subcommand], capture_output=True)
+               for subcommand in ['list-sinks', 'list-sources']]
+  except FileNotFoundError:
+    print('pa.py: pacmd not found', file=sys.stderr)
+    return 1
+  print(format_ports(get_active_port(result.stdout) for result in results))
+  return 0
 
 
 if __name__ == '__main__':
-  main()
+  sys.exit(main())

--- a/pa_test
+++ b/pa_test
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# Tests for pa.py: the pacmd output parser and the status-bar formatting.
+# Regression: with no default sink/source (or PulseAudio down) pa.py printed
+# the literal string "None None"; with pacmd missing it crashed with a
+# traceback.
+
+import importlib.util
+import os
+import subprocess
+import sys
+
+_dir = os.path.dirname(os.path.abspath(__file__))
+_spec = importlib.util.spec_from_file_location('pa', os.path.join(_dir, 'pa.py'))
+pa = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(pa)
+
+SAMPLE = b'''2 sink(s) available.
+    index: 0
+	name: <other-sink>
+	active port: <other-port>
+  * index: 1
+	name: <default-sink>
+	ports:
+		analog-output-speaker: Speakers (priority 10000, latency offset 0 usec)
+	active port: <analog-output-speaker>
+'''
+
+tests_run = 0
+failures = 0
+
+
+def check(label, expected, actual):
+  global tests_run, failures
+  tests_run += 1
+  if expected == actual:
+    print('ok %d %s' % (tests_run, label))
+  else:
+    print('not ok %d %s' % (tests_run, label))
+    print('  expected: %r' % (expected,))
+    print('  actual:   %r' % (actual,))
+    failures += 1
+
+
+check('active port of the default sink is resolved to its name',
+      'Speakers', pa.get_active_port(SAMPLE))
+check('empty pacmd output yields no port, not a crash',
+      None, pa.get_active_port(b''))
+check('output without a default marker yields no port',
+      None, pa.get_active_port(b'    index: 0\n\tactive port: <p>\n'))
+check('missing ports are dropped from the status line',
+      'Speakers', pa.format_ports(['Speakers', None]))
+check('all ports missing renders an empty line, not "None None"',
+      '', pa.format_ports([None, None]))
+
+# End-to-end: pacmd absent must print an error to stderr and exit non-zero,
+# never a traceback.
+env = dict(os.environ, PATH='/nonexistent')
+result = subprocess.run([sys.executable, os.path.join(_dir, 'pa.py')],
+                        capture_output=True, env=env, text=True)
+check('missing pacmd exits non-zero', True, result.returncode != 0)
+check('missing pacmd reports the problem without a traceback',
+      True, 'pacmd not found' in result.stderr
+      and 'Traceback' not in result.stderr)
+
+print()
+print('%d tests, %d passed, %d failed' % (tests_run, tests_run - failures, failures))
+sys.exit(1 if failures else 0)

--- a/pa_test
+++ b/pa_test
@@ -9,6 +9,9 @@ import os
 import subprocess
 import sys
 
+# Don't drop a __pycache__/ dir in the repo when importing pa.py.
+sys.dont_write_bytecode = True
+
 _dir = os.path.dirname(os.path.abspath(__file__))
 _spec = importlib.util.spec_from_file_location('pa', os.path.join(_dir, 'pa.py'))
 pa = importlib.util.module_from_spec(_spec)

--- a/sessionlib
+++ b/sessionlib
@@ -190,9 +190,14 @@ choose_session() {
   # --print-query lets a typed-but-unmatched name become a new session. The
   # preview calls back into this script for the highlighted row's field 2.
   local out query selection
+  # --with-nth=3 alone scopes both display AND search to field 3. Do not
+  # add --nth: fzf applies --nth to the with-nth-transformed line (which
+  # has no tabs left), so --nth=3 made every non-empty query match
+  # nothing and typing in the picker always fell through to "create a
+  # new session by that name".
   out="$(printf '%s\n' "$list" | "${CHANGESESSION_FZF:-fzf}" \
     --ansi \
-    --delimiter='\t' --with-nth=3 --nth=3 \
+    --delimiter='\t' --with-nth=3 \
     --print-query \
     --header='Enter: switch/create   type: filter or new name   ESC: cancel' \
     --preview="$SESSION_SELF --preview {2}" \

--- a/sessionlib_test
+++ b/sessionlib_test
@@ -113,6 +113,58 @@ test_fresh_auto_name_shows_create_entry() {
   test "$creates" -eq 1  || { echo "  FAIL: expected exactly one create entry, got $creates"; TEST_FAILED=1; }
 }
 
+# --- picker search flags -----------------------------------------------------
+
+# Record the args choose_session passes to fzf, via a stub that saves them and
+# cancels. Used by both picker-flag tests below.
+record_fzf_args() {
+  FZF_ARGS_FILE="$TMPDIR_FZF/args"
+  export FZF_ARGS_FILE
+  cat > "$TMPDIR_FZF/fzf" <<'FZF'
+#!/bin/bash
+printf '%s\n' "$@" > "$FZF_ARGS_FILE"
+cat >/dev/null
+exit 130
+FZF
+  chmod +x "$TMPDIR_FZF/fzf"
+  CHANGESESSION_FZF="$TMPDIR_FZF/fzf" SESSION_SELF=/bin/true choose_session >/dev/null 2>&1
+  test -f "$FZF_ARGS_FILE"
+}
+
+test_picker_does_not_pass_nth() {
+  # Regression: --nth=3 alongside --with-nth=3 scoped the search to a field
+  # that doesn't exist in the with-nth-transformed line (which has no tabs
+  # left), so every non-empty query matched nothing and typing in the picker
+  # always fell through to "create a new session by that name".
+  STUB_ROWS="$(printf 'proj/1\tattached\t/home/u/proj\tvim\n')"
+  TMPDIR_FZF="$(mktemp -d)"
+  record_fzf_args || { echo "  FAIL: fzf stub was not invoked"; TEST_FAILED=1; rm -rf "$TMPDIR_FZF"; return 0; }
+  grep -qx -- '--with-nth=3' "$FZF_ARGS_FILE" \
+    || { echo "  FAIL: picker no longer restricts display/search with --with-nth=3"; TEST_FAILED=1; }
+  ! grep -q -- '^--nth' "$FZF_ARGS_FILE" \
+    || { echo "  FAIL: picker passes --nth, which empties the search scope under --with-nth"; TEST_FAILED=1; }
+  rm -rf "$TMPDIR_FZF"
+}
+
+test_picker_query_matches_display_field() {
+  # End-to-end pin with a real fzf: the search flags choose_session uses must
+  # let a typed query match the displayed (command) column. Skips when fzf
+  # isn't installed.
+  command -v fzf >/dev/null 2>&1 || return 0
+  STUB_ROWS="$(printf 'proj/1\tattached\t/home/u/proj\tvim\n')"
+  TMPDIR_FZF="$(mktemp -d)"
+  record_fzf_args || { echo "  FAIL: fzf stub was not invoked"; TEST_FAILED=1; rm -rf "$TMPDIR_FZF"; return 0; }
+  # Replay only the search-scoping flags against the real fzf in filter mode.
+  local search_flags matched
+  search_flags="$(grep -E -- '^--(delimiter|with-nth|nth)' "$FZF_ARGS_FILE")"
+  # shellcheck disable=SC2086
+  matched="$(printf 'switch\tproj/1\t*  proj/1  code  vim\n' | fzf $search_flags --filter=vim)" \
+    || true
+  test -n "$matched" \
+    || { echo "  FAIL: query 'vim' matches nothing under the picker's search flags"; TEST_FAILED=1; }
+  rm -rf "$TMPDIR_FZF"
+}
+
 run_test test_existing_attached_auto_session_listed_once \
   "build_list: an attached auto session is not listed twice"
 run_test test_existing_disconnected_auto_session_listed_once \
@@ -121,6 +173,10 @@ run_test test_reused_auto_target_stays_default_row \
   "build_list: a reused auto target stays the first/default row"
 run_test test_fresh_auto_name_shows_create_entry \
   "build_list: a fresh auto name still shows the create entry first"
+run_test test_picker_does_not_pass_nth \
+  "choose_session: no --nth flag alongside --with-nth (typed filtering works)"
+run_test test_picker_query_matches_display_field \
+  "choose_session: search flags let a query match the command column"
 
 echo
 echo "$TESTS_RUN tests, $TESTS_PASSED passed, $TESTS_FAILED failed"


### PR DESCRIPTION
Fixes from a bug hunt:

- **sessionlib: typing in the picker matched nothing and silently created a new session.** fzf applies `--nth` to the `--with-nth`-transformed line, and the transformed line here is field 3 alone with no tabs left, so `--nth=3` scoped the search to a nonexistent token: every non-empty query emptied the list, and Enter fell through to the typed-new-name path — typing `vim` to narrow to the session running vim created a fresh session named `vim` instead. `--with-nth=3` alone scopes both display and search correctly. Verified against fzf 0.38 and 0.74. This affects `changesession`, `changetmux`, `changeshpool`, and `choosesession`, which all share `choose_session`. The stubbed-fzf tests couldn't see flag semantics, so the new tests pin the flags passed to the stub and, when a real fzf is installed, replay the recorded search flags through `fzf --filter` to prove a query matches the command column (both new tests fail against the old code).
- **Makefile: `make test` never ran `package_test`** — the only `*_test` missing from the target, guarding a script that runs package managers as root. All 50 of its tests pass; it's in the list now.
- **pa.py printed `None None` in the status bar** whenever there was no default sink/source (PulseAudio down, PipeWire without pacmd compat), and crashed with a traceback when `pacmd` wasn't installed. Missing ports are now dropped and a missing pacmd is a clean one-line error + non-zero exit. Added `pa_test` (also wired into `make test`).

Found but not fixed (vestigial, no runtime effect): `gitbackup`'s cleanup guards a `$dfout` that's never assigned, and `confdist`'s unused `run()` reads an uninitialized `$simulate`.

## Testing
`make test`: all 18 suites pass (16 existing + `package_test` now running + new `pa_test`); the sessionlib picker tests were also run against a locally built real fzf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011gsEEigmTU1teqmTVuNW2g

---
_Generated by [Claude Code](https://claude.ai/code/session_011gsEEigmTU1teqmTVuNW2g)_