### PR TITLE
call: dial via Termux with optional SIM-name toast and delay

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 test:
 	./autoshpool_test
+	./call_test
 	./autotmux_test
 	./autosession_test
 	./sessionlib_test

--- a/call
+++ b/call
@@ -1,0 +1,67 @@
+#!/bin/sh
+# Place a phone call using the Termux telephony API.
+#
+# Options:
+#   -t, --toast          show a toast saying "Calling using <SIM name>"
+#   -d, --delay <secs>   wait that many seconds before calling (Ctrl-C to cancel)
+
+usage() {
+    printf 'Usage: call [-t|--toast] [-d|--delay <seconds>] <number>\n' 1>&2
+    exit "${1:-1}"
+}
+
+toast=
+delay=0
+
+while test $# -gt 0; do
+    case $1 in
+        -h|--help)
+            usage 0;;
+        -t|--toast)
+            toast=1;;
+        -d|--delay)
+            shift
+            case $1 in
+                ''|*[!0-9]*)
+                    printf 'call: delay must be a whole number of seconds\n' 1>&2
+                    exit 1;;
+            esac
+            delay=$1;;
+        --)
+            shift
+            break;;
+        -*)
+            printf 'call: unknown option %s\n' "$1" 1>&2
+            usage;;
+        *)
+            break;;
+    esac
+    shift
+done
+
+test $# -eq 1 || usage
+
+number=$1
+
+# The name of the SIM the call will go out on, per the telephony API.
+# Empty if termux-api is missing or the phone reports no operator name.
+sim_name() {
+    termux-telephony-deviceinfo 2>/dev/null |
+        sed -n 's/.*"sim_operator_name": *"\([^"]*\)".*/\1/p'
+}
+
+if test -n "$toast"; then
+    sim=$(sim_name)
+    test -n "$sim" || sim="default SIM"
+    if test "$delay" -gt 0; then
+        termux-toast "Calling using $sim in $delay seconds"
+    else
+        termux-toast "Calling using $sim"
+    fi
+fi
+
+if test "$delay" -gt 0; then
+    sleep "$delay"
+fi
+
+exec termux-telephony-call "$number"

--- a/call_test
+++ b/call_test
@@ -1,0 +1,183 @@
+#!/bin/sh
+# Tests for call
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CALL="$SCRIPT_DIR/call"
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# Stub the Termux commands (and sleep) so tests can run anywhere.  Each stub
+# appends its invocation to $LOG so tests can assert on what ran and in what
+# order.  termux-telephony-deviceinfo prints $DEVICEINFO, letting tests
+# control the reported SIM name.
+STUBS="$(mktemp -d)"
+trap 'rm -rf "$STUBS"' EXIT
+LOG="$STUBS/log"
+export LOG
+DEVICEINFO=
+export DEVICEINFO
+
+for cmd in termux-toast termux-telephony-call sleep; do
+    cat > "$STUBS/$cmd" <<EOF
+#!/bin/sh
+echo "$cmd \$*" >> "\$LOG"
+EOF
+    chmod +x "$STUBS/$cmd"
+done
+cat > "$STUBS/termux-telephony-deviceinfo" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$DEVICEINFO"
+EOF
+chmod +x "$STUBS/termux-telephony-deviceinfo"
+
+# run_call [args...]: run call with stubbed commands, capture output and status.
+run_call() {
+    : > "$LOG"
+    set +e
+    output="$(PATH="$STUBS:$PATH" "$CALL" "$@" 2>&1)"
+    status=$?
+    set -e
+    log="$(cat "$LOG")"
+}
+
+assert_status() {
+    if test "$status" -ne "$1"; then
+        echo "  FAIL: expected exit status $1, got $status"
+        echo "  output: $output"
+        TEST_FAILED=1
+        return 1
+    fi
+}
+
+assert_log_equals() {
+    expected="$1"
+    if test "$log" != "$expected"; then
+        echo "  FAIL: command log mismatch"
+        echo "  expected: $(printf '%s' "$expected" | sed -n l)"
+        echo "  actual:   $(printf '%s' "$log" | sed -n l)"
+        TEST_FAILED=1
+        return 1
+    fi
+}
+
+assert_output_contains() {
+    case $output in
+        *"$1"*) ;;
+        *)
+            echo "  FAIL: output does not contain: $1"
+            echo "  output: $output"
+            TEST_FAILED=1
+            return 1;;
+    esac
+}
+
+run_test() {
+    name="$1"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TEST_FAILED=0
+    echo "TEST: $name"
+    "$name" || TEST_FAILED=1
+    if test "$TEST_FAILED" -eq 0; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
+test_calls_number() {
+    run_call 5551234
+    assert_status 0
+    assert_log_equals 'termux-telephony-call 5551234'
+}
+
+test_toast_shows_sim_name() {
+    DEVICEINFO='{"sim_operator_name": "TestSIM"}'
+    run_call --toast 5551234
+    DEVICEINFO=
+    assert_status 0
+    assert_log_equals 'termux-toast Calling using TestSIM
+termux-telephony-call 5551234'
+}
+
+test_toast_falls_back_without_sim_name() {
+    run_call -t 5551234
+    assert_status 0
+    assert_log_equals 'termux-toast Calling using default SIM
+termux-telephony-call 5551234'
+}
+
+test_delay_sleeps_before_calling() {
+    run_call --delay 3 5551234
+    assert_status 0
+    assert_log_equals 'sleep 3
+termux-telephony-call 5551234'
+}
+
+test_toast_mentions_delay() {
+    DEVICEINFO='{"sim_operator_name": "TestSIM"}'
+    run_call -t -d 5 5551234
+    DEVICEINFO=
+    assert_status 0
+    assert_log_equals 'termux-toast Calling using TestSIM in 5 seconds
+sleep 5
+termux-telephony-call 5551234'
+}
+
+test_zero_delay_does_not_sleep() {
+    run_call -d 0 5551234
+    assert_status 0
+    assert_log_equals 'termux-telephony-call 5551234'
+}
+
+test_rejects_non_numeric_delay() {
+    run_call -d soon 5551234
+    assert_status 1
+    assert_output_contains 'delay must be a whole number'
+    assert_log_equals ''
+}
+
+test_rejects_missing_delay_value() {
+    run_call -d
+    assert_status 1
+    assert_output_contains 'delay must be a whole number'
+    assert_log_equals ''
+}
+
+test_requires_number() {
+    run_call
+    assert_status 1
+    assert_output_contains 'Usage:'
+    assert_log_equals ''
+}
+
+test_rejects_unknown_option() {
+    run_call --bogus 5551234
+    assert_status 1
+    assert_output_contains 'unknown option --bogus'
+    assert_log_equals ''
+}
+
+test_double_dash_allows_dashed_number() {
+    run_call -- -5551234
+    assert_status 0
+    assert_log_equals 'termux-telephony-call -5551234'
+}
+
+run_test test_calls_number
+run_test test_toast_shows_sim_name
+run_test test_toast_falls_back_without_sim_name
+run_test test_delay_sleeps_before_calling
+run_test test_toast_mentions_delay
+run_test test_zero_delay_does_not_sleep
+run_test test_rejects_non_numeric_delay
+run_test test_rejects_missing_delay_value
+run_test test_requires_number
+run_test test_rejects_unknown_option
+run_test test_double_dash_allows_dashed_number
+
+echo
+echo "$TESTS_RUN tests, $TESTS_PASSED passed, $TESTS_FAILED failed"
+test "$TESTS_FAILED" -eq 0


### PR DESCRIPTION
Adds a new `call` script that places a phone call via the Termux telephony API, with the two requested options:

- `-t` / `--toast` — shows a toast saying "Calling using \<SIM name\>". The SIM name comes from `termux-telephony-deviceinfo`'s `sim_operator_name`; if unavailable it falls back to "default SIM".
- `-d` / `--delay <seconds>` — waits that many seconds before dialing, so the call can be cancelled with Ctrl-C. When combined with `--toast`, the toast reads "Calling using \<SIM name\> in N seconds".

Examples:

```sh
call 5551234                 # dial immediately
call -t 5551234              # toast the SIM name, then dial
call -t -d 5 5551234         # toast, wait 5 seconds, then dial
```

Also included:

- `call_test` — 11 tests covering dialing, toast content (with and without a reported SIM name), delay ordering, zero delay, invalid/missing delay values, missing number, unknown options, and `--` handling. The Termux commands and `sleep` are stubbed via `PATH`, so the tests run on any machine.
- `Makefile` — runs `call_test` as part of `make test`.

All tests pass and both scripts are shellcheck-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01926SGAr2fGJXqkrUM6CGzv

---
_Generated by [Claude Code](https://claude.ai/code/session_01926SGAr2fGJXqkrUM6CGzv)_