### PR TITLE
setup: install Node/tsc from the distro (root) or conda-forge/homepkg (--no-root)

### DIFF
--- a/homepkg
+++ b/homepkg
@@ -61,6 +61,15 @@ TOOLS = {
     "helix":   {"conda": "helix",      "github": "helix-editor/helix", "bins": ["hx"]},
     "jj":      {"conda": "jujutsu",    "github": "jj-vcs/jj",          "bins": ["jj"]},
     "nu":      {"conda": "nushell",    "github": "nushell/nushell",    "bins": ["nu"]},
+    # Node toolchain for the setup --no-root path: node/npm/tsc from conda-forge
+    # instead of a distro package, plus fnm (which on root boxes comes from its
+    # own curl installer -- no conda there yet). npm/npx ride along in the nodejs
+    # package; tsc comes from the typescript package. (github is unused on the
+    # default mamba path -- typescript has no standalone binary release, so
+    # --backend github can't provide it; it errors cleanly if attempted.)
+    "node":       {"conda": "nodejs",     "github": "nodejs/node",          "bins": ["node", "npm", "npx"]},
+    "typescript": {"conda": "typescript", "github": "microsoft/TypeScript", "bins": ["tsc"]},
+    "fnm":        {"conda": "fnm",        "github": "Schniz/fnm",           "bins": ["fnm"]},
 }
 
 
@@ -213,11 +222,20 @@ def conda_extract(pkg_path, prefix):
 
 def install_conda(tool, meta, prefix, plat, dry_run):
     pkg = meta["conda"]
-    subdir = conda_subdir(*plat)
-    index, base = conda_index(subdir)
-    found = conda_resolve(index, pkg)
+    # Check the platform subdir first, then noarch: conda-forge publishes
+    # pure-language packages (e.g. typescript) as noarch, so a package can live
+    # in either subdir. The mamba backend's solver handles this transparently;
+    # the stateless conda backend has to look in both itself.
+    found = None
+    for subdir in (conda_subdir(*plat), "noarch"):
+        index, base = conda_index(subdir)
+        found = conda_resolve(index, pkg)
+        if found:
+            break
     if not found:
-        raise HomepkgError(f"{tool}: conda-forge package '{pkg}' not found for {subdir}")
+        raise HomepkgError(
+            f"{tool}: conda-forge package '{pkg}' not found for "
+            f"{conda_subdir(*plat)} or noarch")
     fn, pmeta = found
     url = f"{base}/{fn}"
     info(f"{tool}: conda-forge {pkg} {pmeta['version']} ({subdir})")

--- a/homepkg_test
+++ b/homepkg_test
@@ -61,6 +61,39 @@ _r = hp.conda_resolve(_index, "ripgrep")
 check("conda_resolve picks newest version+build", _r is not None and _r[0] == "ripgrep-14.1.0-1.conda")
 check("conda_resolve returns None for unknown pkg", hp.conda_resolve(_index, "nope") is None)
 
+# install_conda must look in the noarch subdir too: conda-forge ships
+# pure-language tools (e.g. typescript) as noarch, not under the platform
+# subdir, so a platform-only lookup would fail to resolve them.
+_saved_ci = hp.conda_index
+try:
+    def _index_only_noarch(subdir):
+        if subdir == "noarch":
+            return ({"packages.conda": {"typescript-5.4.5-0.conda": {
+                "name": "typescript", "version": "5.4.5", "build_number": 0}}},
+                f"{hp.CONDA_CHANNEL}/noarch")
+        return ({"packages": {}, "packages.conda": {}}, f"{hp.CONDA_CHANNEL}/{subdir}")
+    hp.conda_index = _index_only_noarch
+    _err = None
+    try:
+        hp.install_conda("typescript", {"conda": "typescript", "bins": ["tsc"]},
+                         "/tmp/homepkg-test-noarch", ("linux", "x86_64"), dry_run=True)
+    except Exception as e:  # noqa: BLE001
+        _err = e
+    check("install_conda resolves a noarch-only package", _err is None)
+
+    hp.conda_index = lambda subdir: ({"packages": {}, "packages.conda": {}},
+                                     f"{hp.CONDA_CHANNEL}/{subdir}")
+    _err2 = None
+    try:
+        hp.install_conda("typescript", {"conda": "typescript", "bins": ["tsc"]},
+                         "/tmp/homepkg-test-noarch", ("linux", "x86_64"), dry_run=True)
+    except hp.HomepkgError as e:
+        _err2 = e
+    check("install_conda error names both platform subdir and noarch",
+          _err2 is not None and "noarch" in str(_err2))
+finally:
+    hp.conda_index = _saved_ci
+
 # --- github asset selection --------------------------------------------------
 
 _linux = hp.github_asset_tokens("linux", "x86_64")
@@ -145,6 +178,18 @@ _list = _run("list")
 check("list exits 0", _list.returncode == 0)
 check("list shows every registered tool",
       all(t in _list.stdout for t in hp.TOOLS))
+
+# The node toolchain is served from conda-forge for the setup --no-root path:
+# node/npm/npx from the nodejs package, tsc from typescript, plus fnm.
+check("registry maps node to conda-forge nodejs",
+      hp.TOOLS["node"]["conda"] == "nodejs")
+check("node exposes npm and npx alongside node",
+      set(hp.TOOLS["node"]["bins"]) == {"node", "npm", "npx"})
+check("registry maps typescript with a tsc bin",
+      hp.TOOLS["typescript"]["conda"] == "typescript"
+      and hp.TOOLS["typescript"]["bins"] == ["tsc"])
+check("registry maps fnm to conda-forge fnm",
+      hp.TOOLS["fnm"]["conda"] == "fnm" and hp.TOOLS["fnm"]["bins"] == ["fnm"])
 
 check("unknown tool errors", _run("install", "bogustool").returncode != 0)
 check("install with no tools errors", _run("install").returncode != 0)

--- a/setup
+++ b/setup
@@ -50,12 +50,13 @@
 # agent) or a key file already exists. Pass --ssh to generate one anyway,
 # or --no-ssh to skip it entirely.
 #
-# The distro npm/Node.js package is installed by default, along with the
-# TypeScript compiler (tsc), which setup-kde needs to build Krohnkite from
-# source without fetching from the npm registry at build time. Pass
-# --no-npm to skip both on machines where the npm package fails to install
-# or where Node is provided some other way (nvm, fnm, corepack, a
-# standalone pnpm, etc.) -- then provide tsc yourself.
+# Node.js (node/npm) and the TypeScript compiler (tsc) are installed because
+# setup-kde needs tsc to build Krohnkite from source without fetching from the
+# npm registry at build time. On privileged boxes they come from the distro
+# package (apt/dnf/brew); under --no-root, where the distro installs are
+# skipped, they come from conda-forge via homepkg instead (rootless). Pass
+# --no-npm to skip them where Node is provided some other way (nvm, fnm,
+# corepack, a system package, etc.) -- then provide tsc yourself.
 
 SCRIPTS_REPO="git@github.com:mikelward/scripts.git"
 CONF_REPO="git@github.com:mikelward/conf.git"
@@ -99,12 +100,13 @@ IGNORE_ERRORS=no
 #   no   - never generate (--no-ssh)
 SSH=auto
 
-# Whether to install the npm/Node.js package and the TypeScript compiler
-# (tsc, needed by setup-kde to build Krohnkite). One of:
-#   yes - install them along with the other system packages (the default)
-#   no  - skip them (--no-npm), for machines where the distro npm package
-#         fails to install or where Node is provided some other way
-#         (nvm, fnm, corepack, a standalone pnpm, etc.)
+# Whether to install Node.js (node/npm) and the TypeScript compiler (tsc),
+# needed by setup-kde to build Krohnkite. One of:
+#   yes - install them (the default). Privileged boxes get the distro npm/node
+#         package plus tsc; --no-root boxes get node/npm/tsc from conda-forge
+#         via homepkg instead.
+#   no  - skip them (--no-npm), for machines where Node is provided some other
+#         way (nvm, fnm, corepack, a system package, etc.) -- provide tsc too.
 NPM=yes
 
 # Whether to run sudo at all. One of:
@@ -187,9 +189,9 @@ Options:
                    one. Forwarded to setup-kde/macos
   --ssh            Generate an SSH key even if one is already available
   --no-ssh         Skip SSH key generation
-  --no-npm         Skip the distro npm/Node.js package and the TypeScript
-                   compiler (for machines where npm fails to install or Node
-                   is provided another way; provide tsc yourself)
+  --no-npm         Skip installing Node.js (node/npm) and the TypeScript
+                   compiler (for machines where Node is provided another way;
+                   provide tsc yourself)
   -h, --help       Show this help and exit
 
 By default graphical components are installed only when a display server
@@ -574,6 +576,10 @@ install_packages() {
                 warn "skipping remaining Debian package installs"
                 return 0
             fi
+            # Node.js + tsc from the distro on the privileged path (setup-kde
+            # needs tsc to build Krohnkite). Under --no-root apt is skipped
+            # above, and these come from conda-forge via homepkg instead
+            # (install_home_tools).
             if test "$NPM" = yes; then
                 info "Installing npm"
                 sudo_or_warn apt-get install -y --install-recommends npm \
@@ -689,6 +695,10 @@ install_packages() {
                 warn "skipping remaining Fedora package installs"
                 return 0
             fi
+            # Node.js + tsc from the distro on the privileged path (setup-kde
+            # needs tsc to build Krohnkite). Under --no-root dnf is skipped
+            # above, and these come from conda-forge via homepkg instead
+            # (install_home_tools).
             if test "$NPM" = yes; then
                 info "Installing npm"
                 sudo_or_warn dnf install -y npm \
@@ -810,7 +820,12 @@ install_packages() {
                 unzip \
                 vim \
                 zsh
-            if test "$NPM" = yes; then
+            # Node.js + tsc from Homebrew on the privileged path (setup-kde
+            # needs tsc to build Krohnkite). brew needs no sudo, so unlike the
+            # apt/dnf branches this can't self-skip under --no-root -- gate it on
+            # ROOT so an unprivileged macOS run gets node/tsc from conda-forge
+            # via homepkg (install_home_tools) instead of a second copy here.
+            if test "$NPM" = yes && test "$ROOT" = yes; then
                 info "Installing Node.js (npm)"
                 brew install node
                 # tsc lets setup-kde build Krohnkite from source without
@@ -1068,17 +1083,26 @@ install_extras() {
 # Under --no-root the apt/dnf package installs are skipped, so the CLI tools
 # they'd provide have to come from somewhere else: homepkg installs prebuilt
 # binaries into a home prefix (~/.local), no root required. Core tools mirror
-# the distro CLI package set; the heavyweight extras (helix, jj, nushell) are
-# added unless the minimal profile is in effect. homepkg resolves them into one
-# home-prefix env; a solve/network failure warns rather than aborting the
-# bootstrap.
+# the distro CLI package set; the node toolchain (node/npm/tsc) is added
+# unless --no-npm, and the heavyweight extras (helix, jj, nushell) unless the
+# minimal profile is in effect. homepkg resolves them into one home-prefix env;
+# a solve/network failure warns rather than aborting the bootstrap.
 install_home_tools() {
     homepkg="$SCRIPTS_DIR/homepkg"
     if ! test -x "$homepkg"; then
         warn "homepkg not found at $homepkg; skipping home-prefix tool install"
         return 0
     fi
-    tools="ripgrep fd bat fzf jq delta gh"
+    # fnm (Node version manager) is a convenience tool -- installed regardless
+    # of --no-npm, mirroring the root path's install_fnm (which is skipped under
+    # --no-root, so fnm comes from here instead).
+    tools="ripgrep fd bat fzf jq delta gh fnm"
+    if test "$NPM" = yes; then
+        # node/npm + tsc are the actual build toolchain (setup-kde needs tsc to
+        # build Krohnkite), gated on --no-npm. The --no-root counterpart to the
+        # distro npm/tsc install on the privileged path -- no root, no distro pkg.
+        tools="$tools node typescript"
+    fi
     if test "$MINIMAL_ENABLED" -eq 0; then
         tools="$tools helix jj nu"
         # shpool is source-only (no conda-forge/prebuilt artifact), so the
@@ -1091,6 +1115,15 @@ install_home_tools() {
     fi
     info "Installing CLI tools into a home prefix via homepkg: $tools"
     if "$homepkg" install $tools; then
+        # homepkg links the tools into ~/.local/bin. Put that on PATH for the
+        # rest of THIS run so later steps and child processes find them --
+        # notably setup-kde, which needs tsc on PATH to build Krohnkite. The
+        # conf repo already puts ~/.local/bin on PATH for interactive shells;
+        # this covers the non-interactive bootstrap however setup was invoked.
+        case ":$PATH:" in
+            *":$HOME/.local/bin:"*) ;;
+            *) PATH="$HOME/.local/bin:$PATH" ;;
+        esac
         # A prior cargo run points ~/.config/helix/runtime at the source
         # checkout, and hx searches that before the prebuilt runtime -- so drop
         # the stale symlink (only the one install_helix created), same as the
@@ -1128,7 +1161,21 @@ install_uv() {
 
 # --- Install fnm (Fast Node Manager) ---
 
+# fnm is installed as a convenience for interactive, per-project Node version
+# switching (the conf repo hooks it into the shell). It is NOT used to provide
+# the build toolchain -- node/npm and tsc come from the distro or, under
+# --no-root, from homepkg (see install_packages / install_home_tools) -- so
+# setup-kde never depends on it. On the privileged path fnm comes from its curl
+# installer here; under --no-root it comes from conda-forge via homepkg instead,
+# so this function skips.
 install_fnm() {
+    # TODO: explore sourcing fnm from conda-forge on root boxes too, to drop
+    # this curl|bash installer for one uniform mechanism. Deferred for now to
+    # avoid bootstrapping micromamba on every root box just for fnm.
+    if test "$ROOT" = no; then
+        info "fnm comes from homepkg under --no-root"
+        return
+    fi
     if command -v fnm >/dev/null 2>&1; then
         info "fnm already installed"
         return

--- a/setup_test
+++ b/setup_test
@@ -212,11 +212,11 @@ test_swaync_package_names() {
 # --- TypeScript compiler ---
 
 # setup-kde builds Krohnkite from source without fetching from the npm
-# registry at build time, which needs a local tsc -- so setup installs it
-# alongside npm: Debian/Ubuntu package it as node-typescript, Homebrew as
-# typescript, and Fedora ships no rpm so it's a one-time global npm
-# install during bootstrap.
-test_typescript_installed_with_npm() {
+# registry at build time, which needs a local tsc -- so the privileged path
+# installs it alongside node: Debian/Ubuntu package it as node-typescript,
+# Homebrew as typescript, and Fedora ships no rpm so it's a one-time global
+# npm install. (The --no-root path gets tsc from conda-forge via homepkg.)
+test_typescript_installed_from_distro() {
     assert_source_contains "node-typescript" &&
     assert_source_contains "npm install -g typescript" &&
     assert_source_contains "brew install typescript"
@@ -276,16 +276,23 @@ test_unzip_installed() {
 
 # --- fnm ---
 
-# fnm (Fast Node Manager) is installed via its upstream installer during the
-# install phase, alongside uv. --skip-shell keeps the installer out of the
-# shell rc files, which are managed by the conf repo, not setup. The installer
-# is downloaded to a temp file rather than piped into bash: a piped curl
-# failure is masked (bash exits 0 on empty stdin) so set -e wouldn't catch it.
+# fnm (Fast Node Manager) is installed as a standalone convenience for
+# interactive Node version switching -- not to provision the build toolchain
+# (node/npm/tsc come from the distro or homepkg). On the privileged path it's
+# installed via its upstream curl installer with --skip-shell (the conf repo
+# manages the shell rc files); under --no-root that curl path is skipped and
+# fnm comes from homepkg instead. The installer is downloaded to a temp file
+# rather than piped into bash: a piped curl failure is masked (bash exits 0 on
+# empty stdin) so set -e wouldn't catch it.
 test_fnm_installed() {
     assert_source_contains "install_fnm" &&
     assert_source_contains "https://fnm.vercel.app/install -o" &&
     assert_source_contains "skip-shell" &&
-    assert_source_not_contains "fnm.vercel.app/install | bash"
+    assert_source_not_contains "fnm.vercel.app/install | bash" &&
+    assert_source_contains "fnm comes from homepkg under --no-root" &&
+    # fnm must not drive the Node/tsc install anymore -- no fnm-based provisioning.
+    assert_source_not_contains "fnm install --lts" &&
+    assert_source_not_contains "fnm use lts-latest"
 }
 
 # --- Rust / cargo ---
@@ -372,6 +379,15 @@ test_brew_clears_stale_helix_runtime() {
 test_legacy_root_config_is_logged() {
     assert_source_contains "installing the legacy root config" &&
     assert_source_contains "for the primary Rust root config"
+}
+
+# Under --no-root the distro npm/tsc install is skipped (apt/dnf need root);
+# node/npm and tsc come from conda-forge via homepkg instead, gated on the NPM
+# flag. fnm rides along too as a convenience tool, but outside the NPM gate --
+# installed regardless of --no-npm, mirroring the root path's install_fnm.
+test_home_tools_include_node_toolchain() {
+    assert_source_contains "delta gh fnm" &&
+    assert_source_contains 'tools="$tools node typescript"'
 }
 
 # --- SSH key ---
@@ -550,8 +566,8 @@ run_test "shared Wayland stack installs independently of hyprland" \
     test_shared_wayland_stack_decoupled
 run_test "swaync installs under its distro package names, decoupled" \
     test_swaync_package_names
-run_test "tsc installs alongside npm on every platform" \
-    test_typescript_installed_with_npm
+run_test "tsc installs from the distro alongside node" \
+    test_typescript_installed_from_distro
 run_test "sudo warning includes a useful stderr reason" \
     test_sudo_warning_uses_stderr
 run_test "sudo warning recognizes command-not-found status" \
@@ -562,12 +578,14 @@ run_test "successful sudo preserves its stderr" \
     test_sudo_success_preserves_stderr
 run_test "sudo-dependent blocks guard every privileged call" \
     test_sudo_calls_are_guarded
-run_test "fnm installs via its upstream installer with --skip-shell" \
-    test_fnm_installed
 run_test "rustup installs with --no-modify-path" \
     test_rust_installs_without_modifying_path
 run_test "uv installs with --no-modify-path" \
     test_uv_installs_without_modifying_path
+run_test "fnm installs as a tool, not the node provisioner" \
+    test_fnm_installed
+run_test "--no-root node toolchain comes from homepkg" \
+    test_home_tools_include_node_toolchain
 run_test "unzip installs on every platform" test_unzip_installed
 run_test "SSH key prompt points at GitHub and Codeberg" \
     test_ssh_key_prompt_covers_github_and_codeberg


### PR DESCRIPTION
## Summary

`setup` installed `node`/`npm`/`tsc` from the distro (apt/dnf/brew), which needs root and fails on unprivileged boxes. `setup-kde` needs `tsc` to build Krohnkite from source without touching the npm registry, so the toolchain has to come from *somewhere* on every box.

This splits Node/tsc provisioning by privilege, and keeps **fnm** purely as an interactive convenience (not as the build provisioner):

- **Node/npm + tsc**
  - **privileged boxes:** the distro package (apt/dnf/brew) — unchanged from before.
  - **`--no-root` boxes:** `node`/`npm`/`tsc` from **conda-forge via `homepkg`** (apt/dnf need root there), alongside the other rootless CLI tools.
- **fnm** — installed only for interactive, per-project Node version switching (the conf repo hooks it into the shell); never used to build Krohnkite.
  - **root:** its own curl installer (`install_fnm`).
  - **`--no-root`:** from conda-forge via `homepkg` (`install_fnm` skips), with a TODO to explore sourcing it from conda on root boxes too.

## What changed

- **Restored** the distro `npm`/`node` + `tsc` install in the Debian (`apt`, `node-typescript`), Fedora (`dnf` + global `npm i -g typescript`), and macOS (`brew`) branches. The apt/dnf blocks self-skip under `--no-root` (sudo is gated off); the macOS brew block is explicitly gated on `ROOT=yes` since brew needs no sudo.
- **`homepkg`** registry gains `node` (npm/npx bundled), `typescript` (tsc), and `fnm` — all conda-forge packages. `install_home_tools` installs them under `--no-root`: node/tsc gated on `--no-npm`, fnm always (it's a tool). `~/.local/bin` is put on `PATH` for the run so `setup-kde` finds `tsc`.
- **`install_fnm`** is now a plain installer for the fnm binary (curl, `--skip-shell`), skipped under `--no-root`. All the previous `fnm env` / `fnm install --lts` / `fnm use lts-latest` / `--install-dir` provisioning logic is **removed**.
- `--no-npm` skips node/tsc on both paths (fnm is unaffected — it's a convenience tool).
- Header comment, `NPM` flag docs, and `--help` updated.

## Review findings

Removing the fnm-as-provisioner logic drops every fnm-specific Codex finding on this PR (`fnm env` shell detection, the `lts-latest` alias, stale-fnm PATH ordering, macOS `--install-dir` semantics) — that code no longer exists.

## Testing

- `./setup_test` — 42/42 pass.
- `./homepkg_test` — 57/57 pass (asserts the `node`/`typescript`/`fnm` registry entries).
- `bash -n setup` clean; `homepkg` parses; `shellcheck -S warning setup` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDiQXdrEAn93oQL1kucPuK