### PR TITLE
Add dvorak script to set the keyboard layout to Dvorak

### DIFF
--- a/dvorak
+++ b/dvorak
@@ -1,0 +1,148 @@
+#!/bin/bash
+# dvorak - switch the keyboard layout to US Dvorak using whatever mechanism
+# fits the current environment.
+#
+# It tries every method that applies and applies as many as it can, so it works
+# whether you're on the bare Linux text console, in an X11 session, or in a
+# Wayland desktop (GNOME/KDE), and whether or not an input method (IBus) is
+# running.
+#
+# The headline case -- the Linux virtual console -- does NOT need root. The
+# command is simply `loadkeys dvorak`. loadkeys only needs to own the tty (it
+# does: it's your login console) or CAP_SYS_TTY_CONFIG, not full root, so no
+# sudo and no dpkg-reconfigure required. The US Dvorak console keymap is just
+# named "dvorak"; loadkeys finds /usr/share/keymaps/i386/dvorak/dvorak.map.gz
+# for you.
+#
+# IBus is only touched if it is already running; this script never starts it.
+
+set -u
+
+progname=${0##*/}
+applied=0
+
+have() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+note() {
+    printf '%s: %s\n' "$progname" "$*" >&2
+}
+
+# Linux text console: loadkeys dvorak. Works without root on your own VT.
+# Gated on TERM=linux so we don't poke the console keymap from an X terminal.
+maybe_console() {
+    test "${TERM:-}" = linux || return 1
+    have loadkeys || return 1
+    if loadkeys dvorak >/dev/null 2>&1; then
+        note "Linux console set to Dvorak (loadkeys dvorak)"
+        return 0
+    fi
+    note "loadkeys dvorak failed (need to own this VT or have CAP_SYS_TTY_CONFIG)"
+    return 1
+}
+
+# X11 (including X clients under XWayland): setxkbmap.
+maybe_x11() {
+    test -n "${DISPLAY:-}" || return 1
+    have setxkbmap || return 1
+    if setxkbmap -layout us -variant dvorak 2>/dev/null \
+        || setxkbmap dvorak 2>/dev/null; then
+        note "X11 keyboard set to Dvorak (setxkbmap)"
+        return 0
+    fi
+    return 1
+}
+
+# GNOME (X11 or Wayland): the session input source lives in gsettings.
+maybe_gnome() {
+    have gsettings || return 1
+    case "${XDG_CURRENT_DESKTOP:-}" in
+        *GNOME*|*Unity*|*Cinnamon*) ;;
+        *) return 1 ;;
+    esac
+    schema=org.gnome.desktop.input-sources
+    gsettings get "$schema" sources >/dev/null 2>&1 || return 1
+    if gsettings set "$schema" sources "[('xkb', 'us+dvorak')]" 2>/dev/null; then
+        note "GNOME input source set to Dvorak (gsettings)"
+        return 0
+    fi
+    return 1
+}
+
+# KDE Plasma (X11 or Wayland): persist in kxkbrc, then ask kded to reload it.
+# On X11 setxkbmap has usually applied it live already; on Wayland the reload
+# below (or the next login) makes it take effect.
+maybe_kde() {
+    case "${XDG_CURRENT_DESKTOP:-}" in
+        *KDE*) ;;
+        *) return 1 ;;
+    esac
+    kw=
+    for cmd in kwriteconfig6 kwriteconfig5 kwriteconfig; do
+        if have "$cmd"; then kw=$cmd; break; fi
+    done
+    test -n "$kw" || return 1
+    "$kw" --file kxkbrc --group Layout --key Use true
+    "$kw" --file kxkbrc --group Layout --key LayoutList us
+    "$kw" --file kxkbrc --group Layout --key VariantList dvorak
+    for qd in qdbus6 qdbus-qt6 qdbus; do
+        if have "$qd"; then
+            "$qd" org.kde.keyboard /Layouts org.kde.KeyboardLayouts.setLayout 0 \
+                >/dev/null 2>&1 && break
+        fi
+    done
+    note "KDE configured for Dvorak (kxkbrc; relog if not applied live)"
+    return 0
+}
+
+# IBus: only if it is already running -- never start it.
+maybe_ibus() {
+    have ibus || return 1
+    if ! { pgrep -x ibus-daemon >/dev/null 2>&1 \
+        || test -n "${IBUS_ADDRESS:-}" \
+        || ibus address >/dev/null 2>&1; }; then
+        return 1
+    fi
+    if ibus engine xkb:us:dvorak:eng >/dev/null 2>&1; then
+        note "IBus engine set to US Dvorak (xkb:us:dvorak:eng)"
+        return 0
+    fi
+    return 1
+}
+
+case "${1:-}" in
+    -h|--help)
+        cat >&2 <<EOF
+Usage: $progname
+
+Switch the keyboard layout to US Dvorak using every method that applies to the
+current environment:
+  - Linux text console  : loadkeys dvorak      (no root needed on your own VT)
+  - X11                 : setxkbmap -layout us -variant dvorak
+  - GNOME session       : gsettings input-sources -> us+dvorak
+  - KDE Plasma session  : kxkbrc -> us/dvorak
+  - IBus                : xkb:us:dvorak:eng     (only if IBus already running)
+EOF
+        exit 0
+        ;;
+    "") ;;
+    *)
+        note "unexpected argument: $1 (try --help)"
+        exit 2
+        ;;
+esac
+
+maybe_console && applied=1
+maybe_x11     && applied=1
+maybe_gnome   && applied=1
+maybe_kde     && applied=1
+maybe_ibus    && applied=1
+
+if test "$applied" -eq 0; then
+    note "could not set Dvorak by any method here"
+    note "on a Linux console try: loadkeys dvorak"
+    note "under X11 try:          setxkbmap -layout us -variant dvorak"
+    exit 1
+fi
+exit 0

--- a/dvorak
+++ b/dvorak
@@ -83,9 +83,12 @@ maybe_kde() {
         if have "$cmd"; then kw=$cmd; break; fi
     done
     test -n "$kw" || return 1
-    "$kw" --file kxkbrc --group Layout --key Use true
-    "$kw" --file kxkbrc --group Layout --key LayoutList us
-    "$kw" --file kxkbrc --group Layout --key VariantList dvorak
+    if ! { "$kw" --file kxkbrc --group Layout --key Use true \
+        && "$kw" --file kxkbrc --group Layout --key LayoutList us \
+        && "$kw" --file kxkbrc --group Layout --key VariantList dvorak; }; then
+        note "KDE: writing kxkbrc failed (read-only \$HOME, full disk?)"
+        return 1
+    fi
     for qd in qdbus6 qdbus-qt6 qdbus; do
         if have "$qd"; then
             "$qd" org.kde.keyboard /Layouts org.kde.KeyboardLayouts.setLayout 0 \

--- a/dvorak
+++ b/dvorak
@@ -7,12 +7,14 @@
 # Wayland desktop (GNOME/KDE), and whether or not an input method (IBus) is
 # running.
 #
-# The headline case -- the Linux virtual console -- does NOT need root. The
-# command is simply `loadkeys dvorak`. loadkeys only needs to own the tty (it
-# does: it's your login console) or CAP_SYS_TTY_CONFIG, not full root, so no
-# sudo and no dpkg-reconfigure required. The US Dvorak console keymap is just
-# named "dvorak"; loadkeys finds /usr/share/keymaps/i386/dvorak/dvorak.map.gz
-# for you.
+# The headline case -- the Linux virtual console -- does NOT need root. loadkeys
+# only needs to own the tty (it does: it's your login console) or
+# CAP_SYS_TTY_CONFIG, not full root, so no sudo and no dpkg-reconfigure. It does
+# need a keymap to load, though: `loadkeys dvorak` finds the system keymap when
+# the kbd keymap data is installed, but many minimal systems ship no
+# /usr/share/keymaps at all. For those, this script bundles a self-contained
+# dvorak.kmap alongside it and loads that instead, so the console works with
+# neither root nor the keymap package.
 #
 # IBus is only touched if it is already running; this script never starts it.
 
@@ -20,6 +22,14 @@ set -u
 
 progname=${0##*/}
 applied=0
+
+# Directory holding this script, resolving symlinks, so we can find the bundled
+# dvorak.kmap next to it even when invoked via a symlink on PATH.
+self=${BASH_SOURCE[0]}
+if command -v readlink >/dev/null 2>&1; then
+    self=$(readlink -f "$self" 2>/dev/null || printf '%s' "$self")
+fi
+selfdir=$(cd "$(dirname "$self")" 2>/dev/null && pwd)
 
 have() {
     command -v "$1" >/dev/null 2>&1
@@ -29,8 +39,14 @@ note() {
     printf '%s: %s\n' "$progname" "$*" >&2
 }
 
-# Linux text console: loadkeys dvorak. Works without root on your own VT.
-# Gated on TERM=linux so we don't poke the console keymap from an X terminal.
+# Linux text console. Works without root on your own VT (loadkeys only needs to
+# own the tty or have CAP_SYS_TTY_CONFIG). Gated on TERM=linux so we don't poke
+# the console keymap from an X terminal.
+#
+# First try the system keymap named "dvorak"; if that's not installed (many
+# minimal systems ship no /usr/share/keymaps at all), fall back to the
+# self-contained dvorak.kmap bundled next to this script, which carries the
+# whole layout inline and so needs no keymap package.
 maybe_console() {
     test "${TERM:-}" = linux || return 1
     have loadkeys || return 1
@@ -38,7 +54,12 @@ maybe_console() {
         note "Linux console set to Dvorak (loadkeys dvorak)"
         return 0
     fi
-    note "loadkeys dvorak failed (need to own this VT or have CAP_SYS_TTY_CONFIG)"
+    if test -f "$selfdir/dvorak.kmap" \
+        && loadkeys "$selfdir/dvorak.kmap" >/dev/null 2>&1; then
+        note "Linux console set to Dvorak (bundled dvorak.kmap)"
+        return 0
+    fi
+    note "loadkeys failed (are you on your own VT? is the loadkeys binary present?)"
     return 1
 }
 
@@ -70,9 +91,14 @@ maybe_gnome() {
     return 1
 }
 
-# KDE Plasma (X11 or Wayland): persist in kxkbrc, then ask kded to reload it.
-# On X11 setxkbmap has usually applied it live already; on Wayland the reload
-# below (or the next login) makes it take effect.
+# KDE Plasma (X11 or Wayland): persist the layout in kxkbrc. On X11 the
+# setxkbmap call above has usually applied it live already; modern Plasma's
+# keyboard daemon watches kxkbrc and re-reads it on change, so a fresh login
+# picks it up otherwise.
+#
+# (We deliberately don't poke org.kde.KeyboardLayouts.setLayout: that method
+# takes a layout *name*, not an index, and its signature/behaviour varies
+# across Plasma versions, so an index-based call is both wrong and unreliable.)
 maybe_kde() {
     case "${XDG_CURRENT_DESKTOP:-}" in
         *KDE*) ;;
@@ -89,13 +115,7 @@ maybe_kde() {
         note "KDE: writing kxkbrc failed (read-only \$HOME, full disk?)"
         return 1
     fi
-    for qd in qdbus6 qdbus-qt6 qdbus; do
-        if have "$qd"; then
-            "$qd" org.kde.keyboard /Layouts org.kde.KeyboardLayouts.setLayout 0 \
-                >/dev/null 2>&1 && break
-        fi
-    done
-    note "KDE configured for Dvorak (kxkbrc; relog if not applied live)"
+    note "KDE set to Dvorak in kxkbrc (live on X11; relog on Wayland if not picked up)"
     return 0
 }
 
@@ -121,7 +141,8 @@ Usage: $progname
 
 Switch the keyboard layout to US Dvorak using every method that applies to the
 current environment:
-  - Linux text console  : loadkeys dvorak      (no root needed on your own VT)
+  - Linux text console  : loadkeys dvorak, or the bundled dvorak.kmap if the
+                          system keymaps aren't installed (no root on your VT)
   - X11                 : setxkbmap -layout us -variant dvorak
   - GNOME session       : gsettings input-sources -> us+dvorak
   - KDE Plasma session  : kxkbrc -> us/dvorak
@@ -144,7 +165,7 @@ maybe_ibus    && applied=1
 
 if test "$applied" -eq 0; then
     note "could not set Dvorak by any method here"
-    note "on a Linux console try: loadkeys dvorak"
+    note "on a Linux console try: loadkeys dvorak (or loadkeys $selfdir/dvorak.kmap)"
     note "under X11 try:          setxkbmap -layout us -variant dvorak"
     exit 1
 fi

--- a/dvorak.kmap
+++ b/dvorak.kmap
@@ -1,22 +1,39 @@
 # US Dvorak keymap for the Linux text console (self-contained).
 #
-# This is a partial keymap: it remaps only the keys whose output differs
-# between US QWERTY and US Dvorak, layered on top of the kernel's current
-# keymap. Because it defines the keys inline (no `include` of a base map), it
-# needs nothing from /usr/share/keymaps -- so it loads on minimal systems that
-# don't have the kbd keymap data installed, and without root as long as you
-# own the tty (e.g. you're logged in on the VT):
+# This defines the whole character block inline (no `include` of a base map),
+# so it needs nothing from /usr/share/keymaps -- it loads on minimal systems
+# that don't have the kbd keymap data installed, and without root as long as
+# you own the tty (e.g. you're logged in on the VT):
 #
 #     loadkeys dvorak.kmap
 #
+# Every letter, number and symbol key is defined here rather than inherited, so
+# the result is correct US Dvorak regardless of which layout was previously
+# active (a partial "only the changed keys" map would silently produce a hybrid
+# if the current base were, say, German or Colemak). What is intentionally NOT
+# defined -- Esc/Tab/Enter/Space/Backspace, the modifier keys, the function
+# keys and the keypad -- is layout-independent (identical across Latin console
+# maps), so inheriting it from the active keymap is safe. The AltGr/third level
+# is likewise left alone; US Dvorak doesn't use it.
+#
 # Letters use the `+` prefix so CapsLock treats them as letters and Shift/Ctrl
 # entries are generated automatically. Symbol keys list plain then Shift.
-# Numbers, backtick, backslash, space and the modifiers are identical in
-# Dvorak, so they are intentionally left untouched.
 
-# number row: only the two keys right of 0 change ( -= becomes [] )
+# number row (pinned to US so a non-US base can't leak through)
+keycode   2 = one           exclam
+keycode   3 = two           at
+keycode   4 = three         numbersign
+keycode   5 = four          dollar
+keycode   6 = five          percent
+keycode   7 = six           asciicircum
+keycode   8 = seven         ampersand
+keycode   9 = eight         asterisk
+keycode  10 = nine          parenleft
+keycode  11 = zero          parenright
 keycode  12 = bracketleft   braceleft
 keycode  13 = bracketright  braceright
+keycode  41 = grave         asciitilde
+keycode  43 = backslash     bar
 
 # top letter row: q w e r t y u i o p [ ]  ->  ' , . p y f g c r l / =
 keycode  16 = apostrophe    quotedbl

--- a/dvorak.kmap
+++ b/dvorak.kmap
@@ -1,0 +1,58 @@
+# US Dvorak keymap for the Linux text console (self-contained).
+#
+# This is a partial keymap: it remaps only the keys whose output differs
+# between US QWERTY and US Dvorak, layered on top of the kernel's current
+# keymap. Because it defines the keys inline (no `include` of a base map), it
+# needs nothing from /usr/share/keymaps -- so it loads on minimal systems that
+# don't have the kbd keymap data installed, and without root as long as you
+# own the tty (e.g. you're logged in on the VT):
+#
+#     loadkeys dvorak.kmap
+#
+# Letters use the `+` prefix so CapsLock treats them as letters and Shift/Ctrl
+# entries are generated automatically. Symbol keys list plain then Shift.
+# Numbers, backtick, backslash, space and the modifiers are identical in
+# Dvorak, so they are intentionally left untouched.
+
+# number row: only the two keys right of 0 change ( -= becomes [] )
+keycode  12 = bracketleft   braceleft
+keycode  13 = bracketright  braceright
+
+# top letter row: q w e r t y u i o p [ ]  ->  ' , . p y f g c r l / =
+keycode  16 = apostrophe    quotedbl
+keycode  17 = comma         less
+keycode  18 = period        greater
+keycode  19 = +p
+keycode  20 = +y
+keycode  21 = +f
+keycode  22 = +g
+keycode  23 = +c
+keycode  24 = +r
+keycode  25 = +l
+keycode  26 = slash         question
+keycode  27 = equal         plus
+
+# home row: a s d f g h j k l ; '  ->  a o e u i d h t n s -
+keycode  30 = +a
+keycode  31 = +o
+keycode  32 = +e
+keycode  33 = +u
+keycode  34 = +i
+keycode  35 = +d
+keycode  36 = +h
+keycode  37 = +t
+keycode  38 = +n
+keycode  39 = +s
+keycode  40 = minus         underscore
+
+# bottom row: z x c v b n m , . /  ->  ; q j k x b m w v z
+keycode  44 = semicolon     colon
+keycode  45 = +q
+keycode  46 = +j
+keycode  47 = +k
+keycode  48 = +x
+keycode  49 = +b
+keycode  50 = +m
+keycode  51 = +w
+keycode  52 = +v
+keycode  53 = +z


### PR DESCRIPTION
## What

Adds a `dvorak` script that switches the keyboard layout to **US Dvorak** using whatever mechanism fits the current environment. It tries every applicable method and applies as many as it can, so one command covers the bare Linux console, X11, Wayland desktops (GNOME/KDE), and IBus.

Also adds `dvorak.kmap`, a self-contained US Dvorak console keymap the script falls back to (see below).

## The Linux console case (and its caveats)

On the Linux virtual console the command is:

```
loadkeys dvorak
```

When it works, it needs **no root** — `loadkeys` only needs to own the controlling tty (true on the VT you logged in on) or `CAP_SYS_TTY_CONFIG`, so no `sudo` and no `dpkg-reconfigure`.

**But it has real prerequisites:**

- The `loadkeys` **binary** must be installed (the `kbd` package). On minimal/container systems it may be absent → `command not found`.
- A **keymap to load** must exist. `loadkeys dvorak` looks up the system keymap under `/usr/share/keymaps` (Debian/Ubuntu) or `/usr/share/kbd/keymaps` (Arch/Fedora/openSUSE) — but **many minimal systems ship no keymap data at all**, so it fails with "can't find dvorak" even though you own the tty. Installing that data normally needs root.
- You must be **on your own VT** — from a graphical terminal, SSH, or tmux you don't own the console tty, so it fails with `EPERM`.

To handle the common "no keymap data + no root" case, this PR **bundles `dvorak.kmap`** — a self-contained keymap that defines the whole character block inline (every letter, number, and symbol key), with no `include` of a base file. Because it defines those keys itself rather than inheriting them, the result is correct US Dvorak regardless of which layout was previously active. The script loads it by path when the named system keymap isn't found, so the console switches to Dvorak with **neither root nor the `kbd` keymap package**:

```
loadkeys /path/to/dvorak.kmap
```

Non-character keys (modifiers, function keys, keypad, Enter/Space/…) are intentionally inherited — they're layout-independent across Latin console maps.

## Methods tried

| Environment | Mechanism | Needs the console keymap package? |
|---|---|---|
| Linux text console (`TERM=linux`) | `loadkeys dvorak`, else bundled `dvorak.kmap` | **No** (bundled keymap is self-contained) |
| X11 (incl. XWayland clients) | `setxkbmap -layout us -variant dvorak` | No (uses `/usr/share/X11/xkb`) |
| GNOME session | `gsettings` `org.gnome.desktop.input-sources` → `us+dvorak` | No |
| KDE Plasma session | `kwriteconfig` → `kxkbrc` (`us`/`dvorak`) | No |
| IBus | `ibus engine xkb:us:dvorak:eng` — **only if IBus already running** | No |

The graphical methods do **not** depend on `/usr/share/keymaps` — that data is Linux-console-only.

## Notes

- **IBus is never started** — only touched when a daemon is already running (checked via `pgrep`/`$IBUS_ADDRESS`/`ibus address`).
- **KDE** persists the layout in `kxkbrc` (which modern Plasma re-reads on change); live X11 effect comes from the `setxkbmap` path. It deliberately does **not** call `org.kde.KeyboardLayouts.setLayout`, which takes a layout *name* (not an index) and varies across Plasma versions.
- `maybe_kde` propagates `kwriteconfig` write failures (a read-only `$HOME` or full disk no longer reports success).
- The console keymap is applied per-session (loadkeys doesn't persist across reboots without root/`vconsole.conf`); running `dvorak` from a shell rc is the no-root way to make it stick.
- Follows the existing `screensaver`-style pattern of guarded `maybe_*` helpers.
- Degrades gracefully: if nothing applies, it prints the console/X11 commands to try (including the bundled-keymap path) and exits non-zero. `--help` documents the methods; unexpected arguments exit `2`.

## Testing

- `bash -n dvorak` passes.
- Runtime checks in a minimal environment: no applicable method → prints guidance and exits `1`; `--help` → exits `0`; bad argument → exits `2`; each `maybe_*` guard correctly skips when its environment/tool is absent; `selfdir` resolves the bundled keymap path (symlink-resolved).
- Note: the bundled keymap could not be `loadkeys`-loaded in CI (no `kbd` binary / not a real VT there); it's a standard keymap using canonical keysym names, cross-checked key-by-key against the US Dvorak layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177ZiudkgYMwyVxXMLykGnq