### PR TITLE
setup: install zoxide, atuin and carapace

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,14 @@ repo).
 `setup --no-root` wires this in automatically: it runs unprivileged (implying
 `--no-sudo`, so the `apt`/`dnf` installs and every other privileged step are
 skipped) and installs the CLI tools via `homepkg` instead — the core set
-(`ripgrep fd bat fzf jq delta gh`) plus the extras (`helix jj nu`, unless the
-minimal profile is in effect). `--no-sudo` on its own is just the mechanism
+(`ripgrep fd bat fzf jq delta gh zoxide`) plus the extras (`helix jj nu`, unless
+the minimal profile is in effect). `--no-sudo` on its own is just the mechanism
 (skip sudo); it assumes the tools are provided some other way.
+
+`atuin` and `carapace` — the history search and completion engines the conf
+repo's shell config wires up — are in no distro repo and have no conda-forge
+package, so every `setup` run installs them from their GitHub releases with
+`homepkg --backend github`, regardless of profile or privilege.
 
 The default backend is `mamba`: a rootless [micromamba](https://mamba.readthedocs.io/)
 manages one conda environment, so you get a real solver (full dependency

--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@ repo's shell config wires up — are in no distro repo and have no conda-forge
 package, so every `setup` run installs them from their GitHub releases with
 `homepkg --backend github`, regardless of profile or privilege.
 
+On a host with no internet, stage a bundle for them instead. They can't ride
+in the mamba bundle (no conda-forge package), so build the github variant on
+an online machine and drop it beside the scripts repo (or in `$HOME`, or point
+`$HOMEPKG_SHELL_BUNDLE` at it):
+
+```sh
+homepkg --backend github bundle -o homepkg-shell-tools.tgz atuin carapace
+```
+
+`setup` prefers that bundle over the download, so an offline run never waits
+for a fetch that can't succeed.
+
 The default backend is `mamba`: a rootless [micromamba](https://mamba.readthedocs.io/)
 manages one conda environment, so you get a real solver (full dependency
 closure), native updates, and clean removal. micromamba is bootstrapped

--- a/homepkg
+++ b/homepkg
@@ -554,8 +554,11 @@ def _mamba_subcommand(prefix):
 
 
 def install_mamba(tools, prefix, plat, dry_run):
-    mm = ensure_micromamba(prefix, plat, dry_run)
+    # Resolve the package names first: a github-only tool must fail with the
+    # "--backend github" hint rather than after a micromamba bootstrap, which
+    # needs the network -- exactly what an offline host doesn't have.
     pkgs = conda_pkgs(tools)
+    mm = ensure_micromamba(prefix, plat, dry_run)
     env = mamba_env(prefix)
     subcmd = _mamba_subcommand(prefix)
     info(f"micromamba {subcmd}: {', '.join(pkgs)} -> {env}")
@@ -568,10 +571,11 @@ def install_mamba(tools, prefix, plat, dry_run):
 
 
 def update_mamba(tools, prefix, plat, dry_run):
-    mm = ensure_micromamba(prefix, plat, dry_run)
     # No tools named -> update the whole env. Binaries keep the same env path,
-    # so the existing symlinks stay valid; no re-link needed.
+    # so the existing symlinks stay valid; no re-link needed. Resolved before
+    # the bootstrap for the same reason as install_mamba.
     spec = conda_pkgs(tools) if tools else ["--all"]
+    mm = ensure_micromamba(prefix, plat, dry_run)
     info(f"micromamba update: {' '.join(spec)}")
     _run_mamba(mm, prefix, ["update", "-y", "-p", mamba_env(prefix),
                             *MAMBA_CHANNEL_ARGS, *spec], dry_run)

--- a/homepkg
+++ b/homepkg
@@ -651,10 +651,12 @@ def _fetch_micromamba_bin(plat, dest):
     return os.path.join(dest, "bin", "micromamba")
 
 
-def bundle_mamba(tools, prefix, plat, out, dry_run):
-    # `bundle` with no tools means the whole registry, which includes the
-    # github-only ones -- skip those rather than refusing to build a bundle.
-    pkgs = conda_pkgs(tools, skip_missing=True)
+def bundle_mamba(tools, prefix, plat, out, dry_run, skip_conda_less=False):
+    # Only the whole-registry form (`bundle` with no names) skips the
+    # github-only tools. Naming one explicitly has to fail: the manifest
+    # lists what was asked for, so a silent omission would install clean
+    # and leave the tool missing.
+    pkgs = conda_pkgs(tools, skip_missing=skip_conda_less)
     # Report before touching the network so --dry-run needs no micromamba.
     if dry_run:
         info(f"would solve closure for {', '.join(pkgs)} ({conda_subdir(*plat)}), "
@@ -872,6 +874,7 @@ def main(argv=None):
             p.error("bundle requires -o/--output FILE")
         if args.backend == "conda":
             p.error("bundle supports --backend mamba (default) or github, not conda")
+        whole_registry = not args.tools
         if args.tools:
             tools = args.tools
         elif args.backend == "github":
@@ -888,8 +891,11 @@ def main(argv=None):
         _require_known(p, tools)
         plat = _resolve_plat(p, args.arch)
         try:
-            builder = bundle_github if args.backend == "github" else bundle_mamba
-            builder(tools, args.prefix, plat, args.output, args.dry_run)
+            if args.backend == "github":
+                bundle_github(tools, args.prefix, plat, args.output, args.dry_run)
+            else:
+                bundle_mamba(tools, args.prefix, plat, args.output, args.dry_run,
+                             skip_conda_less=whole_registry)
         except Exception as e:
             warn(str(e))
             return 1

--- a/homepkg
+++ b/homepkg
@@ -63,6 +63,12 @@ TOOLS = {
     "jj":      {"conda": "jujutsu",    "github": "jj-vcs/jj",          "bins": ["jj"]},
     "nu":      {"conda": "nushell",    "github": "nushell/nushell",    "bins": ["nu"]},
     "uv":      {"conda": "uv",         "github": "astral-sh/uv",       "bins": ["uv", "uvx"]},
+    # Interactive shell tools (see the conf repo's shrc/fish/nushell config).
+    # atuin and carapace have no conda-forge feedstock, so conda is None and
+    # they install from their GitHub releases; see conda_pkgs.
+    "zoxide":   {"conda": "zoxide",   "github": "ajeetdsouza/zoxide", "bins": ["zoxide"]},
+    "atuin":    {"conda": None,       "github": "atuinsh/atuin",      "bins": ["atuin"]},
+    "carapace": {"conda": None,       "github": "carapace-sh/carapace-bin", "bins": ["carapace"]},
     # Node toolchain for the setup --no-root path: node/npm/tsc from conda-forge
     # instead of a distro package, plus fnm (which on root boxes comes from its
     # own curl installer -- no conda there yet). npm/npx ride along in the nodejs
@@ -85,6 +91,25 @@ def warn(msg):
 
 class HomepkgError(Exception):
     pass
+
+
+def conda_pkgs(tools, skip_missing=False):
+    """conda-forge package names for `tools`.
+
+    A few tools ship only as GitHub release assets and have no conda-forge
+    feedstock; they carry conda=None. Naming one explicitly on a conda path is
+    an error -- dropping it silently would report a successful install of
+    something that never landed -- while operations over the whole registry
+    (bundle --all) skip it with a warning and carry on.
+    """
+    missing = [t for t in tools if not TOOLS[t].get("conda")]
+    if missing and not skip_missing:
+        raise HomepkgError(
+            f"no conda-forge package for: {', '.join(missing)}; "
+            f"install with --backend github")
+    if missing:
+        warn(f"no conda-forge package, skipping: {', '.join(missing)}")
+    return [TOOLS[t]["conda"] for t in tools if TOOLS[t].get("conda")]
 
 
 # --- Platform ----------------------------------------------------------------
@@ -530,7 +555,7 @@ def _mamba_subcommand(prefix):
 
 def install_mamba(tools, prefix, plat, dry_run):
     mm = ensure_micromamba(prefix, plat, dry_run)
-    pkgs = [TOOLS[t]["conda"] for t in tools]
+    pkgs = conda_pkgs(tools)
     env = mamba_env(prefix)
     subcmd = _mamba_subcommand(prefix)
     info(f"micromamba {subcmd}: {', '.join(pkgs)} -> {env}")
@@ -546,7 +571,7 @@ def update_mamba(tools, prefix, plat, dry_run):
     mm = ensure_micromamba(prefix, plat, dry_run)
     # No tools named -> update the whole env. Binaries keep the same env path,
     # so the existing symlinks stay valid; no re-link needed.
-    spec = [TOOLS[t]["conda"] for t in tools] if tools else ["--all"]
+    spec = conda_pkgs(tools) if tools else ["--all"]
     info(f"micromamba update: {' '.join(spec)}")
     _run_mamba(mm, prefix, ["update", "-y", "-p", mamba_env(prefix),
                             *MAMBA_CHANNEL_ARGS, *spec], dry_run)
@@ -556,7 +581,7 @@ def remove_mamba(tools, prefix, plat, dry_run):
     mm = micromamba_path(prefix)
     if mm is None:
         raise HomepkgError("micromamba is not installed; nothing to remove")
-    pkgs = [TOOLS[t]["conda"] for t in tools]
+    pkgs = conda_pkgs(tools)
     info(f"micromamba remove: {', '.join(pkgs)}")
     _run_mamba(mm, prefix, ["remove", "-y", "-p", mamba_env(prefix), *pkgs], dry_run)
     if not dry_run:
@@ -623,7 +648,9 @@ def _fetch_micromamba_bin(plat, dest):
 
 
 def bundle_mamba(tools, prefix, plat, out, dry_run):
-    pkgs = [TOOLS[t]["conda"] for t in tools]
+    # `bundle` with no tools means the whole registry, which includes the
+    # github-only ones -- skip those rather than refusing to build a bundle.
+    pkgs = conda_pkgs(tools, skip_missing=True)
     # Report before touching the network so --dry-run needs no micromamba.
     if dry_run:
         info(f"would solve closure for {', '.join(pkgs)} ({conda_subdir(*plat)}), "
@@ -809,7 +836,10 @@ def main(argv=None):
     if args.command == "list":
         for name in sorted(TOOLS):
             m = TOOLS[name]
-            print(f"{name:10} conda={m['conda']:12} github={m['github']}")
+            # conda is None for tools with no conda-forge feedstock; show a
+            # dash so `list` says which ones need --backend github.
+            conda = m["conda"] or "-"
+            print(f"{name:10} conda={conda:12} github={m['github']}")
         return 0
 
     if args.command == "bootstrap":

--- a/homepkg
+++ b/homepkg
@@ -933,6 +933,17 @@ def main(argv=None):
             return 1
         return 0
 
+    # The stateless conda backend resolves package names itself, so check
+    # them here: without this a github-only tool would send it looking for a
+    # package named None, and offline the index fetch fails before the
+    # "--backend github" hint is ever printed.
+    if args.backend == "conda":
+        try:
+            conda_pkgs(args.tools)
+        except HomepkgError as e:
+            warn(str(e))
+            return 1
+
     install = EXTRACT_BACKENDS[args.backend]
     failed = []
     for tool in args.tools:

--- a/homepkg_test
+++ b/homepkg_test
@@ -225,6 +225,12 @@ check("install of a github-only tool on the mamba backend errors",
       _run("install", "carapace").returncode != 0)
 check("install of a github-only tool names the github backend in the error",
       "--backend github" in _run("install", "carapace").stderr)
+# The stateless conda backend has to reject it too, before any index fetch --
+# offline, that fetch would fail first and bury the hint.
+_conda_named = _run("--backend", "conda", "install", "carapace")
+check("conda backend rejects a github-only tool", _conda_named.returncode != 0)
+check("conda backend names the github backend in the error",
+      "--backend github" in _conda_named.stderr)
 
 check("unknown tool errors", _run("install", "bogustool").returncode != 0)
 check("install with no tools errors", _run("install").returncode != 0)

--- a/homepkg_test
+++ b/homepkg_test
@@ -193,6 +193,39 @@ check("registry maps fnm to conda-forge fnm",
 check("registry maps uv with uv/uvx bins",
       hp.TOOLS["uv"]["conda"] == "uv" and hp.TOOLS["uv"]["bins"] == ["uv", "uvx"])
 
+# The interactive shell tools the conf repo wires up. zoxide has a conda-forge
+# feedstock; atuin and carapace don't, so they carry conda=None and install
+# from their GitHub releases.
+check("registry maps zoxide to conda-forge zoxide",
+      hp.TOOLS["zoxide"]["conda"] == "zoxide"
+      and hp.TOOLS["zoxide"]["bins"] == ["zoxide"])
+check("registry maps atuin to its github releases only",
+      hp.TOOLS["atuin"]["conda"] is None
+      and hp.TOOLS["atuin"]["github"] == "atuinsh/atuin")
+check("registry maps carapace to carapace-bin releases",
+      hp.TOOLS["carapace"]["conda"] is None
+      and hp.TOOLS["carapace"]["github"] == "carapace-sh/carapace-bin"
+      and hp.TOOLS["carapace"]["bins"] == ["carapace"])
+
+# conda_pkgs is the gate between the registry and every conda/mamba path.
+check("conda_pkgs maps tools to their conda-forge names",
+      hp.conda_pkgs(["ripgrep", "delta"]) == ["ripgrep", "git-delta"])
+try:
+    hp.conda_pkgs(["ripgrep", "carapace"])
+    _conda_pkgs_raised = False
+except hp.HomepkgError as e:
+    _conda_pkgs_raised = "carapace" in str(e) and "--backend github" in str(e)
+check("conda_pkgs errors when a named tool has no conda package",
+      _conda_pkgs_raised)
+check("conda_pkgs skips conda-less tools for whole-registry operations",
+      hp.conda_pkgs(["ripgrep", "carapace"], skip_missing=True) == ["ripgrep"])
+
+# A conda-less tool named explicitly must fail rather than look installed.
+check("install of a github-only tool on the mamba backend errors",
+      _run("install", "carapace").returncode != 0)
+check("install of a github-only tool names the github backend in the error",
+      "--backend github" in _run("install", "carapace").stderr)
+
 check("unknown tool errors", _run("install", "bogustool").returncode != 0)
 check("install with no tools errors", _run("install").returncode != 0)
 check("bad --arch errors", _run("--arch", "weird", "install", "jq").returncode != 0)
@@ -208,7 +241,13 @@ _bundle_all = _run("bundle", "-o",
                    "--dry-run")
 check("bundle with no tools targets every registered package",
       _bundle_all.returncode == 0
-      and all(hp.TOOLS[t]["conda"] in _bundle_all.stderr for t in hp.TOOLS))
+      and all(hp.TOOLS[t]["conda"] in _bundle_all.stderr
+              for t in hp.TOOLS if hp.TOOLS[t]["conda"]))
+# The github-only tools can't be in a mamba bundle; they're named as skipped
+# rather than aborting the whole bundle.
+check("bundle with no tools reports the tools it can't include",
+      all(t in _bundle_all.stderr
+          for t in hp.TOOLS if not hp.TOOLS[t]["conda"]))
 # ...but no-args "all" is mamba-only: not every tool has a github release asset
 # (typescript is npm-only), so the github backend must require explicit names.
 check("bundle --backend github rejects no-args all-tools",

--- a/homepkg_test
+++ b/homepkg_test
@@ -248,6 +248,14 @@ check("bundle with no tools targets every registered package",
 check("bundle with no tools reports the tools it can't include",
       all(t in _bundle_all.stderr
           for t in hp.TOOLS if not hp.TOOLS[t]["conda"]))
+# ...but naming one explicitly must fail: the manifest lists what was asked
+# for, so a silent omission would install clean and leave the tool missing.
+_bundle_named = _run("bundle", "-o",
+                     os.path.join(tempfile.gettempdir(), "hp-bundle-named.tgz"),
+                     "--dry-run", "jq", "carapace")
+check("bundle rejects an explicitly named conda-less tool",
+      _bundle_named.returncode != 0
+      and "--backend github" in _bundle_named.stderr)
 # ...but no-args "all" is mamba-only: not every tool has a github release asset
 # (typescript is npm-only), so the github backend must require explicit names.
 check("bundle --backend github rejects no-args all-tools",

--- a/setup
+++ b/setup
@@ -1292,6 +1292,14 @@ install_home_tools() {
 # and macOS alike. Each shell config skips whichever tool is missing, so a
 # failure here degrades to "no history search / no extra completions" rather
 # than breaking the shell.
+#
+# Offline hosts install from a push bundle instead, the same way
+# install_home_tools does. The mamba bundle can't carry these two (no
+# conda-forge package), so they need the github variant, built on an online
+# host with:
+#     homepkg --backend github bundle -o homepkg-shell-tools.tgz atuin carapace
+# Staged at $HOMEPKG_SHELL_BUNDLE, or beside the scripts repo / in $HOME as
+# homepkg-shell-tools.tgz.
 install_shell_tools() {
     homepkg="$SCRIPTS_DIR/homepkg"
     if ! test -x "$homepkg"; then
@@ -1309,10 +1317,30 @@ install_shell_tools() {
     if test -z "$shell_tools"; then
         return 0
     fi
+
+    shell_bundle=""
+    for cand in "${HOMEPKG_SHELL_BUNDLE:-}" \
+            "$SCRIPTS_DIR/homepkg-shell-tools.tgz" \
+            "$HOME/homepkg-shell-tools.tgz"; do
+        if test -n "$cand" && test -f "$cand"; then
+            shell_bundle="$cand"
+            break
+        fi
+    done
+    if test -n "$shell_bundle"; then
+        # A bundle installs its full contents, so it can't be trimmed to the
+        # missing tools; re-installing one that's already present is harmless.
+        info "Installing$shell_tools from $shell_bundle"
+        if "$homepkg" install-bundle "$shell_bundle"; then
+            return 0
+        fi
+        warn "could not install from the bundle; falling back to the release download"
+    fi
+
     info "Installing$shell_tools via homepkg"
     # shellcheck disable=SC2086  # deliberate word split: one flag per tool
     "$homepkg" --backend github install $shell_tools \
-        || warn "could not install$shell_tools; the shell config skips whichever is missing"
+        || warn "could not install$shell_tools (offline? stage a bundle with 'homepkg --backend github bundle -o homepkg-shell-tools.tgz atuin carapace'); the shell config skips whichever is missing"
 }
 
 # --- Install uv (Python package manager) ---

--- a/setup
+++ b/setup
@@ -660,11 +660,18 @@ install_packages() {
                     shellcheck \
                     unzip \
                     vim \
-                    zoxide \
                     zsh; then
                 warn "skipping remaining Debian package installs"
                 return 0
             fi
+            # zoxide is missing from older releases (Ubuntu 20.04 has no
+            # package), and apt rejects the whole transaction on one unknown
+            # name -- which would take git/make down with it. Its own
+            # best-effort step keeps that contained; the shell config skips
+            # zoxide when it isn't installed.
+            info "Installing zoxide"
+            sudo_or_warn apt-get install -y --install-recommends zoxide \
+                || warn "could not install zoxide; z/zi directory jumps will be unavailable"
             # Node.js + tsc from the distro on the privileged path (setup-kde
             # needs tsc to build Krohnkite). Under --no-root apt is skipped
             # above, and these come from conda-forge via homepkg instead
@@ -780,11 +787,15 @@ install_packages() {
                     ShellCheck \
                     unzip \
                     vim \
-                    zoxide \
                     zsh; then
                 warn "skipping remaining Fedora package installs"
                 return 0
             fi
+            # Its own transaction, for the same reason as the Debian branch:
+            # dnf aborts the lot when one name is unknown.
+            info "Installing zoxide"
+            sudo_or_warn dnf install -y zoxide \
+                || warn "could not install zoxide; z/zi directory jumps will be unavailable"
             # Node.js + tsc from the distro on the privileged path (setup-kde
             # needs tsc to build Krohnkite). Under --no-root dnf is skipped
             # above, and these come from conda-forge via homepkg instead
@@ -909,8 +920,12 @@ install_packages() {
                 shellcheck \
                 unzip \
                 vim \
-                zoxide \
                 zsh
+            # Separate, so a formula rename or a tap outage can't take the
+            # core package list down with it.
+            info "Installing zoxide"
+            brew install zoxide \
+                || warn "could not install zoxide; z/zi directory jumps will be unavailable"
             # Node.js + tsc from Homebrew on the privileged path (setup-kde
             # needs tsc to build Krohnkite). brew needs no sudo, so unlike the
             # apt/dnf branches this can't self-skip under --no-root -- gate it on

--- a/setup
+++ b/setup
@@ -1315,21 +1315,29 @@ install_home_tools() {
 #     homepkg --backend github bundle -o homepkg-shell-tools.tgz atuin carapace
 # Staged at $HOMEPKG_SHELL_BUNDLE, or beside the scripts repo / in $HOME as
 # homepkg-shell-tools.tgz.
+# The shell tools that aren't installed yet, space-prefixed for the messages
+# below. homepkg installs into ~/.local/bin, which isn't necessarily on
+# setup's own PATH, so check there too rather than trusting command -v alone.
+missing_shell_tools() {
+    missing=""
+    for tool in atuin carapace; do
+        if ! command -v "$tool" >/dev/null 2>&1 \
+                && ! test -x "$HOME/.local/bin/$tool"; then
+            missing="$missing $tool"
+        fi
+    done
+    printf '%s' "$missing"
+}
+
 install_shell_tools() {
     homepkg="$SCRIPTS_DIR/homepkg"
     if ! test -x "$homepkg"; then
         warn "homepkg not found at $homepkg; skipping atuin and carapace"
         return 0
     fi
-    shell_tools=""
-    for tool in atuin carapace; do
-        if command -v "$tool" >/dev/null 2>&1; then
-            info "$tool already installed"
-        else
-            shell_tools="$shell_tools $tool"
-        fi
-    done
+    shell_tools="$(missing_shell_tools)"
     if test -z "$shell_tools"; then
+        info "atuin and carapace already installed"
         return 0
     fi
 
@@ -1347,9 +1355,17 @@ install_shell_tools() {
         # missing tools; re-installing one that's already present is harmless.
         info "Installing$shell_tools from $shell_bundle"
         if "$homepkg" install-bundle "$shell_bundle"; then
-            return 0
+            # It only installs what its manifest carries, so a partial or
+            # stale bundle can still leave tools missing. Recheck, and let
+            # whatever it didn't provide fall through to the download.
+            shell_tools="$(missing_shell_tools)"
+            if test -z "$shell_tools"; then
+                return 0
+            fi
+            info "the bundle did not provide$shell_tools"
+        else
+            warn "could not install from the bundle; falling back to the release download"
         fi
-        warn "could not install from the bundle; falling back to the release download"
     fi
 
     info "Installing$shell_tools via homepkg"

--- a/setup
+++ b/setup
@@ -660,6 +660,7 @@ install_packages() {
                     shellcheck \
                     unzip \
                     vim \
+                    zoxide \
                     zsh; then
                 warn "skipping remaining Debian package installs"
                 return 0
@@ -779,6 +780,7 @@ install_packages() {
                     ShellCheck \
                     unzip \
                     vim \
+                    zoxide \
                     zsh; then
                 warn "skipping remaining Fedora package installs"
                 return 0
@@ -907,6 +909,7 @@ install_packages() {
                 shellcheck \
                 unzip \
                 vim \
+                zoxide \
                 zsh
             # Node.js + tsc from Homebrew on the privileged path (setup-kde
             # needs tsc to build Krohnkite). brew needs no sudo, so unlike the
@@ -939,7 +942,7 @@ install_packages() {
             ;;
         *)
             warn "Unsupported OS, skipping package installation"
-            warn "Please install manually: bat curl fd fzf git git-delta golang jq kitty make mercurial npm p7zip python3 ripgrep shellcheck typescript unzip zsh"
+            warn "Please install manually: bat curl fd fzf git git-delta golang jq kitty make mercurial npm p7zip python3 ripgrep shellcheck typescript unzip zoxide zsh"
             ;;
     esac
 }
@@ -1188,7 +1191,7 @@ install_home_tools() {
     # fnm (Node version manager) is a convenience tool -- installed regardless
     # of --no-npm, mirroring the root path's install_fnm (which is skipped under
     # --no-root, so fnm comes from here instead).
-    tools="ripgrep fd bat fzf jq delta gh fnm"
+    tools="ripgrep fd bat fzf jq delta gh fnm zoxide"
     if test "$NPM" = yes; then
         # node/npm + tsc are the actual build toolchain (setup-kde needs tsc to
         # build Krohnkite), gated on --no-npm. The --no-root counterpart to the
@@ -1277,6 +1280,39 @@ install_home_tools() {
         info "Removing stale Helix runtime symlink from the cargo build"
         rm -f "$helix_runtime"
     fi
+}
+
+# --- Install the interactive shell tools with no packaged build ---
+
+# The conf repo's shell config wires up four optional tools. fzf and zoxide
+# are packaged (the distro sets above, or conda-forge via homepkg), but atuin
+# and carapace are in neither the distro repos nor conda-forge, so they come
+# from their GitHub releases through homepkg's stateless github backend. That
+# needs no root, so the same call serves every path -- privileged, --no-root
+# and macOS alike. Each shell config skips whichever tool is missing, so a
+# failure here degrades to "no history search / no extra completions" rather
+# than breaking the shell.
+install_shell_tools() {
+    homepkg="$SCRIPTS_DIR/homepkg"
+    if ! test -x "$homepkg"; then
+        warn "homepkg not found at $homepkg; skipping atuin and carapace"
+        return 0
+    fi
+    shell_tools=""
+    for tool in atuin carapace; do
+        if command -v "$tool" >/dev/null 2>&1; then
+            info "$tool already installed"
+        else
+            shell_tools="$shell_tools $tool"
+        fi
+    done
+    if test -z "$shell_tools"; then
+        return 0
+    fi
+    info "Installing$shell_tools via homepkg"
+    # shellcheck disable=SC2086  # deliberate word split: one flag per tool
+    "$homepkg" --backend github install $shell_tools \
+        || warn "could not install$shell_tools; the shell config skips whichever is missing"
 }
 
 # --- Install uv (Python package manager) ---
@@ -1580,6 +1616,13 @@ elif test "$MINIMAL_ENABLED" -eq 0; then
     install_extras
 else
     info "Skipping heavyweight extras (helix, jj, shpool, nushell); minimal profile"
+fi
+
+# atuin/carapace are small static binaries with no packaged build, so they're
+# installed on every profile (including --minimal) once the scripts repo --
+# and with it homepkg -- is on disk.
+if test "$INSTALL" = yes; then
+    install_shell_tools
 fi
 
 start_services

--- a/setup_test
+++ b/setup_test
@@ -432,6 +432,22 @@ test_shell_tools_install_from_github_releases() {
     assert_source_contains "already installed"
 }
 
+# Offline hosts install from a push bundle instead of the release download,
+# the same way install_home_tools does. These two can't ride in the mamba
+# bundle (no conda-forge package), so it's the github bundle variant, and the
+# online fallback names the command that builds one.
+test_shell_tools_install_from_a_bundle_offline() {
+    assert_source_contains 'HOMEPKG_SHELL_BUNDLE' &&
+    assert_source_contains 'homepkg-shell-tools.tgz' &&
+    assert_source_contains '"$homepkg" install-bundle "$shell_bundle"' &&
+    assert_source_contains "falling back to the release download" &&
+    assert_source_contains "backend github bundle -o homepkg-shell-tools.tgz atuin carapace" &&
+    # The bundle is tried first: a machine with no network must not have to
+    # wait for the download to fail.
+    test "$(grep -n 'install-bundle "\$shell_bundle"' "$SETUP" | cut -d: -f1)" \
+        -lt "$(grep -n 'backend github install \$shell_tools' "$SETUP" | cut -d: -f1)"
+}
+
 # They're small static binaries, so unlike the heavyweight extras they're
 # installed on the minimal profile too -- but still only when installing at
 # all, and only after the scripts repo (which carries homepkg) is on disk.
@@ -778,6 +794,8 @@ run_test "zoxide is installed as a core package" \
     test_zoxide_is_a_core_package
 run_test "atuin and carapace install from their github releases" \
     test_shell_tools_install_from_github_releases
+run_test "the shell tools install from a bundle on an offline host" \
+    test_shell_tools_install_from_a_bundle_offline
 run_test "the shell tools install on every profile, after the clone" \
     test_shell_tools_run_on_every_profile
 

--- a/setup_test
+++ b/setup_test
@@ -435,7 +435,20 @@ test_shell_tools_install_from_github_releases() {
     assert_source_contains 'for tool in atuin carapace' &&
     assert_source_contains '"$homepkg" --backend github install $shell_tools' &&
     assert_source_contains "the shell config skips whichever is missing" &&
-    assert_source_contains "already installed"
+    assert_source_contains "already installed" &&
+    # homepkg installs into ~/.local/bin, which setup's own PATH need not
+    # have, so the presence check looks there as well.
+    assert_source_contains 'test -x "$HOME/.local/bin/$tool"'
+}
+
+# A bundle installs its manifest and nothing else, so a partial or stale one
+# (built before the tool set grew) can still leave a tool missing. The set is
+# recomputed after a successful bundle install, and whatever is left falls
+# through to the release download rather than being silently skipped.
+test_shell_tools_reconcile_after_bundle() {
+    assert_source_contains "the bundle did not provide" &&
+    # Recomputed twice: once up front, once after the bundle install.
+    test "$(grep -c 'shell_tools="$(missing_shell_tools)"' "$SETUP")" -eq 2
 }
 
 # Offline hosts install from a push bundle instead of the release download,
@@ -802,6 +815,8 @@ run_test "atuin and carapace install from their github releases" \
     test_shell_tools_install_from_github_releases
 run_test "the shell tools install from a bundle on an offline host" \
     test_shell_tools_install_from_a_bundle_offline
+run_test "a partial bundle still installs the rest of the shell tools" \
+    test_shell_tools_reconcile_after_bundle
 run_test "the shell tools install on every profile, after the clone" \
     test_shell_tools_run_on_every_profile
 

--- a/setup_test
+++ b/setup_test
@@ -282,7 +282,7 @@ test_sudo_calls_are_guarded() {
 # manual-install hint for unsupported OSes.
 test_unzip_installed() {
     assert_source_contains "unzip" &&
-    assert_source_contains "typescript unzip zsh"
+    assert_source_contains "typescript unzip zoxide zsh"
 }
 
 # --- fnm ---
@@ -404,6 +404,44 @@ test_legacy_root_config_is_logged() {
 test_home_tools_include_node_toolchain() {
     assert_source_contains "delta gh fnm" &&
     assert_source_contains 'tools="$tools node typescript"'
+}
+
+# --- Interactive shell tools ---
+
+# The conf repo's shell config wires up fzf, zoxide, atuin and carapace. fzf
+# and zoxide are packaged everywhere setup runs, so they ride along in the
+# distro package lists and the homepkg core set. Package names go on their own
+# distro lines: apt/dnf abort the whole transaction on one unknown name.
+test_zoxide_is_a_core_package() {
+    # Once per distro list (apt, dnf, brew) plus the manual-install hint.
+    test "$(grep -c '^ *zoxide \\$' "$SETUP")" -eq 3 &&
+    assert_source_contains "unzip zoxide zsh" &&
+    assert_source_contains 'tools="ripgrep fd bat fzf jq delta gh fnm zoxide"'
+}
+
+# atuin and carapace are in no distro repo and have no conda-forge feedstock,
+# so they come from their GitHub releases via homepkg's github backend -- one
+# rootless path that serves the privileged, --no-root and macOS runs alike.
+# Already-installed tools are skipped, and a failure warns instead of aborting
+# the bootstrap: the shell config skips whichever tool is missing.
+test_shell_tools_install_from_github_releases() {
+    assert_source_contains "install_shell_tools" &&
+    assert_source_contains 'for tool in atuin carapace' &&
+    assert_source_contains '"$homepkg" --backend github install $shell_tools' &&
+    assert_source_contains "the shell config skips whichever is missing" &&
+    assert_source_contains "already installed"
+}
+
+# They're small static binaries, so unlike the heavyweight extras they're
+# installed on the minimal profile too -- but still only when installing at
+# all, and only after the scripts repo (which carries homepkg) is on disk.
+test_shell_tools_run_on_every_profile() {
+    assert_source_contains 'if test "$INSTALL" = yes; then
+    install_shell_tools
+fi' &&
+    # After the clone, so $SCRIPTS_DIR/homepkg exists by then.
+    test "$(grep -n 'clone_or_pull "$SCRIPTS_REPO"' "$SETUP" | cut -d: -f1)" \
+        -lt "$(grep -n '^    install_shell_tools$' "$SETUP" | cut -d: -f1)"
 }
 
 # --- SSH key ---
@@ -736,6 +774,12 @@ run_test "brew path clears the stale cargo Helix runtime symlink" \
     test_brew_clears_stale_helix_runtime
 run_test "legacy root config fallback is logged with the remedy" \
     test_legacy_root_config_is_logged
+run_test "zoxide is installed as a core package" \
+    test_zoxide_is_a_core_package
+run_test "atuin and carapace install from their github releases" \
+    test_shell_tools_install_from_github_releases
+run_test "the shell tools install on every profile, after the clone" \
+    test_shell_tools_run_on_every_profile
 
 echo
 echo "$TESTS_RUN tests, $TESTS_PASSED passed, $TESTS_FAILED failed"

--- a/setup_test
+++ b/setup_test
@@ -413,8 +413,14 @@ test_home_tools_include_node_toolchain() {
 # distro package lists and the homepkg core set. Package names go on their own
 # distro lines: apt/dnf abort the whole transaction on one unknown name.
 test_zoxide_is_a_core_package() {
-    # Once per distro list (apt, dnf, brew) plus the manual-install hint.
-    test "$(grep -c '^ *zoxide \\$' "$SETUP")" -eq 3 &&
+    # In its own best-effort transaction per platform, never in the core
+    # package list: apt/dnf reject the whole request on one unknown name,
+    # and zoxide is missing from older releases -- which would take git and
+    # make down with it. Three install steps (apt, dnf, brew) plus the
+    # manual-install hint and the homepkg core set.
+    test "$(grep -c '^ *info "Installing zoxide"$' "$SETUP")" -eq 3 &&
+    test "$(grep -c '^ *zoxide \\$' "$SETUP")" -eq 0 &&
+    assert_source_contains "could not install zoxide" &&
     assert_source_contains "unzip zoxide zsh" &&
     assert_source_contains 'tools="ripgrep fd bat fzf jq delta gh fnm zoxide"'
 }


### PR DESCRIPTION
The conf repo's shell config now wires up four interactive tools (fzf, zoxide, carapace, atuin), so `setup` has to provide them — including on machines with no internet.

## How each one is installed

- **fzf** — already in every distro list and the homepkg core set; unchanged.
- **zoxide** — in its own best-effort transaction per platform, never in the core package list. apt and dnf reject the whole request on one unknown name, and zoxide is missing from older releases (Ubuntu 20.04), which would have taken git and make down with it and left a fresh bootstrap unable to continue.
- **atuin, carapace** — in no distro repo and with no conda-forge feedstock, so they install from their GitHub releases via homepkg's stateless github backend. No root needed, so one `install_shell_tools` call serves the privileged, `--no-root` and macOS paths alike, and it runs on the minimal profile too. A failure warns rather than aborting the bootstrap, since each shell config skips whichever tool is missing.

## Offline hosts

Those two can't ride in the mamba bundle (no conda-forge package), so `setup` looks for a github push bundle first and only falls back to the download:

```sh
homepkg --backend github bundle -o homepkg-shell-tools.tgz atuin carapace
```

Staged at `$HOMEPKG_SHELL_BUNDLE`, or beside the scripts repo or in `$HOME`. After a successful bundle install the missing set is recomputed, so a partial or stale bundle doesn't silently leave a tool uninstalled — whatever it didn't carry falls through to the download, and the failure message names the command that builds a complete one.

## homepkg registry

Entries for conda-less tools carry `conda=None`, and the conda package names go through a `conda_pkgs` helper:

- naming such a tool on any conda path — the mamba backend, the stateless conda backend, or an explicit `bundle` — fails with the `--backend github` hint
- only the whole-registry `bundle` form skips them, with a warning, so a complete offline bundle can still be built
- the names resolve *before* micromamba is bootstrapped and before any index fetch, so on an offline host the actionable message isn't buried under a network failure
- `homepkg list` shows a dash in the conda column for them

## Testing

`setup_test` passes (56 tests, 4 new). `homepkg_test` passes 73 of 74 — the failure, `dry-run bootstrap returns the micromamba path, not None`, also fails on the base branch and is unrelated to this change.

One thing I could not verify from this environment: the egress policy blocks `api.anaconda.org` and non-allowlisted GitHub hosts, so zoxide's presence on conda-forge and the exact release-asset names for atuin and carapace come from documentation rather than a live check. Worth confirming on the first real run.

The companion conf PR wires the tools into the shells.