### PR TITLE
setup: keep rustup and uv installers out of shell config files

### DIFF
--- a/setup
+++ b/setup
@@ -871,7 +871,9 @@ install_nushell() {
 install_uv() {
     if command -v uv >/dev/null 2>&1; then
         info "Updating uv"
-        uv self update
+        # uv self update reruns the installer, which edits the shell rc/profile
+        # files unless UV_NO_MODIFY_PATH is set; PATH is managed by the conf repo.
+        UV_NO_MODIFY_PATH=1 uv self update
     else
         info "Installing uv"
         # --no-modify-path keeps the uv installer out of the shell rc/profile

--- a/setup
+++ b/setup
@@ -803,7 +803,10 @@ install_rust() {
         rustup update
     else
         info "Installing Rust via rustup"
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        # -y runs unattended; --no-modify-path keeps rustup out of the shell
+        # rc/profile files, since PATH is managed by the conf repo. We source
+        # ~/.cargo/env below so cargo is on PATH for the rest of this run.
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path
         . "$HOME/.cargo/env"
     fi
 }
@@ -871,7 +874,10 @@ install_uv() {
         uv self update
     else
         info "Installing uv"
-        curl -LsSf https://astral.sh/uv/install.sh | sh
+        # --no-modify-path keeps the uv installer out of the shell rc/profile
+        # files; PATH is managed by the conf repo. uv installs to ~/.local/bin
+        # (or ~/.cargo/bin), which the conf repo already puts on PATH.
+        curl -LsSf https://astral.sh/uv/install.sh | sh -s -- --no-modify-path
     fi
 }
 

--- a/setup_test
+++ b/setup_test
@@ -284,6 +284,25 @@ test_fnm_installed() {
     assert_source_not_contains "fnm.vercel.app/install | bash"
 }
 
+# --- Rust / cargo ---
+
+# rustup edits the shell rc/profile files by default to put ~/.cargo/bin on
+# PATH. --no-modify-path keeps it out of them, since PATH is managed by the
+# conf repo, not setup. -y still runs the install unattended.
+test_rust_installs_without_modifying_path() {
+    assert_source_contains "sh -s -- -y --no-modify-path" &&
+    assert_source_not_contains "sh.rustup.rs | sh -s -- -y$"
+}
+
+# --- uv ---
+
+# The uv installer also edits shell rc/profile files by default. --no-modify-path
+# keeps it out of them; the conf repo already has ~/.local/bin on PATH.
+test_uv_installs_without_modifying_path() {
+    assert_source_contains "uv/install.sh | sh -s -- --no-modify-path" &&
+    assert_source_not_contains "uv/install.sh | sh$"
+}
+
 # --- SSH key ---
 
 # The default Krohnkite clone is HTTPS, but other repos (conf, scripts) are
@@ -334,6 +353,10 @@ run_test "sudo-dependent blocks guard every privileged call" \
     test_sudo_calls_are_guarded
 run_test "fnm installs via its upstream installer with --skip-shell" \
     test_fnm_installed
+run_test "rustup installs with --no-modify-path" \
+    test_rust_installs_without_modifying_path
+run_test "uv installs with --no-modify-path" \
+    test_uv_installs_without_modifying_path
 run_test "unzip installs on every platform" test_unzip_installed
 run_test "SSH key prompt points at GitHub and Codeberg" \
     test_ssh_key_prompt_covers_github_and_codeberg

--- a/setup_test
+++ b/setup_test
@@ -296,11 +296,14 @@ test_rust_installs_without_modifying_path() {
 
 # --- uv ---
 
-# The uv installer also edits shell rc/profile files by default. --no-modify-path
-# keeps it out of them; the conf repo already has ~/.local/bin on PATH.
+# The uv installer edits shell rc/profile files by default. --no-modify-path
+# keeps the fresh install out of them; the conf repo already has ~/.local/bin
+# on PATH. `uv self update` reruns the installer on the update path, so it needs
+# UV_NO_MODIFY_PATH=1 to stay out of the config files too.
 test_uv_installs_without_modifying_path() {
     assert_source_contains "uv/install.sh | sh -s -- --no-modify-path" &&
-    assert_source_not_contains "uv/install.sh | sh$"
+    assert_source_not_contains "uv/install.sh | sh$" &&
+    assert_source_contains "UV_NO_MODIFY_PATH=1 uv self update"
 }
 
 # --- SSH key ---


### PR DESCRIPTION
## Summary

`setup` installs several tools via their upstream `curl | sh` installers. By default, both the **rustup** (cargo) and **uv** installers edit shell rc/profile files (`~/.profile`, `~/.bashrc`, `~/.zshenv`, etc.) to add their bin directories to `PATH`. Shell config is managed by the conf repo, not `setup`, so these edits are unwanted.

This passes `--no-modify-path` to both installers so they leave config files alone — matching how `fnm` is already invoked with `--skip-shell`.

## Changes

- **rustup**: `sh -s -- -y` → `sh -s -- -y --no-modify-path`. `~/.cargo/env` is still sourced afterward so cargo is on `PATH` for the rest of the run.
- **uv**: `sh` → `sh -s -- --no-modify-path`. uv's bin dir (`~/.local/bin`) is already on `PATH` via the conf repo.
- Added source-assertion tests for both flags, alongside the existing fnm test.

Other `curl | sh` installers were checked: **fnm** already uses `--skip-shell`, and **Homebrew**'s installer only prints PATH instructions rather than editing config files (and `setup` sets up brew's `PATH` itself).

## Testing

`./setup_test` — 22 tests, all passing (including the 2 new ones). `shellcheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EsJJLD7BpXg73BXVi1maiw)_