### PR TITLE
Add --no-sudo mode, centralized in the sudo_or_warn wrapper

### DIFF
--- a/setup
+++ b/setup
@@ -31,6 +31,15 @@
 # instead of aborting on the first one. Both flags are forwarded to
 # setup-kde / setup-macos.
 #
+# Every privileged command runs through sudo_or_warn, so an unexpected sudo
+# denial already degrades to a warning instead of aborting the bootstrap --
+# which means a box that only permits "sudo apt" works as-is (the package
+# installs succeed and the other privileged steps warn and skip). Pass
+# --no-sudo when the box has no sudo at all: sudo_or_warn then skips every
+# privileged command up front, package installs included, so setup never
+# prompts for a password or stalls on a command it can't run. --no-sudo is
+# forwarded to setup-kde / setup-hypr / setup-sway / setup-macos.
+#
 # An SSH key is generated only when one isn't already available -- the
 # check skips generation when ssh-add -l lists a key (e.g. a forwarded
 # agent) or a key file already exists. Pass --ssh to generate one anyway,
@@ -93,6 +102,19 @@ SSH=auto
 #         (nvm, fnm, corepack, a standalone pnpm, etc.)
 NPM=yes
 
+# Whether to run sudo at all. One of:
+#   yes - sudo is available; run every privileged step (the default). An
+#         unexpected sudo failure is still folded into a warning by
+#         sudo_or_warn and the bootstrap continues -- so a box that only lets
+#         you "sudo apt" already works in this mode: the package installs
+#         succeed and every other privileged step warns and skips on the denial.
+#   no  - no sudo (--no-sudo). sudo_or_warn skips every privileged command up
+#         front instead of attempting it -- so setup never prompts for a
+#         password or stalls on a command it can't run. For machines with no
+#         sudo at all (packages preinstalled or provided some other way).
+# Override with --sudo / --no-sudo, or by exporting SUDO before running.
+SUDO="${SUDO:-yes}"
+
 # Which Linux desktop to install and configure (ignored on macOS). One of:
 #   kde   - KDE Plasma + Krohnkite, via setup-kde (the default)
 #   hypr  - Hyprland Wayland desktop, via setup-hypr
@@ -104,8 +126,8 @@ DESKTOP="${DESKTOP:-kde}"
 usage() {
     cat <<'USAGE'
 Usage: setup [--gui | --no-gui] [--kde | --hypr | --sway] [--minimal | --full]
-             [--no-install] [--ignore-errors] [--ssh | --no-ssh] [--no-npm]
-             [-h | --help]
+             [--no-install] [--no-sudo] [--ignore-errors] [--ssh | --no-ssh]
+             [--no-npm] [-h | --help]
 
 Bootstrap a new machine: install packages, fonts, tools, and dotfiles.
 
@@ -120,6 +142,12 @@ Options:
   --full           Install everything, even when disk space looks tight
   --no-install     Skip every install step (packages, fonts, uv, extras, root
                    config) and only (re)apply config. Forwarded to setup-kde/macos
+  --no-sudo        Run no sudo at all: every privileged command (package
+                   installs included) is skipped up front instead of attempted,
+                   so setup never prompts or stalls. For boxes with no sudo. A
+                   box that allows only "sudo apt" needs nothing special --
+                   leave sudo on and the denials warn and skip themselves.
+                   Forwarded to the desktop setup helpers
   --ignore-errors  Keep going past failures instead of aborting on the first
                    one. Forwarded to setup-kde/macos
   --ssh            Generate an SSH key even if one is already available
@@ -150,8 +178,20 @@ warn() {
 # line is folded into a concise warning. Shell-standard 126/127 statuses are
 # more useful than some sudo implementations' diagnostics, so name those
 # explicitly.
+#
+# Under --no-sudo (SUDO=no) the command is skipped up front rather than
+# attempted, and reported with a non-zero return so a caller's `|| warn` or
+# `if sudo_or_warn ...` guard skips the dependent work. This is the single
+# choke point for every privileged command, so gating it here is all it takes
+# to make setup never invoke sudo. (A box that allows only "sudo apt" doesn't
+# need this: leave sudo on and the reactive path below warns and skips on the
+# denials by itself.)
 sudo_or_warn() {
     _sudo_name=${1##*/}
+    if test "$SUDO" = no; then
+        warn "skipping 'sudo $_sudo_name' (--no-sudo)"
+        return 1
+    fi
     _sudo_stderr=$(mktemp) || {
         warn "sudo $_sudo_name: could not create a temporary error log"
         return 1
@@ -220,6 +260,12 @@ while test $# -gt 0; do
         --no-install)
             INSTALL=no
             ;;
+        --sudo)
+            SUDO=yes
+            ;;
+        --no-sudo)
+            SUDO=no
+            ;;
         --ignore-errors)
             IGNORE_ERRORS=yes
             ;;
@@ -259,6 +305,9 @@ fi
 DESKTOP_SETUP_FLAGS=""
 if test "$INSTALL" = no; then
     DESKTOP_SETUP_FLAGS="$DESKTOP_SETUP_FLAGS --no-install"
+fi
+if test "$SUDO" = no; then
+    DESKTOP_SETUP_FLAGS="$DESKTOP_SETUP_FLAGS --no-sudo"
 fi
 if test "$IGNORE_ERRORS" = yes; then
     DESKTOP_SETUP_FLAGS="$DESKTOP_SETUP_FLAGS --ignore-errors"

--- a/setup-hypr
+++ b/setup-hypr
@@ -62,6 +62,51 @@ is_command() {
     test -x "$(command -v "$1")"
 }
 
+# Run one privileged command without letting a sudo failure abort the helper
+# under set -e. Mirrors setup's sudo_or_warn: on a box where sudo is allowed
+# for package installs but denied for other commands, a denied lid/service
+# step warns and the helper keeps going instead of exiting. The proactive
+# --no-sudo skip is handled by the caller's SUDO guard below, so this wrapper
+# only needs the reactive path -- but it still honours SUDO=no defensively.
+sudo_or_warn() {
+    _sudo_name=${1##*/}
+    if test "$SUDO" = no; then
+        warn "skipping 'sudo $_sudo_name' (--no-sudo)"
+        return 1
+    fi
+    _sudo_stderr=$(mktemp) || {
+        warn "sudo $_sudo_name: could not create a temporary error log"
+        return 1
+    }
+
+    if sudo "$@" 2>"$_sudo_stderr"; then
+        cat "$_sudo_stderr" >&2
+        rm -f "$_sudo_stderr"
+        return 0
+    else
+        _sudo_status=$?
+    fi
+    _sudo_detail=$(awk 'NF { line = $0 } END { print line }' "$_sudo_stderr")
+    rm -f "$_sudo_stderr"
+
+    case "$_sudo_status" in
+        126) _sudo_detail="permission denied" ;;
+        127) _sudo_detail="command not found" ;;
+        *)
+            case "$_sudo_detail" in
+                "sudo: $_sudo_name: "*) _sudo_detail=${_sudo_detail#"sudo: $_sudo_name: "} ;;
+                "sudo: "*) _sudo_detail=${_sudo_detail#"sudo: "} ;;
+                "$_sudo_name: "*) _sudo_detail=${_sudo_detail#"$_sudo_name: "} ;;
+            esac
+            if test -z "$_sudo_detail"; then
+                _sudo_detail="failed (exit status $_sudo_status)"
+            fi
+            ;;
+    esac
+    warn "sudo $_sudo_name: $_sudo_detail"
+    return "$_sudo_status"
+}
+
 usage() {
     cat <<'USAGE'
 Usage: setup-hypr [--no-install] [--no-sudo] [--ignore-errors] [-h | --help]
@@ -132,8 +177,13 @@ install_logind_lid_dropin() {
     fi
     dropin="$LOGIND_DIR/10-hypr-lid.conf"
     info "Installing logind lid drop-in ($dropin)"
-    sudo mkdir -p "$LOGIND_DIR"
-    sudo tee "$dropin" >/dev/null <<'CONF'
+    # sudo_or_warn so a denied step (e.g. sudo allowed for apt but not for
+    # this) warns and returns instead of aborting the helper under set -e.
+    if ! sudo_or_warn mkdir -p "$LOGIND_DIR"; then
+        warn "could not create $LOGIND_DIR; skipping the lid drop-in"
+        return 0
+    fi
+    if ! sudo_or_warn tee "$dropin" >/dev/null <<'CONF'
 # Installed by setup-hypr. Let Hyprland's lid handler (lid.sh) manage the lid
 # so a docked laptop with the lid closed keeps running on its external display.
 [Login]
@@ -141,8 +191,12 @@ HandleLidSwitch=ignore
 HandleLidSwitchExternalPower=ignore
 HandleLidSwitchDocked=ignore
 CONF
+    then
+        warn "could not write $dropin; skipping the lid drop-in"
+        return 0
+    fi
     # Reload logind so the drop-in takes effect without a reboot.
-    sudo systemctl kill -s HUP systemd-logind 2>/dev/null \
+    sudo_or_warn systemctl kill -s HUP systemd-logind \
         || warn "could not reload systemd-logind; changes apply after reboot"
 }
 
@@ -152,7 +206,7 @@ enable_services() {
     is_command systemctl || { warn "systemd not detected; enable power-profiles-daemon manually"; return 0; }
     if systemctl list-unit-files power-profiles-daemon.service >/dev/null 2>&1; then
         info "Enabling power-profiles-daemon"
-        sudo systemctl enable --now power-profiles-daemon.service \
+        sudo_or_warn systemctl enable --now power-profiles-daemon.service \
             || warn "could not enable power-profiles-daemon"
     else
         warn "power-profiles-daemon.service not found; install power-profiles-daemon"

--- a/setup-hypr
+++ b/setup-hypr
@@ -23,9 +23,19 @@
 #
 # --no-install skips the system-modifying steps (logind drop-in, enabling the
 # service). --ignore-errors keeps going past failures. setup forwards both.
+#
+# --no-sudo (also forwarded by setup) skips the same system-modifying steps:
+# the logind drop-in and enabling power-profiles-daemon both need sudo, which
+# a no-sudo machine lacks. The user-level config (seeding hyprland.conf.local)
+# still runs.
 
 # Whether to install packages. "no" (via --no-install) skips the install.
 INSTALL=yes
+
+# Whether to run the privileged steps. "yes" runs them (the default); "no"
+# (via --no-sudo) skips them -- the logind drop-in and enabling
+# power-profiles-daemon both need sudo.
+SUDO=yes
 
 # Whether to keep going past failures. "no" aborts on the first error via
 # set -e; "yes" (via --ignore-errors) leaves it off and pushes through.
@@ -54,12 +64,14 @@ is_command() {
 
 usage() {
     cat <<'USAGE'
-Usage: setup-hypr [--no-install] [--ignore-errors] [-h | --help]
+Usage: setup-hypr [--no-install] [--no-sudo] [--ignore-errors] [-h | --help]
 
 Configure a Hyprland-based Wayland desktop (packages come from `setup`).
 
 Options:
   --no-install     Skip the system-modifying steps (logind drop-in, services)
+  --no-sudo        Skip the same steps: the logind drop-in and enabling
+                   power-profiles-daemon both need sudo
   --ignore-errors  Keep going past failures instead of aborting on the first
   -h, --help       Show this help and exit
 USAGE
@@ -74,6 +86,12 @@ while test $# -gt 0; do
             ;;
         --no-install)
             INSTALL=no
+            ;;
+        --sudo)
+            SUDO=yes
+            ;;
+        --no-sudo)
+            SUDO=no
             ;;
         --ignore-errors)
             IGNORE_ERRORS=yes
@@ -193,8 +211,11 @@ seed_conf_local() {
 
 # The Wayland desktop packages are installed by the top-level `setup`. Here we
 # only apply the system-modifying config; --no-install skips it (e.g. a dry run
-# or when re-running just to source setup-hypr.local).
-if test "$INSTALL" = yes; then
+# or when re-running just to source setup-hypr.local). --no-sudo skips it too,
+# since the logind drop-in and service enablement both need sudo.
+if test "$SUDO" = no; then
+    info "Skipping logind drop-in and service enablement (needs sudo; --no-sudo)"
+elif test "$INSTALL" = yes; then
     install_logind_lid_dropin
     enable_services
 else

--- a/setup-hypr_test
+++ b/setup-hypr_test
@@ -202,6 +202,19 @@ test_no_install_skips_system_changes() {
     assert_output_contains "Skipping logind"
 }
 
+# --no-sudo skips the same privileged steps (the logind drop-in and enabling
+# power-profiles-daemon both need sudo) -- no sudo is called -- while the
+# user-level config.local seeding still runs.
+test_no_sudo_skips_privileged_steps() {
+    mkdir -p "$XDG_CONFIG_HOME/hypr"
+    echo "# template body" > "$XDG_CONFIG_HOME/hypr/hyprland.conf.local.template"
+    run_hypr --no-sudo
+    assert_status 0 &&
+    assert_not_called "sudo" &&
+    assert_output_contains "needs sudo; --no-sudo" &&
+    assert_file_contains "$XDG_CONFIG_HOME/hypr/hyprland.conf.local" "template body"
+}
+
 # --- per-machine hyprland.conf.local seeding ---
 
 assert_file_contains() {
@@ -291,6 +304,8 @@ run_test "commented lid entry does not skip the drop-in" \
 run_test "reloads logind" test_reloads_logind
 run_test "enables power-profiles-daemon" test_enables_power_profiles_daemon
 run_test "no-install skips system changes" test_no_install_skips_system_changes
+run_test "no-sudo skips privileged steps, keeps user config" \
+    test_no_sudo_skips_privileged_steps
 run_test "seeds hyprland.conf.local from the template" \
     test_seeds_conf_local_from_template
 run_test "creates an empty hyprland.conf.local without the template" \

--- a/setup-hypr_test
+++ b/setup-hypr_test
@@ -215,6 +215,26 @@ test_no_sudo_skips_privileged_steps() {
     assert_file_contains "$XDG_CONFIG_HOME/hypr/hyprland.conf.local" "template body"
 }
 
+# Partial sudo (allowed for apt, denied here): the privileged lid/service
+# steps now go through sudo_or_warn, so a denial WARNS and the helper keeps
+# going instead of aborting under set -e. The user-level seeding still runs.
+test_denied_sudo_warns_and_continues() {
+    cat > "$TEST_TMPDIR/bin/sudo" <<MOCK
+#!/bin/sh
+echo "sudo \$*" >> "$CALLS"
+echo "sudo: a password is required" >&2
+exit 1
+MOCK
+    chmod +x "$TEST_TMPDIR/bin/sudo"
+    mkdir -p "$XDG_CONFIG_HOME/hypr"
+    echo "# template body" > "$XDG_CONFIG_HOME/hypr/hyprland.conf.local.template"
+    run_hypr
+    assert_status 0 &&
+    assert_called "sudo mkdir -p $SETUP_LOGIND_DIR" &&
+    assert_output_contains "Warning" &&
+    assert_file_contains "$XDG_CONFIG_HOME/hypr/hyprland.conf.local" "template body"
+}
+
 # --- per-machine hyprland.conf.local seeding ---
 
 assert_file_contains() {
@@ -306,6 +326,8 @@ run_test "enables power-profiles-daemon" test_enables_power_profiles_daemon
 run_test "no-install skips system changes" test_no_install_skips_system_changes
 run_test "no-sudo skips privileged steps, keeps user config" \
     test_no_sudo_skips_privileged_steps
+run_test "denied sudo warns and continues (partial sudo)" \
+    test_denied_sudo_warns_and_continues
 run_test "seeds hyprland.conf.local from the template" \
     test_seeds_conf_local_from_template
 run_test "creates an empty hyprland.conf.local without the template" \

--- a/setup-kde
+++ b/setup-kde
@@ -14,11 +14,16 @@
 #           .kwinscript), go-task (preferred build tool), p7zip
 #
 # Usage:
-#     setup-kde [--no-install] [--ignore-errors] [-h | --help]
+#     setup-kde [--no-install] [--no-sudo] [--ignore-errors] [-h | --help]
 #
 # --no-install skips building/installing Krohnkite and only (re)applies the
 # KDE configuration. --ignore-errors keeps going past failures instead of
 # aborting on the first one. setup forwards both flags here.
+#
+# --no-sudo is accepted (and forwarded by setup) for consistency with the
+# other setup helpers, but has nothing to skip: as noted above this helper
+# uses no sudo, so it already runs unchanged on a machine with restricted
+# sudo.
 #
 # Krohnkite comes from my fork's mikel branch by default; set KROHNKITE_REPO
 # (any git URL or local path) and/or KROHNKITE_BRANCH to clone something
@@ -69,12 +74,14 @@ is_command() {
 
 usage() {
     cat <<'USAGE'
-Usage: setup-kde [--no-install] [--ignore-errors] [-h | --help]
+Usage: setup-kde [--no-install] [--no-sudo] [--ignore-errors] [-h | --help]
 
 Configure the KDE Plasma 6 desktop environment.
 
 Options:
   --no-install     Skip building/installing Krohnkite; only (re)apply config
+  --no-sudo        Accepted for consistency with setup; setup-kde uses no
+                   sudo, so there's nothing to skip
   --ignore-errors  Keep going past failures instead of aborting on the first
   -h, --help       Show this help and exit
 USAGE
@@ -89,6 +96,10 @@ while test $# -gt 0; do
             ;;
         --no-install)
             INSTALL=no
+            ;;
+        --sudo|--no-sudo)
+            # setup-kde performs no privileged operations, so --no-sudo is
+            # accepted (and forwarded by setup) but has nothing to skip.
             ;;
         --ignore-errors)
             IGNORE_ERRORS=yes

--- a/setup-kde_test
+++ b/setup-kde_test
@@ -227,6 +227,14 @@ test_unknown_option() {
     assert_output_contains "Unknown option"
 }
 
+# --no-sudo is accepted (setup forwards it) and is a pure no-op here: setup-kde
+# uses no sudo, so config still goes through kwriteconfig6 and the run succeeds.
+test_no_sudo_accepted_noop() {
+    run_kde --no-install --no-sudo
+    assert_status 0 &&
+    assert_called "kwriteconfig6 --file kwinrc --group Plugins --key krohnkiteEnabled true"
+}
+
 # setup-kde is entirely user-scoped. Even a sudo executable that always fails
 # must be irrelevant to KDE configuration.
 test_failing_sudo_is_not_used() {
@@ -425,6 +433,7 @@ MOCK
 
 run_test "help flag" test_help_flag
 run_test "unknown option errors" test_unknown_option
+run_test "--no-sudo is accepted as a no-op" test_no_sudo_accepted_noop
 run_test "failing sudo does not affect user-scoped KDE setup" \
     test_failing_sudo_is_not_used
 run_test "clones my krohnkite fork by default" test_clones_fork_by_default

--- a/setup-macos
+++ b/setup-macos
@@ -18,12 +18,13 @@
 # Requires: defaults, hidutil
 #
 # Usage:
-#     setup-macos [--no-install] [--ignore-errors] [-h | --help]
+#     setup-macos [--no-install] [--no-sudo] [--ignore-errors] [-h | --help]
 #
-# setup forwards --no-install and --ignore-errors here. macOS configuration
-# installs no separate software (everything is `defaults`/Automator config),
-# so --no-install is accepted but has nothing to skip. --ignore-errors keeps
-# going past failures instead of aborting on the first one.
+# setup forwards --no-install, --no-sudo, and --ignore-errors here. macOS
+# configuration installs no separate software (everything is
+# `defaults`/Automator config) and uses no sudo, so --no-install and --no-sudo
+# are accepted but have nothing to skip. --ignore-errors keeps going past
+# failures instead of aborting on the first one.
 
 # Whether to keep going past failures. "no" aborts on the first error via
 # set -e; "yes" (via --ignore-errors) leaves it off and pushes through.
@@ -39,13 +40,15 @@ warn() {
 
 usage() {
     cat <<'USAGE'
-Usage: setup-macos [--no-install] [--ignore-errors] [-h | --help]
+Usage: setup-macos [--no-install] [--no-sudo] [--ignore-errors] [-h | --help]
 
 Configure the macOS desktop environment.
 
 Options:
   --no-install     Accepted for consistency with setup; macOS configuration
                    installs no separate software, so there's nothing to skip
+  --no-sudo        Accepted for consistency with setup; macOS configuration
+                   uses no sudo, so there's nothing to skip
   --ignore-errors  Keep going past failures instead of aborting on the first
   -h, --help       Show this help and exit
 USAGE
@@ -55,9 +58,9 @@ USAGE
 
 while test $# -gt 0; do
     case "$1" in
-        --install|--no-install)
-            # No separate install step on macOS; accepted as a no-op so
-            # setup can forward the flag uniformly.
+        --install|--no-install|--sudo|--no-sudo)
+            # No separate install step and no sudo on macOS; accepted as a
+            # no-op so setup can forward these flags uniformly.
             ;;
         --ignore-errors)
             IGNORE_ERRORS=yes

--- a/setup-sway
+++ b/setup-sway
@@ -67,6 +67,51 @@ is_command() {
     test -x "$(command -v "$1")"
 }
 
+# Run one privileged command without letting a sudo failure abort the helper
+# under set -e. Mirrors setup's sudo_or_warn: on a box where sudo is allowed
+# for package installs but denied for other commands, a denied lid/service
+# step warns and the helper keeps going instead of exiting. The proactive
+# --no-sudo skip is handled by the caller's SUDO guard below, so this wrapper
+# only needs the reactive path -- but it still honours SUDO=no defensively.
+sudo_or_warn() {
+    _sudo_name=${1##*/}
+    if test "$SUDO" = no; then
+        warn "skipping 'sudo $_sudo_name' (--no-sudo)"
+        return 1
+    fi
+    _sudo_stderr=$(mktemp) || {
+        warn "sudo $_sudo_name: could not create a temporary error log"
+        return 1
+    }
+
+    if sudo "$@" 2>"$_sudo_stderr"; then
+        cat "$_sudo_stderr" >&2
+        rm -f "$_sudo_stderr"
+        return 0
+    else
+        _sudo_status=$?
+    fi
+    _sudo_detail=$(awk 'NF { line = $0 } END { print line }' "$_sudo_stderr")
+    rm -f "$_sudo_stderr"
+
+    case "$_sudo_status" in
+        126) _sudo_detail="permission denied" ;;
+        127) _sudo_detail="command not found" ;;
+        *)
+            case "$_sudo_detail" in
+                "sudo: $_sudo_name: "*) _sudo_detail=${_sudo_detail#"sudo: $_sudo_name: "} ;;
+                "sudo: "*) _sudo_detail=${_sudo_detail#"sudo: "} ;;
+                "$_sudo_name: "*) _sudo_detail=${_sudo_detail#"$_sudo_name: "} ;;
+            esac
+            if test -z "$_sudo_detail"; then
+                _sudo_detail="failed (exit status $_sudo_status)"
+            fi
+            ;;
+    esac
+    warn "sudo $_sudo_name: $_sudo_detail"
+    return "$_sudo_status"
+}
+
 usage() {
     cat <<'USAGE'
 Usage: setup-sway [--no-install] [--no-sudo] [--ignore-errors] [-h | --help]
@@ -136,8 +181,13 @@ install_logind_lid_dropin() {
     fi
     dropin="$LOGIND_DIR/10-sway-lid.conf"
     info "Installing logind lid drop-in ($dropin)"
-    sudo mkdir -p "$LOGIND_DIR"
-    sudo tee "$dropin" >/dev/null <<'CONF'
+    # sudo_or_warn so a denied step (e.g. sudo allowed for apt but not for
+    # this) warns and returns instead of aborting the helper under set -e.
+    if ! sudo_or_warn mkdir -p "$LOGIND_DIR"; then
+        warn "could not create $LOGIND_DIR; skipping the lid drop-in"
+        return 0
+    fi
+    if ! sudo_or_warn tee "$dropin" >/dev/null <<'CONF'
 # Installed by setup-sway. Let the compositor's lid handler (Sway's lid.sh,
 # or Hyprland's -- they implement the same policy) manage the lid so a docked
 # laptop with the lid closed keeps running on its external display.
@@ -146,8 +196,12 @@ HandleLidSwitch=ignore
 HandleLidSwitchExternalPower=ignore
 HandleLidSwitchDocked=ignore
 CONF
+    then
+        warn "could not write $dropin; skipping the lid drop-in"
+        return 0
+    fi
     # Reload logind so the drop-in takes effect without a reboot.
-    sudo systemctl kill -s HUP systemd-logind 2>/dev/null \
+    sudo_or_warn systemctl kill -s HUP systemd-logind \
         || warn "could not reload systemd-logind; changes apply after reboot"
 }
 
@@ -157,7 +211,7 @@ enable_services() {
     is_command systemctl || { warn "systemd not detected; enable power-profiles-daemon manually"; return 0; }
     if systemctl list-unit-files power-profiles-daemon.service >/dev/null 2>&1; then
         info "Enabling power-profiles-daemon"
-        sudo systemctl enable --now power-profiles-daemon.service \
+        sudo_or_warn systemctl enable --now power-profiles-daemon.service \
             || warn "could not enable power-profiles-daemon"
     else
         warn "power-profiles-daemon.service not found; install power-profiles-daemon"

--- a/setup-sway
+++ b/setup-sway
@@ -28,9 +28,19 @@
 #
 # --no-install skips the system-modifying steps (logind drop-in, enabling the
 # service). --ignore-errors keeps going past failures. setup forwards both.
+#
+# --no-sudo (also forwarded by setup) skips the same system-modifying steps:
+# the logind drop-in and enabling power-profiles-daemon both need sudo, which
+# a no-sudo machine lacks. The user-level config (seeding config.local) still
+# runs.
 
 # Whether to install packages. "no" (via --no-install) skips the install.
 INSTALL=yes
+
+# Whether to run the privileged steps. "yes" runs them (the default); "no"
+# (via --no-sudo) skips them -- the logind drop-in and enabling
+# power-profiles-daemon both need sudo.
+SUDO=yes
 
 # Whether to keep going past failures. "no" aborts on the first error via
 # set -e; "yes" (via --ignore-errors) leaves it off and pushes through.
@@ -59,12 +69,14 @@ is_command() {
 
 usage() {
     cat <<'USAGE'
-Usage: setup-sway [--no-install] [--ignore-errors] [-h | --help]
+Usage: setup-sway [--no-install] [--no-sudo] [--ignore-errors] [-h | --help]
 
 Configure a Sway-based Wayland desktop (packages come from `setup`).
 
 Options:
   --no-install     Skip the system-modifying steps (logind drop-in, services)
+  --no-sudo        Skip the same steps: the logind drop-in and enabling
+                   power-profiles-daemon both need sudo
   --ignore-errors  Keep going past failures instead of aborting on the first
   -h, --help       Show this help and exit
 USAGE
@@ -79,6 +91,12 @@ while test $# -gt 0; do
             ;;
         --no-install)
             INSTALL=no
+            ;;
+        --sudo)
+            SUDO=yes
+            ;;
+        --no-sudo)
+            SUDO=no
             ;;
         --ignore-errors)
             IGNORE_ERRORS=yes
@@ -185,7 +203,11 @@ seed_config_local() {
 # The Wayland desktop packages are installed by the top-level `setup`. Here we
 # only apply the system-modifying config; --no-install skips it (e.g. a dry run
 # or when re-running just to reseed config.local / source setup-sway.local).
-if test "$INSTALL" = yes; then
+# --no-sudo skips it too, since the logind drop-in and service enablement both
+# need sudo.
+if test "$SUDO" = no; then
+    info "Skipping logind drop-in and service enablement (needs sudo; --no-sudo)"
+elif test "$INSTALL" = yes; then
     install_logind_lid_dropin
     enable_services
 else

--- a/setup-sway_test
+++ b/setup-sway_test
@@ -206,6 +206,19 @@ test_no_install_skips_system_changes() {
     assert_output_contains "Skipping logind"
 }
 
+# --no-sudo skips the same privileged steps (the logind drop-in and enabling
+# power-profiles-daemon both need sudo) -- no sudo is called -- while the
+# user-level config.local seeding still runs.
+test_no_sudo_skips_privileged_steps() {
+    mkdir -p "$XDG_CONFIG_HOME/sway"
+    echo "# template body" > "$XDG_CONFIG_HOME/sway/config.local.template"
+    run_sway --no-sudo
+    assert_status 0 &&
+    assert_not_called "sudo" &&
+    assert_output_contains "needs sudo; --no-sudo" &&
+    assert_file_contains "$XDG_CONFIG_HOME/sway/config.local" "template body"
+}
+
 # --- per-host config.local seeding ---
 
 test_seeds_config_local_from_template() {
@@ -272,6 +285,8 @@ run_test "commented lid entry does not skip the drop-in" \
     test_commented_lid_entry_does_not_skip_dropin
 run_test "enables power-profiles-daemon" test_enables_power_profiles_daemon
 run_test "no-install skips system changes" test_no_install_skips_system_changes
+run_test "no-sudo skips privileged steps, keeps user config" \
+    test_no_sudo_skips_privileged_steps
 run_test "seeds config.local from the template" test_seeds_config_local_from_template
 run_test "never overwrites an existing config.local" \
     test_never_overwrites_existing_config_local

--- a/setup-sway_test
+++ b/setup-sway_test
@@ -219,6 +219,26 @@ test_no_sudo_skips_privileged_steps() {
     assert_file_contains "$XDG_CONFIG_HOME/sway/config.local" "template body"
 }
 
+# Partial sudo (allowed for apt, denied here): the privileged lid/service
+# steps now go through sudo_or_warn, so a denial WARNS and the helper keeps
+# going instead of aborting under set -e. The user-level seeding still runs.
+test_denied_sudo_warns_and_continues() {
+    cat > "$TEST_TMPDIR/bin/sudo" <<MOCK
+#!/bin/sh
+echo "sudo \$*" >> "$CALLS"
+echo "sudo: a password is required" >&2
+exit 1
+MOCK
+    chmod +x "$TEST_TMPDIR/bin/sudo"
+    mkdir -p "$XDG_CONFIG_HOME/sway"
+    echo "# template body" > "$XDG_CONFIG_HOME/sway/config.local.template"
+    run_sway
+    assert_status 0 &&
+    assert_called "sudo mkdir -p $SETUP_LOGIND_DIR" &&
+    assert_output_contains "Warning" &&
+    assert_file_contains "$XDG_CONFIG_HOME/sway/config.local" "template body"
+}
+
 # --- per-host config.local seeding ---
 
 test_seeds_config_local_from_template() {
@@ -287,6 +307,8 @@ run_test "enables power-profiles-daemon" test_enables_power_profiles_daemon
 run_test "no-install skips system changes" test_no_install_skips_system_changes
 run_test "no-sudo skips privileged steps, keeps user config" \
     test_no_sudo_skips_privileged_steps
+run_test "denied sudo warns and continues (partial sudo)" \
+    test_denied_sudo_warns_and_continues
 run_test "seeds config.local from the template" test_seeds_config_local_from_template
 run_test "never overwrites an existing config.local" \
     test_never_overwrites_existing_config_local

--- a/setup_test
+++ b/setup_test
@@ -63,6 +63,10 @@ assert_source_not_contains() {
 # tests the diagnostics without executing the bootstrap's system changes.
 run_sudo_helper() {
     sudo_mode="$1"
+    # Optional: the SUDO setting (yes/no) the wrapper runs under. Defaults to
+    # yes so the existing diagnostics tests exercise the real sudo path; pass
+    # "no" to check the --no-sudo short-circuit.
+    sudo_setting="${2:-yes}"
     sudo_tmpdir="$(mktemp -d)"
     cat > "$sudo_tmpdir/sudo" <<'MOCK'
 #!/bin/sh
@@ -91,7 +95,7 @@ MOCK
     ' "$SETUP")
 
     set +e
-    output="$(SUDO_MODE="$sudo_mode" PATH="$sudo_tmpdir:$PATH" \
+    output="$(SUDO_MODE="$sudo_mode" SUDO="$sudo_setting" PATH="$sudo_tmpdir:$PATH" \
         sh -c "$sudo_functions
 sudo_or_warn apt-get update" 2>&1)"
     status=$?
@@ -335,6 +339,67 @@ test_offers_ssh_remote_switch() {
     assert_source_contains "gittossh" &&
     assert_source_contains "from HTTPS to SSH?"
 }
+
+# --- no-sudo mode ---
+
+# --no-sudo is a known option: it's accepted (not an "Unknown option" error),
+# so a later --help is still reached and prints usage with exit 0.
+test_no_sudo_flag_accepted() {
+    run_setup --no-sudo --help
+    assert_status 0 &&
+    assert_output_contains "Usage: setup"
+}
+
+# --no-sudo is documented in usage.
+test_no_sudo_in_usage() {
+    run_setup --help
+    assert_status 0 &&
+    assert_output_contains "--no-sudo"
+}
+
+# --no-sudo sets SUDO=no and --sudo sets it back; setup forwards --no-sudo to
+# the desktop helpers so they skip their own privileged steps too.
+test_no_sudo_parsing_and_forwarding() {
+    assert_source_contains 'SUDO="${SUDO:-yes}"' &&
+    assert_source_contains '[-]-no-sudo)' &&
+    assert_source_contains "SUDO=no" &&
+    assert_source_contains "SUDO=yes" &&
+    assert_source_contains 'DESKTOP_SETUP_FLAGS --no-sudo'
+}
+
+# The whole --no-sudo behaviour lives in one place: sudo_or_warn skips the
+# command up front when SUDO=no. There are no scattered per-call guards -- the
+# single choke point is all it takes to make setup never invoke sudo.
+test_no_sudo_gate_is_in_the_wrapper() {
+    assert_source_contains 'if test "$SUDO" = no; then' &&
+    assert_source_contains "skipping 'sudo"
+}
+
+# Behavioural: under SUDO=no the wrapper skips the command up front and returns
+# non-zero WITHOUT invoking sudo -- even when the mocked sudo would have
+# succeeded/denied. The skip warning names the command, not a sudo diagnostic.
+test_no_sudo_skips_command_up_front() {
+    run_sudo_helper denied no
+    assert_status 1 &&
+    assert_output_contains "skipping 'sudo apt-get' (--no-sudo)" &&
+    # the mock sudo's own message must NOT appear: sudo was never called
+    case "$output" in
+        *"permission denied"*)
+            echo "  FAIL: sudo was invoked under --no-sudo"
+            TEST_FAILED=1
+            return 1
+            ;;
+    esac
+}
+
+run_test "--no-sudo is accepted as a known option" test_no_sudo_flag_accepted
+run_test "--no-sudo is documented in usage" test_no_sudo_in_usage
+run_test "--no-sudo parses and forwards to desktop helpers" \
+    test_no_sudo_parsing_and_forwarding
+run_test "--no-sudo gate lives in the sudo_or_warn wrapper" \
+    test_no_sudo_gate_is_in_the_wrapper
+run_test "--no-sudo skips the command up front without invoking sudo" \
+    test_no_sudo_skips_command_up_front
 
 run_test "--sway flag dispatches to setup-sway" test_sway_flag_and_dispatch
 run_test "Sway package names are the upstream ones" test_sway_package_names


### PR DESCRIPTION
## Summary

Adds a `--no-sudo` mode for boxes with **no sudo at all**, implemented entirely inside the existing `sudo_or_warn` wrapper.

`sudo_or_warn` already handles an *unexpected* sudo denial reactively — the command is attempted and a failure degrades to a warning instead of aborting. That already covers the "only `sudo apt` is allowed" box: the package installs succeed and every other privileged step warns and skips on the denial, no flag needed.

`--no-sudo` is the proactive opt-out for when there's no sudo at all: `sudo_or_warn` skips the command **up front** (returns non-zero without invoking sudo) when `SUDO=no`, so setup never prompts for a password or stalls on a command it can't run. Because every privileged command already funnels through this one wrapper, a single gate there is all it takes — no scattered per-call guards. Package installs are skipped too (they're expected to be preinstalled or provided some other way on such a box).

Set via the `--sudo` / `--no-sudo` flags or the `SUDO` env var (`SUDO=no`).

## Naming

`--no-sudo` / `SUDO` (not `--no-root`) — matches this repo's `--no-*` flag convention and main's "restricted sudo" (`sudo_or_warn`) framing.

## Forwarding

`--no-sudo` is forwarded to the desktop helpers:

- `setup-kde` and `setup-macos` accept it as a no-op — they perform no privileged operations
- `setup-hypr` and `setup-sway` skip their logind lid drop-in and `power-profiles-daemon` enablement under `--no-sudo`, while still seeding their user-level per-machine config (`hyprland.conf.local` / `config.local`). They now also route their `sudo mkdir`/`sudo tee`/`sudo systemctl` calls through the same `sudo_or_warn` wrapper, so on a partial-sudo box (apt allowed, other sudo denied) a denied lid/service step warns and the helper continues instead of aborting under `set -e`.

## Testing

- Behavioural test: under `SUDO=no`, `sudo_or_warn` skips the command up front and returns non-zero **without invoking sudo** (verified against the mock sudo — its output never appears). Plus flag parsing/forwarding, the single-gate assertion, and helper coverage.
- Helper tests: a denied sudo (partial-sudo) warns and continues — the helper exits 0 and still seeds its user-level config — rather than aborting.
- Preserves main's existing `sudo_or_warn` diagnostics tests. `make test` passes (all suites green); `sh -n` / `bash -n` / `shellcheck -S error` clean on every changed script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)