### PR TITLE
Handle restricted sudo during setup

### DIFF
--- a/setup
+++ b/setup
@@ -145,6 +145,46 @@ warn() {
     printf "Warning: %s\n" "$*" >&2
 }
 
+# Run one privileged command without letting a sudo failure abort the whole
+# bootstrap. Stderr is preserved on success; on failure its last non-empty
+# line is folded into a concise warning. Shell-standard 126/127 statuses are
+# more useful than some sudo implementations' diagnostics, so name those
+# explicitly.
+sudo_or_warn() {
+    _sudo_name=${1##*/}
+    _sudo_stderr=$(mktemp) || {
+        warn "sudo $_sudo_name: could not create a temporary error log"
+        return 1
+    }
+
+    if sudo "$@" 2>"$_sudo_stderr"; then
+        cat "$_sudo_stderr" >&2
+        rm -f "$_sudo_stderr"
+        return 0
+    else
+        _sudo_status=$?
+    fi
+    _sudo_detail=$(awk 'NF { line = $0 } END { print line }' "$_sudo_stderr")
+    rm -f "$_sudo_stderr"
+
+    case "$_sudo_status" in
+        126) _sudo_detail="permission denied" ;;
+        127) _sudo_detail="command not found" ;;
+        *)
+            case "$_sudo_detail" in
+                "sudo: $_sudo_name: "*) _sudo_detail=${_sudo_detail#"sudo: $_sudo_name: "} ;;
+                "sudo: "*) _sudo_detail=${_sudo_detail#"sudo: "} ;;
+                "$_sudo_name: "*) _sudo_detail=${_sudo_detail#"$_sudo_name: "} ;;
+            esac
+            if test -z "$_sudo_detail"; then
+                _sudo_detail="failed (exit status $_sudo_status)"
+            fi
+            ;;
+    esac
+    warn "sudo $_sudo_name: $_sudo_detail"
+    return "$_sudo_status"
+}
+
 error() {
     printf "Error: %s\n" "$*" >&2
 }
@@ -361,53 +401,61 @@ install_packages() {
     case "$OS" in
         debian)
             info "Updating package lists"
-            sudo apt-get update -qq
+            if ! sudo_or_warn apt-get update -qq; then
+                warn "skipping Debian package installation because apt-get update failed"
+                return 0
+            fi
             info "Installing system packages"
-            sudo apt-get install -y --install-recommends \
-                adb \
-                bat \
-                build-essential \
-                curl \
-                fd-find \
-                fzf \
-                gh \
-                git \
-                git-delta \
-                git-email \
-                golang \
-                jq \
-                mercurial \
-                micro \
-                p7zip-full \
-                python3 \
-                python3-pip \
-                python3-venv \
-                ripgrep \
-                shellcheck \
-                unzip \
-                vim \
-                zsh
+            if ! sudo_or_warn apt-get install -y --install-recommends \
+                    adb \
+                    bat \
+                    build-essential \
+                    curl \
+                    fd-find \
+                    fzf \
+                    gh \
+                    git \
+                    git-delta \
+                    git-email \
+                    golang \
+                    jq \
+                    mercurial \
+                    micro \
+                    p7zip-full \
+                    python3 \
+                    python3-pip \
+                    python3-venv \
+                    ripgrep \
+                    shellcheck \
+                    unzip \
+                    vim \
+                    zsh; then
+                warn "skipping remaining Debian package installs"
+                return 0
+            fi
             if test "$NPM" = yes; then
                 info "Installing npm"
-                sudo apt-get install -y --install-recommends npm
+                sudo_or_warn apt-get install -y --install-recommends npm \
+                    || warn "could not install the distro npm package; continuing with the TypeScript attempt"
                 # tsc lets setup-kde build Krohnkite from source without
                 # fetching typescript from the npm registry at build time.
                 # Debian/Ubuntu package it as node-typescript; fall back to
                 # a one-time global npm install where that's unavailable.
                 info "Installing TypeScript (tsc)"
-                sudo apt-get install -y --install-recommends node-typescript \
-                    || sudo npm install -g typescript \
+                sudo_or_warn apt-get install -y --install-recommends node-typescript \
+                    || sudo_or_warn npm install -g typescript \
                     || warn "could not install tsc; setup-kde needs it to build Krohnkite"
             fi
             if test "$GUI_ENABLED" -eq 1; then
                 info "Installing kitty"
-                sudo apt-get install -y --install-recommends kitty
+                sudo_or_warn apt-get install -y --install-recommends kitty \
+                    || warn "skipping kitty installation"
                 info "Installing KDE graphical packages"
-                sudo apt-get install -y --install-recommends \
+                sudo_or_warn apt-get install -y --install-recommends \
                     kde-standard \
                     kwin-dev \
-                    plasma-desktop \
-                    plasma-sdk
+                    plasma-desktop plasma-sdk \
+                    || warn "skipping KDE graphical package installation"
                 # Shared Wayland desktop stack, used by BOTH the Hyprland and
                 # Sway builds (bar, launcher, notifications, portal, audio,
                 # applets, fonts). Installed unconditionally alongside KDE so
@@ -417,7 +465,7 @@ install_packages() {
                 # release without hyprland must not take the Sway/Hyprland
                 # shared pieces down with it.
                 info "Installing shared Wayland desktop packages"
-                sudo apt-get install -y --install-recommends \
+                sudo_or_warn apt-get install -y --install-recommends \
                     xdg-desktop-portal-gtk \
                     waybar fuzzel kanshi \
                     power-profiles-daemon \
@@ -431,19 +479,19 @@ install_packages() {
                 # 24.04, Debian 13); try the upstream name for backports.
                 # Its own transaction so a missing name can't abort the
                 # shared stack above.
-                sudo apt-get install -y --install-recommends sway-notification-center \
-                    || sudo apt-get install -y --install-recommends swaync \
+                sudo_or_warn apt-get install -y --install-recommends sway-notification-center \
+                    || sudo_or_warn apt-get install -y --install-recommends swaync \
                     || warn "swaync unavailable via apt (sway-notification-center); notifications need a manual build"
                 # Hyprland-only packages. `|| warn` because the hypr* tools
                 # may need a backport and shouldn't abort.
                 info "Installing Hyprland desktop packages"
-                sudo apt-get install -y --install-recommends \
+                sudo_or_warn apt-get install -y --install-recommends \
                     hyprland hypridle hyprlock \
                     || warn "some Hyprland packages are unavailable; you may need a backport or manual build (hyprland, hypridle, hyprlock, swww)"
                 # These are in the default repos even where hyprland isn't, so
                 # install them separately -- otherwise a missing hyprland fails
                 # the whole command above and takes these down with it.
-                sudo apt-get install -y --install-recommends \
+                sudo_or_warn apt-get install -y --install-recommends \
                     grim slurp wl-clipboard playerctl gnome-calculator \
                     || warn "screenshot/media/calculator tools unavailable via apt"
                 # Sway Wayland desktop packages, installed unconditionally
@@ -452,71 +500,77 @@ install_packages() {
                 # default repos; the bar/launcher/notification stack above
                 # (waybar, fuzzel, swaync, ...) is shared with Hyprland.
                 info "Installing Sway desktop packages"
-                sudo apt-get install -y --install-recommends \
+                sudo_or_warn apt-get install -y --install-recommends \
                     sway swaybg swayidle swaylock xdg-desktop-portal-wlr \
                     || warn "some Sway packages are unavailable via apt"
                 # autotiling (dwindle-style dynamic tiling) is packaged
                 # separately and missing from some releases; its absence
                 # only costs the dynamic splits, not the desktop.
-                sudo apt-get install -y --install-recommends autotiling \
+                sudo_or_warn apt-get install -y --install-recommends autotiling \
                     || warn "autotiling unavailable via apt; install with 'pipx install autotiling'"
                 # yazi (terminal file manager) is often not in the default repos;
                 # install it separately so its absence doesn't block the rest.
-                sudo apt-get install -y --install-recommends yazi \
+                sudo_or_warn apt-get install -y --install-recommends yazi \
                     || warn "yazi unavailable via apt; install with 'cargo install --locked yazi-fm yazi-cli'"
                 # uwsm (opt-in Universal Wayland Session Manager). Installed so
                 # it's available; it does NOT change how you log in unless you
                 # pick the uwsm session -- see conf/config/hypr/README.md.
-                sudo apt-get install -y --install-recommends uwsm \
+                sudo_or_warn apt-get install -y --install-recommends uwsm \
                     || warn "uwsm unavailable via apt (optional; skip)"
             fi
             ;;
         redhat)
             info "Installing system packages"
-            sudo dnf install -y \
-                '@development-tools' \
-                android-tools \
-                bat \
-                curl \
-                fd-find \
-                fzf \
-                gh \
-                git \
-                git-delta \
-                git-email \
-                golang \
-                jq \
-                mercurial \
-                micro \
-                p7zip \
-                p7zip-plugins \
-                python3 \
-                python3-pip \
-                ripgrep \
-                ShellCheck \
-                unzip \
-                vim \
-                zsh
+            if ! sudo_or_warn dnf install -y \
+                    '@development-tools' \
+                    android-tools \
+                    bat \
+                    curl \
+                    fd-find \
+                    fzf \
+                    gh \
+                    git \
+                    git-delta \
+                    git-email \
+                    golang \
+                    jq \
+                    mercurial \
+                    micro \
+                    p7zip \
+                    p7zip-plugins \
+                    python3 \
+                    python3-pip \
+                    ripgrep \
+                    ShellCheck \
+                    unzip \
+                    vim \
+                    zsh; then
+                warn "skipping remaining Fedora package installs"
+                return 0
+            fi
             if test "$NPM" = yes; then
                 info "Installing npm"
-                sudo dnf install -y npm
+                sudo_or_warn dnf install -y npm \
+                    || warn "could not install the distro npm package; continuing with the TypeScript attempt"
                 # tsc lets setup-kde build Krohnkite from source without
                 # fetching typescript from the npm registry at build time.
                 # Fedora ships no typescript rpm, so this is a one-time
                 # global npm install during bootstrap.
                 info "Installing TypeScript (tsc)"
-                sudo npm install -g typescript \
+                sudo_or_warn npm install -g typescript \
                     || warn "could not install tsc; setup-kde needs it to build Krohnkite"
             fi
             if test "$GUI_ENABLED" -eq 1; then
                 info "Installing kitty"
-                sudo dnf install -y kitty
+                sudo_or_warn dnf install -y kitty \
+                    || warn "skipping kitty installation"
                 info "Installing KDE graphical packages"
-                sudo dnf install -y \
+                sudo_or_warn dnf install -y \
                     '@kde-desktop-environment' \
                     kwin-devel \
                     plasma-desktop \
-                    plasma-sdk
+                    plasma-sdk \
+                    || warn "skipping KDE graphical package installation"
                 # Hyprland Wayland desktop packages, installed unconditionally
                 # alongside KDE so either desktop is available (--kde/--hypr
                 # only choose which one to *configure*). `|| warn` because
@@ -524,15 +578,18 @@ install_packages() {
                 # Fedora doesn't ship Hyprland in its default repos, so enable
                 # the lionheartp/Hyprland COPR first (needs the copr dnf plugin).
                 info "Enabling the lionheartp/Hyprland COPR"
-                sudo dnf install -y dnf-plugins-core || true
-                sudo dnf copr enable -y lionheartp/Hyprland \
-                    || warn "could not enable the lionheartp/Hyprland COPR; hyprland may be unavailable"
+                if sudo_or_warn dnf install -y dnf-plugins-core; then
+                    sudo_or_warn dnf copr enable -y lionheartp/Hyprland \
+                        || warn "could not enable the lionheartp/Hyprland COPR; hyprland may be unavailable"
+                else
+                    warn "skipping COPR enable because the dnf plugin could not be installed"
+                fi
                 # Shared Wayland desktop stack, used by BOTH the Hyprland and
                 # Sway builds. Its own transaction, all default-repo, so a
                 # failed COPR / missing hyprland can't take the bar, launcher,
                 # and power pieces down with it.
                 info "Installing shared Wayland desktop packages"
-                sudo dnf install -y \
+                sudo_or_warn dnf install -y \
                     xdg-desktop-portal-gtk \
                     waybar fuzzel kanshi \
                     power-profiles-daemon \
@@ -546,20 +603,20 @@ install_packages() {
                 # upstream name too in case a COPR provides it. Its own
                 # transaction so a missing name can't abort the shared stack
                 # above.
-                sudo dnf install -y SwayNotificationCenter \
-                    || sudo dnf install -y swaync \
+                sudo_or_warn dnf install -y SwayNotificationCenter \
+                    || sudo_or_warn dnf install -y swaync \
                     || warn "swaync unavailable via dnf (SwayNotificationCenter); notifications need a manual build"
                 # Hyprland-only packages (these are the ones that need the
                 # COPR above).
                 info "Installing Hyprland desktop packages"
-                sudo dnf install -y \
+                sudo_or_warn dnf install -y \
                     hyprland hypridle hyprlock \
                     xdg-desktop-portal-hyprland swww \
                     || warn "some Hyprland packages are unavailable; check the lionheartp/Hyprland COPR or build manually"
                 # In the default repos even where hyprland isn't, so install
                 # separately -- a missing hyprland above shouldn't take these
                 # down with it.
-                sudo dnf install -y \
+                sudo_or_warn dnf install -y \
                     grim slurp wl-clipboard playerctl gnome-calculator \
                     || warn "screenshot/media/calculator tools unavailable via dnf"
                 # Sway Wayland desktop packages, installed unconditionally
@@ -569,22 +626,22 @@ install_packages() {
                 # The bar/launcher/notification stack above (waybar, fuzzel,
                 # swaync, ...) is shared with Hyprland.
                 info "Installing Sway desktop packages"
-                sudo dnf install -y \
+                sudo_or_warn dnf install -y \
                     sway swaybg swayidle swaylock xdg-desktop-portal-wlr \
                     || warn "some Sway packages are unavailable via dnf"
                 # autotiling (dwindle-style dynamic tiling) is packaged
                 # separately; its absence only costs the dynamic splits,
                 # not the desktop.
-                sudo dnf install -y autotiling \
+                sudo_or_warn dnf install -y autotiling \
                     || warn "autotiling unavailable via dnf; install with 'pipx install autotiling'"
                 # yazi (terminal file manager) may need a COPR; install it
                 # separately so its absence doesn't block the rest.
-                sudo dnf install -y yazi \
+                sudo_or_warn dnf install -y yazi \
                     || warn "yazi unavailable via dnf; install with 'cargo install --locked yazi-fm yazi-cli'"
                 # uwsm (opt-in Universal Wayland Session Manager). Installed so
                 # it's available; it does NOT change how you log in unless you
                 # pick the uwsm session -- see conf/config/hypr/README.md.
-                sudo dnf install -y uwsm \
+                sudo_or_warn dnf install -y uwsm \
                     || warn "uwsm unavailable via dnf (optional; skip)"
             fi
             ;;
@@ -950,7 +1007,8 @@ set_default_terminal() {
         debian)
             if command -v update-alternatives >/dev/null 2>&1 && command -v kitty >/dev/null 2>&1; then
                 info "Setting kitty as default terminal"
-                sudo update-alternatives --set x-terminal-emulator "$(command -v kitty)"
+                sudo_or_warn update-alternatives --set x-terminal-emulator "$(command -v kitty)" \
+                    || warn "skipping default-terminal update"
             fi
             ;;
         redhat)
@@ -982,22 +1040,32 @@ configure_keyboard() {
     case "$OS" in
         debian)
             info "Configuring keyboard: Dvorak layout, Caps Lock as Compose"
-            sudo tee /etc/default/keyboard >/dev/null <<'KEYBOARD'
+            if sudo_or_warn tee /etc/default/keyboard >/dev/null <<'KEYBOARD'
 XKBMODEL="pc105"
 XKBLAYOUT="us"
 XKBVARIANT="dvorak"
 XKBOPTIONS="compose:caps"
 BACKSPACE="guess"
 KEYBOARD
-            # Apply to virtual consoles
-            if command -v setupcon >/dev/null 2>&1; then
-                sudo setupcon --save
+            then
+                # Applying the console copy depends on the persistent config
+                # write above. Skip it if that sudo command was denied.
+                if command -v setupcon >/dev/null 2>&1; then
+                    sudo_or_warn setupcon --save \
+                        || warn "could not apply the keyboard config to virtual consoles"
+                fi
+            else
+                warn "skipping the rest of the system keyboard configuration"
             fi
             ;;
         redhat)
             info "Configuring keyboard: Dvorak layout, Caps Lock as Compose"
-            sudo localectl set-keymap us-dvorak
-            sudo localectl set-x11-keymap us "" dvorak compose:caps
+            if sudo_or_warn localectl set-keymap us-dvorak; then
+                sudo_or_warn localectl set-x11-keymap us "" dvorak compose:caps \
+                    || warn "could not configure the X11 keyboard layout"
+            else
+                warn "skipping the rest of the system keyboard configuration"
+            fi
             ;;
         macos)
             # Handled by setup-macos
@@ -1107,10 +1175,12 @@ if test "$INSTALL" = yes; then
     fi
     if command -v cargo >/dev/null 2>&1; then
         make -C "$ROOT_DIR"
-        sudo make -C "$ROOT_DIR" install
+        sudo_or_warn make -C "$ROOT_DIR" install \
+            || warn "skipping root config installation"
     else
         info "cargo unavailable; installing legacy root config from $ROOT_DIR/legacy"
-        sudo make -C "$ROOT_DIR/legacy" install
+        sudo_or_warn make -C "$ROOT_DIR/legacy" install \
+            || warn "skipping legacy root config installation"
     fi
 else
     info "Skipping root config installation (--no-install)"
@@ -1127,6 +1197,9 @@ if test "$OS" = "macos"; then
     info "On macOS, use System Settings to manage admin group membership"
 else
     root_group=$(getent group 0 | cut -d: -f1)
-    sudo gpasswd -a "$USER" "$root_group"
-    info "Added $USER to $root_group group (log out and back in for this to take effect)"
+    if sudo_or_warn gpasswd -a "$USER" "$root_group"; then
+        info "Added $USER to $root_group group (log out and back in for this to take effect)"
+    else
+        warn "skipping root-group membership update"
+    fi
 fi

--- a/setup-kde
+++ b/setup-kde
@@ -8,6 +8,8 @@
 # - Application launch shortcuts (browser, terminal, music)
 #
 # Requires: git, kpackagetool6, kwriteconfig6
+# This helper does not use sudo: Krohnkite and every KDE setting are installed
+# for the current user, so setup-kde still works when system sudo is restricted.
 # Optional: tsc (only to build Krohnkite when the checkout has no prebuilt
 #           .kwinscript), go-task (preferred build tool), p7zip
 #

--- a/setup-kde_test
+++ b/setup-kde_test
@@ -227,6 +227,22 @@ test_unknown_option() {
     assert_output_contains "Unknown option"
 }
 
+# setup-kde is entirely user-scoped. Even a sudo executable that always fails
+# must be irrelevant to KDE configuration.
+test_failing_sudo_is_not_used() {
+    cat > "$TEST_TMPDIR/bin/sudo" <<MOCK
+#!/bin/sh
+echo "sudo \$*" >> "$CALLS"
+echo "sudo: permission denied" >&2
+exit 1
+MOCK
+    chmod +x "$TEST_TMPDIR/bin/sudo"
+    run_kde --no-install
+    assert_status 0 &&
+    assert_not_called "sudo" &&
+    assert_output_contains "KDE configured successfully"
+}
+
 # --- installation (mocked git/kpackagetool6; npm is a never-called canary) ---
 
 # The clone must come from my Codeberg fork's mikel branch.
@@ -409,6 +425,8 @@ MOCK
 
 run_test "help flag" test_help_flag
 run_test "unknown option errors" test_unknown_option
+run_test "failing sudo does not affect user-scoped KDE setup" \
+    test_failing_sudo_is_not_used
 run_test "clones my krohnkite fork by default" test_clones_fork_by_default
 run_test "KROHNKITE_REPO overrides the clone source" \
     test_krohnkite_repo_env_overrides_clone_source

--- a/setup_test
+++ b/setup_test
@@ -248,9 +248,10 @@ test_sudo_success_preserves_stderr() {
 # Every privileged operation goes through the wrapper, and blocks with
 # dependent follow-up work test its result before continuing.
 test_sudo_calls_are_guarded() {
-    raw_sudo_calls=$(grep -c '^[[:space:]]*sudo ' "$SETUP")
-    if test "$raw_sudo_calls" -ne 1; then
-        echo "  FAIL: expected only sudo_or_warn's internal sudo call, got $raw_sudo_calls"
+    wrapper_sudo_calls=$(grep -c 'sudo "\$@"' "$SETUP")
+    unwrapped_sudo_calls=$(grep -c '^[[:space:]]*sudo ' "$SETUP" || true)
+    if test "$wrapper_sudo_calls" -ne 1 || test "$unwrapped_sudo_calls" -ne 0; then
+        echo "  FAIL: expected one wrapped sudo call and no direct sudo calls"
         TEST_FAILED=1
         return 1
     fi

--- a/setup_test
+++ b/setup_test
@@ -59,6 +59,46 @@ assert_source_not_contains() {
     fi
 }
 
+# Run setup's sudo wrapper in isolation against a controlled sudo mock. This
+# tests the diagnostics without executing the bootstrap's system changes.
+run_sudo_helper() {
+    sudo_mode="$1"
+    sudo_tmpdir="$(mktemp -d)"
+    cat > "$sudo_tmpdir/sudo" <<'MOCK'
+#!/bin/sh
+case "$SUDO_MODE" in
+    denied)
+        echo "sudo: permission denied" >&2
+        exit 1
+        ;;
+    missing)
+        exit 127
+        ;;
+    silent)
+        exit 42
+        ;;
+    success)
+        echo "sudo notice" >&2
+        exit 0
+        ;;
+esac
+MOCK
+    chmod +x "$sudo_tmpdir/sudo"
+    sudo_functions=$(awk '
+        /^warn\(\) \{/ { copying = 1 }
+        /^error\(\) \{/ { copying = 0 }
+        copying { print }
+    ' "$SETUP")
+
+    set +e
+    output="$(SUDO_MODE="$sudo_mode" PATH="$sudo_tmpdir:$PATH" \
+        sh -c "$sudo_functions
+sudo_or_warn apt-get update" 2>&1)"
+    status=$?
+    set -e
+    rm -rf "$sudo_tmpdir"
+}
+
 run_test() {
     name="$1"
     func="$2"
@@ -178,6 +218,48 @@ test_typescript_installed_with_npm() {
     assert_source_contains "brew install typescript"
 }
 
+# sudo failures are warnings rather than fatal set -e exits. Use stderr when
+# it has a useful reason, the shell-standard 127 meaning when it does not, and
+# an explicit status as the final fallback.
+test_sudo_warning_uses_stderr() {
+    run_sudo_helper denied
+    assert_status 1 &&
+    assert_output_contains "Warning: sudo apt-get: permission denied"
+}
+
+test_sudo_warning_uses_exit_status() {
+    run_sudo_helper missing
+    assert_status 127 &&
+    assert_output_contains "Warning: sudo apt-get: command not found"
+}
+
+test_sudo_warning_falls_back_to_numeric_status() {
+    run_sudo_helper silent
+    assert_status 42 &&
+    assert_output_contains "Warning: sudo apt-get: failed (exit status 42)"
+}
+
+test_sudo_success_preserves_stderr() {
+    run_sudo_helper success
+    assert_status 0 &&
+    assert_output_contains "sudo notice"
+}
+
+# Every privileged operation goes through the wrapper, and blocks with
+# dependent follow-up work test its result before continuing.
+test_sudo_calls_are_guarded() {
+    raw_sudo_calls=$(grep -c '^[[:space:]]*sudo ' "$SETUP")
+    if test "$raw_sudo_calls" -ne 1; then
+        echo "  FAIL: expected only sudo_or_warn's internal sudo call, got $raw_sudo_calls"
+        TEST_FAILED=1
+        return 1
+    fi
+    assert_source_contains "if ! sudo_or_warn apt-get update" &&
+    assert_source_contains "if sudo_or_warn tee /etc/default/keyboard" &&
+    assert_source_contains "if sudo_or_warn localectl set-keymap" &&
+    assert_source_contains "if sudo_or_warn gpasswd"
+}
+
 # --- unzip ---
 
 # unzip is a core package installed on every platform, and listed in the
@@ -239,6 +321,16 @@ run_test "swaync installs under its distro package names, decoupled" \
     test_swaync_package_names
 run_test "tsc installs alongside npm on every platform" \
     test_typescript_installed_with_npm
+run_test "sudo warning includes a useful stderr reason" \
+    test_sudo_warning_uses_stderr
+run_test "sudo warning recognizes command-not-found status" \
+    test_sudo_warning_uses_exit_status
+run_test "sudo warning falls back to the numeric status" \
+    test_sudo_warning_falls_back_to_numeric_status
+run_test "successful sudo preserves its stderr" \
+    test_sudo_success_preserves_stderr
+run_test "sudo-dependent blocks guard every privileged call" \
+    test_sudo_calls_are_guarded
 run_test "fnm installs via its upstream installer with --skip-shell" \
     test_fnm_installed
 run_test "unzip installs on every platform" test_unzip_installed


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- route privileged setup operations through a warning-producing sudo wrapper
- stop dependent privileged blocks after a failed sudo command while allowing independent setup work to continue
- preserve user-scoped `setup-kde` behavior when sudo is unavailable
- cover stderr, exit-status, and block-guard behavior in tests

## Testing
- shell syntax checks passed
- `setup_test`: 20 passed
- `setup-kde_test`: 17 passed
- `make test`: passed
- shellcheck was unavailable in the environment
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d94877f-9675-4598-966b-d1b53d5dacd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d94877f-9675-4598-966b-d1b53d5dacd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

