### PR TITLE
setup/homepkg: bundle-first offline provisioning, and easy bundle-all

### DIFF
--- a/homepkg
+++ b/homepkg
@@ -22,7 +22,8 @@ Usage:
     homepkg list
 
 Push bundles (build on an online host, install on an air-gapped target):
-    homepkg bundle -o tools.tgz TOOL...            # online: solve + download
+    homepkg bundle -o tools.tgz                     # online: bundle ALL tools
+    homepkg bundle -o tools.tgz TOOL...            # ...or just the named ones
     homepkg --backend github bundle -o t.tgz TOOL... # static-asset variant
     homepkg install-bundle tools.tgz               # target: install offline
 
@@ -61,6 +62,7 @@ TOOLS = {
     "helix":   {"conda": "helix",      "github": "helix-editor/helix", "bins": ["hx"]},
     "jj":      {"conda": "jujutsu",    "github": "jj-vcs/jj",          "bins": ["jj"]},
     "nu":      {"conda": "nushell",    "github": "nushell/nushell",    "bins": ["nu"]},
+    "uv":      {"conda": "uv",         "github": "astral-sh/uv",       "bins": ["uv", "uvx"]},
     # Node toolchain for the setup --no-root path: node/npm/tsc from conda-forge
     # instead of a distro package, plus fnm (which on root boxes comes from its
     # own curl installer -- no conda there yet). npm/npx ride along in the nodejs
@@ -621,14 +623,16 @@ def _fetch_micromamba_bin(plat, dest):
 
 
 def bundle_mamba(tools, prefix, plat, out, dry_run):
+    pkgs = [TOOLS[t]["conda"] for t in tools]
+    # Report before touching the network so --dry-run needs no micromamba.
+    if dry_run:
+        info(f"would solve closure for {', '.join(pkgs)} ({conda_subdir(*plat)}), "
+             f"download it, and write {out}")
+        return
     # The solver must RUN on this builder, so use the builder's own micromamba;
     # the bundle needs the TARGET arch's micromamba, which differs under --arch.
     solver = ensure_micromamba(prefix, detect_platform(), dry_run)
-    pkgs = [TOOLS[t]["conda"] for t in tools]
     info(f"solving closure for {', '.join(pkgs)} ({conda_subdir(*plat)})")
-    if dry_run:
-        info(f"  would solve, download the closure, and write {out}")
-        return
     fetch = _mamba_solve(solver, prefix, plat, pkgs)
     info(f"  {len(fetch)} packages in the closure")
     with tempfile.TemporaryDirectory() as td:
@@ -832,15 +836,26 @@ def main(argv=None):
     if args.command == "bundle":
         if not args.output:
             p.error("bundle requires -o/--output FILE")
-        if not args.tools:
-            p.error("bundle requires at least one tool")
         if args.backend == "conda":
             p.error("bundle supports --backend mamba (default) or github, not conda")
-        _require_known(p, args.tools)
+        if args.tools:
+            tools = args.tools
+        elif args.backend == "github":
+            # No "bundle everything" for github: not every registered tool has a
+            # static release asset (e.g. typescript is npm-only), so an all-tools
+            # github bundle would abort partway. Require explicit names there.
+            p.error("bundle --backend github needs explicit tool names "
+                    "(no-args = all is mamba-only)")
+        else:
+            # No tool names on the mamba backend means "bundle everything
+            # registered" -- the easy way to stage a complete offline toolchain
+            # without listing packages by hand.
+            tools = sorted(TOOLS)
+        _require_known(p, tools)
         plat = _resolve_plat(p, args.arch)
         try:
             builder = bundle_github if args.backend == "github" else bundle_mamba
-            builder(args.tools, args.prefix, plat, args.output, args.dry_run)
+            builder(tools, args.prefix, plat, args.output, args.dry_run)
         except Exception as e:
             warn(str(e))
             return 1

--- a/homepkg_test
+++ b/homepkg_test
@@ -190,6 +190,8 @@ check("registry maps typescript with a tsc bin",
       and hp.TOOLS["typescript"]["bins"] == ["tsc"])
 check("registry maps fnm to conda-forge fnm",
       hp.TOOLS["fnm"]["conda"] == "fnm" and hp.TOOLS["fnm"]["bins"] == ["fnm"])
+check("registry maps uv with uv/uvx bins",
+      hp.TOOLS["uv"]["conda"] == "uv" and hp.TOOLS["uv"]["bins"] == ["uv", "uvx"])
 
 check("unknown tool errors", _run("install", "bogustool").returncode != 0)
 check("install with no tools errors", _run("install").returncode != 0)
@@ -197,6 +199,21 @@ check("bad --arch errors", _run("--arch", "weird", "install", "jq").returncode !
 check("unknown backend errors", _run("--backend", "apt", "install", "jq").returncode != 0)
 # These stay subprocesses: argparse rejects them before any backend/network.
 check("remove requires tools", _run("remove").returncode != 0)
+
+# `bundle` with no tool names stages EVERY registered tool -- the easy way to
+# build a complete offline toolchain by hand. --dry-run must stay network-free
+# (it reports the closure without bootstrapping micromamba).
+_bundle_all = _run("bundle", "-o",
+                   os.path.join(tempfile.gettempdir(), "hp-bundle-test.tgz"),
+                   "--dry-run")
+check("bundle with no tools targets every registered package",
+      _bundle_all.returncode == 0
+      and all(hp.TOOLS[t]["conda"] in _bundle_all.stderr for t in hp.TOOLS))
+# ...but no-args "all" is mamba-only: not every tool has a github release asset
+# (typescript is npm-only), so the github backend must require explicit names.
+check("bundle --backend github rejects no-args all-tools",
+      _run("--backend", "github", "bundle", "-o",
+           os.path.join(tempfile.gettempdir(), "hp-gh-test.tgz")).returncode != 0)
 
 # --- micromamba backend: env paths and symlink management --------------------
 

--- a/setup
+++ b/setup
@@ -375,9 +375,21 @@ clone_or_pull() {
 
     if test -d "$dir/.git"; then
         info "$dir already exists, pulling latest changes"
-        git -C "$dir" pull
-        git -C "$dir" submodule update --init --recursive
+        # A failed pull (e.g. no network) must not abort the bootstrap: the
+        # existing checkout is enough to keep going. This is also what lets an
+        # offline "setup --no-root" reach the homepkg bundle install, which runs
+        # after these repo refreshes -- warn and continue rather than exiting
+        # under set -e.
+        if git -C "$dir" pull; then
+            git -C "$dir" submodule update --init --recursive \
+                || warn "could not update submodules in $dir; using the existing checkout"
+        else
+            warn "could not pull $dir (offline?); using the existing checkout"
+        fi
     else
+        # No existing checkout, so a failed clone stays fatal: there's nothing
+        # to fall back to, and later steps (confinst, the root build) need the
+        # repo. An offline box must therefore pre-stage the repos it needs.
         info "Cloning $repo into $dir"
         git clone --recurse-submodules "$repo" "$dir"
     fi
@@ -1086,7 +1098,9 @@ install_extras() {
 # the distro CLI package set; the node toolchain (node/npm/tsc) is added
 # unless --no-npm, and the heavyweight extras (helix, jj, nushell) unless the
 # minimal profile is in effect. homepkg resolves them into one home-prefix env;
-# a solve/network failure warns rather than aborting the bootstrap.
+# a solve/network failure warns rather than aborting the bootstrap. When a
+# prebuilt bundle is present it's used first (so a fresh box provisions fully
+# offline), then refreshed online best-effort -- see the provisioning block.
 install_home_tools() {
     homepkg="$SCRIPTS_DIR/homepkg"
     if ! test -x "$homepkg"; then
@@ -1105,57 +1119,106 @@ install_home_tools() {
     fi
     if test "$MINIMAL_ENABLED" -eq 0; then
         tools="$tools helix jj nu"
-        # shpool is source-only (no conda-forge/prebuilt artifact), so the
-        # homepkg path can't provide it -- same as the brew path. start_services
-        # skips its user service when shpool is absent, so the shell falls back
-        # to tmux.
+        # shpool is source-only (no conda-forge/prebuilt artifact), so neither
+        # the homepkg nor the brew path can provide it. start_services skips its
+        # user service when shpool is absent, so the shell falls back to tmux.
         warn "shpool is not available on the homepkg path (source-only); sessions fall back to tmux"
-    else
-        info "Skipping heavyweight CLI extras (helix, jj, nushell); minimal profile"
     fi
-    info "Installing CLI tools into a home prefix via homepkg: $tools"
-    if "$homepkg" install $tools; then
-        # homepkg links the tools into ~/.local/bin. Put that on PATH for the
-        # rest of THIS run so later steps and child processes find them --
-        # notably setup-kde, which needs tsc on PATH to build Krohnkite. The
-        # conf repo already puts ~/.local/bin on PATH for interactive shells;
-        # this covers the non-interactive bootstrap however setup was invoked.
-        case ":$PATH:" in
-            *":$HOME/.local/bin:"*) ;;
-            *) PATH="$HOME/.local/bin:$PATH" ;;
-        esac
-        # A prior cargo run points ~/.config/helix/runtime at the source
-        # checkout, and hx searches that before the prebuilt runtime -- so drop
-        # the stale symlink (only the one install_helix created), same as the
-        # brew path. Gated on a successful install so a prior cargo hx keeps its
-        # runtime if homepkg failed; and only when helix was in this run's list.
-        if test "$MINIMAL_ENABLED" -eq 0; then
-            helix_runtime="${XDG_CONFIG_HOME:-$HOME/.config}/helix/runtime"
-            if test -L "$helix_runtime" \
-                    && test "$(readlink "$helix_runtime")" = "$SRC_DIR/helix/runtime"; then
-                info "Removing stale Helix runtime symlink from the cargo build"
-                rm -f "$helix_runtime"
-            fi
+
+    # Optimistic provisioning. On a FRESH env, prefer a prebuilt bundle (which
+    # installs fully offline); otherwise install the requested set online.
+    # install-bundle needs a fresh env, so the bundle only applies on the first
+    # provision. Look for a bundle at $HOMEPKG_BUNDLE, then homepkg-bundle.tgz
+    # beside the scripts repo or in $HOME. Build one on an online host with
+    # "homepkg bundle -o homepkg-bundle.tgz" (no args = every tool).
+    #
+    # TODO: a pinned/--frozen (+ --no-bundle) flag pair to skip the optimistic
+    #   online reconcile/refresh, for a reproducible bundle-exact install.
+    env_dir="$HOME/.local/share/homepkg/env"   # mirrors homepkg's <prefix>/share/homepkg/env
+    bundle=""
+    for cand in "${HOMEPKG_BUNDLE:-}" "$SCRIPTS_DIR/homepkg-bundle.tgz" "$HOME/homepkg-bundle.tgz"; do
+        if test -n "$cand" && test -f "$cand"; then
+            bundle="$cand"
+            break
         fi
-    else
-        warn "some CLI tools could not be installed via homepkg"
+    done
+
+    provisioned=no
+    if test -n "$bundle" && ! test -d "$env_dir/conda-meta"; then
+        # A bundle installs its FULL contents in one shot (install-bundle can't
+        # cherry-pick), so --minimal/--no-npm don't trim it. Then reconcile the
+        # requested set online with `install $tools`: this ADDS any requested
+        # tool the bundle lacked -- e.g. a partial $HOMEPKG_BUNDLE missing tsc,
+        # which a bare `update` would never add since it only touches packages
+        # already in the env -- and freshens them. Offline it warns and we rely
+        # on whatever the bundle carried.
+        info "Installing CLI tools from bundle (offline-capable): $bundle"
+        info "  a bundle installs its full contents; --minimal/--no-npm don't trim it"
+        if "$homepkg" install-bundle "$bundle"; then
+            provisioned=yes
+            "$homepkg" install $tools \
+                || warn "installed the bundle; couldn't reconcile the requested tools online (offline?)"
+        else
+            warn "install-bundle failed; falling back to an online install"
+        fi
+    fi
+    if test "$provisioned" = no; then
+        test "$MINIMAL_ENABLED" -eq 0 \
+            || info "Skipping heavyweight CLI extras (helix, jj, nushell); minimal profile"
+        info "Installing CLI tools into a home prefix via homepkg: $tools"
+        if "$homepkg" install $tools; then
+            provisioned=yes
+        else
+            warn "some CLI tools could not be installed via homepkg"
+        fi
+    fi
+
+    test "$provisioned" = yes || return 0
+
+    # homepkg links the tools into ~/.local/bin. Put that on PATH for the rest
+    # of THIS run so later steps and child processes find them -- notably
+    # setup-kde, which needs tsc on PATH to build Krohnkite. The conf repo
+    # already puts ~/.local/bin on PATH for interactive shells; this covers the
+    # non-interactive bootstrap however setup was invoked.
+    case ":$PATH:" in
+        *":$HOME/.local/bin:"*) ;;
+        *) PATH="$HOME/.local/bin:$PATH" ;;
+    esac
+
+    # A prior cargo run points ~/.config/helix/runtime at the source checkout,
+    # and hx searches that before the prebuilt runtime -- so drop the stale
+    # symlink (only the one install_helix created). Gate on hx actually being
+    # installed by homepkg (which links it into ~/.local/bin) rather than the
+    # minimal profile: a full bundle can install helix even under --minimal.
+    helix_runtime="${XDG_CONFIG_HOME:-$HOME/.config}/helix/runtime"
+    if test -x "$HOME/.local/bin/hx" \
+            && test -L "$helix_runtime" \
+            && test "$(readlink "$helix_runtime")" = "$SRC_DIR/helix/runtime"; then
+        info "Removing stale Helix runtime symlink from the cargo build"
+        rm -f "$helix_runtime"
     fi
 }
 
 # --- Install uv (Python package manager) ---
 
 install_uv() {
+    # Both paths are non-fatal: a failed update/install (e.g. no network) must
+    # not abort the bootstrap. install_uv runs before install_home_tools, so on
+    # an offline "setup --no-root" a hard failure here would kill the run before
+    # the homepkg bundle install -- where uv can instead come from the bundle.
     if command -v uv >/dev/null 2>&1; then
         info "Updating uv"
         # uv self update reruns the installer, which edits the shell rc/profile
         # files unless UV_NO_MODIFY_PATH is set; PATH is managed by the conf repo.
-        UV_NO_MODIFY_PATH=1 uv self update
+        UV_NO_MODIFY_PATH=1 uv self update \
+            || warn "could not update uv (offline?); keeping the installed version"
     else
         info "Installing uv"
         # --no-modify-path keeps the uv installer out of the shell rc/profile
         # files; PATH is managed by the conf repo. uv installs to ~/.local/bin
         # (or ~/.cargo/bin), which the conf repo already puts on PATH.
-        curl -LsSf https://astral.sh/uv/install.sh | sh -s -- --no-modify-path
+        curl -LsSf https://astral.sh/uv/install.sh | sh -s -- --no-modify-path \
+            || warn "could not install uv (offline?); it may come from a homepkg bundle instead"
     fi
 }
 

--- a/setup_test
+++ b/setup_test
@@ -310,11 +310,16 @@ test_rust_installs_without_modifying_path() {
 # The uv installer edits shell rc/profile files by default. --no-modify-path
 # keeps the fresh install out of them; the conf repo already has ~/.local/bin
 # on PATH. `uv self update` reruns the installer on the update path, so it needs
-# UV_NO_MODIFY_PATH=1 to stay out of the config files too.
+# UV_NO_MODIFY_PATH=1 to stay out of the config files too. Both paths are
+# non-fatal: install_uv runs before install_home_tools, so a hard failure here
+# (e.g. offline) would kill an offline "setup --no-root" before the bundle
+# install where uv can instead come from the bundle.
 test_uv_installs_without_modifying_path() {
     assert_source_contains "uv/install.sh | sh -s -- --no-modify-path" &&
     assert_source_not_contains "uv/install.sh | sh$" &&
-    assert_source_contains "UV_NO_MODIFY_PATH=1 uv self update"
+    assert_source_contains "UV_NO_MODIFY_PATH=1 uv self update" &&
+    assert_source_contains "could not update uv" &&
+    assert_source_contains "could not install uv"
 }
 
 # --- Homebrew extras backend ---
@@ -531,10 +536,38 @@ test_home_tools_warns_about_shpool() {
 # brew path -- and only after a successful install so a failed run doesn't strip
 # a still-active cargo hx's runtime.
 test_home_tools_clears_stale_helix_runtime() {
-    assert_source_contains 'if "$homepkg" install $tools; then' &&
-    assert_source_contains 'helix_runtime=' &&
+    # Gated on hx being installed (linked into ~/.local/bin), not on the minimal
+    # profile -- a full bundle can install helix even under --minimal.
+    assert_source_contains 'test -x "$HOME/.local/bin/hx"' &&
     assert_source_contains 'readlink "$helix_runtime"' &&
     assert_source_contains "Removing stale Helix runtime symlink"
+}
+
+# On a fresh env, install_home_tools prefers a prebuilt bundle (which installs
+# offline). A bundle installs its full contents, so afterward it reconciles the
+# requested set online with "install $tools" -- adding any requested tool the
+# bundle lacked (a bare "update" wouldn't) and freshening -- rather than only
+# updating what's already present. An existing env or a missing bundle takes the
+# online install. Discovery: $HOMEPKG_BUNDLE, or homepkg-bundle.tgz beside the
+# scripts repo / in $HOME.
+test_home_tools_uses_bundle_optimistically() {
+    assert_source_contains '"$homepkg" install-bundle "$bundle"' &&
+    assert_source_contains 'HOMEPKG_BUNDLE' &&
+    assert_source_contains 'homepkg-bundle.tgz' &&
+    assert_source_contains 'conda-meta' &&
+    assert_source_contains "a bundle installs its full contents" &&
+    assert_source_contains "couldn't reconcile the requested tools online"
+}
+
+# A failed pull on an EXISTING checkout (e.g. offline) must warn and continue,
+# not abort under set -e -- otherwise the offline "setup --no-root" bootstrap
+# dies on the scripts/conf pull before reaching the homepkg bundle install. A
+# failed clone (no checkout to fall back to) stays fatal, so success is never
+# faked when there's nothing usable on disk.
+test_clone_or_pull_degrades_offline() {
+    assert_source_contains "could not pull" &&
+    assert_source_contains "using the existing checkout" &&
+    assert_source_not_contains "could not clone"
 }
 
 run_test "--no-sudo is accepted as a known option" test_no_sudo_flag_accepted
@@ -549,6 +582,10 @@ run_test "--no-root/--root are the policy flags (SUDO is the mechanism)" \
     test_no_root_flags
 run_test "--no-root implies --no-sudo" \
     test_no_root_implies_no_sudo
+run_test "--no-root prefers a prebuilt bundle, then refreshes online" \
+    test_home_tools_uses_bundle_optimistically
+run_test "clone_or_pull warns and continues on an offline failure" \
+    test_clone_or_pull_degrades_offline
 run_test "--no-root installs CLI tools into a home prefix via homepkg" \
     test_no_root_installs_via_homepkg
 run_test "--no-root is accepted and documented" \


### PR DESCRIPTION
Follow-up to #137. Makes the `--no-root` toolchain install able to provision an air-gapped box from a prebuilt bundle, with online boxes unchanged.

## What changed

- **`install_home_tools` prefers a prebuilt bundle on a fresh env.** On the first provision, if a bundle is found it's installed via `homepkg install-bundle` (which works fully offline), then **optimistically refreshed online** (best-effort — a `warn`/no-op when the box is offline). An existing env, or no bundle, falls back to the online `homepkg install` exactly as before. `install-bundle` requires a fresh env, which is why the bundle path is gated to the first provision.
  - Bundle discovery: `$HOMEPKG_BUNDLE`, then `homepkg-bundle.tgz` beside the scripts repo, then in `$HOME`.
- **`homepkg bundle` with no tool names now stages *every* registered tool** — a complete offline toolchain is one command (`homepkg bundle -o homepkg-bundle.tgz`), no hand-listing.
- **`homepkg bundle --dry-run` is now network-free** — it reports the closure without bootstrapping micromamba (also makes it unit-testable).
- **Registered `uv` (`uv`/`uvx`)** in the homepkg registry so it rides in bundles — an air-gapped box gets uv without the curl installer.

## Offline flow

```
# online staging host — one command bundles everything:
homepkg bundle -o homepkg-bundle.tgz
# air-gapped target — setup finds and installs it, no network:
setup --no-root        # (with homepkg-bundle.tgz beside the scripts repo or in $HOME)
```

## Deferred (TODO in the code)

A pinned/`--frozen` (+ `--no-bundle`) flag pair to skip the optimistic online refresh, for a reproducible bundle-exact install. Left as a TODO per discussion.

## Testing

- `./setup_test` — 43/43 (adds a bundle-chain assertion).
- `./homepkg_test` — 61/61 (adds `uv` registry + `bundle`-with-no-tools coverage).
- `bash -n setup` clean; `homepkg` parses; `shellcheck -S warning setup` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDiQXdrEAn93oQL1kucPuK

---
_Generated by [Claude Code](https://claude.ai/code/session_01DDiQXdrEAn93oQL1kucPuK)_