### PR TITLE
homepkg: one bundle covering conda and release-asset tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,17 +39,18 @@ repo's shell config wires up — are in no distro repo and have no conda-forge
 package, so every `setup` run installs them from their GitHub releases with
 `homepkg --backend github`, regardless of profile or privilege.
 
-On a host with no internet, stage a bundle for them instead. They can't ride
-in the mamba bundle (no conda-forge package), so build the github variant on
-an online machine and drop it beside the scripts repo (or in `$HOME`, or point
-`$HOMEPKG_SHELL_BUNDLE` at it):
+On a host with no internet, stage a bundle instead. The one-shot bundle below
+covers them along with everything else, which is all a `--no-root` machine
+needs. On a privileged machine the distro packages come from apt/dnf and that
+bundle isn't installed, so stage these two on their own — beside the scripts
+repo, in `$HOME`, or wherever `$HOMEPKG_SHELL_BUNDLE` points:
 
 ```sh
 homepkg --backend github bundle -o homepkg-shell-tools.tgz atuin carapace
 ```
 
-`setup` prefers that bundle over the download, so an offline run never waits
-for a fetch that can't succeed.
+`setup` prefers a bundle over the download, so an offline run never waits for
+a fetch that can't succeed.
 
 The default backend is `mamba`: a rootless [micromamba](https://mamba.readthedocs.io/)
 manages one conda environment, so you get a real solver (full dependency
@@ -85,17 +86,24 @@ internet, and install offline:
 
 ```sh
 # online builder
-homepkg bundle -o tools.tgz ripgrep fd jq     # solve closure + micromamba
+homepkg bundle -o tools.tgz                   # every registered tool
+homepkg bundle -o tools.tgz ripgrep fd jq     # ...or just the named ones
 homepkg --backend github bundle -o tools.tgz ripgrep fd jq   # static-asset variant
 
 # air-gapped target (no network)
 homepkg install-bundle tools.tgz
 ```
 
-The default (`mamba`) bundle carries the full dependency closure plus the
-micromamba binary, so the target builds a correct environment with no network
-and micromamba relocates it into the target's prefix. The `github` variant
-carries static release assets — smaller, but only for self-contained tools.
+`bundle` with no tool names is the one-shot: it covers the whole registry,
+taking each tool from wherever it comes from. Tools with a conda-forge package
+go in as a solved dependency closure alongside the micromamba binary that
+replays it, so the target builds a correct environment with no network at all;
+the few with no feedstock (`atuin`, `carapace`) go in as static release assets.
+`install-bundle` replays whichever payloads the bundle carries.
+
+The `github` variant builds a bundle of release assets only. It needs explicit
+tool names, since not every registered tool publishes one (`typescript` is
+npm-only).
 
 ## Third-party code
 

--- a/homepkg
+++ b/homepkg
@@ -27,6 +27,11 @@ Push bundles (build on an online host, install on an air-gapped target):
     homepkg --backend github bundle -o t.tgz TOOL... # static-asset variant
     homepkg install-bundle tools.tgz               # target: install offline
 
+A bundle carries whatever each tool needs: the solved conda closure for the
+tools with a conda-forge package, release assets for the ones without, and the
+micromamba to replay the closure with. `bundle` with no tool names covers the
+whole registry, so one file provisions a machine with no network at all.
+
 Tool names are logical (ripgrep, fd, ...); the registry maps each to its conda
 package and GitHub repo.
 """
@@ -651,64 +656,106 @@ def _fetch_micromamba_bin(plat, dest):
     return os.path.join(dest, "bin", "micromamba")
 
 
-def bundle_mamba(tools, prefix, plat, out, dry_run, skip_conda_less=False):
-    # Only the whole-registry form (`bundle` with no names) skips the
-    # github-only tools. Naming one explicitly has to fail: the manifest
-    # lists what was asked for, so a silent omission would install clean
-    # and leave the tool missing.
-    pkgs = conda_pkgs(tools, skip_missing=skip_conda_less)
-    # Report before touching the network so --dry-run needs no micromamba.
-    if dry_run:
-        info(f"would solve closure for {', '.join(pkgs)} ({conda_subdir(*plat)}), "
-             f"download it, and write {out}")
-        return
+def _stage_mamba(tools, prefix, plat, td):
+    """Solve and download the conda closure for `tools` into staging dir `td`."""
+    pkgs = conda_pkgs(tools)
     # The solver must RUN on this builder, so use the builder's own micromamba;
     # the bundle needs the TARGET arch's micromamba, which differs under --arch.
-    solver = ensure_micromamba(prefix, detect_platform(), dry_run)
+    solver = ensure_micromamba(prefix, detect_platform(), False)
     info(f"solving closure for {', '.join(pkgs)} ({conda_subdir(*plat)})")
     fetch = _mamba_solve(solver, prefix, plat, pkgs)
     info(f"  {len(fetch)} packages in the closure")
+    pkgdir = os.path.join(td, "pkgs")
+    os.makedirs(pkgdir)
+    lines = ["@EXPLICIT"]
+    for f in fetch:
+        download(f["url"], os.path.join(pkgdir, f["fn"]))
+        lines.append(f["url"] + _explicit_frag(f))
+    with open(os.path.join(td, "explicit.txt"), "w") as fh:
+        fh.write("\n".join(lines) + "\n")
+    # Always ship the conda-forge micromamba for the target arch -- a
+    # static, self-contained binary. Never reuse the solver: it may be an
+    # arbitrary dynamically-linked micromamba from the builder's PATH that
+    # won't run on the air-gapped target.
+    with tempfile.TemporaryDirectory() as mmtmp:
+        shutil.copy2(_fetch_micromamba_bin(plat, mmtmp),
+                     os.path.join(td, "micromamba"))
+    return list(tools)
+
+
+def _stage_github(tools, plat, td, skip_unavailable=False):
+    """Download a release asset per tool in `tools` into staging dir `td`."""
+    tokens = github_asset_tokens(*plat)
+    info(f"collecting github assets for {', '.join(tools)}")
+    adir = os.path.join(td, "assets")
+    os.makedirs(adir, exist_ok=True)
+    entries = []
+    for t in tools:
+        tag, assets = github_latest_assets(TOOLS[t]["github"])
+        picked = github_pick_asset(assets, tokens)
+        if not picked:
+            msg = f"{t}: no {plat[0]}/{plat[1]} asset in {TOOLS[t]['github']} {tag}"
+            # Naming a tool explicitly means it has to be in the bundle; over
+            # the whole registry, one tool without an asset for this platform
+            # must not cost you the other twenty.
+            if not skip_unavailable:
+                raise HomepkgError(msg)
+            warn(msg + "; leaving it out of the bundle")
+            continue
+        name, url = picked
+        download(url, os.path.join(adir, name))
+        entries.append({"tool": t, "asset": name, "bins": TOOLS[t]["bins"]})
+    return entries
+
+
+def bundle_all(tools, prefix, plat, out, dry_run, whole_registry=False):
+    """Bundle `tools` from wherever each one comes from, in one file.
+
+    Most tools come from conda-forge; the few with no feedstock come from their
+    GitHub releases. Splitting that across two bundles would make the caller
+    track which tool went where, so one bundle carries both payloads and
+    install-bundle replays whichever parts are present.
+    """
+    conda_tools = [t for t in tools if TOOLS[t].get("conda")]
+    github_tools = [t for t in tools if not TOOLS[t].get("conda")
+                    and TOOLS[t].get("github")]
+    unavailable = [t for t in tools if t not in conda_tools and t not in github_tools]
+    if unavailable:
+        warn(f"no source for: {', '.join(unavailable)}; leaving them out of the bundle")
+    if not conda_tools and not github_tools:
+        raise HomepkgError("nothing to bundle")
+
+    # Report before touching the network so --dry-run needs no micromamba.
+    if dry_run:
+        if conda_tools:
+            info(f"would solve closure for {', '.join(conda_pkgs(conda_tools))} "
+                 f"({conda_subdir(*plat)}) and download it")
+        if github_tools:
+            info(f"would download github release assets for {', '.join(github_tools)}")
+        info(f"would write {out}")
+        return
+
     with tempfile.TemporaryDirectory() as td:
-        pkgdir = os.path.join(td, "pkgs")
-        os.makedirs(pkgdir)
-        lines = ["@EXPLICIT"]
-        for f in fetch:
-            download(f["url"], os.path.join(pkgdir, f["fn"]))
-            lines.append(f["url"] + _explicit_frag(f))
-        with open(os.path.join(td, "explicit.txt"), "w") as fh:
-            fh.write("\n".join(lines) + "\n")
-        # Always ship the conda-forge micromamba for the target arch -- a
-        # static, self-contained binary. Never reuse the solver: it may be an
-        # arbitrary dynamically-linked micromamba from the builder's PATH that
-        # won't run on the air-gapped target.
-        with tempfile.TemporaryDirectory() as mmtmp:
-            shutil.copy2(_fetch_micromamba_bin(plat, mmtmp),
-                         os.path.join(td, "micromamba"))
+        manifest = {"format": 1, "backend": "combined",
+                    "platform": f"{plat[0]}/{plat[1]}"}
+        if conda_tools:
+            manifest["mamba"] = {"tools": _stage_mamba(conda_tools, prefix, plat, td)}
+        if github_tools:
+            manifest["github"] = {"tools": _stage_github(
+                github_tools, plat, td, skip_unavailable=whole_registry)}
         with open(os.path.join(td, "manifest.json"), "w") as fh:
-            json.dump({"format": 1, "backend": "mamba",
-                       "platform": f"{plat[0]}/{plat[1]}", "tools": tools}, fh)
+            json.dump(manifest, fh)
         _write_bundle(out, td)
     info(f"wrote {out} ({os.path.getsize(out) // 1024} KiB)")
 
 
 def bundle_github(tools, prefix, plat, out, dry_run):
-    tokens = github_asset_tokens(*plat)
     info(f"collecting github assets for {', '.join(tools)}")
     if dry_run:
         info(f"  would download release assets and write {out}")
         return
     with tempfile.TemporaryDirectory() as td:
-        adir = os.path.join(td, "assets")
-        os.makedirs(adir)
-        entries = []
-        for t in tools:
-            tag, assets = github_latest_assets(TOOLS[t]["github"])
-            picked = github_pick_asset(assets, tokens)
-            if not picked:
-                raise HomepkgError(f"{t}: no {plat[0]}/{plat[1]} asset in {TOOLS[t]['github']} {tag}")
-            name, url = picked
-            download(url, os.path.join(adir, name))
-            entries.append({"tool": t, "asset": name, "bins": TOOLS[t]["bins"]})
+        entries = _stage_github(tools, plat, td)
         with open(os.path.join(td, "manifest.json"), "w") as fh:
             json.dump({"format": 1, "backend": "github",
                        "platform": f"{plat[0]}/{plat[1]}", "tools": entries}, fh)
@@ -784,7 +831,14 @@ def install_bundle(bundle_file, prefix, plat, dry_run):
                 f"bundle is for {got}, but this host is {want} "
                 "(pass --arch to override)")
         info(f"bundle: {backend}, platform {got}")
-        if backend == "mamba":
+        if backend == "combined":
+            # One bundle, both payloads: conda tools first (the env install
+            # wants a fresh prefix), then the static release assets.
+            if "mamba" in manifest:
+                _install_bundle_mamba(td, manifest["mamba"], prefix, dry_run)
+            if "github" in manifest:
+                _install_bundle_github(td, manifest["github"], prefix, dry_run)
+        elif backend == "mamba":
             _install_bundle_mamba(td, manifest, prefix, dry_run)
         elif backend == "github":
             _install_bundle_github(td, manifest, prefix, dry_run)
@@ -878,15 +932,16 @@ def main(argv=None):
         if args.tools:
             tools = args.tools
         elif args.backend == "github":
-            # No "bundle everything" for github: not every registered tool has a
-            # static release asset (e.g. typescript is npm-only), so an all-tools
-            # github bundle would abort partway. Require explicit names there.
+            # No "bundle everything" for the github-only variant: not every
+            # registered tool has a static release asset (typescript is
+            # npm-only), and asking for that variant means asking for those
+            # assets specifically. The default backend covers everything.
             p.error("bundle --backend github needs explicit tool names "
-                    "(no-args = all is mamba-only)")
+                    "(no-args = all is the default backend)")
         else:
-            # No tool names on the mamba backend means "bundle everything
-            # registered" -- the easy way to stage a complete offline toolchain
-            # without listing packages by hand.
+            # No tool names means "bundle everything registered" -- one file
+            # that provisions a machine offline, conda closure and release
+            # assets alike.
             tools = sorted(TOOLS)
         _require_known(p, tools)
         plat = _resolve_plat(p, args.arch)
@@ -894,8 +949,8 @@ def main(argv=None):
             if args.backend == "github":
                 bundle_github(tools, args.prefix, plat, args.output, args.dry_run)
             else:
-                bundle_mamba(tools, args.prefix, plat, args.output, args.dry_run,
-                             skip_conda_less=whole_registry)
+                bundle_all(tools, args.prefix, plat, args.output, args.dry_run,
+                           whole_registry=whole_registry)
         except Exception as e:
             warn(str(e))
             return 1

--- a/homepkg
+++ b/homepkg
@@ -377,6 +377,7 @@ def github_extract(asset_path, name, prefix, bins):
     bindir = os.path.join(prefix, "bin")
     os.makedirs(bindir, exist_ok=True)
     low = name.lower()
+    root = None
     if low.endswith((".tar.gz", ".tgz", ".tar.xz", ".tar.bz2", ".tar")):
         root = os.path.join(os.path.dirname(asset_path), "x")
         with tarfile.open(asset_path) as tf:
@@ -385,22 +386,32 @@ def github_extract(asset_path, name, prefix, bins):
         root = os.path.join(os.path.dirname(asset_path), "x")
         with zipfile.ZipFile(asset_path) as zf:
             _safe_extract_zip(zf, root)
+    if root is not None:
+        placed = []
+        for b in bins:
+            src = _find_file(root, b)
+            if src is None:
+                continue
+            dest = os.path.join(bindir, b)
+            shutil.copy2(src, dest)
+            _ensure_executable(dest)
+            placed.append(b)
     else:
         # Raw single binary (e.g. jq-linux-amd64): treat the asset as bins[0].
         dest = os.path.join(bindir, bins[0])
         shutil.copy2(asset_path, dest)
         _ensure_executable(dest)
-        return [bins[0]]
-    placed = []
-    for b in bins:
-        src = _find_file(root, b)
-        if src is None:
-            warn(f"binary '{b}' not found in {name}")
-            continue
-        dest = os.path.join(bindir, b)
-        shutil.copy2(src, dest)
-        _ensure_executable(dest)
-        placed.append(b)
+        placed = [bins[0]]
+    # An asset that doesn't carry everything the registry says it does --
+    # a changed release layout, an asset picked by the wrong token -- is a
+    # failed tool, not a warning: the caller has to know to get it another
+    # way. Whatever was found stays, since it works and the reinstall
+    # replaces it.
+    missing = [b for b in bins if b not in placed]
+    if missing:
+        raise HomepkgError(
+            f"{name} doesn't contain {', '.join(missing)}"
+            + (f" (kept {', '.join(placed)})" if placed else ""))
     return placed
 
 
@@ -809,13 +820,29 @@ def _install_bundle_mamba(td, manifest, prefix, dry_run):
 
 
 def _install_bundle_github(td, manifest, prefix, dry_run):
+    """Unpack each tool's asset. Returns the tools that couldn't be installed.
+
+    One tool is not allowed to cost the others: a bundle built when an asset
+    was unavailable, or one that arrived truncated, still installs everything
+    it does carry. The caller reports what was missed.
+    """
+    failed = []
     for e in manifest["tools"]:
         _require_basename(e["asset"], "asset name")
+        asset = os.path.join(td, "assets", e["asset"])
+        if not os.path.exists(asset):
+            warn(f"{e['tool']}: {e['asset']} is not in the bundle; skipping it")
+            failed.append(e["tool"])
+            continue
         info(f"{e['tool']}: {e['asset']}")
         if dry_run:
             continue
-        github_extract(os.path.join(td, "assets", e["asset"]),
-                       e["asset"], prefix, e["bins"])
+        try:
+            github_extract(asset, e["asset"], prefix, e["bins"])
+        except Exception as exc:  # extraction, permissions, truncated asset
+            warn(f"{e['tool']}: {exc}; skipping it")
+            failed.append(e["tool"])
+    return failed
 
 
 def install_bundle(bundle_file, prefix, plat, dry_run):
@@ -831,19 +858,37 @@ def install_bundle(bundle_file, prefix, plat, dry_run):
                 f"bundle is for {got}, but this host is {want} "
                 "(pass --arch to override)")
         info(f"bundle: {backend}, platform {got}")
+        failed = []
         if backend == "combined":
             # One bundle, both payloads: conda tools first (the env install
-            # wants a fresh prefix), then the static release assets.
+            # wants a fresh prefix), then the static release assets. The two
+            # are independent, so a closure that can't be replayed -- an env
+            # already present, say -- mustn't cost you the static binaries.
             if "mamba" in manifest:
-                _install_bundle_mamba(td, manifest["mamba"], prefix, dry_run)
+                try:
+                    _install_bundle_mamba(td, manifest["mamba"], prefix, dry_run)
+                except Exception as exc:
+                    # Anything the replay can raise: our own "env already
+                    # exists", micromamba exiting non-zero (CalledProcessError),
+                    # a truncated payload. Narrowing this to HomepkgError would
+                    # let the commonest failure of all -- the create itself --
+                    # skip the static assets below.
+                    warn(f"conda tools: {exc}")
+                    failed.extend(manifest["mamba"].get("tools", ["conda tools"]))
             if "github" in manifest:
-                _install_bundle_github(td, manifest["github"], prefix, dry_run)
+                failed.extend(_install_bundle_github(
+                    td, manifest["github"], prefix, dry_run))
         elif backend == "mamba":
             _install_bundle_mamba(td, manifest, prefix, dry_run)
         elif backend == "github":
-            _install_bundle_github(td, manifest, prefix, dry_run)
+            failed.extend(_install_bundle_github(td, manifest, prefix, dry_run))
         else:
             raise HomepkgError(f"unknown bundle backend: {backend}")
+        if failed:
+            # Non-zero so the caller can fall back to installing them online
+            # (setup does), while everything the bundle did carry stays put.
+            raise HomepkgError(
+                f"bundle installed without: {', '.join(failed)}")
 
 
 # --- CLI ---------------------------------------------------------------------

--- a/homepkg_test
+++ b/homepkg_test
@@ -249,19 +249,24 @@ check("bundle with no tools targets every registered package",
       _bundle_all.returncode == 0
       and all(hp.TOOLS[t]["conda"] in _bundle_all.stderr
               for t in hp.TOOLS if hp.TOOLS[t]["conda"]))
-# The github-only tools can't be in a mamba bundle; they're named as skipped
-# rather than aborting the whole bundle.
-check("bundle with no tools reports the tools it can't include",
+# The tools with no conda-forge feedstock come from their release assets in
+# the same bundle, so one no-args build covers the whole registry rather than
+# leaving a couple of tools for the caller to chase separately.
+check("bundle with no tools also collects the conda-less tools",
       all(t in _bundle_all.stderr
           for t in hp.TOOLS if not hp.TOOLS[t]["conda"]))
-# ...but naming one explicitly must fail: the manifest lists what was asked
-# for, so a silent omission would install clean and leave the tool missing.
+check("bundle with no tools reports both payloads",
+      "would solve closure" in _bundle_all.stderr
+      and "github release assets" in _bundle_all.stderr)
+# Naming a conda-less tool works the same way: it lands in the bundle's
+# github payload instead of erroring.
 _bundle_named = _run("bundle", "-o",
                      os.path.join(tempfile.gettempdir(), "hp-bundle-named.tgz"),
                      "--dry-run", "jq", "carapace")
-check("bundle rejects an explicitly named conda-less tool",
-      _bundle_named.returncode != 0
-      and "--backend github" in _bundle_named.stderr)
+check("bundle covers an explicitly named conda-less tool",
+      _bundle_named.returncode == 0
+      and "carapace" in _bundle_named.stderr
+      and "jq" in _bundle_named.stderr)
 # ...but no-args "all" is mamba-only: not every tool has a github release asset
 # (typescript is npm-only), so the github backend must require explicit names.
 check("bundle --backend github rejects no-args all-tools",
@@ -352,6 +357,47 @@ with tempfile.TemporaryDirectory() as td:
     check("_localize_explicit keeps @EXPLICIT", res[0] == "@EXPLICIT")
     check("_localize_explicit rewrites url to a local file:// path",
           res[1] == "file:///b/pkgs/jq-1.8.2-h0.conda#abc")
+
+# A combined bundle carries both payloads. Only the github half is exercised
+# end-to-end here (the mamba half needs micromamba and a solved closure), but
+# install_bundle has to find and replay it from the "github" sub-object rather
+# than the top level, and must not trip over a manifest with only one half.
+with tempfile.TemporaryDirectory() as td:
+    src = os.path.join(td, "src")
+    os.makedirs(os.path.join(src, "assets"))
+    asset = "tool-x86_64-unknown-linux-musl.tar.gz"
+    _make_targz(os.path.join(src, "assets", asset), {"tool-1.0/rg": b"#!/bin/sh\necho rg\n"})
+    with open(os.path.join(src, "manifest.json"), "w") as f:
+        json.dump({"format": 1, "backend": "combined", "platform": "linux/x86_64",
+                   "github": {"tools": [{"tool": "ripgrep", "asset": asset,
+                                         "bins": ["rg"]}]}}, f)
+    bundle = os.path.join(td, "combined.tar.gz")
+    hp._write_bundle(bundle, src)
+    prefix = os.path.join(td, "prefix")
+    hp.install_bundle(bundle, prefix, ("linux", "x86_64"), False)
+    check("install-bundle (combined) unpacks the github half offline",
+          os.access(os.path.join(prefix, "bin", "rg"), os.X_OK))
+
+# A combined manifest naming an unknown backend still errors rather than
+# silently installing nothing.
+with tempfile.TemporaryDirectory() as td:
+    src = os.path.join(td, "src")
+    os.makedirs(src)
+    with open(os.path.join(src, "manifest.json"), "w") as f:
+        json.dump({"format": 1, "backend": "combined", "platform": "linux/x86_64"}, f)
+    bundle = os.path.join(td, "empty.tar.gz")
+    hp._write_bundle(bundle, src)
+    _err = None
+    try:
+        hp.install_bundle(bundle, os.path.join(td, "prefix"), ("linux", "x86_64"), False)
+    except Exception as e:  # noqa: BLE001
+        _err = e
+    check("install-bundle tolerates a combined bundle with neither half", _err is None)
+
+# The tool split is what makes one bundle enough: everything with a
+# conda-forge package goes through the closure, the rest through releases.
+check("every registered tool has a source for the combined bundle",
+      all(hp.TOOLS[t].get("conda") or hp.TOOLS[t].get("github") for t in hp.TOOLS))
 
 # A github bundle round-trips fully offline: build the tarball by hand, then
 # install-bundle unpacks the asset and places the binary -- no network.

--- a/homepkg_test
+++ b/homepkg_test
@@ -150,6 +150,27 @@ with tempfile.TemporaryDirectory() as td:
     jq = os.path.join(prefix, "bin", "jq")
     check("github_extract treats a raw asset as the binary", placed == ["jq"] and os.access(jq, os.X_OK))
 
+# An asset that's missing one of the binaries the registry names -- a release
+# that changed its layout, or the asset picker choosing the wrong archive --
+# has to be a failure. Warning and returning the rest would let install-bundle
+# exit 0, and setup would then skip the online top-up for a tool that isn't
+# there.
+with tempfile.TemporaryDirectory() as td:
+    prefix = os.path.join(td, "prefix")
+    asset = os.path.join(td, "helix-x86_64-linux.tar.gz")
+    _make_targz(asset, {"helix-25.01/hx": b"#!/bin/sh\necho hx\n"})
+    _err = None
+    try:
+        hp.github_extract(asset, os.path.basename(asset), prefix, ["hx", "hxdoc"])
+    except hp.HomepkgError as e:
+        _err = e
+    check("github_extract fails when the asset lacks a listed binary",
+          _err is not None and "hxdoc" in str(_err))
+    check("github_extract keeps the binaries the asset did have",
+          os.access(os.path.join(prefix, "bin", "hx"), os.X_OK))
+    check("github_extract says what it kept",
+          _err is not None and "hx" in str(_err).split("kept")[-1])
+
 # --- conda extraction (.tar.bz2, no zstd needed) -----------------------------
 
 with tempfile.TemporaryDirectory() as td:
@@ -377,6 +398,98 @@ with tempfile.TemporaryDirectory() as td:
     hp.install_bundle(bundle, prefix, ("linux", "x86_64"), False)
     check("install-bundle (combined) unpacks the github half offline",
           os.access(os.path.join(prefix, "bin", "rg"), os.X_OK))
+
+# A bundle that lost an asset -- built when the release had none for this
+# platform, or truncated in transit -- still installs everything else, and
+# says what it couldn't install so the caller can fetch it another way.
+with tempfile.TemporaryDirectory() as td:
+    src = os.path.join(td, "src")
+    os.makedirs(os.path.join(src, "assets"))
+    good = "tool-x86_64-unknown-linux-musl.tar.gz"
+    _make_targz(os.path.join(src, "assets", good), {"tool-1.0/rg": b"#!/bin/sh\necho rg\n"})
+    with open(os.path.join(src, "manifest.json"), "w") as f:
+        json.dump({"format": 1, "backend": "combined", "platform": "linux/x86_64",
+                   "github": {"tools": [
+                       {"tool": "ripgrep", "asset": good, "bins": ["rg"]},
+                       {"tool": "atuin", "asset": "atuin-missing.tar.gz",
+                        "bins": ["atuin"]}]}}, f)
+    bundle = os.path.join(td, "partial.tar.gz")
+    hp._write_bundle(bundle, src)
+    prefix = os.path.join(td, "prefix")
+    _err = None
+    try:
+        hp.install_bundle(bundle, prefix, ("linux", "x86_64"), False)
+    except hp.HomepkgError as e:
+        _err = e
+    check("a bundle missing one asset still installs the others",
+          os.access(os.path.join(prefix, "bin", "rg"), os.X_OK))
+    check("a bundle missing one asset reports which tool it skipped",
+          _err is not None and "atuin" in str(_err))
+    check("a bundle missing one asset doesn't claim the others failed",
+          _err is not None and "ripgrep" not in str(_err))
+
+# Same again for an asset that IS in the bundle but doesn't carry the binary
+# it's supposed to. Silent success here is the worse failure of the two: the
+# caller is told everything installed and never tops the tool up.
+with tempfile.TemporaryDirectory() as td:
+    src = os.path.join(td, "src")
+    os.makedirs(os.path.join(src, "assets"))
+    good = "tool-x86_64-unknown-linux-musl.tar.gz"
+    hollow = "atuin-x86_64-unknown-linux-musl.tar.gz"
+    _make_targz(os.path.join(src, "assets", good), {"tool-1.0/rg": b"#!/bin/sh\n"})
+    _make_targz(os.path.join(src, "assets", hollow), {"atuin-1.0/README": b"docs\n"})
+    with open(os.path.join(src, "manifest.json"), "w") as f:
+        json.dump({"format": 1, "backend": "github", "platform": "linux/x86_64",
+                   "tools": [{"tool": "ripgrep", "asset": good, "bins": ["rg"]},
+                             {"tool": "atuin", "asset": hollow,
+                              "bins": ["atuin"]}]}, f)
+    bundle = os.path.join(td, "hollow.tar.gz")
+    hp._write_bundle(bundle, src)
+    prefix = os.path.join(td, "prefix")
+    _err = None
+    try:
+        hp.install_bundle(bundle, prefix, ("linux", "x86_64"), False)
+    except hp.HomepkgError as e:
+        _err = e
+    check("an asset without its binary counts the tool as failed",
+          _err is not None and "atuin" in str(_err))
+    check("an asset without its binary doesn't stop the other tools",
+          os.access(os.path.join(prefix, "bin", "rg"), os.X_OK))
+
+# The two halves are independent, and the commonest way the conda half fails
+# is micromamba itself exiting non-zero -- a CalledProcessError, not one of
+# ours. Catching only HomepkgError there would skip the static assets in the
+# same bundle, which is exactly what an offline host has no other way to get.
+with tempfile.TemporaryDirectory() as td:
+    src = os.path.join(td, "src")
+    os.makedirs(os.path.join(src, "assets"))
+    asset = "tool-x86_64-unknown-linux-musl.tar.gz"
+    _make_targz(os.path.join(src, "assets", asset), {"tool-1.0/atuin": b"#!/bin/sh\n"})
+    with open(os.path.join(src, "manifest.json"), "w") as f:
+        json.dump({"format": 1, "backend": "combined", "platform": "linux/x86_64",
+                   "mamba": {"tools": ["jq"]},
+                   "github": {"tools": [{"tool": "atuin", "asset": asset,
+                                         "bins": ["atuin"]}]}}, f)
+    bundle = os.path.join(td, "replay-fails.tar.gz")
+    hp._write_bundle(bundle, src)
+    prefix = os.path.join(td, "prefix")
+
+    def _replay_fails(*args, **kwargs):
+        raise subprocess.CalledProcessError(1, ["micromamba", "create"])
+
+    _orig = hp._install_bundle_mamba
+    hp._install_bundle_mamba = _replay_fails
+    _err = None
+    try:
+        hp.install_bundle(bundle, prefix, ("linux", "x86_64"), False)
+    except hp.HomepkgError as e:
+        _err = e
+    finally:
+        hp._install_bundle_mamba = _orig
+    check("a failed conda replay still leaves the release assets installed",
+          os.access(os.path.join(prefix, "bin", "atuin"), os.X_OK))
+    check("a failed conda replay reports the tools it couldn't install",
+          _err is not None and "jq" in str(_err))
 
 # A combined manifest naming an unknown backend still errors rather than
 # silently installing nothing.

--- a/setup
+++ b/setup
@@ -1252,14 +1252,29 @@ install_home_tools() {
         info "  a bundle installs its full contents; --minimal/--no-npm don't trim it"
         if "$homepkg" install-bundle "$bundle"; then
             provisioned=yes
-            # shellcheck disable=SC2086  # $tools is a space-separated list expanded into multiple args
-            "$homepkg" install $tools \
-                || warn "installed the bundle; couldn't reconcile the requested tools online (offline?)"
         else
-            warn "install-bundle failed; falling back to an online install"
+            # install-bundle exits non-zero when it couldn't install
+            # everything the manifest listed -- a release asset the bundle
+            # was built without, say -- having installed the rest. So what
+            # follows is a top-up rather than a redo.
+            warn "the bundle didn't provide everything; topping up online"
         fi
-    fi
-    if test "$provisioned" = no; then
+        # shellcheck disable=SC2086  # $tools is a space-separated list expanded into multiple args
+        if "$homepkg" install $tools; then
+            provisioned=yes
+        elif test "$provisioned" = yes; then
+            warn "installed the bundle; couldn't reconcile the requested tools online (offline?)"
+        elif test -d "$env_dir/conda-meta"; then
+            # A partial install-bundle still built the env out of whatever it
+            # carried, so an offline top-up failure doesn't make this run
+            # unprovisioned: the steps below still have to put ~/.local/bin on
+            # PATH for the tools that did land.
+            warn "couldn't top up the missing tools online (offline?); keeping what the bundle installed"
+            provisioned=yes
+        else
+            warn "the bundle installed nothing and the online top-up failed (offline?)"
+        fi
+    else
         test "$MINIMAL_ENABLED" -eq 0 \
             || info "Skipping heavyweight CLI extras (helix, jj, nushell); minimal profile"
         info "Installing CLI tools into a home prefix via homepkg: $tools"
@@ -1364,7 +1379,9 @@ install_shell_tools() {
             fi
             info "the bundle did not provide$shell_tools"
         else
-            warn "could not install from the bundle; falling back to the release download"
+            # Non-zero can mean a partial install -- whatever the bundle did
+        # carry stays put, and the download below covers the rest.
+        warn "the bundle didn't provide everything; falling back to the release download"
         fi
     fi
 

--- a/setup_test
+++ b/setup_test
@@ -643,6 +643,18 @@ test_home_tools_uses_bundle_optimistically() {
     assert_source_contains "couldn't reconcile the requested tools online"
 }
 
+# install-bundle exits non-zero when the bundle was short of a tool, having
+# installed the rest. If the online top-up then fails too (offline), the env
+# is still there with whatever the bundle carried, so the run counts as
+# provisioned -- otherwise install_home_tools returns before putting
+# ~/.local/bin on PATH and later steps (setup-kde needs tsc) can't find the
+# tools that did land.
+test_home_tools_provisioned_by_a_partial_bundle() {
+    assert_source_contains 'elif test -d "\$env_dir/conda-meta"; then' &&
+    assert_source_contains "keeping what the bundle installed" &&
+    assert_source_contains "the bundle installed nothing and the online top-up failed"
+}
+
 # A failed pull on an EXISTING checkout (e.g. offline) must warn and continue,
 # not abort under set -e -- otherwise the offline "setup --no-root" bootstrap
 # dies on the scripts/conf pull before reaching the homepkg bundle install. A
@@ -749,6 +761,8 @@ run_test "--no-root implies --no-sudo" \
     test_no_root_implies_no_sudo
 run_test "--no-root prefers a prebuilt bundle, then refreshes online" \
     test_home_tools_uses_bundle_optimistically
+run_test "a partial bundle provisions the run even with no network" \
+    test_home_tools_provisioned_by_a_partial_bundle
 run_test "clone_or_pull warns and continues on an offline failure" \
     test_clone_or_pull_degrades_offline
 run_test "--no-root installs CLI tools into a home prefix via homepkg" \


### PR DESCRIPTION
Follow-up to #152. `homepkg bundle` with no tool names was mamba-only: it skipped the tools with no conda-forge feedstock, so provisioning a machine with no internet meant building two bundles and knowing which tool went where.

It's now a genuine one-shot:

```sh
homepkg bundle -o tools.tgz          # online: the whole registry
homepkg install-bundle tools.tgz     # air-gapped target: everything
```

Each tool goes in from wherever it comes from — a solved conda closure plus the micromamba that replays it for the tools with a feedstock, static release assets for `atuin` and `carapace` — and both payloads travel in one file. `install-bundle` replays whichever are present, and still understands the older single-backend manifests.

## Behaviour changes

- Naming a conda-less tool in a bundle no longer errors; it lands in the github payload. That supersedes the rule added in #152, which existed only because a bundle couldn't carry it at all.
- Over the whole registry, a tool with no release asset for the target platform is left out with a warning rather than aborting the build — one missing asset shouldn't cost you the other twenty. Naming a tool explicitly still fails in that case: asking for it by name means it has to be there.
- `--backend github bundle` is unchanged and still requires explicit names, since not every registered tool publishes an asset (`typescript` is npm-only).

## Degrading when a bundle is short

An air-gapped host gets whatever the bundle carried and needs to be told exactly what it didn't, so no single tool can take the rest down with it:

- The two payloads are independent. A conda closure that won't replay — micromamba exiting non-zero, an env already present, a truncated payload — still leaves the static release assets installed, which on an offline host are the half with no alternative source.
- A missing or unextractable asset is skipped with the tool named, rather than aborting the run.
- An asset that unpacks but doesn't contain a binary the registry lists is a failed tool, not a warning. Silent success there was the worst case of the three: `install-bundle` would exit 0 and `setup` would never top the tool up. Whatever the asset did contain stays on disk. This covers the online `install` path too, which had the same hole.
- `install-bundle` ends non-zero naming everything it couldn't install, so `setup` treats it as a top-up rather than a redo — and when the top-up can't run either (no network), it detects the created env so `~/.local/bin` still reaches this run's `PATH` for later steps like `setup-kde`.

The dedicated `homepkg-shell-tools.tgz` path in `setup` stays useful for privileged machines, where the distro packages come from apt/dnf and the full bundle isn't installed. On a `--no-root` machine the one-shot bundle now covers everything, including atuin and carapace.

## Testing

`homepkg_test` passes 87 of 88 — the failure, `dry-run bootstrap returns the micromamba path, not None`, also fails on main and is unrelated. `setup_test` passes (57). New coverage: the no-args dry run reports both payloads, an explicitly named conda-less tool is included rather than rejected, a combined bundle round-trips its github half offline, a combined manifest with neither half doesn't throw, every registered tool has at least one source, a failed conda replay still installs the release assets, an asset missing a listed binary fails the tool while keeping the others, and the partial-bundle provisioning paths in `setup`.

Exercised against the real CLI, which needs no network for the dry runs:

```
$ homepkg bundle -o /tmp/all.tgz --dry-run
would solve closure for bat, git-delta, fd, fnm, fzf, gh, helix, jujutsu, jq,
  nodejs, nushell, ripgrep, typescript, uv, zoxide (linux-64) and download it
would download github release assets for atuin, carapace
would write /tmp/all.tgz
```

The download paths themselves still can't be exercised here — this environment's egress policy blocks conda-forge and non-allowlisted GitHub hosts — so the first real build is worth watching.