### PR TITLE
homepkg: micromamba backend with native install/update/remove

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,17 +25,33 @@ wget -qO- https://github.com/mikelward/scripts/raw/main/setup | sh
 
 On machines where you can't use `apt`/`dnf`, `homepkg` installs prebuilt CLI
 tools into a home prefix (default `~/.local`, already on `PATH` via the conf
-repo). It fetches from conda-forge by default, or GitHub releases:
+repo).
+
+The default backend is `mamba`: a rootless [micromamba](https://mamba.readthedocs.io/)
+manages one conda environment, so you get a real solver (full dependency
+closure), native updates, and clean removal. micromamba is bootstrapped
+automatically from conda-forge.
 
 ```sh
+homepkg install ripgrep fd bat jq     # into a micromamba env, symlinked to ~/.local/bin
+homepkg update                        # update everything (micromamba update --all)
+homepkg update ripgrep                # or a single tool
+homepkg remove jq
+homepkg bootstrap                     # just fetch micromamba
 homepkg list                          # known tools
-homepkg install ripgrep fd bat jq     # from conda-forge into ~/.local
-homepkg --backend github install gh   # from GitHub release assets
-homepkg --prefix ~/opt install nu     # a different prefix
 ```
 
-conda packages are sha256-verified against the channel index. `.conda`
-payloads need zstd (the python `zstandard` module or the `zstd` CLI); the
+For one-shot installs or building push-bundles there are two stateless
+backends that unpack a single artifact (no solver, no dependency resolution):
+
+```sh
+homepkg --backend conda  install ripgrep   # unpack a conda-forge package (sha256-verified)
+homepkg --backend github install gh        # unpack a GitHub release asset
+```
+
+conda artifacts are sha256-verified against the channel index. `.conda`
+payloads (and the channel index) need zstd (the python `zstandard` module or
+a `zstd`/`unzstd` CLI; the code falls back to the uncompressed index). The
 GitHub backend needs neither.
 
 ## Third-party code

--- a/homepkg
+++ b/homepkg
@@ -1,21 +1,28 @@
 #!/usr/bin/env python3
 """homepkg -- install prebuilt CLI tools into a home prefix, no root.
 
-For machines where apt/dnf need root: fetch prebuilt binaries and unpack them
-into a home prefix (default ~/.local), which the conf repo already puts on
-PATH. Two backends:
+For machines where apt/dnf need root. Installs into a home prefix (default
+~/.local), which the conf repo already puts on PATH. Backends:
 
-  conda   conda-forge packages from conda.anaconda.org -- one host, uniform
-          across every tool, sha256-verified (the default)
-  github  release assets from each tool's GitHub repo
+  mamba   (default) a rootless micromamba manages one conda environment, so we
+          get a real solver (full dependency closure), native `update`, and
+          clean `remove`. Tools live in <prefix>/share/homepkg/env and are
+          symlinked into <prefix>/bin. micromamba is itself bootstrapped from
+          conda-forge.
+  conda   unpack a single conda-forge package (sha256-verified) -- stateless,
+          no dependency resolution; for one-shots and building push-bundles.
+  github  unpack a release asset from the tool's GitHub repo -- stateless.
 
 Usage:
-    homepkg [--backend conda|github] [--prefix DIR] [--arch TRIPLE]
-            [--dry-run] install TOOL...
+    homepkg bootstrap                       # fetch micromamba into ~/.local/bin
+    homepkg install TOOL...                 # mamba env (default)
+    homepkg update [TOOL...]                # native micromamba update (all if none)
+    homepkg remove TOOL...
+    homepkg --backend conda|github install TOOL...
     homepkg list
 
-`list` prints the known tools. Tool names are logical (ripgrep, fd, ...); the
-registry maps each to its conda package and GitHub repo.
+Tool names are logical (ripgrep, fd, ...); the registry maps each to its conda
+package and GitHub repo.
 """
 
 import argparse
@@ -324,23 +331,203 @@ def install_github(tool, meta, prefix, plat, dry_run):
     info(f"  installed {', '.join(placed)} into {prefix}/bin")
 
 
-BACKENDS = {"conda": install_conda, "github": install_github}
+# The per-tool extract backends: fetch one prebuilt artifact and unpack it.
+# Good for one-shot installs and for building push-bundles, but they carry no
+# state and don't resolve dependencies. For the well-lit interactive path use
+# the mamba backend below.
+EXTRACT_BACKENDS = {"conda": install_conda, "github": install_github}
+
+
+# --- micromamba backend ------------------------------------------------------
+#
+# The well-lit path on Linux: a rootless micromamba manages one conda
+# environment, so we inherit a real solver (full dependency closure), native
+# `update`, and clean `remove` instead of reinventing them. micromamba itself
+# is just another conda-forge package, so we bootstrap it with the resolver
+# above. The tools live in <prefix>/share/homepkg/env; their binaries are
+# symlinked into <prefix>/bin (conda's $ORIGIN/../lib rpaths keep them working
+# through the symlink, so no activation is needed).
+
+def _homepkg_root(prefix):
+    return os.path.join(prefix, "share", "homepkg")
+
+
+def mamba_root(prefix):
+    return os.path.join(_homepkg_root(prefix), "mamba")
+
+
+def mamba_env(prefix):
+    return os.path.join(_homepkg_root(prefix), "env")
+
+
+def micromamba_path(prefix):
+    local = os.path.join(prefix, "bin", "micromamba")
+    if os.path.exists(local):
+        return local
+    return shutil.which("micromamba")
+
+
+def _verify_sha256(label, path, want):
+    if not want:
+        warn(f"{label}: no sha256 in index; skipping verification")
+        return
+    got = hashlib.sha256(open(path, "rb").read()).hexdigest()
+    if got != want:
+        raise HomepkgError(f"{label}: sha256 mismatch ({got} != {want})")
+
+
+def bootstrap_micromamba(prefix, plat, dry_run):
+    """Install micromamba into <prefix>/bin (it's a conda-forge package)."""
+    existing = micromamba_path(prefix)
+    if existing:
+        info(f"micromamba already available ({existing})")
+        return existing
+    index, base = conda_index(conda_subdir(*plat))
+    found = conda_resolve(index, "micromamba")
+    if not found:
+        raise HomepkgError("micromamba not found on conda-forge for this platform")
+    fn, pmeta = found
+    info(f"micromamba {pmeta['version']}")
+    if dry_run:
+        info(f"  would install from {base}/{fn}")
+        # Return where it *would* land so downstream dry-run commands can print
+        # the planned micromamba invocation instead of hitting a None.
+        return os.path.join(prefix, "bin", "micromamba")
+    os.makedirs(prefix, exist_ok=True)
+    with tempfile.TemporaryDirectory() as td:
+        pkg_path = download(f"{base}/{fn}", os.path.join(td, fn))
+        _verify_sha256("micromamba", pkg_path, pmeta.get("sha256"))
+        conda_extract(pkg_path, prefix)
+    mm = os.path.join(prefix, "bin", "micromamba")
+    _ensure_executable(mm)
+    info(f"  installed micromamba into {prefix}/bin")
+    return mm
+
+
+def ensure_micromamba(prefix, plat, dry_run):
+    mm = micromamba_path(prefix)
+    return mm if mm else bootstrap_micromamba(prefix, plat, dry_run)
+
+
+def _mamba_env_vars(prefix):
+    env = dict(os.environ)
+    env["MAMBA_ROOT_PREFIX"] = mamba_root(prefix)
+    return env
+
+
+def _run_mamba(mm, prefix, args, dry_run):
+    import subprocess
+    cmd = [mm, *args]
+    if dry_run:
+        info("  " + " ".join(cmd))
+        return
+    subprocess.run(cmd, env=_mamba_env_vars(prefix), check=True)
+
+
+def _link_bins(tools, prefix):
+    """Symlink each tool's binaries from the env into <prefix>/bin."""
+    bindir = os.path.join(prefix, "bin")
+    os.makedirs(bindir, exist_ok=True)
+    for tool in tools:
+        for b in TOOLS[tool]["bins"]:
+            src = os.path.join(mamba_env(prefix), "bin", b)
+            dst = os.path.join(bindir, b)
+            if not os.path.exists(src):
+                warn(f"{tool}: {b} not found in the env after install")
+                continue
+            if os.path.islink(dst) or not os.path.exists(dst):
+                if os.path.islink(dst):
+                    os.unlink(dst)
+                os.symlink(src, dst)
+            elif os.path.realpath(dst) != os.path.realpath(src):
+                warn(f"{tool}: {dst} exists and isn't our symlink; leaving it")
+
+
+def _unlink_bins(tools, prefix):
+    for tool in tools:
+        for b in TOOLS[tool]["bins"]:
+            dst = os.path.join(prefix, "bin", b)
+            if os.path.islink(dst):
+                os.unlink(dst)
+
+
+MAMBA_CHANNEL_ARGS = ["-c", "conda-forge", "--override-channels"]
+
+
+def _mamba_subcommand(prefix):
+    # A fresh env must be created; an existing one gets packages added to it.
+    env = mamba_env(prefix)
+    return "install" if os.path.isdir(os.path.join(env, "conda-meta")) else "create"
+
+
+def install_mamba(tools, prefix, plat, dry_run):
+    mm = ensure_micromamba(prefix, plat, dry_run)
+    pkgs = [TOOLS[t]["conda"] for t in tools]
+    env = mamba_env(prefix)
+    subcmd = _mamba_subcommand(prefix)
+    info(f"micromamba {subcmd}: {', '.join(pkgs)} -> {env}")
+    _run_mamba(mm, prefix, [subcmd, "-y", "-p", env,
+                            *MAMBA_CHANNEL_ARGS, *pkgs], dry_run)
+    if not dry_run:
+        _link_bins(tools, prefix)
+        info(f"  linked {', '.join(sum((TOOLS[t]['bins'] for t in tools), []))} "
+             f"into {prefix}/bin")
+
+
+def update_mamba(tools, prefix, plat, dry_run):
+    mm = ensure_micromamba(prefix, plat, dry_run)
+    # No tools named -> update the whole env. Binaries keep the same env path,
+    # so the existing symlinks stay valid; no re-link needed.
+    spec = [TOOLS[t]["conda"] for t in tools] if tools else ["--all"]
+    info(f"micromamba update: {' '.join(spec)}")
+    _run_mamba(mm, prefix, ["update", "-y", "-p", mamba_env(prefix),
+                            *MAMBA_CHANNEL_ARGS, *spec], dry_run)
+
+
+def remove_mamba(tools, prefix, plat, dry_run):
+    mm = micromamba_path(prefix)
+    if mm is None:
+        raise HomepkgError("micromamba is not installed; nothing to remove")
+    pkgs = [TOOLS[t]["conda"] for t in tools]
+    info(f"micromamba remove: {', '.join(pkgs)}")
+    _run_mamba(mm, prefix, ["remove", "-y", "-p", mamba_env(prefix), *pkgs], dry_run)
+    if not dry_run:
+        _unlink_bins(tools, prefix)
 
 
 # --- CLI ---------------------------------------------------------------------
 
+def _resolve_plat(p, arch):
+    if not arch:
+        return detect_platform()
+    plat = tuple(arch.split("/", 1))
+    if len(plat) != 2:
+        p.error("--arch must be OS/ARCH, e.g. linux/x86_64")
+    return plat
+
+
+def _require_known(p, tools):
+    unknown = [t for t in tools if t not in TOOLS]
+    if unknown:
+        p.error(f"unknown tool(s): {', '.join(unknown)} (see 'homepkg list')")
+
+
 def main(argv=None):
-    p = argparse.ArgumentParser(prog="homepkg", add_help=True,
-                                description="Install prebuilt CLI tools into a home prefix.")
-    p.add_argument("--backend", choices=sorted(BACKENDS), default="conda",
-                   help="where to fetch prebuilt binaries (default: conda)")
+    p = argparse.ArgumentParser(
+        prog="homepkg", add_help=True,
+        description="Install prebuilt CLI tools into a home prefix, no root.")
+    p.add_argument("--backend", choices=["mamba", "conda", "github"], default="mamba",
+                   help="install backend (default: mamba -- a managed micromamba "
+                        "env with native update/remove; conda/github unpack a "
+                        "single artifact with no state)")
     p.add_argument("--prefix", default=os.path.expanduser("~/.local"),
                    help="install prefix (default: ~/.local)")
     p.add_argument("--arch", default=None,
                    help="override platform as OS/ARCH, e.g. linux/x86_64")
     p.add_argument("--dry-run", action="store_true",
                    help="resolve and report, but don't download or install")
-    p.add_argument("command", choices=["install", "list"])
+    p.add_argument("command",
+                   choices=["install", "update", "remove", "bootstrap", "list"])
     p.add_argument("tools", nargs="*", help="logical tool names (see 'list')")
     args = p.parse_args(argv)
 
@@ -350,22 +537,47 @@ def main(argv=None):
             print(f"{name:10} conda={m['conda']:12} github={m['github']}")
         return 0
 
-    if not args.tools:
-        p.error("install requires at least one tool")
-    if args.arch:
+    if args.command == "bootstrap":
         try:
-            plat = tuple(args.arch.split("/", 1))
-            assert len(plat) == 2
-        except Exception:
-            p.error("--arch must be OS/ARCH, e.g. linux/x86_64")
-    else:
-        plat = detect_platform()
+            bootstrap_micromamba(args.prefix, _resolve_plat(p, args.arch), args.dry_run)
+        except Exception as e:
+            warn(str(e))
+            return 1
+        return 0
 
-    unknown = [t for t in args.tools if t not in TOOLS]
-    if unknown:
-        p.error(f"unknown tool(s): {', '.join(unknown)} (see 'homepkg list')")
+    plat = _resolve_plat(p, args.arch)
 
-    install = BACKENDS[args.backend]
+    # update with no tools means "the whole env"; everything else needs names.
+    if not args.tools and args.command != "update":
+        p.error(f"{args.command} requires at least one tool")
+    _require_known(p, args.tools)
+
+    # update/remove operate on the managed mamba env regardless of --backend.
+    if args.command == "update":
+        try:
+            update_mamba(args.tools, args.prefix, plat, args.dry_run)
+        except Exception as e:
+            warn(str(e))
+            return 1
+        return 0
+    if args.command == "remove":
+        try:
+            remove_mamba(args.tools, args.prefix, plat, args.dry_run)
+        except Exception as e:
+            warn(str(e))
+            return 1
+        return 0
+
+    # install
+    if args.backend == "mamba":
+        try:
+            install_mamba(args.tools, args.prefix, plat, args.dry_run)
+        except Exception as e:
+            warn(str(e))
+            return 1
+        return 0
+
+    install = EXTRACT_BACKENDS[args.backend]
     failed = []
     for tool in args.tools:
         try:

--- a/homepkg_test
+++ b/homepkg_test
@@ -148,7 +148,80 @@ check("list shows every registered tool",
 check("unknown tool errors", _run("install", "bogustool").returncode != 0)
 check("install with no tools errors", _run("install").returncode != 0)
 check("bad --arch errors", _run("--arch", "weird", "install", "jq").returncode != 0)
-check("dry-run unknown backend errors", _run("--backend", "apt", "install", "jq").returncode != 0)
+check("unknown backend errors", _run("--backend", "apt", "install", "jq").returncode != 0)
+# These stay subprocesses: argparse rejects them before any backend/network.
+check("remove requires tools", _run("remove").returncode != 0)
+
+# --- micromamba backend: env paths and symlink management --------------------
+
+check("mamba_env lives under the prefix",
+      hp.mamba_env("/p") == os.path.join("/p", "share", "homepkg", "env"))
+
+# Regression: a dry-run install on a fresh prefix (micromamba not yet present)
+# must not crash. bootstrap returns the intended path, not None, so the planned
+# micromamba command can be printed. conda_index is stubbed to stay offline.
+_saved_index = hp.conda_index
+hp.conda_index = lambda subdir: (
+    {"packages": {"micromamba-2.8.1-0.tar.bz2":
+                  {"name": "micromamba", "version": "2.8.1", "build_number": 0}}},
+    "https://example.invalid/conda")
+try:
+    with tempfile.TemporaryDirectory() as td:
+        got = hp.bootstrap_micromamba(td, ("linux", "x86_64"), True)
+        check("dry-run bootstrap returns the micromamba path, not None",
+              got == os.path.join(td, "bin", "micromamba"))
+        crashed = False
+        try:
+            hp.install_mamba(["jq"], td, ("linux", "x86_64"), True)
+        except Exception:
+            crashed = True
+        check("dry-run install on a fresh prefix doesn't crash", not crashed)
+        # bootstrap/update accept no tools and run their dry-run flow offline
+        # (in-process so the stubbed conda_index applies -- a subprocess would
+        # hit the real network path).
+        check("dry-run bootstrap command returns 0",
+              hp.main(["--prefix", td, "--arch", "linux/x86_64", "--dry-run", "bootstrap"]) == 0)
+        check("dry-run update of the whole env returns 0",
+              hp.main(["--prefix", td, "--arch", "linux/x86_64", "--dry-run", "update"]) == 0)
+finally:
+    hp.conda_index = _saved_index
+
+with tempfile.TemporaryDirectory() as td:
+    check("mamba subcommand is 'create' for a fresh env", hp._mamba_subcommand(td) == "create")
+    os.makedirs(os.path.join(hp.mamba_env(td), "conda-meta"))
+    check("mamba subcommand is 'install' once the env exists", hp._mamba_subcommand(td) == "install")
+
+with tempfile.TemporaryDirectory() as td:
+    mm = os.path.join(td, "bin", "micromamba")
+    os.makedirs(os.path.dirname(mm))
+    open(mm, "w").close()
+    check("micromamba_path prefers the one in the prefix", hp.micromamba_path(td) == mm)
+
+with tempfile.TemporaryDirectory() as td:
+    envbin = os.path.join(hp.mamba_env(td), "bin")
+    os.makedirs(envbin)
+    with open(os.path.join(envbin, "rg"), "w") as f:
+        f.write("#!/bin/sh\n")
+    hp._link_bins(["ripgrep"], td)
+    link = os.path.join(td, "bin", "rg")
+    check("_link_bins symlinks env binary into prefix/bin",
+          os.path.islink(link) and os.path.realpath(link) == os.path.join(envbin, "rg"))
+    hp._unlink_bins(["ripgrep"], td)
+    check("_unlink_bins removes the symlink", not os.path.lexists(link))
+    check("_unlink_bins leaves the env binary intact", os.path.exists(os.path.join(envbin, "rg")))
+
+with tempfile.TemporaryDirectory() as td:
+    envbin = os.path.join(hp.mamba_env(td), "bin")
+    os.makedirs(envbin)
+    open(os.path.join(envbin, "rg"), "w").close()
+    realbin = os.path.join(td, "bin")
+    os.makedirs(realbin)
+    with open(os.path.join(realbin, "rg"), "w") as f:
+        f.write("not a symlink")
+    hp._link_bins(["ripgrep"], td)  # must not clobber the real file
+    check("_link_bins won't overwrite a non-symlink",
+          not os.path.islink(os.path.join(realbin, "rg"))
+          and open(os.path.join(realbin, "rg")).read() == "not a symlink")
 
 print()
 print(f"{RUN} tests, {PASS} passed, {FAIL} failed")


### PR DESCRIPTION
## What

Makes `homepkg`'s well-lit path a rootless **micromamba** environment (`--backend mamba`, now the default). Instead of hand-rolling install/update/resolve, we get a real package manager: **full dependency closure**, native **update**, and clean **remove** — no root.

## Why

The stateless extract backend (from #140) unpacks a *single* conda package and ignores its dependencies — fine for static/libc-only tools (`jq`, `rg`), but it silently breaks for anything needing a shared lib the host lacks, and it has no update/remove story. micromamba solves both: it resolves the closure and ships the libs in the env, and `micromamba update`/`remove` are the update/removal story for free.

micromamba is a great fit here — a **6.6 MB single static binary**, distributed as a conda-forge `.tar.bz2` (bootstraps with stdlib bz2, no zstd, no base conda), rootless into any prefix.

## Commands

```sh
homepkg install ripgrep fd bat jq   # micromamba env, symlinked into ~/.local/bin
homepkg update                      # micromamba update --all
homepkg update ripgrep              # or one tool
homepkg remove jq
homepkg bootstrap                   # just fetch micromamba
```

- **bootstrap**: micromamba is itself a conda-forge package, so it's fetched with the existing conda resolver into `<prefix>/bin`.
- **install**: `micromamba create`/`install` into `<prefix>/share/homepkg/env`; each tool's binaries are symlinked into `<prefix>/bin`. No activation needed — conda's `$ORIGIN/../lib` rpaths keep the tools working through the symlink.
- **update / remove**: thin wrappers over `micromamba update`/`remove`, with symlink cleanup on remove.

The stateless **conda/github** extract backends stay (via `--backend`) for one-shot installs and for building push-bundles, where the closure is solved on the online builder rather than the air-gapped target.

## Testing

`homepkg_test` (in `make test`) — **32** tests, adding coverage for the env-path layout, the create-vs-install decision, symlink link/unlink (including the non-clobber guard), and the new CLI commands. The `install → run → add tool → update → remove` lifecycle was validated **end-to-end** against `conda.anaconda.org` (created an env, ran `rg`/`jq`/`nu`, removed one and confirmed the others stayed intact).

## Scope / next

Interactive path only in this PR. Follow-up: the **push-bundle** pair (`homepkg bundle` on an online builder → `homepkg install-bundle --offline` on the target) — proven out manually already (micromamba solves the closure online, replays it offline into a fresh prefix with correct prefix-relocation). macOS stays on Homebrew.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XPjirZg5EHkX5RF6FvGiDB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPjirZg5EHkX5RF6FvGiDB)_