### PR TITLE
homepkg: harden bundle extraction against symlink traversal

### DIFF
--- a/homepkg
+++ b/homepkg
@@ -292,25 +292,24 @@ def _require_basename(name, what):
 
 
 def _safe_extract_tar(tf, dest):
-    """extractall guarding against path traversal and unsafe links. Assets and
-    bundles come from other hosts, so treat their members as untrusted."""
+    """Extract a tar treating members as untrusted. Only directories and
+    regular files are created, each validated to stay within dest; special
+    files are rejected and links are skipped -- never materialized. Members are
+    extracted one-by-one, so no symlink is ever created for a later member to
+    traverse through (the validate-then-extractall path-traversal). Our bundles
+    contain no links; release tarballs may, but we only need their binaries."""
     dest_real = os.path.realpath(dest)
     for m in tf.getmembers():
-        if not (m.isdir() or m.isfile() or m.issym() or m.islnk()):
+        if m.issym() or m.islnk():
+            continue  # never materialize a link from an untrusted archive
+        if not (m.isdir() or m.isfile()):
             raise HomepkgError(f"unsupported member type in archive: {m.name}")
-        if not _within(dest_real, os.path.join(dest, m.name)):
+        # Reject absolute paths and any '..' component outright (clean archives
+        # have neither), then belt-and-suspenders check the resolved path.
+        if (os.path.isabs(m.name) or ".." in m.name.split("/")
+                or not _within(dest_real, os.path.join(dest, m.name))):
             raise HomepkgError(f"unsafe path in archive: {m.name}")
-        # A symlink's target resolves relative to the link's own directory; a
-        # hard link's linkname resolves relative to the extraction root.
-        if m.issym():
-            link = os.path.join(dest, os.path.dirname(m.name), m.linkname)
-        elif m.islnk():
-            link = os.path.join(dest, m.linkname)
-        else:
-            continue
-        if not _within(dest_real, link):
-            raise HomepkgError(f"unsafe link in archive: {m.name} -> {m.linkname}")
-    tf.extractall(dest)
+        tf.extract(m, dest)
 
 
 def _safe_extract_zip(zf, dest):

--- a/homepkg_test
+++ b/homepkg_test
@@ -324,22 +324,48 @@ with tempfile.TemporaryDirectory() as td:
         raised = True
     check("install-bundle rejects path-traversal members", raised)
 
-# hard-link linkname resolves relative to the extraction root (not the member's
-# dir), so a d/rg hardlink to ../secret must also be rejected.
+# Links are never materialized -- a sym/hard link member is skipped entirely.
 with tempfile.TemporaryDirectory() as td:
-    hl = os.path.join(td, "hl.tar")
-    with tarfile.open(hl, "w") as tf:
-        ti = tarfile.TarInfo("d/rg")
-        ti.type = tarfile.LNKTYPE
-        ti.linkname = "../secret"
-        tf.addfile(ti)
+    lt = os.path.join(td, "l.tar")
+    with tarfile.open(lt, "w") as tf:
+        s = tarfile.TarInfo("slink")
+        s.type = tarfile.SYMTYPE
+        s.linkname = "/etc/passwd"
+        tf.addfile(s)
+        h = tarfile.TarInfo("hlink")
+        h.type = tarfile.LNKTYPE
+        h.linkname = "../secret"
+        tf.addfile(h)
+    out = os.path.join(td, "out")
+    with tarfile.open(lt) as tf:
+        hp._safe_extract_tar(tf, out)
+    check("_safe_extract_tar skips link members",
+          not os.path.lexists(os.path.join(out, "slink"))
+          and not os.path.lexists(os.path.join(out, "hlink")))
+
+# The validate-then-extractall traversal: a symlink `safe/link -> ..` followed
+# by a file `safe/link/../pwn`. The symlink is skipped and the file member is
+# rejected (it has a `..` component), so nothing escapes.
+with tempfile.TemporaryDirectory() as td:
+    toc = os.path.join(td, "toctou.tar")
+    with tarfile.open(toc, "w") as tf:
+        s = tarfile.TarInfo("safe/link")
+        s.type = tarfile.SYMTYPE
+        s.linkname = ".."
+        tf.addfile(s)
+        data = b"pwn"
+        f = tarfile.TarInfo("safe/link/../pwn")
+        f.size = len(data)
+        tf.addfile(f, io.BytesIO(data))
+    out = os.path.join(td, "out")
     raised = False
     try:
-        with tarfile.open(hl) as tf:
-            hp._safe_extract_tar(tf, os.path.join(td, "out"))
+        with tarfile.open(toc) as tf:
+            hp._safe_extract_tar(tf, out)
     except hp.HomepkgError:
         raised = True
-    check("_safe_extract_tar rejects escaping hard links", raised)
+    check("_safe_extract_tar can't escape via a symlinked component",
+          raised and not os.path.exists(os.path.join(td, "pwn")))
 
 # special files (FIFO/device) are rejected -- a FIFO named manifest.json would
 # otherwise block install_bundle when it opens the manifest.


### PR DESCRIPTION
## What

Closes the one remaining finding from #142's review that landed after merge: a **validate-then-`extractall` symlink TOCTOU** in `_safe_extract_tar`.

## The bug

The helper validated each member's path and then called `tarfile.extractall()`. `extractall` follows symlinks created *earlier in the same archive*, so a crafted bundle/asset with a symlink like `safe/link -> ..` followed by a regular file `safe/link/../pwn` passes the pre-check (the file path looks in-bounds before the symlink exists) but writes **outside** the extraction directory at extract time. Since `install-bundle` and GitHub-asset extraction treat archives as untrusted, this was a real path-traversal class bug.

## The fix

Extract members **one at a time** and **never materialize links**:
- sym/hard links are **skipped** (never created), so there's no symlink for a later member to traverse through;
- special files (FIFO/device) are rejected;
- each remaining member is rejected if it has an absolute path or a `..` component, and confirmed to resolve inside the destination, before extraction.

Our bundles contain no links; release tarballs may, but we only copy their named binaries, so skipping links is harmless. This supersedes the earlier link-target validation, which fundamentally couldn't close the TOCTOU.

## Testing

`homepkg_test` — **53** tests. Updated the extraction tests: links are skipped (not materialized), and the symlinked-component traversal (`safe/link -> ..` + `safe/link/../pwn`) is rejected. Special-file rejection and the `../evil` path-traversal test still hold. The live `bundle → install-bundle --offline` round-trip still passes (`jq-1.8.2` from a fresh air-gapped prefix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XPjirZg5EHkX5RF6FvGiDB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPjirZg5EHkX5RF6FvGiDB)_