### PR TITLE
setup: add --github flag to clone repos from an internal mirror

### DIFF
--- a/setup
+++ b/setup
@@ -4,7 +4,7 @@
 # Usage:
 #     setup [--gui | --no-gui] [--kde | --hypr] [--minimal | --full] \
 #           [--no-install] [--ignore-errors] [--ssh | --no-ssh] [--no-npm] \
-#           [-h | --help]
+#           [--github PREFIX] [-h | --help]
 #
 #  or, to bootstrap from scratch:
 #     curl -fsSL https://mikelward.com/setup | sh
@@ -57,10 +57,29 @@
 # skipped, they come from conda-forge via homepkg instead (rootless). Pass
 # --no-npm to skip them where Node is provided some other way (nvm, fnm,
 # corepack, a system package, etc.) -- then provide tsc yourself.
+#
+# The scripts/conf/root repos clone from github.com over SSH by default. Behind
+# a corporate network that mirrors GitHub at an internal host -- or serves it
+# over HTTPS -- pass --github PREFIX to point the clones there, e.g.
+#     setup --github git@ghe.corp.example.com    (internal SSH host)
+#     setup --github https://ghe.corp.example.com (internal HTTPS mirror)
+# PREFIX is the part before OWNER/REPO; a bare host is treated as SSH, and its
+# trailing separator (: or /) is supplied for you. GITHUB_PREFIX in the
+# environment does the same, which is handy when piping setup from a mirror.
 
-SCRIPTS_REPO="git@github.com:mikelward/scripts.git"
-CONF_REPO="git@github.com:mikelward/conf.git"
-ROOT_REPO="git@github.com:mikelward/root.git"
+# The three repositories setup clones, kept as OWNER/REPO paths. The host and
+# protocol come from GITHUB_PREFIX, which defaults to GitHub over SSH and can be
+# pointed at an internal mirror with --github (e.g. behind a corporate network
+# that proxies github.com at a different host, or serves it over HTTPS). One
+# flag carries the whole prefix because SSH and HTTPS remotes are shaped
+# differently -- git@HOST: vs https://HOST/ -- so a bare host couldn't tell them
+# apart. The path is appended to the prefix; the URLs themselves are assembled
+# after argument parsing (see normalize_github_prefix). Override the default
+# host by exporting GITHUB_PREFIX, or per-run with --github.
+GITHUB_PREFIX="${GITHUB_PREFIX:-git@github.com:}"
+SCRIPTS_REPO_PATH="mikelward/scripts.git"
+CONF_REPO_PATH="mikelward/conf.git"
+ROOT_REPO_PATH="mikelward/root.git"
 
 SCRIPTS_DIR="$HOME/scripts"
 CONF_DIR="$HOME/conf"
@@ -155,7 +174,7 @@ usage() {
     cat <<'USAGE'
 Usage: setup [--gui | --no-gui] [--kde | --hypr | --sway] [--minimal | --full]
              [--no-install] [--no-sudo] [--no-root] [--ignore-errors]
-             [--ssh | --no-ssh] [--no-npm] [-h | --help]
+             [--ssh | --no-ssh] [--no-npm] [--github PREFIX] [-h | --help]
 
 Bootstrap a new machine: install packages, fonts, tools, and dotfiles.
 
@@ -192,6 +211,13 @@ Options:
   --no-npm         Skip installing Node.js (node/npm) and the TypeScript
                    compiler (for machines where Node is provided another way;
                    provide tsc yourself)
+  --github PREFIX  Clone the scripts/conf/root repos from PREFIX instead of
+                   github.com over SSH -- for an internal GitHub mirror. PREFIX
+                   is the host or full prefix before OWNER/REPO; its protocol is
+                   taken as given, e.g. an internal SSH host (git@ghe.corp or
+                   git@ghe.corp:) or an HTTPS mirror (https://ghe.corp). A bare
+                   host is treated as SSH. Also settable via the GITHUB_PREFIX
+                   environment variable
   -h, --help       Show this help and exit
 
 By default graphical components are installed only when a display server
@@ -266,6 +292,21 @@ error() {
     printf "Error: %s\n" "$*" >&2
 }
 
+# normalize_github_prefix PREFIX: echo PREFIX with a trailing separator so a
+# repo path (OWNER/REPO.git) can be appended directly. A prefix that already
+# ends in ':' or '/' is used unchanged; a URL-scheme prefix (https://host,
+# ssh://git@host) gets a trailing '/'; an scp-style or bare host (git@host,
+# host) gets a trailing ':'. This lets --github accept the target in whatever
+# form its protocol wants -- with or without the separator the user would
+# otherwise have to remember -- without a second flag to say which protocol.
+normalize_github_prefix() {
+    case "$1" in
+        */ | *:) printf '%s' "$1" ;;
+        *://*)   printf '%s/' "$1" ;;
+        *)       printf '%s:' "$1" ;;
+    esac
+}
+
 # --- Parse arguments ---
 
 while test $# -gt 0; do
@@ -330,6 +371,18 @@ while test $# -gt 0; do
         --no-npm)
             NPM=no
             ;;
+        --github)
+            shift
+            if test $# -eq 0; then
+                error "--github requires a host/prefix argument"
+                usage >&2
+                exit 1
+            fi
+            GITHUB_PREFIX="$1"
+            ;;
+        --github=*)
+            GITHUB_PREFIX="${1#--github=}"
+            ;;
         -h|--help)
             usage
             exit 0
@@ -342,6 +395,14 @@ while test $# -gt 0; do
     esac
     shift
 done
+
+# Assemble the repo URLs now that --github (if any) has been parsed. The prefix
+# is normalized to end in the right separator so github.com stays the default
+# and an internal mirror needs only --github HOST (or a full https://HOST/).
+GITHUB_PREFIX=$(normalize_github_prefix "$GITHUB_PREFIX")
+SCRIPTS_REPO="${GITHUB_PREFIX}${SCRIPTS_REPO_PATH}"
+CONF_REPO="${GITHUB_PREFIX}${CONF_REPO_PATH}"
+ROOT_REPO="${GITHUB_PREFIX}${ROOT_REPO_PATH}"
 
 # Abort on the first error by default. --ignore-errors leaves set -e off so
 # the bootstrap pushes through failing steps. We toggle this only after

--- a/setup
+++ b/setup
@@ -373,11 +373,18 @@ while test $# -gt 0; do
             ;;
         --github)
             shift
-            if test $# -eq 0; then
-                error "--github requires a host/prefix argument"
-                usage >&2
-                exit 1
-            fi
+            # Reject a missing value or an option-looking one. A real
+            # host/prefix never starts with '-', so "setup --github --no-install"
+            # is a forgotten value, not a request to clone from "--no-install":
+            # swallowing the flag would silently drop it and then fail at clone
+            # time on a bogus "--no-install:mikelward/..." remote.
+            case "${1:-}" in
+                "" | -*)
+                    error "--github requires a host/prefix argument"
+                    usage >&2
+                    exit 1
+                    ;;
+            esac
             GITHUB_PREFIX="$1"
             ;;
         --github=*)

--- a/setup
+++ b/setup
@@ -307,6 +307,24 @@ normalize_github_prefix() {
     esac
 }
 
+# require_github_prefix VALUE: abort with the usage error unless VALUE is a
+# usable --github argument. Both flag forms route through this so they can't
+# drift. Two shapes are rejected up front rather than failing later at clone
+# time: an empty value ("--github=" or a bare "--github" with no following
+# word, which would normalize to ":" and clone from ":mikelward/..."), and an
+# option-looking value (a real host/prefix never starts with '-', so
+# "setup --github --no-install" is a forgotten value that would otherwise
+# swallow the flag and clone from "--no-install:mikelward/...").
+require_github_prefix() {
+    case "$1" in
+        "" | -*)
+            error "--github requires a host/prefix argument"
+            usage >&2
+            exit 1
+            ;;
+    esac
+}
+
 # --- Parse arguments ---
 
 while test $# -gt 0; do
@@ -373,22 +391,12 @@ while test $# -gt 0; do
             ;;
         --github)
             shift
-            # Reject a missing value or an option-looking one. A real
-            # host/prefix never starts with '-', so "setup --github --no-install"
-            # is a forgotten value, not a request to clone from "--no-install":
-            # swallowing the flag would silently drop it and then fail at clone
-            # time on a bogus "--no-install:mikelward/..." remote.
-            case "${1:-}" in
-                "" | -*)
-                    error "--github requires a host/prefix argument"
-                    usage >&2
-                    exit 1
-                    ;;
-            esac
+            require_github_prefix "${1:-}"
             GITHUB_PREFIX="$1"
             ;;
         --github=*)
             GITHUB_PREFIX="${1#--github=}"
+            require_github_prefix "$GITHUB_PREFIX"
             ;;
         -h|--help)
             usage

--- a/setup_test
+++ b/setup_test
@@ -604,6 +604,16 @@ test_github_requires_argument() {
     assert_output_contains "requires a host/prefix argument"
 }
 
+# A forgotten value before another flag (setup --github --no-install) must be
+# rejected, not swallow the next flag as the prefix -- otherwise --no-install is
+# silently dropped and setup clones from a bogus "--no-install:mikelward/..."
+# remote. A real host/prefix never starts with '-'.
+test_github_rejects_option_as_value() {
+    run_setup --github --no-install
+    assert_status 1 &&
+    assert_output_contains "requires a host/prefix argument"
+}
+
 # The repos are assembled from GITHUB_PREFIX + path, defaulting to GitHub over
 # SSH, so an unset --github clones from github.com exactly as before.
 test_github_default_and_assembly() {
@@ -632,6 +642,8 @@ test_normalize_github_prefix() {
 run_test "--github is accepted and takes an argument" test_github_flag_accepted
 run_test "--github=VALUE form parses" test_github_equals_form_accepted
 run_test "--github without an argument errors" test_github_requires_argument
+run_test "--github rejects an option-looking value" \
+    test_github_rejects_option_as_value
 run_test "repos default to github.com over SSH via GITHUB_PREFIX" \
     test_github_default_and_assembly
 run_test "normalize_github_prefix appends the right separator" \

--- a/setup_test
+++ b/setup_test
@@ -59,6 +59,14 @@ assert_source_not_contains() {
     fi
 }
 
+assert_eq() {
+    if test "$1" != "$2"; then
+        echo "  FAIL: got '$1', expected '$2'"
+        TEST_FAILED=1
+        return 1
+    fi
+}
+
 # Run setup's sudo wrapper in isolation against a controlled sudo mock. This
 # tests the diagnostics without executing the bootstrap's system changes.
 run_sudo_helper() {
@@ -569,6 +577,65 @@ test_clone_or_pull_degrades_offline() {
     assert_source_contains "using the existing checkout" &&
     assert_source_not_contains "could not clone"
 }
+
+# --- --github internal-mirror flag ---
+
+# --github takes a value and is a known option: setup consumes the argument and
+# then reaches --help (exit 0), so it neither errors as unknown nor swallows the
+# following flag. The equals form parses too.
+test_github_flag_accepted() {
+    run_setup --github git@ghe.corp.example.com --help
+    assert_status 0 &&
+    assert_output_contains "Usage: setup" &&
+    assert_output_contains "--github"
+}
+
+test_github_equals_form_accepted() {
+    run_setup --github=https://ghe.corp.example.com --help
+    assert_status 0 &&
+    assert_output_contains "Usage: setup"
+}
+
+# --github with no following argument is an error, not a silent no-op that would
+# leave GITHUB_PREFIX as the default and clone from github.com anyway.
+test_github_requires_argument() {
+    run_setup --github
+    assert_status 1 &&
+    assert_output_contains "requires a host/prefix argument"
+}
+
+# The repos are assembled from GITHUB_PREFIX + path, defaulting to GitHub over
+# SSH, so an unset --github clones from github.com exactly as before.
+test_github_default_and_assembly() {
+    assert_source_contains 'GITHUB_PREFIX="${GITHUB_PREFIX:-git@github.com:}"' &&
+    assert_source_contains 'SCRIPTS_REPO_PATH="mikelward/scripts.git"' &&
+    assert_source_contains 'SCRIPTS_REPO="${GITHUB_PREFIX}${SCRIPTS_REPO_PATH}"' &&
+    assert_source_contains 'CONF_REPO="${GITHUB_PREFIX}${CONF_REPO_PATH}"' &&
+    assert_source_contains 'ROOT_REPO="${GITHUB_PREFIX}${ROOT_REPO_PATH}"' &&
+    assert_source_contains 'normalize_github_prefix "$GITHUB_PREFIX"'
+}
+
+# Exercise the real normalize_github_prefix by extracting it from setup: a
+# prefix that already ends in a separator is left alone, a URL-scheme prefix
+# gets a trailing '/', and an scp-style or bare host gets a trailing ':'. This
+# is what lets one flag carry either an SSH or an HTTPS target.
+test_normalize_github_prefix() {
+    eval "$(sed -n '/^normalize_github_prefix() {/,/^}/p' "$SETUP")"
+    assert_eq "$(normalize_github_prefix 'git@github.com:')" 'git@github.com:' &&
+    assert_eq "$(normalize_github_prefix 'git@ghe.corp:')" 'git@ghe.corp:' &&
+    assert_eq "$(normalize_github_prefix 'git@ghe.corp')" 'git@ghe.corp:' &&
+    assert_eq "$(normalize_github_prefix 'https://ghe.corp/')" 'https://ghe.corp/' &&
+    assert_eq "$(normalize_github_prefix 'https://ghe.corp')" 'https://ghe.corp/' &&
+    assert_eq "$(normalize_github_prefix 'ssh://git@ghe.corp')" 'ssh://git@ghe.corp/'
+}
+
+run_test "--github is accepted and takes an argument" test_github_flag_accepted
+run_test "--github=VALUE form parses" test_github_equals_form_accepted
+run_test "--github without an argument errors" test_github_requires_argument
+run_test "repos default to github.com over SSH via GITHUB_PREFIX" \
+    test_github_default_and_assembly
+run_test "normalize_github_prefix appends the right separator" \
+    test_normalize_github_prefix
 
 run_test "--no-sudo is accepted as a known option" test_no_sudo_flag_accepted
 run_test "--no-sudo is documented in usage" test_no_sudo_in_usage

--- a/setup_test
+++ b/setup_test
@@ -614,6 +614,15 @@ test_github_rejects_option_as_value() {
     assert_output_contains "requires a host/prefix argument"
 }
 
+# The equals form must apply the same validation: "--github=" is an empty
+# required value that would otherwise normalize to ":" and clone from
+# ":mikelward/...", so it errors immediately like the separate-argument form.
+test_github_rejects_empty_equals() {
+    run_setup --github=
+    assert_status 1 &&
+    assert_output_contains "requires a host/prefix argument"
+}
+
 # The repos are assembled from GITHUB_PREFIX + path, defaulting to GitHub over
 # SSH, so an unset --github clones from github.com exactly as before.
 test_github_default_and_assembly() {
@@ -644,6 +653,7 @@ run_test "--github=VALUE form parses" test_github_equals_form_accepted
 run_test "--github without an argument errors" test_github_requires_argument
 run_test "--github rejects an option-looking value" \
     test_github_rejects_option_as_value
+run_test "--github= rejects an empty value" test_github_rejects_empty_equals
 run_test "repos default to github.com over SSH via GITHUB_PREFIX" \
     test_github_default_and_assembly
 run_test "normalize_github_prefix appends the right separator" \


### PR DESCRIPTION
## Summary

`setup` hard-coded the scripts/conf/root repos to `git@github.com:mikelward/…`. Behind a corporate network that mirrors GitHub at a different host — or serves it over HTTPS — there was no way to point the clones elsewhere.

This adds a single `--github PREFIX` flag (and a matching `GITHUB_PREFIX` environment variable) to retarget those three clones at an internal mirror.

## Why one flag

The flag carries the whole host+protocol prefix rather than just a host, because SSH and HTTPS remotes are shaped differently — `git@HOST:OWNER/REPO` vs `https://HOST/OWNER/REPO` — so a bare host alone couldn't tell which protocol to use. Passing the full prefix lets the user encode the protocol themselves, in one flag.

`normalize_github_prefix` supplies the trailing separator so the user doesn't have to remember it:

| `--github` value | resulting clone URL |
|---|---|
| *(unset — default)* | `git@github.com:mikelward/scripts.git` |
| `git@ghe.corp` | `git@ghe.corp:mikelward/scripts.git` |
| `git@ghe.corp:` | `git@ghe.corp:mikelward/scripts.git` |
| `https://ghe.corp` | `https://ghe.corp/mikelward/scripts.git` |
| `https://ghe.corp/` | `https://ghe.corp/mikelward/scripts.git` |

A prefix already ending in `:` or `/` is used as-is; a URL-scheme prefix (`https://…`, `ssh://…`) gets `/`; a bare or scp-style host gets `:`. The default stays `git@github.com:`, so behavior is unchanged when the flag is absent.

## Changes

- `setup`: repos kept as `OWNER/REPO` paths; URLs assembled from `GITHUB_PREFIX` after argument parsing. New `--github` / `--github=VALUE` cases (missing argument is an error), `normalize_github_prefix` helper, and header + `usage()` docs.
- `setup_test`: 5 new tests — flag accepted with a value, `=` form parses, missing argument errors, default/assembly wiring, and a functional check of `normalize_github_prefix` for each remote shape.

## Testing

- `./setup_test` — 49 passed, 0 failed
- `./gittossh_test` — passes (unchanged)
- `shellcheck -s sh setup` — no new warnings from these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KaZsUa8nqtT1c9sbmSBihp

---
_Generated by [Claude Code](https://claude.ai/code/session_01KaZsUa8nqtT1c9sbmSBihp)_