### PR TITLE
setup: add --no-root policy flag that installs CLI tools via homepkg

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,12 @@ On machines where you can't use `apt`/`dnf`, `homepkg` installs prebuilt CLI
 tools into a home prefix (default `~/.local`, already on `PATH` via the conf
 repo).
 
-`setup --no-sudo` wires this in automatically: it skips the `apt`/`dnf`
-package installs (and every other privileged step) and installs the CLI tools
-via `homepkg` instead — the core set (`ripgrep fd bat fzf jq delta gh`) plus
-the extras (`helix jj nu`, unless the minimal profile is in effect).
+`setup --no-root` wires this in automatically: it runs unprivileged (implying
+`--no-sudo`, so the `apt`/`dnf` installs and every other privileged step are
+skipped) and installs the CLI tools via `homepkg` instead — the core set
+(`ripgrep fd bat fzf jq delta gh`) plus the extras (`helix jj nu`, unless the
+minimal profile is in effect). `--no-sudo` on its own is just the mechanism
+(skip sudo); it assumes the tools are provided some other way.
 
 The default backend is `mamba`: a rootless [micromamba](https://mamba.readthedocs.io/)
 manages one conda environment, so you get a real solver (full dependency

--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ On machines where you can't use `apt`/`dnf`, `homepkg` installs prebuilt CLI
 tools into a home prefix (default `~/.local`, already on `PATH` via the conf
 repo).
 
+`setup --no-sudo` wires this in automatically: it skips the `apt`/`dnf`
+package installs (and every other privileged step) and installs the CLI tools
+via `homepkg` instead — the core set (`ripgrep fd bat fzf jq delta gh`) plus
+the extras (`helix jj nu`, unless the minimal profile is in effect).
+
 The default backend is `mamba`: a rootless [micromamba](https://mamba.readthedocs.io/)
 manages one conda environment, so you get a real solver (full dependency
 closure), native updates, and clean removal. micromamba is bootstrapped

--- a/setup
+++ b/setup
@@ -1034,6 +1034,32 @@ install_extras() {
     install_extras_cargo
 }
 
+# --- Install CLI tools into a home prefix (no sudo) ---
+
+# Under --no-sudo the apt/dnf package installs are skipped, so the CLI tools
+# they'd provide have to come from somewhere else: homepkg installs prebuilt
+# binaries into a home prefix (~/.local), no root required. Core tools mirror
+# the distro CLI package set; the heavyweight extras (helix, jj, nushell) are
+# added unless the minimal profile is in effect. homepkg resolves them into one
+# home-prefix env; a solve/network failure warns rather than aborting the
+# bootstrap.
+install_home_tools() {
+    homepkg="$SCRIPTS_DIR/homepkg"
+    if ! test -x "$homepkg"; then
+        warn "homepkg not found at $homepkg; skipping home-prefix tool install"
+        return 0
+    fi
+    tools="ripgrep fd bat fzf jq delta gh"
+    if test "$MINIMAL_ENABLED" -eq 0; then
+        tools="$tools helix jj nu"
+    else
+        info "Skipping heavyweight CLI extras (helix, jj, nushell); minimal profile"
+    fi
+    info "Installing CLI tools into a home prefix via homepkg: $tools"
+    "$homepkg" install $tools \
+        || warn "some CLI tools could not be installed via homepkg"
+}
+
 # --- Install uv (Python package manager) ---
 
 install_uv() {
@@ -1305,6 +1331,10 @@ fi
 
 if test "$INSTALL" = no; then
     info "Skipping heavyweight extras (helix, jj, shpool, nushell); --no-install"
+elif test "$SUDO" = no; then
+    # No sudo: apt/dnf were skipped, so install the CLI tools (the core distro
+    # package set plus the extras) into a home prefix with homepkg instead.
+    install_home_tools
 elif test "$MINIMAL_ENABLED" -eq 0; then
     install_extras
 else

--- a/setup
+++ b/setup
@@ -1052,6 +1052,11 @@ install_home_tools() {
     tools="ripgrep fd bat fzf jq delta gh"
     if test "$MINIMAL_ENABLED" -eq 0; then
         tools="$tools helix jj nu"
+        # shpool is source-only (no conda-forge/prebuilt artifact), so the
+        # homepkg path can't provide it -- same as the brew path. start_services
+        # skips its user service when shpool is absent and the shell falls back
+        # to tmux; use --cargo (or apt) if you want shpool itself.
+        warn "shpool is not available on the homepkg path; use --cargo (or apt) for it (sessions fall back to tmux)"
     else
         info "Skipping heavyweight CLI extras (helix, jj, nushell); minimal profile"
     fi

--- a/setup
+++ b/setup
@@ -1054,9 +1054,10 @@ install_home_tools() {
         tools="$tools helix jj nu"
         # shpool is source-only (no conda-forge/prebuilt artifact), so the
         # homepkg path can't provide it -- same as the brew path. start_services
-        # skips its user service when shpool is absent and the shell falls back
-        # to tmux; use --cargo (or apt) if you want shpool itself.
-        warn "shpool is not available on the homepkg path; use --cargo (or apt) for it (sessions fall back to tmux)"
+        # skips its user service when shpool is absent, so the shell falls back
+        # to tmux. (--cargo/apt would build it, but both are unavailable in this
+        # mode: --no-sudo routes here before install_extras, and apt needs sudo.)
+        warn "shpool is not available on the homepkg path (source-only); sessions fall back to tmux"
     else
         info "Skipping heavyweight CLI extras (helix, jj, nushell); minimal profile"
     fi

--- a/setup
+++ b/setup
@@ -120,6 +120,18 @@ NPM=yes
 # Override with --sudo / --no-sudo, or by exporting SUDO before running.
 SUDO="${SUDO:-yes}"
 
+# Whether we have root/admin privileges on this machine (policy, as opposed to
+# SUDO's mechanism). One of:
+#   yes - privileged: install system packages, the root config, etc. (default)
+#   no  - unprivileged (--no-root). Implies --no-sudo (an unprivileged user
+#         can't escalate), and, since the apt/dnf packages are then skipped,
+#         installs the CLI tools into a home prefix with homepkg instead.
+# SUDO is the "do we invoke sudo" mechanism; ROOT is the "do we have privileges"
+# policy. --no-sudo alone just skips sudo (tools assumed provided some other
+# way); --no-root additionally provisions the tools rootlessly via homepkg.
+# Override with --root / --no-root, or by exporting ROOT before running.
+ROOT="${ROOT:-yes}"
+
 # Which Linux desktop to install and configure (ignored on macOS). One of:
 #   kde   - KDE Plasma + Krohnkite, via setup-kde (the default)
 #   hypr  - Hyprland Wayland desktop, via setup-hypr
@@ -140,8 +152,8 @@ EXTRAS=auto
 usage() {
     cat <<'USAGE'
 Usage: setup [--gui | --no-gui] [--kde | --hypr | --sway] [--minimal | --full]
-             [--no-install] [--no-sudo] [--ignore-errors] [--ssh | --no-ssh]
-             [--no-npm] [-h | --help]
+             [--no-install] [--no-sudo] [--no-root] [--ignore-errors]
+             [--ssh | --no-ssh] [--no-npm] [-h | --help]
 
 Bootstrap a new machine: install packages, fonts, tools, and dotfiles.
 
@@ -167,6 +179,10 @@ Options:
                    box that allows only "sudo apt" needs nothing special --
                    leave sudo on and the denials warn and skip themselves.
                    Forwarded to the desktop setup helpers
+  --no-root        Unprivileged install. Implies --no-sudo, and since the
+                   apt/dnf packages are then skipped, installs the CLI tools
+                   (core set plus extras) into a home prefix with homepkg
+                   instead. For machines where you have no root at all
   --ignore-errors  Keep going past failures instead of aborting on the first
                    one. Forwarded to setup-kde/macos
   --ssh            Generate an SSH key even if one is already available
@@ -291,6 +307,12 @@ while test $# -gt 0; do
         --no-sudo)
             SUDO=no
             ;;
+        --root)
+            ROOT=yes
+            ;;
+        --no-root)
+            ROOT=no
+            ;;
         --ignore-errors)
             IGNORE_ERRORS=yes
             ;;
@@ -324,6 +346,13 @@ done
 # parsing args, so an unknown option above still exits non-zero.
 if test "$IGNORE_ERRORS" = no; then
     set -e
+fi
+
+# --no-root is a policy that implies the no-sudo mechanism: an unprivileged
+# user can't escalate. (--no-sudo alone leaves ROOT=yes -- just the mechanism.)
+# Set this before the SUDO-keyed forwarding below so it propagates too.
+if test "$ROOT" = no; then
+    SUDO=no
 fi
 
 # Flags to forward to the desktop setup helpers (setup-kde / setup-macos).
@@ -1034,9 +1063,9 @@ install_extras() {
     install_extras_cargo
 }
 
-# --- Install CLI tools into a home prefix (no sudo) ---
+# --- Install CLI tools into a home prefix (--no-root) ---
 
-# Under --no-sudo the apt/dnf package installs are skipped, so the CLI tools
+# Under --no-root the apt/dnf package installs are skipped, so the CLI tools
 # they'd provide have to come from somewhere else: homepkg installs prebuilt
 # binaries into a home prefix (~/.local), no root required. Core tools mirror
 # the distro CLI package set; the heavyweight extras (helix, jj, nushell) are
@@ -1055,15 +1084,29 @@ install_home_tools() {
         # shpool is source-only (no conda-forge/prebuilt artifact), so the
         # homepkg path can't provide it -- same as the brew path. start_services
         # skips its user service when shpool is absent, so the shell falls back
-        # to tmux. (--cargo/apt would build it, but both are unavailable in this
-        # mode: --no-sudo routes here before install_extras, and apt needs sudo.)
+        # to tmux.
         warn "shpool is not available on the homepkg path (source-only); sessions fall back to tmux"
     else
         info "Skipping heavyweight CLI extras (helix, jj, nushell); minimal profile"
     fi
     info "Installing CLI tools into a home prefix via homepkg: $tools"
-    "$homepkg" install $tools \
-        || warn "some CLI tools could not be installed via homepkg"
+    if "$homepkg" install $tools; then
+        # A prior cargo run points ~/.config/helix/runtime at the source
+        # checkout, and hx searches that before the prebuilt runtime -- so drop
+        # the stale symlink (only the one install_helix created), same as the
+        # brew path. Gated on a successful install so a prior cargo hx keeps its
+        # runtime if homepkg failed; and only when helix was in this run's list.
+        if test "$MINIMAL_ENABLED" -eq 0; then
+            helix_runtime="${XDG_CONFIG_HOME:-$HOME/.config}/helix/runtime"
+            if test -L "$helix_runtime" \
+                    && test "$(readlink "$helix_runtime")" = "$SRC_DIR/helix/runtime"; then
+                info "Removing stale Helix runtime symlink from the cargo build"
+                rm -f "$helix_runtime"
+            fi
+        fi
+    else
+        warn "some CLI tools could not be installed via homepkg"
+    fi
 }
 
 # --- Install uv (Python package manager) ---
@@ -1337,9 +1380,11 @@ fi
 
 if test "$INSTALL" = no; then
     info "Skipping heavyweight extras (helix, jj, shpool, nushell); --no-install"
-elif test "$SUDO" = no; then
-    # No sudo: apt/dnf were skipped, so install the CLI tools (the core distro
-    # package set plus the extras) into a home prefix with homepkg instead.
+elif test "$ROOT" = no; then
+    # Unprivileged (--no-root): apt/dnf were skipped, so install the CLI tools
+    # (the core distro package set plus the extras) into a home prefix with
+    # homepkg instead. --no-sudo alone (ROOT=yes) leaves this to install_extras
+    # below, whose cargo/brew builds are themselves rootless.
     install_home_tools
 elif test "$MINIMAL_ENABLED" -eq 0; then
     install_extras

--- a/setup_test
+++ b/setup_test
@@ -456,15 +456,43 @@ test_no_sudo_skips_command_up_front() {
     esac
 }
 
-# Under --no-sudo the apt/dnf installs are skipped, so setup installs the CLI
+# SUDO is the mechanism (do we invoke sudo); ROOT is the policy (do we have
+# privileges). --no-root sets ROOT=no; --root sets it back. Both default to yes.
+test_no_root_flags() {
+    assert_source_contains 'ROOT="${ROOT:-yes}"' &&
+    assert_source_contains '[-]-no-root)' &&
+    assert_source_contains '[-]-root)' &&
+    assert_source_contains "ROOT=no" &&
+    assert_source_contains "ROOT=yes"
+}
+
+# --no-root (policy) implies --no-sudo (mechanism): an unprivileged user can't
+# escalate. The implication is applied after arg parsing, before the SUDO-keyed
+# desktop forwarding, so --no-root propagates --no-sudo to the helpers too.
+test_no_root_implies_no_sudo() {
+    assert_source_contains 'if test "$ROOT" = no; then' &&
+    assert_source_contains "SUDO=no"
+}
+
+# Under --no-root the apt/dnf installs are skipped, so setup installs the CLI
 # tools into a home prefix with homepkg instead (core set plus the extras).
-# The extras dispatch routes SUDO=no to install_home_tools.
-test_no_sudo_installs_via_homepkg() {
+# The extras dispatch routes ROOT=no to install_home_tools -- so --no-sudo
+# alone (ROOT=yes) still reaches install_extras and honors --cargo/--brew.
+test_no_root_installs_via_homepkg() {
     assert_source_contains "install_home_tools" &&
-    assert_source_contains 'elif test "$SUDO" = no; then' &&
+    assert_source_contains 'elif test "$ROOT" = no; then' &&
     assert_source_contains '"$homepkg" install $tools' &&
     assert_source_contains "ripgrep fd bat fzf jq delta gh" &&
     assert_source_contains 'tools="$tools helix jj nu"'
+}
+
+# --no-root is a known option (accepted, not an "Unknown option" error) and is
+# documented in usage.
+test_no_root_accepted_and_documented() {
+    run_setup --no-root --help
+    assert_status 0 &&
+    assert_output_contains "Usage: setup" &&
+    assert_output_contains "--no-root"
 }
 
 # The homepkg tool install degrades: a missing homepkg or a failed install
@@ -475,10 +503,22 @@ test_home_tools_install_degrades() {
 }
 
 # shpool is source-only, so (like the brew path) the homepkg path can't provide
-# it. The full no-sudo run must say so explicitly rather than silently dropping
-# it, since the normal full cargo path installs shpool.
+# it. The full --no-root run must say so explicitly rather than silently
+# dropping it, since the normal full cargo path installs shpool.
 test_home_tools_warns_about_shpool() {
     assert_source_contains "shpool is not available on the homepkg path"
+}
+
+# Switching a prior cargo hx to the homepkg hx leaves ~/.config/helix/runtime
+# pointing at the source checkout, which hx searches first. The homepkg path
+# removes that stale symlink (only the one install_helix created), same as the
+# brew path -- and only after a successful install so a failed run doesn't strip
+# a still-active cargo hx's runtime.
+test_home_tools_clears_stale_helix_runtime() {
+    assert_source_contains 'if "$homepkg" install $tools; then' &&
+    assert_source_contains 'helix_runtime=' &&
+    assert_source_contains 'readlink "$helix_runtime"' &&
+    assert_source_contains "Removing stale Helix runtime symlink"
 }
 
 run_test "--no-sudo is accepted as a known option" test_no_sudo_flag_accepted
@@ -489,12 +529,20 @@ run_test "--no-sudo gate lives in the sudo_or_warn wrapper" \
     test_no_sudo_gate_is_in_the_wrapper
 run_test "--no-sudo skips the command up front without invoking sudo" \
     test_no_sudo_skips_command_up_front
-run_test "--no-sudo installs CLI tools into a home prefix via homepkg" \
-    test_no_sudo_installs_via_homepkg
+run_test "--no-root/--root are the policy flags (SUDO is the mechanism)" \
+    test_no_root_flags
+run_test "--no-root implies --no-sudo" \
+    test_no_root_implies_no_sudo
+run_test "--no-root installs CLI tools into a home prefix via homepkg" \
+    test_no_root_installs_via_homepkg
+run_test "--no-root is accepted and documented" \
+    test_no_root_accepted_and_documented
 run_test "home-prefix tool install degrades on failure" \
     test_home_tools_install_degrades
 run_test "home-prefix full install warns that shpool is unavailable" \
     test_home_tools_warns_about_shpool
+run_test "home-prefix path clears the stale cargo Helix runtime symlink" \
+    test_home_tools_clears_stale_helix_runtime
 
 run_test "--sway flag dispatches to setup-sway" test_sway_flag_and_dispatch
 run_test "Sway package names are the upstream ones" test_sway_package_names

--- a/setup_test
+++ b/setup_test
@@ -456,6 +456,24 @@ test_no_sudo_skips_command_up_front() {
     esac
 }
 
+# Under --no-sudo the apt/dnf installs are skipped, so setup installs the CLI
+# tools into a home prefix with homepkg instead (core set plus the extras).
+# The extras dispatch routes SUDO=no to install_home_tools.
+test_no_sudo_installs_via_homepkg() {
+    assert_source_contains "install_home_tools" &&
+    assert_source_contains 'elif test "$SUDO" = no; then' &&
+    assert_source_contains '"$homepkg" install $tools' &&
+    assert_source_contains "ripgrep fd bat fzf jq delta gh" &&
+    assert_source_contains 'tools="$tools helix jj nu"'
+}
+
+# The homepkg tool install degrades: a missing homepkg or a failed install
+# warns and continues rather than aborting the bootstrap.
+test_home_tools_install_degrades() {
+    assert_source_contains "homepkg not found at" &&
+    assert_source_contains "some CLI tools could not be installed via homepkg"
+}
+
 run_test "--no-sudo is accepted as a known option" test_no_sudo_flag_accepted
 run_test "--no-sudo is documented in usage" test_no_sudo_in_usage
 run_test "--no-sudo parses and forwards to desktop helpers" \
@@ -464,6 +482,10 @@ run_test "--no-sudo gate lives in the sudo_or_warn wrapper" \
     test_no_sudo_gate_is_in_the_wrapper
 run_test "--no-sudo skips the command up front without invoking sudo" \
     test_no_sudo_skips_command_up_front
+run_test "--no-sudo installs CLI tools into a home prefix via homepkg" \
+    test_no_sudo_installs_via_homepkg
+run_test "home-prefix tool install degrades on failure" \
+    test_home_tools_install_degrades
 
 run_test "--sway flag dispatches to setup-sway" test_sway_flag_and_dispatch
 run_test "Sway package names are the upstream ones" test_sway_package_names

--- a/setup_test
+++ b/setup_test
@@ -474,6 +474,13 @@ test_home_tools_install_degrades() {
     assert_source_contains "some CLI tools could not be installed via homepkg"
 }
 
+# shpool is source-only, so (like the brew path) the homepkg path can't provide
+# it. The full no-sudo run must say so explicitly rather than silently dropping
+# it, since the normal full cargo path installs shpool.
+test_home_tools_warns_about_shpool() {
+    assert_source_contains "shpool is not available on the homepkg path"
+}
+
 run_test "--no-sudo is accepted as a known option" test_no_sudo_flag_accepted
 run_test "--no-sudo is documented in usage" test_no_sudo_in_usage
 run_test "--no-sudo parses and forwards to desktop helpers" \
@@ -486,6 +493,8 @@ run_test "--no-sudo installs CLI tools into a home prefix via homepkg" \
     test_no_sudo_installs_via_homepkg
 run_test "home-prefix tool install degrades on failure" \
     test_home_tools_install_degrades
+run_test "home-prefix full install warns that shpool is unavailable" \
+    test_home_tools_warns_about_shpool
 
 run_test "--sway flag dispatches to setup-sway" test_sway_flag_and_dispatch
 run_test "Sway package names are the upstream ones" test_sway_package_names


### PR DESCRIPTION
## Summary

Builds on the `--no-sudo` mode from #134 and completes it. That change made
`setup` skip privileged commands via the `sudo_or_warn` choke point, but left
the CLI tools those packages would have provided "preinstalled or provided some
other way." This adds *that other way* and cleanly separates two concepts that
were getting conflated:

- **`SUDO` (mechanism)** — whether `sudo_or_warn` invokes sudo. `--no-sudo`.
- **`ROOT` (policy)** — whether we have privileges at all. `--no-root`.

## What changed

- **New `--root`/`--no-root` flags** and `ROOT` var (default `yes`). `--no-root`
  **implies `--no-sudo`** (an unprivileged user can't escalate), applied before
  the `SUDO`-keyed desktop-helper forwarding so it propagates too.
- **The home-prefix homepkg install triggers on `ROOT=no`**, not `SUDO=no`. So
  `--no-sudo` alone (mechanism only) still reaches `install_extras` and honors
  `--cargo`/`--brew` — whose builds are themselves rootless — while `--no-root`
  swaps in `homepkg`.
- **`install_home_tools`**: installs the core set (`ripgrep fd bat fzf jq delta
  gh`) plus extras (`helix jj nu`, unless minimal) into `~/.local`. Degrades
  gracefully (missing homepkg / failed install → warn, continue). Clears the
  stale `~/.config/helix/runtime` cargo symlink after a successful install (same
  as the brew path) so a homepkg `hx` upgrade doesn't keep old grammars. Warns
  that shpool isn't available on this path (source-only; sessions fall back to
  tmux).
- README documents `--no-root` (policy, uses homepkg) vs `--no-sudo` (mechanism).

## Codex findings addressed

- **shpool missing in full mode** — now explicit (warning); benign, `start_services` guards on `command -v shpool`.
- **"Honor `--cargo` in no-sudo mode"** — resolved structurally: routing homepkg on `ROOT=no` means `--no-sudo --cargo` reaches the rootless cargo builds.
- **Stale Helix runtime symlink** — the homepkg path now clears it.
- Three earlier threads were against a prior `ROOT` implementation that #134 superseded; they're outdated.

## Testing

- `make test` — all suites green, including new `setup_test` cases for the
  `ROOT`/`SUDO` split, the `--no-root ⇒ --no-sudo` implication, the `ROOT=no`
  homepkg dispatch, graceful degradation, the shpool warning, and the Helix
  runtime cleanup.
- `sh -n setup` and `shellcheck -s sh -S error setup` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XPjirZg5EHkX5RF6FvGiDB