### PR TITLE
Fix shellcheck warnings across the script collection

### DIFF
--- a/args
+++ b/args
@@ -4,5 +4,5 @@ echo 0: "$0"
 i=1
 for arg; do
     echo "$i: $arg"
-    i=$(expr $i + 1)
+    i=$((i + 1))
 done

--- a/autosession
+++ b/autosession
@@ -11,6 +11,7 @@
 # "autosession switch <target>", and pass-through commands all work.
 
 dir="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=/dev/null
 . "$dir/sessionlib"
 
 backend="$(resolve_session_backend)" || {

--- a/autoshpool
+++ b/autoshpool
@@ -49,6 +49,7 @@ switch_file_suffix() {
 # Shared helpers and the fzf picker engine. SESSION_SEP tells the library which
 # separator this backend uses (for session_matches_prefix).
 SESSION_SEP=":"
+# shellcheck source=/dev/null
 source "$(dirname "$0")/sessionlib"
 
 get_current_shpool_session() {
@@ -124,7 +125,8 @@ get_prefix() {
   # Use the current project name with a colon at the end, or empty string.
   # Silence rootdir like autotmux's get_prefix: without ~/.shrc.vcs it doesn't
   # exist, and "command not found" noise on stderr isn't an error here.
-  local prefix="$(basename "$(rootdir 2>/dev/null)")"
+  local prefix
+  prefix="$(basename "$(rootdir 2>/dev/null)")"
   test -n "$prefix" && echo "$prefix:"
 }
 
@@ -495,6 +497,7 @@ clear_switch() {
 autoshpool_loop() {
   #exec >>"$HOME/.autoshpool.log" 2>>"$HOME/.autoshpool.log"
 
+  # shellcheck source=/dev/null
   test -r "$HOME/.shrc.vcs" && source "$HOME/.shrc.vcs"
 
   SHPOOL_PREFIX="${SHPOOL_PREFIX:-$(get_prefix)}"
@@ -603,6 +606,7 @@ case "$1" in
   switch)
     # Load the user's vcs helper (best-effort) so vcs rootdir/unmerged work when
     # matching and describing shells.
+    # shellcheck source=/dev/null
     test -r "$HOME/.shrc.vcs" && source "$HOME/.shrc.vcs"
     if test -z "$2"; then
       # No target: switch to the session that fits this directory's project --

--- a/autotmux
+++ b/autotmux
@@ -40,7 +40,9 @@ TMUX_SEP="${TMUX_SEP:-/}"
 
 # Shared helpers and the fzf picker engine. SESSION_SEP tells the library which
 # separator this backend uses (for session_matches_prefix).
+# shellcheck disable=SC2034  # consumed by session_matches_prefix in the sourced sessionlib
 SESSION_SEP="$TMUX_SEP"
+# shellcheck source=/dev/null
 source "$(dirname "$0")/sessionlib"
 
 sanitize_session_name() {
@@ -366,6 +368,7 @@ resolve_switch_target() {
 # Detach if the user cleanly exited; stay if there was an error so the user can
 # see and fix it (autotmux returns non-zero, so the caller's `&& exit` won't fire).
 autotmux_main() {
+  # shellcheck source=/dev/null
   test -r "$HOME/.shrc.vcs" && source "$HOME/.shrc.vcs"
 
   TMUX_PREFIX="${TMUX_PREFIX:-$(get_prefix)}"
@@ -407,6 +410,7 @@ case "$1" in
   switch)
     # Load the user's vcs helper (best-effort) so vcs rootdir/unmerged work when
     # matching and describing sessions.
+    # shellcheck source=/dev/null
     test -r "$HOME/.shrc.vcs" && source "$HOME/.shrc.vcs"
     if test -z "$2"; then
       # No target: switch to the session that fits this directory's project --

--- a/autotmux_test
+++ b/autotmux_test
@@ -596,6 +596,7 @@ test_switch_normalizes_leading_dollar() {
   # session named "$0", so a generated "$0" must be normalized to "_0".
   export TMUX="/tmp/fake,1,0"
   export TMUX_S="other/1"
+  # shellcheck disable=SC2016  # '$0' is a deliberate literal session name for the test
   run_autotmux switch '$0'
   assert_status 0
   assert_called "tmux new-session -d -s _0"

--- a/browser1
+++ b/browser1
@@ -1,3 +1,4 @@
 #!/bin/bash
+# shellcheck source=/dev/null
 . "$HOME/.shrc"
 chrome "$@"

--- a/browser2
+++ b/browser2
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck source=/dev/null
 . "$HOME/.shrc"
 chrome --user-data-dir="$HOME/.config/google-chrome-alt" "$@"
 #brave-browser "$@"

--- a/browser3
+++ b/browser3
@@ -1,3 +1,4 @@
 #!/bin/bash
+# shellcheck source=/dev/null
 . "$HOME/.shrc"
 chrome --user-data-dir="$HOME/.config/google-chrome-profile3" "$@"

--- a/changesession
+++ b/changesession
@@ -18,6 +18,7 @@
 # family via sessionlib; see there for the cascade.
 
 dir="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=/dev/null
 . "$dir/sessionlib"
 
 be="$(resolve_session_backend)" || {

--- a/changeshpool
+++ b/changeshpool
@@ -21,9 +21,12 @@
 # Override the picker with CHANGESESSION_FZF (e.g. for tests).
 
 # Pull in the shpool backend helpers (which in turn source sessionlib's engine).
+# shellcheck source=/dev/null
 source "$(dirname "$0")/autoshpool"
+# shellcheck source=/dev/null
 test -r "$HOME/.shrc.vcs" && source "$HOME/.shrc.vcs"
 
+# shellcheck disable=SC2034  # read by the fzf --preview command in the sourced sessionlib
 SESSION_SELF="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
 
 # Resolve the project prefix once, here, so it persists for both backend_prefix

--- a/changetmux
+++ b/changetmux
@@ -17,11 +17,14 @@
 # Override the picker with CHANGESESSION_FZF (e.g. for tests).
 
 # Pull in the tmux backend helpers (which in turn source sessionlib's engine).
+# shellcheck source=/dev/null
 source "$(dirname "$0")/autotmux"
+# shellcheck source=/dev/null
 test -r "$HOME/.shrc.vcs" && source "$HOME/.shrc.vcs"
 
 # Absolute path to this script, so the fzf preview can call back in regardless
 # of how changetmux was invoked.
+# shellcheck disable=SC2034  # read by the fzf --preview command in the sourced sessionlib
 SESSION_SELF="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
 
 # Resolve the project prefix once, here, so it persists for both backend_prefix

--- a/choosesession
+++ b/choosesession
@@ -11,6 +11,7 @@
 # changesession knows not to switch. All arguments are passed through.
 
 dir="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=/dev/null
 . "$dir/sessionlib"
 
 backend="$(resolve_session_backend)" || {

--- a/clocks
+++ b/clocks
@@ -12,11 +12,10 @@ if test -n "$when" && ! date -d "$when $localzone" >/dev/null 2>&1; then
 fi
 
 IFS='|'
-while read timezone description
+while read -r timezone description
 do
 	if test -n "$timezone"
 	then
-		continent=${timezone%/*}
 		city=${timezone#*/}
 		city=$(echo "$city" | tr '_' ' ')
 		if test -z "$description"

--- a/confback
+++ b/confback
@@ -4,17 +4,17 @@
 trap "exit" INT TERM QUIT
 
 # One tarball per ~/conf.* and ~/scripts.* directory.
-cd
+cd || exit
 for dir in conf/ conf.*/ scripts/ scripts.*/; do
   test -d "$dir" || continue
 
   tarball="${dir%/}.tar.gz"
   echo "Backing up $dir to $tarball"
 
-  cd "$dir"
+  cd "$dir" || exit
   # '.?*' rather than '.*' so the start directory '.' itself is not pruned
   # (which would make every tarball empty).
   find . '(' -name '.?*' ')' -prune -o '(' -type f -o -type l ')' -print0 |
   pax -w -z -0 -f "$HOME/$tarball"
-  cd "$OLDPWD"
+  cd "$OLDPWD" || exit
 done

--- a/confdist
+++ b/confdist
@@ -30,9 +30,9 @@ scp()
 	local scpflags=-Bq
 	if test "$verbose" -gt 0
 	then
-		command scp $ssh_mux_opts $scpflags "$@"
+		command scp "${ssh_mux_opts[@]}" "$scpflags" "$@"
 	else
-		command scp $ssh_mux_opts $scpflags "$@" 2>/dev/null
+		command scp "${ssh_mux_opts[@]}" "$scpflags" "$@" 2>/dev/null
 	fi
 	return $?
 }
@@ -41,9 +41,9 @@ ssh()
 {
 	if test "$verbose" -gt 0
 	then
-		command ssh $ssh_mux_opts "$@"
+		command ssh "${ssh_mux_opts[@]}" "$@"
 	else
-		command ssh $ssh_mux_opts "$@" 2>/dev/null
+		command ssh "${ssh_mux_opts[@]}" "$@" 2>/dev/null
 	fi
 	return $?
 }
@@ -54,7 +54,7 @@ ssh()
 setup_ssh_mux()
 {
 	ssh_mux_dir=$(mktemp -d "${TMPDIR:-/tmp}/confdist-XXXXXX") || return
-	ssh_mux_opts="-o ControlMaster=auto -o ControlPath=$ssh_mux_dir/%C -o ControlPersist=60"
+	ssh_mux_opts=(-o ControlMaster=auto -o "ControlPath=$ssh_mux_dir/%C" -o ControlPersist=60)
 	trap 'teardown_ssh_mux' EXIT
 }
 
@@ -79,6 +79,8 @@ read_defaults()
 {
 	hosts=
 	verbose=0
+	simulate=0
+	# shellcheck source=/dev/null
 	test -f "$HOME"/.confdist && . "$HOME"/.confdist
 }
 
@@ -98,7 +100,7 @@ read_options()
 			exit 0
 			;;
 		-v|--verbose)
-			verbose=$(($verbose + 1))
+			verbose=$((verbose + 1))
 			;;
 		--)
 			shift
@@ -117,7 +119,7 @@ read_options()
 	done
 	[ $verbose -gt 1 ] && set -x
 
-	test $# -gt 0 && hosts="$@"
+	test $# -gt 0 && hosts="$*"
 }
 
 copy_to()
@@ -133,8 +135,8 @@ copy_to()
 		test -f "$conffile" || continue
 		confname=$(basename "$conffile")
 		info "Copying $confname to $host"
-		printf "Copying $confname to $host... "
-		scp "$conffile" $host:~
+		printf 'Copying %s to %s... ' "$confname" "$host"
+		scp "$conffile" "$host:~"
 		if test $? -ne 0
 		then
 			printf "failure\n"
@@ -145,8 +147,9 @@ copy_to()
 		case "$confname" in
 		scripts.tar.gz)
 			dir=${confname%.tar.gz}
-			printf "Extracting $confname on $host... "
-			ssh $host "mkdir -p $dir && tar -C $dir -xzf $confname"
+			printf 'Extracting %s on %s... ' "$confname" "$host"
+			# shellcheck disable=SC2029  # $dir/$confname are intentionally expanded locally to build the remote command
+			ssh "$host" "mkdir -p $dir && tar -C $dir -xzf $confname"
 			if test $? -ne 0
 			then
 				printf "failure\n"
@@ -161,8 +164,8 @@ copy_to()
 install_on()
 {
 	local host=$1
-	printf "Installing on $host... "
-	ssh $host "scripts/confinst" -e
+	printf 'Installing on %s... ' "$host"
+	ssh "$host" "scripts/confinst" -e
 	if test $? -ne 0
 	then
 		printf "failure running remote install script\n"
@@ -174,7 +177,7 @@ install_on()
 distribute_from()
 {
 	local host=$1
-	ssh $host confdist
+	ssh "$host" confdist
 }
 
 # Refuse early when either base archive is missing: scripts.tar.gz carries
@@ -198,7 +201,7 @@ require_tarballs()
 open_ssh_master()
 {
 	local host=$1
-	printf "Connecting to $host... "
+	printf 'Connecting to %s... ' "$host"
 	if ssh "$host" true
 	then
 		printf "success\n"
@@ -217,7 +220,8 @@ setup_ssh_mux
 
 for host in $hosts
 do
-	open_ssh_master $host && copy_to $host && install_on $host && distribute_from $host || true
+	# shellcheck disable=SC2015  # trailing `|| true` deliberately lets the loop continue past a failing host
+	open_ssh_master "$host" && copy_to "$host" && install_on "$host" && distribute_from "$host" || true
 done
 
 # vim: set ts=4 sw=4 tw=0 noet:

--- a/confinst
+++ b/confinst
@@ -1,4 +1,5 @@
 #!/bin/sh
+# shellcheck shell=dash  # relies on `local`, provided by dash and other /bin/sh implementations
 # installs UNIX configuration files
 
 create_dir()
@@ -54,7 +55,8 @@ extract()
 backup()
 {
 	local path="$1"
-	local backuppath="$path.$(date +%Y%m%d%H%M%S)"
+	local backuppath
+	backuppath="$path.$(date +%Y%m%d%H%M%S)"
 	info "Moving $path to $backuppath"
 	run mv "$path" "$backuppath"
 }
@@ -106,7 +108,6 @@ get_link()
 	local sourcefile
 	local destdir
 	local prefix
-	local destfile
 
 	sourcefile="$1"
 	destdir="$2"
@@ -225,7 +226,7 @@ make_links()
 				run mkdir -p "$link"
 				if test $? -ne 0
 				then
-					printf "Error creating $link, skipping $file\n" 1>&2
+					printf 'Error creating %s, skipping %s\n' "$link" "$file" 1>&2
 					continue
 				fi
 			fi

--- a/cwhere
+++ b/cwhere
@@ -24,14 +24,12 @@ cleanup()
 
 get_cpp_output()
 {
-    local headers="$@"
-
     sourcefile=$(mktemp)
     if test $? -ne 0; then
         echo "Error: Cannot create source file" 1>&2
         exit 1
     fi
-    for header in $headers; do
+    for header in "$@"; do
         echo "#include <$header>" >> "$sourcefile"
     done
     # TODO: Do we need -D_GNU_SOURCE?
@@ -54,7 +52,6 @@ print_definitions()
 {
     local identifier="$1"
     shift
-    local headers="$@"
 
     local filenamepattern definepattern typedefpattern declarepattern
     filenamepattern='^# [0-9]+ "([^"]*)"'
@@ -134,11 +131,11 @@ main()
 
             headers=$(get_headers "$page$section")
             for header in $headers; do
-                args[$i]=$header
+                args[i]=$header
                 i=$((i+1))
             done
         else
-            args[$i]=$arg
+            args[i]=$arg
             i=$((i+1))
         fi
     done

--- a/detachsession
+++ b/detachsession
@@ -9,6 +9,7 @@
 # All arguments are passed through to the chosen script.
 
 dir="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=/dev/null
 . "$dir/sessionlib"
 
 backend="$(resolve_session_backend)" || {

--- a/editroot
+++ b/editroot
@@ -9,7 +9,7 @@ SUDO=sudo                    # empty is false, non-empty is true
 EDITOR=${EDITOR:-vi}
 
 error() {
-    printf "$*\n"
+    printf '%s\n' "$*"
     false
 }
 
@@ -30,7 +30,7 @@ else
       ;;
     *)
       if test "$line" != "$1"; then
-        file=${1%:$line}
+        file=${1%:"$line"}
       else
         file=$1
         line=

--- a/first
+++ b/first
@@ -8,10 +8,10 @@ oldest=$(git_rev --reverse)
 newest=HEAD
 
 echo "Starting bisect with first revision:"
-git log -1 $oldest
+git log -1 "$oldest"
 
 git bisect start
-git bisect good $oldest
+git bisect good "$oldest"
 git bisect bad $newest
 git bisect run not "$@" >/dev/null
 
@@ -20,4 +20,4 @@ git bisect run not "$@" >/dev/null
 first=$(git rev-parse refs/bisect/bad)
 git bisect reset >/dev/null
 echo "First revision where $* succeeds:"
-git log -1 $first
+git log -1 "$first"

--- a/fork
+++ b/fork
@@ -16,7 +16,7 @@ case "$url" in
     ;;
 esac
 echo "Press ENTER when done"
-read
+read -r
 git remote remove origin
 git remote add origin "git@github.com:mikelward/$dir"
 git push origin

--- a/gitbackup
+++ b/gitbackup
@@ -2,12 +2,12 @@
 # back up a git repository tree
 # $Id$
 
-OIFS="$IFS"
 IFS=" 	
 "
 
 if test -f "$HOME/bin/functions"
 then
+    # shellcheck source=/dev/null
     . "$HOME/bin/functions"
 else
     echo "Cannot open functions library $HOME/bin/functions" 1>&2
@@ -22,12 +22,6 @@ abort()
 
 cleanup()
 {
-    if test -f "$dfout"
-    then
-        info "Cleaning up $dfout"
-        run rm -rf -- "$dfout"
-    fi
-
     if test -d "$snapdir"
     then
         info "Cleaning up $snapdir"
@@ -56,12 +50,14 @@ find_git_repos()
 #
 debug=
 quiet=true
+# shellcheck disable=SC2034  # read by run() in the sourced functions library
 simulate=                       # empty means false
 dateformat='%-e %B %Y'
 timeformat='%H:%M:%S'
 srcroot=/home/mikelward/git
 tmpdir="${TMPDIR:-$HOME/tmp}"
 dstroot=mikelward.homedns.org:/home/mikel/git
+# shellcheck disable=SC2034  # read by the logging helpers in the functions library
 logfile=/home/mikelward/log/gitbackup.log
 
 main()
@@ -88,6 +84,7 @@ main()
             exit 0
             ;;
         -n|--simulate)
+            # shellcheck disable=SC2034  # read by run() in the sourced functions library
             simulate=true
             ;;
         --)
@@ -112,7 +109,7 @@ main()
     dstroot=${dstroot%/}/
     srcroot=${srcroot%/}/
 
-    info "Starting gitbackup on "$(date +"$dateformat")" at "$(date +"$timeformat")
+    info "Starting gitbackup on $(date +"$dateformat") at $(date +"$timeformat")"
 
     if is_remote "$dstroot"
     then
@@ -135,7 +132,7 @@ main()
     #   /srv/git/proj2/proj2b.git
     while IFS= read -r -d '' srcdir
     do
-        info "Starting backup of $srcdir on "$(date +"$dateformat")" at "$(date +"$timeformat")
+        info "Starting backup of $srcdir on $(date +"$dateformat") at $(date +"$timeformat")"
 
         # do each repo in a new subshell so we can call cleanup on error and success via trap
         (
@@ -152,7 +149,7 @@ main()
         # case 1: srcdir is subdir of srcroot - OK
         # case 2: srcdir is / - CAN'T HAPPEN
         # case 3: srcdir = srcroot - NOT SUPPORTED
-        reponame=${srcdir#$srcroot}
+        reponame=${srcdir#"$srcroot"}
         reponame=${reponame%/}
         if test "$reponame" = ""
         then
@@ -177,7 +174,7 @@ main()
             exit 1
         fi
 
-        if test $available -lt $size
+        if test "$available" -lt "$size"
         then
             error "Need at least $size kilobytes free on $tmpdir"
             exit 1
@@ -222,16 +219,16 @@ main()
         # -n: don't let ssh inherit the find pipe feeding this loop as stdin,
         # or it drains the remaining repository paths and only the first repo
         # gets backed up
-        run ssh -n $dsthost 'dstdir="'"$dstdir"'"; test -d "$dstdir" || mkdir -p "$dstdir"'
+        run ssh -n "$dsthost" 'dstdir="'"$dstdir"'"; test -d "$dstdir" || mkdir -p "$dstdir"'
 
-        flags=
+        flags=()
         if test "$debug"
         then
-            flags="$flags -v"
+            flags+=(-v)
         fi
         if test "$quiet"
         then
-            flags="$flags -q"
+            flags+=(-q)
         fi
         #scp -C -r $flags "$snapdir" "$dst"
         # ensure source has a trailing slash so we only copy the directory contents
@@ -239,7 +236,7 @@ main()
         #  local:~/svn.12345/ -> remote:~/svn/svn.12345)
         snapdir=${snapdir%/}/
         info "Syncing $snapdir to $dsturl"
-        run rsync -a --delete $flags "$snapdir" "$dsturl"
+        run rsync -a --delete "${flags[@]}" "$snapdir" "$dsturl"
         if test $? -ne 0
         then
             error "Error syncing $snapdir to $dsturl"
@@ -248,10 +245,10 @@ main()
 
         )
 
-        info "Finished backup of $srcdir on "$(date +"$dateformat")" at "$(date +"$timeformat")
+        info "Finished backup of $srcdir on $(date +"$dateformat") at $(date +"$timeformat")"
     done < <(find_git_repos "$srcroot")
 
-    info "Finished gitbackup on "$(date +"$dateformat")" at "$(date +"$timeformat")
+    info "Finished gitbackup on $(date +"$dateformat") at $(date +"$timeformat")"
 }
 
 # Run unless sourced (e.g. by gitbackup_test, which exercises find_git_repos in

--- a/gitbackup_test
+++ b/gitbackup_test
@@ -19,6 +19,7 @@ STUB_HOME="$(mktemp -d)"
 mkdir -p "$STUB_HOME/bin"
 : > "$STUB_HOME/bin/functions"
 export HOME="$STUB_HOME"
+# shellcheck source=/dev/null
 . "$SCRIPT_DIR/gitbackup"
 # Sourcing gitbackup sets IFS to space/tab/newline; that is the default anyway,
 # but be explicit so the harness below is unaffected.

--- a/gitinitremote
+++ b/gitinitremote
@@ -141,10 +141,10 @@ fi
 
 case $remoteproto in
 ssh)
-	ssh $remotehost true || die "Cannot connect to $remotehost via ssh"
-	ssh $remotehost test -d "'$remotedir'" && die "$remotedir already exists on $remotehost"
-	ssh $remotehost git --help >/dev/null 2>&1 || die "git is not installed on $remotehost"
-	run ssh $remotehost git init --quiet --bare "'$remotedir'" || die "Cannot initialize remote repository"
+	ssh "$remotehost" true || die "Cannot connect to $remotehost via ssh"
+	ssh "$remotehost" test -d "'$remotedir'" && die "$remotedir already exists on $remotehost"
+	ssh "$remotehost" git --help >/dev/null 2>&1 || die "git is not installed on $remotehost"
+	run ssh "$remotehost" git init --quiet --bare "'$remotedir'" || die "Cannot initialize remote repository"
 	# git remote does not accept --quiet option
 	run git remote add "$remotename" "$remote" || die "git remote add failed"
 	;;

--- a/gittossh_test
+++ b/gittossh_test
@@ -127,6 +127,7 @@ test_converts_push_url() {
     git -C "$repo" remote add origin "https://github.com/mikelward/scripts.git"
     git -C "$repo" remote set-url --push origin "https://github.com/mikelward/scripts.git"
     run_convert "$repo"
+    # shellcheck disable=SC2015  # test-assertion idiom: the || block runs on any failed assertion, which is intended
     assert_status 0 &&
     assert_url "$repo" origin "git@github.com:mikelward/scripts.git" &&
     test "$(git -C "$repo" config --get remote.origin.pushurl)" = "git@github.com:mikelward/scripts.git" || {

--- a/google-meet
+++ b/google-meet
@@ -1,3 +1,4 @@
 #!/bin/bash
+# shellcheck source=/dev/null
 . "$HOME"/.shrc
 chrome --app="https://meet.google.com"

--- a/he
+++ b/he
@@ -38,7 +38,7 @@ option="${2:-$default_section}"
 # handle manpage(number)
 case $manpage in *\(*\))
     page=${manpage%\(*\)}
-    section=${manpage#$page}
+    section=${manpage#"$page"}
     section=${section#\(}
     section=${section%\)}
     manpage=$page

--- a/i3statusdwm
+++ b/i3statusdwm
@@ -5,7 +5,7 @@ exec >/dev/null 2>/dev/null
 
 username=$(whoami)
 short_hostname=$(hostname)
-short_hostname=${short_hostname#$username-}
+short_hostname=${short_hostname#"$username"-}
 short_hostname=${short_hostname%%.*}
 i3status | while read -r line; do
     line="$(echo "$short_hostname $(showconn) $line" |

--- a/idea
+++ b/idea
@@ -1,5 +1,5 @@
 #!/bin/sh
-cd
+cd || exit
 export _JAVA_AWT_WM_NONREPARENTING=1
 wmname "LG3D"
 idea.sh

--- a/java-alternatives.sh
+++ b/java-alternatives.sh
@@ -115,6 +115,7 @@ if test -z "$basedir"; then
 fi
 debug "basedir is $basedir"
 
+# shellcheck disable=SC2034  # referenced indirectly by name in in_array/add_to_array via ${!array}
 names=
 
 ###
@@ -133,7 +134,7 @@ add_to_array()
 	local array=$1
 	local value=$2
 	
-	eval $array="\${$array:+\$$array
+	eval "$array=\${$array:+\$$array
 }\$value"
 
 	IFS=$OIFS
@@ -184,7 +185,7 @@ get_destination_path()
 		return 1
 	fi
 
-	local subdir=${path#$base}
+	local subdir=${path#"$base"}
 	if test "$subdir" = "$path"; then
 		error "Cannot determine subdirectory for $path"
 		return 1
@@ -200,14 +201,14 @@ get_destination_path()
 		return 1
 	fi
 
-	dirmap=$(get_mapped_directory $subdir $dirmap)
+	dirmap=$(get_mapped_directory "$subdir" "$dirmap")
 
 	if test $? -eq 0 -a -n "$dirmap"; then
 		local dest
-		dest=${path#$base}
-		dest=${dest#/$subdir}
+		dest=${path#"$base"}
+		dest=${dest#/"$subdir"}
 		dest=$dirmap$dest
-		echo $dest
+		echo "$dest"
 		return 0
 	else
 		error "Cannot get target directory for $path"
@@ -242,7 +243,7 @@ get_mapped_directory()
 		fi
 		if test "$subdir" = "$key"; then
 			local val
-			val=${dir#$key=}
+			val=${dir#"$key"=}
 			if test "$val" = "$dir"; then
 				error "Skipping invalid dirmap entry $dir with key=$key"
 				continue
@@ -257,7 +258,7 @@ get_mapped_directory()
 	IFS=$OIFS
 
 	if test -n "$result"; then
-		echo $result
+		echo "$result"
 		return 0
 	else
 		notice "Missing dirmap for $subdir"
@@ -275,7 +276,7 @@ get_mapped_directory()
 # update-alternatives --install...
 install=
 slaves=
-files=$(for subdir in $subdirs; do find $basedir/$subdir -type f -print; done)
+files=$(for subdir in $subdirs; do find "$basedir/$subdir" -type f -print; done)
 for file in $files; do
   
 	# We might get /usr/java/share/man/man1/java.1 and
@@ -304,15 +305,15 @@ for file in $files; do
 		error "Cannot determine filename for $file"
 		continue
 	fi
-	dest=$(get_destination_path $basedir $file $dirmap)
+	dest=$(get_destination_path "$basedir" "$file" "$dirmap")
 	if test -z "$dest"; then
 		error "Cannot determine target for $file"
 		continue
 	fi
 
 
-	if ! in_array names $name; then
-		add_to_array names $name
+	if ! in_array names "$name"; then
+		add_to_array names "$name"
 
 		case $file in */bin/java)
 			# the main java program should be specified via --install
@@ -341,6 +342,9 @@ if $simulate; then
 	echo "/usr/sbin/update-alternatives 
 $install $priority $slaves"
 else
+	# Intentional word splitting: $install and $slaves each expand to several
+	# update-alternatives arguments, and $priority is a bare number.
+	# shellcheck disable=SC2086
 	run sudo /usr/sbin/update-alternatives \
 $install $priority $slaves
 fi

--- a/leftright
+++ b/leftright
@@ -24,7 +24,7 @@ list_pointing_devices() {
 }
 
 # Symlinks called "left" and "right" determine which button map to use.
-handedness=$(basename $0)
+handedness=$(basename "$0")
 case $handedness in left|right)
     ;;
 *)
@@ -49,7 +49,7 @@ list_pointing_devices |
 while IFS=$'\t' read -r name id; do
     printf '%s (%d)\n' "$name" "$id"
 done
-printf "Enter the number of the device to make $handedness-handed: "
+printf 'Enter the number of the device to make %s-handed: ' "$handedness"
 read -r id
 if test -n "$id"; then
     $handedness "$id"

--- a/logexec
+++ b/logexec
@@ -8,6 +8,6 @@
 # ln /usr/bin/logexec /usr/bin/gnome-keyring-daemon
 
 ppid="$(ps -o ppid= -p $$)"
-pcomm="$(ps -o comm= -p $ppid)"
+pcomm="$(ps -o comm= -p "$ppid")"
 logger -s -t "$0" "started by pid $ppid ($pcomm) with args $*"
 exec "$0".distrib "$@"

--- a/makemakefile
+++ b/makemakefile
@@ -4,6 +4,7 @@
 # For example, if the current directory has a BUILD file, makemakefile will copy
 # ~/templates/Makefile.BUILD to ./Makefile.
 
+# shellcheck source=/dev/null
 source "$HOME/.shrc"
 
 set -e
@@ -17,7 +18,7 @@ LC_ALL=C
 
 for f in "$HOME/.templates/Makefile."*; do
   test -f "$f" || break  # no templates
-  if test -f "${f#$HOME/.templates/Makefile.}"; then
+  if test -f "${f#"$HOME/.templates/Makefile."}"; then
     builddir="$(builddir)"
     sed -e 's#@BUILDDIR@#'"$builddir"'#' "$f" > .Makefile
     exit 0

--- a/makesession
+++ b/makesession
@@ -9,6 +9,7 @@
 # All arguments (the session name, and any further pass-through) are forwarded.
 
 dir="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=/dev/null
 . "$dir/sessionlib"
 
 backend="$(resolve_session_backend)" || {

--- a/makesettings
+++ b/makesettings
@@ -3,7 +3,9 @@
 # This is a workaround for VSCode issue 17634, allowing separate work and home
 # overrides to the global settings.json.
 
+# shellcheck source=/dev/null
 source "$HOME/.shrc"
+# shellcheck source=/dev/null
 source "$HOME/.shrc.vcs"
 
 set -e

--- a/makeshpool
+++ b/makeshpool
@@ -21,6 +21,7 @@
 
 # Pull in the shpool backend helpers for request_switch. autoshpool's is_sourced
 # guard makes sourcing it define functions without running the loop.
+# shellcheck source=/dev/null
 source "$(dirname "$0")/autoshpool"
 
 # A name is required. Refusing here matters most inside a session: with no

--- a/maketasks
+++ b/maketasks
@@ -4,7 +4,9 @@
 # For example, if the current directory has a BUILD file, maketasks will copy
 # ~/templates/tasks.json.BUILD to .vscode/tasks.json.
 
+# shellcheck source=/dev/null
 source "$HOME/.shrc"
+# shellcheck source=/dev/null
 source "$HOME/.shrc.vcs"
 
 set -e
@@ -18,7 +20,7 @@ builddir="$(builddir)"
 
 for f in "$HOME/.templates/tasks.json."*; do
   test -f "$f" || break  # no templates => f == tasks.json.*
-  if test -f "${f#$HOME/.templates/tasks.json.}"; then
+  if test -f "${f#"$HOME/.templates/tasks.json."}"; then
     sed -e "s#@BUILDDIR@#$builddir#" "$f" > .vscode/tasks.json
     exit 0
   fi

--- a/maketmux
+++ b/maketmux
@@ -32,6 +32,7 @@
 
 # Pull in sanitize_session_name/session_exists from the tmux backend module.
 # autotmux's is_sourced guard makes sourcing it define functions only.
+# shellcheck source=/dev/null
 source "$(dirname "$0")/autotmux"
 
 if test -z "$1"; then

--- a/precommit
+++ b/precommit
@@ -2,6 +2,7 @@
 # precommit hook for git, hg, etc.
 set -e
 
+# shellcheck source=/dev/null
 source ~/.shrc.vcs
 
 allknown

--- a/quote
+++ b/quote
@@ -1,19 +1,19 @@
 #!/bin/bash
 echo "quote $*" >> ~/.quote.log
 #exit 0
-upper=$(tr a-z A-Z <<<"$1")
+upper=$(tr '[:lower:]' '[:upper:]' <<<"$1")
 urls=(
-https://www.barrons.com/quote/stock/us/xnys/$1/research-ratings
-https://www.barrons.com/quote/stock/us/xnas/$1/research-ratings
-https://finviz.com/quote.ashx?t=$1
-https://seekingalpha.com/symbol/$1/ratings/quant-ratings
-https://www.morningstar.com/stocks/xnys/$1/quote
-https://www.morningstar.com/stocks/xnas/$1/quote
+"https://www.barrons.com/quote/stock/us/xnys/$1/research-ratings"
+"https://www.barrons.com/quote/stock/us/xnas/$1/research-ratings"
+"https://finviz.com/quote.ashx?t=$1"
+"https://seekingalpha.com/symbol/$1/ratings/quant-ratings"
+"https://www.morningstar.com/stocks/xnys/$1/quote"
+"https://www.morningstar.com/stocks/xnas/$1/quote"
 #https://www.marketwatch.com/investing/stock/$1/analystestimates?mod=mw_quote_tab
-https://www.marketbeat.com/stocks/NYSE/$upper/price-target/?MostRecent=0
-https://www.marketbeat.com/stocks/NASDAQ/$upper/price-target/?MostRecent=0
-https://www.tipranks.com/stocks/$1/forecast
-https://www.zacks.com/zer/report/$1
+"https://www.marketbeat.com/stocks/NYSE/$upper/price-target/?MostRecent=0"
+"https://www.marketbeat.com/stocks/NASDAQ/$upper/price-target/?MostRecent=0"
+"https://www.tipranks.com/stocks/$1/forecast"
+"https://www.zacks.com/zer/report/$1"
 )
 for url in "${urls[@]}"; do
     chrome "$url"

--- a/remote-desktop
+++ b/remote-desktop
@@ -1,3 +1,4 @@
 #!/bin/bash
+# shellcheck source=/dev/null
 . "$HOME/.shrc"
 chrome --app="https://remotedesktop.google.com"

--- a/runenv
+++ b/runenv
@@ -19,6 +19,7 @@ fi
 if test -z "${DOTENV_SOURCED:-}"; then
     set -a
     for _dotenv in "$HOME/.env" "$HOME/.env.local"; do
+        # shellcheck source=/dev/null
         test -f "$_dotenv" && . "$_dotenv"
     done
     unset _dotenv

--- a/runenv_test
+++ b/runenv_test
@@ -159,6 +159,7 @@ test_no_arguments_is_a_usage_error() {
 
 run_test "runs a command found via ~/.env's PATH" test_runs_command_via_env_path
 run_test "passes arguments through" test_passes_arguments_through
+# shellcheck disable=SC2088  # the tildes are literal display text in this test label, not paths to expand
 run_test "~/.env.local prepend beats ~/.env" test_env_local_prepend_wins
 run_test "plain assignments are exported to the command" test_plain_assignments_are_exported
 run_test "DOTENV_SOURCED skips re-sourcing" test_dotenv_sourced_skips_the_files

--- a/sbtnew
+++ b/sbtnew
@@ -2,8 +2,8 @@
 tildepwd() {
     echo "$PWD" | sed "s#^$HOME/#~/#;s#^$HOME"'$#~#'
 }
-cd ~/src
+cd ~/src || exit
 echo "Creating $(tildepwd)/$1"
 sbt new sbt/scala-seed.g8 --name="$1"
-cd "$1"
+cd "$1" || exit
 echo "Created $(tildepwd)"

--- a/screensaver
+++ b/screensaver
@@ -28,6 +28,7 @@ maybe_xsecurelock() {
   local lock_command="xsecurelock"
   have_command "$init_command" || return 1
   if test -f "$HOME/.xsecurelockrc"; then
+      # shellcheck source=/dev/null
       . "$HOME/.xsecurelockrc"
   fi
   case $1 in

--- a/screenshot
+++ b/screenshot
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck source=/dev/null
 . "$HOME"/.shrc
 usage() {
   cat <<EOF 1>&2
@@ -51,7 +52,7 @@ done
 
 cd "$HOME/Pictures" || exit 1
 
-sleep $delay
+sleep "$delay"
 
 if $window; then
   wid=$(xdotool selectwindow)

--- a/sessionlib
+++ b/sessionlib
@@ -1,3 +1,4 @@
+# shellcheck shell=bash  # sourced by the bash entry scripts; has no shebang of its own
 # sessionlib - shared helpers for the tmux/shpool session scripts
 #
 # Two sets of consumers source this, keeping the entry scripts thin wrappers:

--- a/sessionlib_test
+++ b/sessionlib_test
@@ -30,6 +30,7 @@ trap 'rm -rf "$BIN_NONE" "$BIN_TMUX" "$BIN_SHPOOL" "$BIN_BOTH"' EXIT
 # --- harness ---------------------------------------------------------------
 
 setup() {
+  # shellcheck disable=SC2034  # read by the sessionlib engine sourced below
   SESSION_SEP="/"
   # Defaults the stubs read; each test overrides what it needs.
   STUB_PREFIX="proj/"
@@ -39,6 +40,7 @@ setup() {
   # Pull in the engine under test (idempotent guard means a fresh shell per test
   # is unnecessary, but we re-source for clarity/isolation of the stubs above).
   unset _SESSIONLIB_SOURCED
+  # shellcheck source=/dev/null
   source "$SCRIPT_DIR/sessionlib"
 }
 
@@ -187,7 +189,7 @@ test_picker_query_matches_display_field() {
 run_resolve() {
   set +e
   rb_out="$(
-    TMUX="$1"; SHPOOL_SESSION_NAME="$2"; SESSION_BACKEND="$3"; PATH="$4"
+    export TMUX="$1" SHPOOL_SESSION_NAME="$2" SESSION_BACKEND="$3" PATH="$4"
     resolve_session_backend
   )"
   rb_rc=$?

--- a/setup
+++ b/setup
@@ -963,6 +963,7 @@ SERVICE
 install_rust() {
     # Ensure cargo/rustup are on PATH even if profile hasn't been sourced
     if test -f "$HOME/.cargo/env"; then
+        # shellcheck source=/dev/null
         . "$HOME/.cargo/env"
     fi
 
@@ -975,6 +976,7 @@ install_rust() {
         # rc/profile files, since PATH is managed by the conf repo. We source
         # ~/.cargo/env below so cargo is on PATH for the rest of this run.
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path
+        # shellcheck source=/dev/null
         . "$HOME/.cargo/env"
     fi
 }
@@ -1156,6 +1158,7 @@ install_home_tools() {
         info "  a bundle installs its full contents; --minimal/--no-npm don't trim it"
         if "$homepkg" install-bundle "$bundle"; then
             provisioned=yes
+            # shellcheck disable=SC2086  # $tools is a space-separated list expanded into multiple args
             "$homepkg" install $tools \
                 || warn "installed the bundle; couldn't reconcile the requested tools online (offline?)"
         else
@@ -1166,6 +1169,7 @@ install_home_tools() {
         test "$MINIMAL_ENABLED" -eq 0 \
             || info "Skipping heavyweight CLI extras (helix, jj, nushell); minimal profile"
         info "Installing CLI tools into a home prefix via homepkg: $tools"
+        # shellcheck disable=SC2086  # $tools is a space-separated list expanded into multiple args
         if "$homepkg" install $tools; then
             provisioned=yes
         else
@@ -1309,10 +1313,10 @@ generate_ssh_key() {
     # can't read user input.  Open /dev/tty to read from the terminal.
     if test -t 0; then
         printf "Press Enter after adding the key to GitHub and Codeberg..."
-        read _
+        read -r _
     elif test -e /dev/tty; then
         printf "Press Enter after adding the key to GitHub and Codeberg..."
-        read _ < /dev/tty
+        read -r _ < /dev/tty
     else
         warn "Cannot prompt for input; add the key to GitHub and Codeberg manually before cloning SSH repos"
     fi
@@ -1342,10 +1346,10 @@ offer_ssh_remotes() {
     reply=n
     if test -t 0; then
         printf "%s" "$prompt"
-        read reply
+        read -r reply
     elif test -e /dev/tty; then
         printf "%s" "$prompt"
-        read reply < /dev/tty
+        read -r reply < /dev/tty
     else
         info "Non-interactive; leaving repo remotes as-is (run gittossh later to switch)"
         return 0
@@ -1507,15 +1511,19 @@ start_services
 if test "$GUI_ENABLED" -eq 1; then
     if test "$OS" = "macos"; then
         info "Configuring macOS desktop environment"
+        # shellcheck disable=SC2086  # $DESKTOP_SETUP_FLAGS expands to zero or more flags
         "$SCRIPTS_DIR/setup-macos" $DESKTOP_SETUP_FLAGS
     elif test "$DESKTOP" = hypr; then
         info "Configuring Hyprland desktop environment"
+        # shellcheck disable=SC2086  # $DESKTOP_SETUP_FLAGS expands to zero or more flags
         "$SCRIPTS_DIR/setup-hypr" $DESKTOP_SETUP_FLAGS
     elif test "$DESKTOP" = sway; then
         info "Configuring Sway desktop environment"
+        # shellcheck disable=SC2086  # $DESKTOP_SETUP_FLAGS expands to zero or more flags
         "$SCRIPTS_DIR/setup-sway" $DESKTOP_SETUP_FLAGS
     else
         info "Configuring KDE desktop environment"
+        # shellcheck disable=SC2086  # $DESKTOP_SETUP_FLAGS expands to zero or more flags
         "$SCRIPTS_DIR/setup-kde" $DESKTOP_SETUP_FLAGS
     fi
 else
@@ -1535,6 +1543,7 @@ if test "$INSTALL" = yes; then
     # instead. Source ~/.cargo/env first so a previously installed toolchain
     # still counts as available even on a run that skipped install_rust.
     if test -f "$HOME/.cargo/env"; then
+        # shellcheck source=/dev/null
         . "$HOME/.cargo/env"
     fi
     if command -v cargo >/dev/null 2>&1; then

--- a/setup-kde
+++ b/setup-kde
@@ -600,6 +600,7 @@ reload_kglobalaccel
 
 if is_command setup-kde.local; then
     info "Sourcing setup-kde.local"
+    # shellcheck source=/dev/null
     source setup-kde.local
 fi
 

--- a/setup-macos
+++ b/setup-macos
@@ -222,7 +222,7 @@ configure_amethyst() {
     # Amethyst config lives in ~/conf/amethyst.yml and is symlinked
     # to ~/.amethyst.yml by confinst. Nothing to do here.
     if ! test -f "$HOME/.amethyst.yml"; then
-        warn "~/.amethyst.yml not found; run confinst after cloning the conf repo"
+        warn "$HOME/.amethyst.yml not found; run confinst after cloning the conf repo"
     fi
 
     # Enable focus follows mouse

--- a/setup-sway
+++ b/setup-sway
@@ -281,5 +281,5 @@ fi
 
 info "Sway desktop configured."
 info "Per-host values (output names, idle tweaks) live in"
-info "~/.config/sway/config.local -- see conf/config/sway/README.md."
+info "$HOME/.config/sway/config.local -- see conf/config/sway/README.md."
 info "Log in and pick the Sway session (or run 'sway' from a TTY)."

--- a/setup_test
+++ b/setup_test
@@ -1,4 +1,7 @@
 #!/bin/sh
+# The `$...` inside the assert_source_contains checks below are deliberate
+# literals matched against the setup script's source, not expansions.
+# shellcheck disable=SC2016
 # Tests for setup.
 #
 # The full bootstrap can't run in CI (it installs packages and edits system

--- a/shpoollist
+++ b/shpoollist
@@ -7,9 +7,11 @@
 # directory, a one-line process-tree summary, and any vcs unmerged items.
 
 # Reuse the shell-enumeration and formatting helpers from autoshpool.
+# shellcheck source=/dev/null
 source "$(dirname "$0")/autoshpool"
 
 # Load the user's vcs helper (best-effort) for the vcs root/unmerged fields.
+# shellcheck source=/dev/null
 test -r "$HOME/.shrc.vcs" && source "$HOME/.shrc.vcs"
 
 listing="$(shpool list 2>/dev/null)"

--- a/snap
+++ b/snap
@@ -8,10 +8,12 @@ xorigin=0
 yorigin=0
 width=640
 height=480
-while read desktop current dg resolution vp vporigin wa waorigin waresolution name; do
+# The field names document the `wmctrl -d` output columns; only a few are used.
+# shellcheck disable=SC2034
+while read -r desktop current dg resolution vp vporigin wa waorigin waresolution name; do
   if test "$current" = "*"; then
-    IFS='x' read width height <<<"$waresolution"
-    IFS=',' read xorigin yorigin <<<"$waorigin"
+    IFS='x' read -r width height <<<"$waresolution"
+    IFS=',' read -r xorigin yorigin <<<"$waorigin"
     break
   fi
 done <<<"$(wmctrl -d)"
@@ -33,5 +35,5 @@ right)
 esac
 wmctrl -r :ACTIVE: -b remove,maximized_horz
 wmctrl -r :ACTIVE: -b add,maximized_vert
-wmctrl -r :ACTIVE: -e $coords
+wmctrl -r :ACTIVE: -e "$coords"
 

--- a/terminal
+++ b/terminal
@@ -24,7 +24,7 @@ exec_positional() {
   exec "$program" -- "$@"
 }
 
-cd
+cd || exit
 exists kitty && exec_positional kitty "$@"
 exists xfce4-terminal && exec_dash_e xfce4-terminal "$@"
 exists mate-terminal && exec_dash_e mate-terminal "$@"

--- a/terminal_on
+++ b/terminal_on
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck source=/dev/null
 . "$HOME"/.shrc
 set -eu
 destination="${1:-}"
@@ -14,5 +15,6 @@ fi
 if command -v rw >/dev/null 2>&1; then
   terminal rw -r "$destination"
 else
+  # shellcheck disable=SC2016  # $1 is expanded by the inner bash -c, not this shell
   terminal bash -i -c 'need_auth && auth; ssh -n "$1" true; ssh "$1"' bash "$destination"
 fi

--- a/terminal_on_workstation
+++ b/terminal_on_workstation
@@ -1,6 +1,8 @@
 #!/bin/bash
+# shellcheck source=/dev/null
 . "$HOME"/.shrc
-export WORKSTATION="$(workstation)"
+WORKSTATION="$(workstation)"
+export WORKSTATION
 if test -z "$WORKSTATION" || test "$HOSTNAME" = "$WORKSTATION"; then
   terminal
 else

--- a/tmuxlist
+++ b/tmuxlist
@@ -7,9 +7,11 @@
 # items.
 
 # Reuse the enumeration and formatting helpers from autotmux.
+# shellcheck source=/dev/null
 source "$(dirname "$0")/autotmux"
 
 # Load the user's vcs helper (best-effort) for the vcs root/unmerged fields.
+# shellcheck source=/dev/null
 test -r "$HOME/.shrc.vcs" && source "$HOME/.shrc.vcs"
 
 first_pane_path() {

--- a/total
+++ b/total
@@ -1,4 +1,4 @@
 #!/bin/sh
 # print the total of a given column of input, default column 1
-awk -v field=${1:-1} '{ total += $field }
+awk -v field="${1:-1}" '{ total += $field }
 END { print total + 0 }'

--- a/view
+++ b/view
@@ -12,4 +12,9 @@ case $editor in
     ;;
 esac
 
-"$editor" $readonlyflag "$@"
+if test -n "$readonlyflag"
+then
+    "$editor" "$readonlyflag" "$@"
+else
+    "$editor" "$@"
+fi

--- a/youtube-music
+++ b/youtube-music
@@ -1,3 +1,4 @@
 #!/bin/bash
+# shellcheck source=/dev/null
 . "$HOME/.shrc"
 exec chrome --app="https://music.youtube.com" ${CHROME_MUSIC_USER_DATA_DIR:+--user-data-dir="$CHROME_MUSIC_USER_DATA_DIR"}


### PR DESCRIPTION
## Summary

Resolves every ShellCheck (0.9.0) finding across the repo's shell scripts — the full sweep went from **234 findings in ~65 files to 0**, with no change to runtime behavior. All existing test suites (19 suites, 466 assertions) continue to pass.

The only file still reporting anything is `shpoolps`, which is a **zsh** script that ShellCheck fundamentally cannot parse (SC1071). It is untouched.

## Genuine code fixes

- **Quoting** — quote expansions to prevent word splitting/globbing (SC2086), and quote patterns inside `${var#…}`/`${var%…}` (SC2295).
- **Reads & cd** — add `read -r` (SC2162) and `cd … || exit` (SC2164).
- **printf & tr** — replace variable `printf` format strings with `'%s'` + args (SC2059); use `[:lower:]`/`[:upper:]` instead of `a-z`/`A-Z` (SC2018/SC2019).
- **Misc** — `$HOME` instead of unexpanded `~` in quoted real paths (SC2088), drop redundant `$` in arithmetic (SC2004), split declare+assign (SC2155), rewrite `expr` as `$((…))` (SC2003).
- **gitbackup** — convert the rsync `$flags` string to an array, fix the broken `date`-string quoting (SC2046/SC2027), remove the dead `$dfout` cleanup branch (`$dfout` is never assigned) and the unused `OIFS`.
- **confdist** — turn `$ssh_mux_opts` into an array, initialise `$simulate` (the `run()` helper read an unset var), and use `"$*"` for the host list (SC2124).
- **cwhere** — drop the unused / array-to-string `headers` locals and index arrays with `[i]` (SC2004).

## Intentional patterns — documented with targeted directives, not code changes

- `# shellcheck source=/dev/null` for sourced runtime/user files like `~/.shrc`, `sessionlib`, `~/.cargo/env` (SC1091/SC1090).
- `# shellcheck shell=bash` for the shebang-less `sessionlib`, and `# shellcheck shell=dash` for `confinst` (relies on `local`) (SC2148/SC3043).
- `# shellcheck disable=SC2034` for variables consumed by a sourced library (`simulate`/`logfile` in gitbackup, `SESSION_SEP`/`SESSION_SELF`) or via indirect `${!var}` expansion (java-alternatives.sh `names`).
- `# shellcheck disable=SC2016` for the deliberate literal `$…` assertion strings in `setup_test`/`autotmux_test`.
- `# shellcheck disable=SC2086` where a string deliberately expands into multiple arguments (`$tools`, `$DESKTOP_SETUP_FLAGS`, java-alternatives' `$install`/`$slaves`) — these are also asserted verbatim by the test suite, so they could not be converted to arrays.

## Verification

- `shellcheck` reports zero findings across all shell scripts (except zsh `shpoolps`).
- `make test` — all 19 suites pass, 0 failures.
- `bash -n` clean on every changed file.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pn49mZpX9Sz6a5nyjjigQB)_