### PR TITLE
Guard non-apt sudo actions and avoid sudo npm fallback on apt-only hosts

### DIFF
--- a/setup
+++ b/setup
@@ -101,7 +101,6 @@ NPM=yes
 # running.
 DESKTOP="${DESKTOP:-kde}"
 
-
 usage() {
     cat <<'USAGE'
 Usage: setup [--gui | --no-gui] [--kde | --hypr | --sway] [--minimal | --full]
@@ -393,12 +392,12 @@ install_packages() {
                 sudo apt-get install -y --install-recommends npm
                 # tsc lets setup-kde build Krohnkite from source without
                 # fetching typescript from the npm registry at build time.
-                # Debian/Ubuntu package it as node-typescript. Do not fall
-                # back to sudo npm here: locked-down hosts may only permit
-                # sudo apt against system repositories.
+                # Debian/Ubuntu package it as node-typescript; fall back to
+                # a one-time global npm install where that's unavailable.
                 info "Installing TypeScript (tsc)"
                 sudo apt-get install -y --install-recommends node-typescript \
-                    || warn "could not install tsc from apt; setup-kde needs it to build Krohnkite"
+                    || sudo npm install -g typescript \
+                    || warn "could not install tsc; setup-kde needs it to build Krohnkite"
             fi
             if test "$GUI_ENABLED" -eq 1; then
                 info "Installing kitty"

--- a/setup
+++ b/setup
@@ -101,6 +101,7 @@ NPM=yes
 # running.
 DESKTOP="${DESKTOP:-kde}"
 
+
 usage() {
     cat <<'USAGE'
 Usage: setup [--gui | --no-gui] [--kde | --hypr | --sway] [--minimal | --full]
@@ -392,12 +393,12 @@ install_packages() {
                 sudo apt-get install -y --install-recommends npm
                 # tsc lets setup-kde build Krohnkite from source without
                 # fetching typescript from the npm registry at build time.
-                # Debian/Ubuntu package it as node-typescript; fall back to
-                # a one-time global npm install where that's unavailable.
+                # Debian/Ubuntu package it as node-typescript. Do not fall
+                # back to sudo npm here: locked-down hosts may only permit
+                # sudo apt against system repositories.
                 info "Installing TypeScript (tsc)"
                 sudo apt-get install -y --install-recommends node-typescript \
-                    || sudo npm install -g typescript \
-                    || warn "could not install tsc; setup-kde needs it to build Krohnkite"
+                    || warn "could not install tsc from apt; setup-kde needs it to build Krohnkite"
             fi
             if test "$GUI_ENABLED" -eq 1; then
                 info "Installing kitty"
@@ -950,7 +951,8 @@ set_default_terminal() {
         debian)
             if command -v update-alternatives >/dev/null 2>&1 && command -v kitty >/dev/null 2>&1; then
                 info "Setting kitty as default terminal"
-                sudo update-alternatives --set x-terminal-emulator "$(command -v kitty)"
+                sudo update-alternatives --set x-terminal-emulator "$(command -v kitty)" \
+                    || warn "could not set kitty as default terminal; sudo outside apt may be unavailable"
             fi
             ;;
         redhat)
@@ -982,16 +984,25 @@ configure_keyboard() {
     case "$OS" in
         debian)
             info "Configuring keyboard: Dvorak layout, Caps Lock as Compose"
-            sudo tee /etc/default/keyboard >/dev/null <<'KEYBOARD'
+            # Try the privileged write directly. On apt-only sudo systems this
+            # fails, and we skip the rest of the system keyboard block while
+            # still applying the layout to the current graphical session below.
+            if sudo tee /etc/default/keyboard >/dev/null <<'KEYBOARD'
 XKBMODEL="pc105"
 XKBLAYOUT="us"
 XKBVARIANT="dvorak"
 XKBOPTIONS="compose:caps"
 BACKSPACE="guess"
 KEYBOARD
-            # Apply to virtual consoles
-            if command -v setupcon >/dev/null 2>&1; then
-                sudo setupcon --save
+            then
+                # Apply to virtual consoles only if the system config write
+                # succeeded; otherwise sudo outside apt is likely unavailable.
+                if command -v setupcon >/dev/null 2>&1; then
+                    sudo setupcon --save \
+                        || warn "could not apply console keyboard config; sudo outside apt may be unavailable"
+                fi
+            else
+                warn "skipping system keyboard config; sudo outside apt may be unavailable"
             fi
             ;;
         redhat)
@@ -1095,22 +1106,28 @@ fi
 # The root config builds helper tools and installs files via make, so it's
 # an install step too: skip it under --no-install.
 if test "$INSTALL" = yes; then
-    mkdir -p "$SRC_DIR"
-    clone_or_pull "$ROOT_REPO" "$ROOT_DIR"
-    # The default root config builds helper tools that require cargo. When
-    # cargo isn't available (e.g. a --minimal run, or rustup was skipped),
-    # install the legacy config from the repo's legacy/ subdirectory instead.
-    # Source ~/.cargo/env first so a previously installed toolchain still
-    # counts as available even on a run that skipped install_rust.
-    if test -f "$HOME/.cargo/env"; then
-        . "$HOME/.cargo/env"
-    fi
-    if command -v cargo >/dev/null 2>&1; then
-        make -C "$ROOT_DIR"
-        sudo make -C "$ROOT_DIR" install
+    # The root config install writes system files with sudo make install. Try
+    # sudo first and skip the whole block if this host only permits sudo apt.
+    if sudo -v; then
+        mkdir -p "$SRC_DIR"
+        clone_or_pull "$ROOT_REPO" "$ROOT_DIR"
+        # The default root config builds helper tools that require cargo. When
+        # cargo isn't available (e.g. a --minimal run, or rustup was skipped),
+        # install the legacy config from the repo's legacy/ subdirectory instead.
+        # Source ~/.cargo/env first so a previously installed toolchain still
+        # counts as available even on a run that skipped install_rust.
+        if test -f "$HOME/.cargo/env"; then
+            . "$HOME/.cargo/env"
+        fi
+        if command -v cargo >/dev/null 2>&1; then
+            make -C "$ROOT_DIR"
+            sudo make -C "$ROOT_DIR" install
+        else
+            info "cargo unavailable; installing legacy root config from $ROOT_DIR/legacy"
+            sudo make -C "$ROOT_DIR/legacy" install
+        fi
     else
-        info "cargo unavailable; installing legacy root config from $ROOT_DIR/legacy"
-        sudo make -C "$ROOT_DIR/legacy" install
+        warn "skipping root config installation; sudo outside apt may be unavailable"
     fi
 else
     info "Skipping root config installation (--no-install)"
@@ -1127,6 +1144,9 @@ if test "$OS" = "macos"; then
     info "On macOS, use System Settings to manage admin group membership"
 else
     root_group=$(getent group 0 | cut -d: -f1)
-    sudo gpasswd -a "$USER" "$root_group"
-    info "Added $USER to $root_group group (log out and back in for this to take effect)"
+    if sudo gpasswd -a "$USER" "$root_group"; then
+        info "Added $USER to $root_group group (log out and back in for this to take effect)"
+    else
+        warn "skipping root-group membership update; sudo outside apt may be unavailable"
+    fi
 fi

--- a/setup-kde
+++ b/setup-kde
@@ -8,6 +8,8 @@
 # - Application launch shortcuts (browser, terminal, music)
 #
 # Requires: git, kpackagetool6, kwriteconfig6
+# No root access or sudo is required; Krohnkite and KDE settings are installed
+# into the current user account.
 # Optional: tsc (only to build Krohnkite when the checkout has no prebuilt
 #           .kwinscript), go-task (preferred build tool), p7zip
 #

--- a/setup_test
+++ b/setup_test
@@ -169,10 +169,13 @@ test_swaync_package_names() {
 
 # setup-kde builds Krohnkite from source without fetching from the npm
 # registry at build time, which needs a local tsc -- so setup installs it
-# alongside npm. Debian/Ubuntu apt-only hosts must stay within system repos,
-# so they use node-typescript and do not fall back to sudo npm.
+# alongside npm: Debian/Ubuntu package it as node-typescript, Homebrew as
+# typescript, and Fedora ships no rpm so it's a one-time global npm
+# install during bootstrap. On locked-down hosts, sudo npm may fail; that's
+# ok because this fallback is isolated to the TypeScript install attempt.
 test_typescript_installed_with_npm() {
     assert_source_contains "node-typescript" &&
+    assert_source_contains "npm install -g typescript" &&
     assert_source_contains "brew install typescript"
 }
 

--- a/setup_test
+++ b/setup_test
@@ -169,13 +169,21 @@ test_swaync_package_names() {
 
 # setup-kde builds Krohnkite from source without fetching from the npm
 # registry at build time, which needs a local tsc -- so setup installs it
-# alongside npm: Debian/Ubuntu package it as node-typescript, Homebrew as
-# typescript, and Fedora ships no rpm so it's a one-time global npm
-# install during bootstrap.
+# alongside npm. Debian/Ubuntu apt-only hosts must stay within system repos,
+# so they use node-typescript and do not fall back to sudo npm.
 test_typescript_installed_with_npm() {
     assert_source_contains "node-typescript" &&
-    assert_source_contains "npm install -g typescript" &&
     assert_source_contains "brew install typescript"
+}
+
+# Locked-down Debian/Ubuntu hosts can allow `sudo apt` while denying all
+# other root actions. For non-apt privileged blocks, setup should try sudo
+# directly and skip the rest of that block if sudo fails.
+test_debian_apt_only_sudo_supported() {
+    assert_source_contains "sudo tee /etc/default/keyboard" &&
+    assert_source_contains "if sudo -v; then" &&
+    assert_source_contains "sudo outside apt may be unavailable" &&
+    assert_source_not_contains "SUDO_APT_ONLY"
 }
 
 # --- unzip ---
@@ -239,6 +247,8 @@ run_test "swaync installs under its distro package names, decoupled" \
     test_swaync_package_names
 run_test "tsc installs alongside npm on every platform" \
     test_typescript_installed_with_npm
+run_test "Debian apt-only sudo systems skip failed non-apt sudo blocks" \
+    test_debian_apt_only_sudo_supported
 run_test "fnm installs via its upstream installer with --skip-shell" \
     test_fnm_installed
 run_test "unzip installs on every platform" test_unzip_installed


### PR DESCRIPTION
### Motivation

- Make the bootstrap scripts resilient on locked-down Debian/Ubuntu hosts that permit `sudo apt` but disallow other privileged actions executed via `sudo`. 
- Avoid unsafe or failing fallbacks like running `sudo npm` when system repositories should be used instead. 

### Description

- Removed the one-time `sudo npm install -g typescript` fallback and changed messaging to only attempt the Debian/Ubuntu package `node-typescript` and warn on failure. 
- Guarded non-apt privileged operations by checking `sudo -v` before running root-install blocks for the root config and by warning and skipping those blocks if `sudo` is not available. 
- Made other privileged actions tolerant of restricted `sudo` environments by catching failures and emitting warnings for `update-alternatives --set`, the system keyboard file write via `sudo tee /etc/default/keyboard`, `setupcon --save`, and `gpasswd -a`, while still applying user-level configuration where possible. 
- Added a brief documentation note in `setup-kde` header stating that no root access is required for user KDE/Krohnkite setup. 
- Updated tests to reflect the removed `sudo npm` fallback and to add a `test_debian_apt_only_sudo_supported` case that asserts the new guarded sudo behavior is present. 

### Testing

- Ran the automated test suite via `setup_test`, which includes the new `test_debian_apt_only_sudo_supported` test. 
- All `setup_test` checks completed and reported success (no test failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56ae62c4e0832b9c4f2cad2cc66f73)