### PR TITLE
homepkg: rootless conda-forge / GitHub tool installer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ test:
 	./mdf_test
 	./pa_test
 	./package_test
+	./homepkg_test
 	./gittossh_test
 	./runenv_test
 	./setup_test

--- a/README.md
+++ b/README.md
@@ -21,6 +21,23 @@ curl -fsSL https://github.com/mikelward/scripts/raw/main/setup | sh
 wget -qO- https://github.com/mikelward/scripts/raw/main/setup | sh
 ```
 
+## Installing tools without root
+
+On machines where you can't use `apt`/`dnf`, `homepkg` installs prebuilt CLI
+tools into a home prefix (default `~/.local`, already on `PATH` via the conf
+repo). It fetches from conda-forge by default, or GitHub releases:
+
+```sh
+homepkg list                          # known tools
+homepkg install ripgrep fd bat jq     # from conda-forge into ~/.local
+homepkg --backend github install gh   # from GitHub release assets
+homepkg --prefix ~/opt install nu     # a different prefix
+```
+
+conda packages are sha256-verified against the channel index. `.conda`
+payloads need zstd (the python `zstandard` module or the `zstd` CLI); the
+GitHub backend needs neither.
+
 ## Third-party code
 
 This repository vendors [pidcat](https://github.com/JakeWharton/pidcat)

--- a/homepkg
+++ b/homepkg
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+"""homepkg -- install prebuilt CLI tools into a home prefix, no root.
+
+For machines where apt/dnf need root: fetch prebuilt binaries and unpack them
+into a home prefix (default ~/.local), which the conf repo already puts on
+PATH. Two backends:
+
+  conda   conda-forge packages from conda.anaconda.org -- one host, uniform
+          across every tool, sha256-verified (the default)
+  github  release assets from each tool's GitHub repo
+
+Usage:
+    homepkg [--backend conda|github] [--prefix DIR] [--arch TRIPLE]
+            [--dry-run] install TOOL...
+    homepkg list
+
+`list` prints the known tools. Tool names are logical (ripgrep, fd, ...); the
+registry maps each to its conda package and GitHub repo.
+"""
+
+import argparse
+import hashlib
+import io
+import json
+import os
+import platform
+import shutil
+import sys
+import tarfile
+import tempfile
+import urllib.request
+import zipfile
+
+# --- Tool registry -----------------------------------------------------------
+#
+# conda:  conda-forge package name (verified against current_repodata).
+# github: "owner/repo" for the release backend.
+# bins:   binary basenames to expose on PATH (default: the tool name). A conda
+#         package is unpacked whole (bin/lib/share); for github we locate these
+#         names in the extracted asset.
+TOOLS = {
+    "ripgrep": {"conda": "ripgrep",   "github": "BurntSushi/ripgrep", "bins": ["rg"]},
+    "fd":      {"conda": "fd",         "github": "sharkdp/fd",         "bins": ["fd"]},
+    "bat":     {"conda": "bat",        "github": "sharkdp/bat",        "bins": ["bat"]},
+    "fzf":     {"conda": "fzf",        "github": "junegunn/fzf",       "bins": ["fzf"]},
+    "jq":      {"conda": "jq",         "github": "jqlang/jq",          "bins": ["jq"]},
+    "delta":   {"conda": "git-delta",  "github": "dandavison/delta",   "bins": ["delta"]},
+    "gh":      {"conda": "gh",         "github": "cli/cli",            "bins": ["gh"]},
+    "helix":   {"conda": "helix",      "github": "helix-editor/helix", "bins": ["hx"]},
+    "jj":      {"conda": "jujutsu",    "github": "jj-vcs/jj",          "bins": ["jj"]},
+    "nu":      {"conda": "nushell",    "github": "nushell/nushell",    "bins": ["nu"]},
+}
+
+
+def info(msg):
+    print(msg, file=sys.stderr)
+
+
+def warn(msg):
+    print("Warning: " + msg, file=sys.stderr)
+
+
+class HomepkgError(Exception):
+    pass
+
+
+# --- Platform ----------------------------------------------------------------
+
+def detect_platform():
+    """Return (os, arch) normalised: os in {linux, macos}, arch in
+    {x86_64, aarch64}."""
+    sysname = platform.system()
+    osname = {"Linux": "linux", "Darwin": "macos"}.get(sysname)
+    if osname is None:
+        raise HomepkgError(f"unsupported OS: {sysname}")
+    machine = platform.machine().lower()
+    arch = {
+        "x86_64": "x86_64", "amd64": "x86_64",
+        "aarch64": "aarch64", "arm64": "aarch64",
+    }.get(machine)
+    if arch is None:
+        raise HomepkgError(f"unsupported architecture: {machine}")
+    return osname, arch
+
+
+def conda_subdir(osname, arch):
+    return {
+        ("linux", "x86_64"): "linux-64",
+        ("linux", "aarch64"): "linux-aarch64",
+        ("macos", "x86_64"): "osx-64",
+        ("macos", "aarch64"): "osx-arm64",
+    }[(osname, arch)]
+
+
+# Tokens used to pick a GitHub release asset for this platform. Ordered by
+# preference (first match wins), so a musl build beats gnu on Linux.
+def github_asset_tokens(osname, arch):
+    if osname == "linux":
+        archtok = ["x86_64", "amd64"] if arch == "x86_64" else ["aarch64", "arm64"]
+        return {"os": ["linux", "unknown-linux"], "arch": archtok,
+                "prefer": ["musl", "gnu"]}
+    archtok = ["x86_64", "amd64"] if arch == "x86_64" else ["aarch64", "arm64"]
+    return {"os": ["apple-darwin", "darwin", "macos", "apple"], "arch": archtok,
+            "prefer": ["", ""]}
+
+
+# --- HTTP --------------------------------------------------------------------
+
+def http_get(url, accept=None):
+    req = urllib.request.Request(url, headers={"User-Agent": "homepkg"})
+    if accept:
+        req.add_header("Accept", accept)
+    with urllib.request.urlopen(req, timeout=120) as resp:
+        return resp.read()
+
+
+def download(url, dest):
+    info(f"  downloading {url}")
+    data = http_get(url)
+    with open(dest, "wb") as f:
+        f.write(data)
+    return dest
+
+
+# --- zstd (for conda .zst payloads) -----------------------------------------
+
+def zstd_decompress(data, max_output_size):
+    """Decompress zstd via the zstandard module or a zstd/unzstd CLI."""
+    try:
+        import zstandard
+        return zstandard.ZstdDecompressor().decompress(
+            data, max_output_size=max_output_size)
+    except ImportError:
+        pass
+    for exe in ("zstd", "unzstd"):
+        if shutil.which(exe):
+            import subprocess
+            return subprocess.run(
+                [exe, "-dc"], input=data, stdout=subprocess.PIPE, check=True).stdout
+    raise HomepkgError(
+        "zstd support is required for conda packages: install the python "
+        "'zstandard' module or the 'zstd' CLI, or use --backend github")
+
+
+# --- conda backend -----------------------------------------------------------
+
+CONDA_CHANNEL = "https://conda.anaconda.org/conda-forge"
+
+
+def conda_index(subdir):
+    """Fetch current_repodata for a subdir (latest build of each package)."""
+    base = f"{CONDA_CHANNEL}/{subdir}"
+    try:
+        raw = http_get(f"{base}/current_repodata.json.zst")
+        raw = zstd_decompress(raw, 400_000_000)
+    except Exception:
+        # Fall back to the uncompressed index (no zstd needed to *read* it).
+        raw = http_get(f"{base}/current_repodata.json")
+    return json.loads(raw), base
+
+
+def _version_key(v):
+    parts = []
+    for tok in v.replace("-", ".").split("."):
+        parts.append((1, int(tok)) if tok.isdigit() else (0, tok))
+    return parts
+
+
+def conda_resolve(index, pkg):
+    """Return (filename, meta) for the newest build of pkg, or None."""
+    best = None
+    for key in ("packages", "packages.conda"):
+        for fn, meta in index.get(key, {}).items():
+            if meta.get("name") != pkg:
+                continue
+            rank = (_version_key(meta["version"]), meta.get("build_number", 0))
+            if best is None or rank > best[0]:
+                best = (rank, fn, meta)
+    return (best[1], best[2]) if best else None
+
+
+def conda_extract(pkg_path, prefix):
+    """Unpack a .conda or .tar.bz2 package into prefix, skipping info/."""
+    installed = []
+    if pkg_path.endswith(".conda"):
+        with zipfile.ZipFile(pkg_path) as zf:
+            inner = next(n for n in zf.namelist()
+                         if n.startswith("pkg-") and n.endswith(".tar.zst"))
+            tar_bytes = zstd_decompress(zf.read(inner), 500_000_000)
+        tf = tarfile.open(fileobj=io.BytesIO(tar_bytes))
+    else:  # .tar.bz2
+        tf = tarfile.open(pkg_path, "r:bz2")
+    with tf:
+        for m in tf.getmembers():
+            if m.name.startswith("info/") or not (m.isfile() or m.issym()):
+                continue
+            tf.extract(m, path=prefix)
+            installed.append(m.name)
+    return installed
+
+
+def install_conda(tool, meta, prefix, plat, dry_run):
+    pkg = meta["conda"]
+    subdir = conda_subdir(*plat)
+    index, base = conda_index(subdir)
+    found = conda_resolve(index, pkg)
+    if not found:
+        raise HomepkgError(f"{tool}: conda-forge package '{pkg}' not found for {subdir}")
+    fn, pmeta = found
+    url = f"{base}/{fn}"
+    info(f"{tool}: conda-forge {pkg} {pmeta['version']} ({subdir})")
+    if dry_run:
+        info(f"  would install from {url}")
+        return
+    os.makedirs(prefix, exist_ok=True)
+    with tempfile.TemporaryDirectory() as td:
+        pkg_path = download(url, os.path.join(td, fn))
+        want = pmeta.get("sha256")
+        if want:
+            got = hashlib.sha256(open(pkg_path, "rb").read()).hexdigest()
+            if got != want:
+                raise HomepkgError(f"{tool}: sha256 mismatch ({got} != {want})")
+        else:
+            warn(f"{tool}: no sha256 in index; skipping verification")
+        conda_extract(pkg_path, prefix)
+    for b in meta["bins"]:
+        _ensure_executable(os.path.join(prefix, "bin", b))
+    info(f"  installed {', '.join(meta['bins'])} into {prefix}/bin")
+
+
+# --- github backend ----------------------------------------------------------
+
+def github_latest_assets(repo):
+    data = json.loads(http_get(
+        f"https://api.github.com/repos/{repo}/releases/latest",
+        accept="application/vnd.github+json"))
+    return data.get("tag_name", "?"), [
+        (a["name"], a["browser_download_url"]) for a in data.get("assets", [])]
+
+
+def github_pick_asset(assets, tokens):
+    """Choose the best asset for this platform from (name, url) pairs."""
+    def score(name):
+        low = name.lower()
+        if not any(t in low for t in tokens["arch"]):
+            return None
+        if tokens["os"] and not any(t in low for t in tokens["os"]):
+            return None
+        # Skip checksums/signatures/source archives.
+        if any(low.endswith(x) for x in (".sha256", ".asc", ".sig", ".txt", ".sbom")):
+            return None
+        s = 0
+        for i, pref in enumerate(tokens["prefer"]):
+            if pref and pref in low:
+                s = len(tokens["prefer"]) - i
+        return s
+    best = None
+    for name, url in assets:
+        sc = score(name)
+        if sc is not None and (best is None or sc > best[0]):
+            best = (sc, name, url)
+    return (best[1], best[2]) if best else None
+
+
+def _ensure_executable(path):
+    if os.path.exists(path):
+        os.chmod(path, 0o755)
+
+
+def github_extract(asset_path, name, prefix, bins):
+    """Unpack an asset and copy the wanted binaries into prefix/bin."""
+    bindir = os.path.join(prefix, "bin")
+    os.makedirs(bindir, exist_ok=True)
+    low = name.lower()
+    if low.endswith((".tar.gz", ".tgz", ".tar.xz", ".tar.bz2", ".tar")):
+        with tarfile.open(asset_path) as tf:
+            tf.extractall(os.path.join(os.path.dirname(asset_path), "x"))
+        root = os.path.join(os.path.dirname(asset_path), "x")
+    elif low.endswith(".zip"):
+        with zipfile.ZipFile(asset_path) as zf:
+            zf.extractall(os.path.join(os.path.dirname(asset_path), "x"))
+        root = os.path.join(os.path.dirname(asset_path), "x")
+    else:
+        # Raw single binary (e.g. jq-linux-amd64): treat the asset as bins[0].
+        dest = os.path.join(bindir, bins[0])
+        shutil.copy2(asset_path, dest)
+        _ensure_executable(dest)
+        return [bins[0]]
+    placed = []
+    for b in bins:
+        src = _find_file(root, b)
+        if src is None:
+            warn(f"binary '{b}' not found in {name}")
+            continue
+        dest = os.path.join(bindir, b)
+        shutil.copy2(src, dest)
+        _ensure_executable(dest)
+        placed.append(b)
+    return placed
+
+
+def _find_file(root, name):
+    for dirpath, _dirs, files in os.walk(root):
+        if name in files:
+            return os.path.join(dirpath, name)
+    return None
+
+
+def install_github(tool, meta, prefix, plat, dry_run):
+    repo = meta["github"]
+    tokens = github_asset_tokens(*plat)
+    tag, assets = github_latest_assets(repo)
+    picked = github_pick_asset(assets, tokens)
+    if not picked:
+        raise HomepkgError(f"{tool}: no matching {plat[0]}/{plat[1]} asset in {repo} {tag}")
+    name, url = picked
+    info(f"{tool}: github {repo} {tag} -> {name}")
+    if dry_run:
+        info(f"  would install from {url}")
+        return
+    with tempfile.TemporaryDirectory() as td:
+        asset_path = download(url, os.path.join(td, name))
+        placed = github_extract(asset_path, name, prefix, meta["bins"])
+    info(f"  installed {', '.join(placed)} into {prefix}/bin")
+
+
+BACKENDS = {"conda": install_conda, "github": install_github}
+
+
+# --- CLI ---------------------------------------------------------------------
+
+def main(argv=None):
+    p = argparse.ArgumentParser(prog="homepkg", add_help=True,
+                                description="Install prebuilt CLI tools into a home prefix.")
+    p.add_argument("--backend", choices=sorted(BACKENDS), default="conda",
+                   help="where to fetch prebuilt binaries (default: conda)")
+    p.add_argument("--prefix", default=os.path.expanduser("~/.local"),
+                   help="install prefix (default: ~/.local)")
+    p.add_argument("--arch", default=None,
+                   help="override platform as OS/ARCH, e.g. linux/x86_64")
+    p.add_argument("--dry-run", action="store_true",
+                   help="resolve and report, but don't download or install")
+    p.add_argument("command", choices=["install", "list"])
+    p.add_argument("tools", nargs="*", help="logical tool names (see 'list')")
+    args = p.parse_args(argv)
+
+    if args.command == "list":
+        for name in sorted(TOOLS):
+            m = TOOLS[name]
+            print(f"{name:10} conda={m['conda']:12} github={m['github']}")
+        return 0
+
+    if not args.tools:
+        p.error("install requires at least one tool")
+    if args.arch:
+        try:
+            plat = tuple(args.arch.split("/", 1))
+            assert len(plat) == 2
+        except Exception:
+            p.error("--arch must be OS/ARCH, e.g. linux/x86_64")
+    else:
+        plat = detect_platform()
+
+    unknown = [t for t in args.tools if t not in TOOLS]
+    if unknown:
+        p.error(f"unknown tool(s): {', '.join(unknown)} (see 'homepkg list')")
+
+    install = BACKENDS[args.backend]
+    failed = []
+    for tool in args.tools:
+        try:
+            install(tool, TOOLS[tool], args.prefix, plat, args.dry_run)
+        except HomepkgError as e:
+            warn(str(e))
+            failed.append(tool)
+        except Exception as e:  # network, extraction, ...
+            warn(f"{tool}: {e}")
+            failed.append(tool)
+    if failed:
+        warn(f"failed: {', '.join(failed)}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/homepkg_test
+++ b/homepkg_test
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Tests for homepkg.
+
+Offline unit tests for the pure logic -- platform mapping, conda version
+resolution, GitHub asset selection, and archive extraction -- plus a few CLI
+argument-parsing checks. The network-dependent install paths are exercised
+manually (conda against conda.anaconda.org); here we drive extraction with
+locally built archives so the suite needs no network.
+"""
+
+import io
+import os
+import subprocess
+import sys
+import tarfile
+import tempfile
+
+# Load the extensionless homepkg script as a module without running main().
+_here = os.path.dirname(os.path.abspath(__file__))
+_hp_path = os.path.join(_here, "homepkg")
+hp = type(sys)("homepkg")
+hp.__dict__["__name__"] = "homepkg"
+exec(compile(open(_hp_path).read(), _hp_path, "exec"), hp.__dict__)
+
+RUN = PASS = FAIL = 0
+
+
+def check(name, cond):
+    global RUN, PASS, FAIL
+    RUN += 1
+    if cond:
+        PASS += 1
+        print(f"ok {RUN} - {name}")
+    else:
+        FAIL += 1
+        print(f"not ok {RUN} - {name}")
+
+
+# --- platform / subdir -------------------------------------------------------
+
+check("conda_subdir linux x86_64", hp.conda_subdir("linux", "x86_64") == "linux-64")
+check("conda_subdir macos aarch64", hp.conda_subdir("macos", "aarch64") == "osx-arm64")
+
+# --- conda version resolution ------------------------------------------------
+
+check("version_key orders numerically",
+      hp._version_key("15.1.0") > hp._version_key("9.2.0"))
+
+_index = {
+    "packages": {
+        "ripgrep-13.0.0-0.tar.bz2": {"name": "ripgrep", "version": "13.0.0", "build_number": 0},
+    },
+    "packages.conda": {
+        "ripgrep-14.1.0-0.conda": {"name": "ripgrep", "version": "14.1.0", "build_number": 0},
+        "ripgrep-14.1.0-1.conda": {"name": "ripgrep", "version": "14.1.0", "build_number": 1},
+        "other-1.0-0.conda": {"name": "other", "version": "1.0", "build_number": 0},
+    },
+}
+_r = hp.conda_resolve(_index, "ripgrep")
+check("conda_resolve picks newest version+build", _r is not None and _r[0] == "ripgrep-14.1.0-1.conda")
+check("conda_resolve returns None for unknown pkg", hp.conda_resolve(_index, "nope") is None)
+
+# --- github asset selection --------------------------------------------------
+
+_linux = hp.github_asset_tokens("linux", "x86_64")
+_assets = [
+    ("rg-14.1.0-x86_64-unknown-linux-gnu.tar.gz", "u1"),
+    ("rg-14.1.0-x86_64-unknown-linux-musl.tar.gz", "u2"),
+    ("rg-14.1.0-aarch64-unknown-linux-gnu.tar.gz", "u3"),
+    ("rg-14.1.0-x86_64-apple-darwin.tar.gz", "u4"),
+    ("rg-14.1.0-x86_64-unknown-linux-musl.tar.gz.sha256", "u5"),
+]
+_pick = hp.github_pick_asset(_assets, _linux)
+check("github_pick_asset prefers musl on linux", _pick is not None and _pick[1] == "u2")
+check("github_pick_asset skips .sha256", _pick[0].endswith(".tar.gz"))
+
+_mac = hp.github_asset_tokens("macos", "aarch64")
+_pick_mac = hp.github_pick_asset(_assets + [
+    ("rg-14.1.0-aarch64-apple-darwin.tar.gz", "m1")], _mac)
+check("github_pick_asset picks macos arm64", _pick_mac is not None and _pick_mac[1] == "m1")
+
+_jq = [("jq-linux-amd64", "j1"), ("jq-macos-arm64", "j2"), ("jq-windows-amd64.exe", "j3")]
+_pick_jq = hp.github_pick_asset(_jq, _linux)
+check("github_pick_asset matches single-binary amd64", _pick_jq is not None and _pick_jq[1] == "j1")
+
+check("github_pick_asset returns None when nothing matches",
+      hp.github_pick_asset([("tool-win.zip", "x")], _linux) is None)
+
+# --- github extraction -------------------------------------------------------
+
+def _make_targz(path, members):
+    with tarfile.open(path, "w:gz") as tf:
+        for arcname, data in members.items():
+            ti = tarfile.TarInfo(arcname)
+            ti.size = len(data)
+            ti.mode = 0o755
+            tf.addfile(ti, io.BytesIO(data))
+
+
+with tempfile.TemporaryDirectory() as td:
+    prefix = os.path.join(td, "prefix")
+    asset = os.path.join(td, "rg-x86_64-unknown-linux-musl.tar.gz")
+    _make_targz(asset, {"ripgrep-14.1.0-x86_64/rg": b"#!/bin/sh\necho rg\n",
+                        "ripgrep-14.1.0-x86_64/doc/rg.1": b"man page"})
+    placed = hp.github_extract(asset, os.path.basename(asset), prefix, ["rg"])
+    rg = os.path.join(prefix, "bin", "rg")
+    check("github_extract places binary from tar.gz subdir", placed == ["rg"] and os.path.exists(rg))
+    check("github_extract makes the binary executable", os.access(rg, os.X_OK))
+
+with tempfile.TemporaryDirectory() as td:
+    prefix = os.path.join(td, "prefix")
+    asset = os.path.join(td, "jq-linux-amd64")
+    with open(asset, "wb") as f:
+        f.write(b"#!/bin/sh\necho jq\n")
+    placed = hp.github_extract(asset, os.path.basename(asset), prefix, ["jq"])
+    jq = os.path.join(prefix, "bin", "jq")
+    check("github_extract treats a raw asset as the binary", placed == ["jq"] and os.access(jq, os.X_OK))
+
+# --- conda extraction (.tar.bz2, no zstd needed) -----------------------------
+
+with tempfile.TemporaryDirectory() as td:
+    prefix = os.path.join(td, "prefix")
+    os.makedirs(prefix)
+    pkg = os.path.join(td, "foo-1.0-0.tar.bz2")
+    with tarfile.open(pkg, "w:bz2") as tf:
+        for arcname, data in {"bin/foo": b"#!/bin/sh\necho foo\n",
+                              "info/index.json": b"{}"}.items():
+            ti = tarfile.TarInfo(arcname)
+            ti.size = len(data)
+            ti.mode = 0o755
+            tf.addfile(ti, io.BytesIO(data))
+    installed = hp.conda_extract(pkg, prefix)
+    check("conda_extract unpacks bin/", os.path.exists(os.path.join(prefix, "bin", "foo")))
+    check("conda_extract skips info/", "info/index.json" not in installed
+          and not os.path.exists(os.path.join(prefix, "info")))
+
+# --- CLI argument parsing ----------------------------------------------------
+
+def _run(*args):
+    return subprocess.run([sys.executable, _hp_path, *args],
+                          capture_output=True, text=True)
+
+_list = _run("list")
+check("list exits 0", _list.returncode == 0)
+check("list shows every registered tool",
+      all(t in _list.stdout for t in hp.TOOLS))
+
+check("unknown tool errors", _run("install", "bogustool").returncode != 0)
+check("install with no tools errors", _run("install").returncode != 0)
+check("bad --arch errors", _run("--arch", "weird", "install", "jq").returncode != 0)
+check("dry-run unknown backend errors", _run("--backend", "apt", "install", "jq").returncode != 0)
+
+print()
+print(f"{RUN} tests, {PASS} passed, {FAIL} failed")
+sys.exit(1 if FAIL else 0)


### PR DESCRIPTION
## What

Adds `homepkg`, a no-root installer that unpacks prebuilt CLI tools into a home prefix (default `~/.local`, already on `PATH` via the conf repo) — for machines where `apt`/`dnf` need root. This is the first of the package **backends** for the no-root effort; a follow-up wires it into `setup`.

## Backends

Two backends behind a shared tool registry (`ripgrep`, `fd`, `bat`, `fzf`, `jq`, `delta`, `gh`, `helix`, `jj`, `nu`):

- **conda** (default): resolves the newest build from conda-forge's channel index, downloads from `conda.anaconda.org`, **verifies the sha256**, and unpacks the package into the prefix. Handles both `.conda` and `.tar.bz2` payloads. One host, uniform across every tool.
- **github**: picks the right release asset for the platform (musl preferred on Linux; single-binary assets like `jq` handled), extracts (tar.gz/xz/bz2/zip or raw binary), and places the binaries in `<prefix>/bin`.

```sh
homepkg list
homepkg install ripgrep fd bat jq        # conda-forge -> ~/.local
homepkg --backend github install gh
homepkg --prefix ~/opt install nu
homepkg --dry-run install ripgrep        # resolve + report only
```

## Why conda-forge as the default

It's the cleanest rootless route: a single allowlisted host, prebuilt binaries for the whole tool set, and sha256 verification from the channel index — no GitHub release-asset gating, no compiler. The GitHub backend is there for tools/versions you'd rather pull straight from upstream, and needs no zstd.

Note: `.conda` payloads need zstd (the python `zstandard` module or a `zstd`/`unzstd` CLI); the code falls back to the uncompressed channel index and errors clearly if zstd is unavailable. The GitHub backend needs neither.

## Testing

`homepkg_test` (wired into `make test`) — 21 offline unit tests covering platform/subdir mapping, conda version resolution, GitHub asset selection (musl preference, single-binary, macOS arm64, checksum-skipping), archive extraction (tar.gz subdir, raw binary, `.tar.bz2` skipping `info/`), and CLI argument parsing. The conda install path was also validated end-to-end against `conda.anaconda.org` (resolved → downloaded → sha256-verified → extracted → ran `jq --version`).

## Scope / next

Standalone tool in this PR — `setup` is unchanged. Follow-ups: wire `homepkg` into a `setup --no-root` path, re-add `shpool` optimistically, and add the apt/dnf-mirror `prefix` backend (`apt-get download`/`dnf download` + extract) for the air-gapped-mirror case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XPjirZg5EHkX5RF6FvGiDB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPjirZg5EHkX5RF6FvGiDB)_