### PR TITLE
Set the Fcitx5 input method to Dvorak too

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,4 @@ test:
 	./setup-hypr_test
 	./setup-sway_test
 	./setup-kde_test
+	./dvorak_test

--- a/dvorak
+++ b/dvorak
@@ -4,8 +4,8 @@
 #
 # It tries every method that applies and applies as many as it can, so it works
 # whether you're on the bare Linux text console, in an X11 session, or in a
-# Wayland desktop (GNOME/KDE), and whether or not an input method (IBus) is
-# running.
+# Wayland desktop (GNOME/KDE), and whether or not an input method (IBus,
+# Fcitx5) is running.
 #
 # The headline case -- the Linux virtual console -- does NOT need root. loadkeys
 # only needs to own the tty (it does: it's your login console) or
@@ -16,7 +16,8 @@
 # dvorak.kmap alongside it and loads that instead, so the console works with
 # neither root nor the keymap package.
 #
-# IBus is only touched if it is already running; this script never starts it.
+# Input methods are only touched if they are already running; this script never
+# starts one.
 
 set -u
 
@@ -134,6 +135,36 @@ maybe_ibus() {
     return 1
 }
 
+# Fcitx5: only if it is already running -- never start it. `fcitx5-remote -s`
+# switches the active input method to the XKB us(dvorak) one, which Fcitx5 names
+# keyboard-us-dvorak.
+maybe_fcitx() {
+    have fcitx5-remote || return 1
+    pgrep -x fcitx5 >/dev/null 2>&1 || return 1
+    if ! fcitx5-remote -s keyboard-us-dvorak >/dev/null 2>&1; then
+        note "Fcitx5: switching to keyboard-us-dvorak failed"
+        return 1
+    fi
+    # -s exits 0 even when the name isn't in the current input method group, so
+    # read the active method back to see whether it really took.
+    current=$(fcitx5-remote -n 2>/dev/null)
+    readback=$?
+    # An older fcitx5-remote with no -n and a failed call (a dropped session bus,
+    # say) both exit non-zero with nothing on stdout, so we can't tell them
+    # apart. Either way the switch itself succeeded and only the confirmation is
+    # missing -- say that rather than claim a verified switch.
+    if test "$readback" -ne 0 || test -z "$current"; then
+        note "Fcitx5 switched to US Dvorak, but reading the active method back failed"
+        return 0
+    fi
+    if test "$current" != keyboard-us-dvorak; then
+        note "Fcitx5 still on $current -- add US (Dvorak) to your input method group"
+        return 1
+    fi
+    note "Fcitx5 input method set to US Dvorak (keyboard-us-dvorak)"
+    return 0
+}
+
 case "${1:-}" in
     -h|--help)
         cat >&2 <<EOF
@@ -147,6 +178,7 @@ current environment:
   - GNOME session       : gsettings input-sources -> us+dvorak
   - KDE Plasma session  : kxkbrc -> us/dvorak
   - IBus                : xkb:us:dvorak:eng     (only if IBus already running)
+  - Fcitx5              : keyboard-us-dvorak    (only if Fcitx5 already running)
 EOF
         exit 0
         ;;
@@ -162,6 +194,7 @@ maybe_x11     && applied=1
 maybe_gnome   && applied=1
 maybe_kde     && applied=1
 maybe_ibus    && applied=1
+maybe_fcitx   && applied=1
 
 if test "$applied" -eq 0; then
     note "could not set Dvorak by any method here"

--- a/dvorak_test
+++ b/dvorak_test
@@ -1,0 +1,227 @@
+#!/bin/sh
+# Tests for dvorak
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DVORAK="$SCRIPT_DIR/dvorak"
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# Each test runs dvorak against a stub PATH holding nothing but the handful of
+# tools it may use, so every layer's outcome is decided here rather than by
+# whatever happens to be installed on the machine running the tests.
+make_stubs() {
+    stubdir="$(mktemp -d)"
+
+    # dvorak itself needs these; everything else stays absent so the console,
+    # X11, GNOME, KDE and IBus layers all skip.
+    for tool in cat dirname readlink; do
+        path="$(command -v "$tool")"
+        ln -s "$path" "$stubdir/$tool"
+    done
+
+    # dvorak asks about ibus-daemon and fcitx5; only fcitx5 can be "running".
+    cat > "$stubdir/pgrep" <<'EOF'
+#!/bin/sh
+case "$2" in
+    fcitx5) test "${STUB_FCITX:-no}" = yes ;;
+    *) exit 1 ;;
+esac
+EOF
+
+    cat > "$stubdir/fcitx5-remote" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >> "$STUB_CALLS"
+case "$1" in
+    -s) exit "${STUB_SET_STATUS:-0}" ;;
+    -n)
+        test -n "${STUB_CURRENT_IM:-}" && printf '%s\n' "$STUB_CURRENT_IM"
+        exit "${STUB_READBACK_STATUS:-0}"
+        ;;
+esac
+EOF
+
+    chmod +x "$stubdir/pgrep" "$stubdir/fcitx5-remote"
+    : > "$stubdir/calls"
+}
+
+cleanup_stubs() {
+    rm -rf "$stubdir"
+}
+
+# run_dvorak [args...]: run dvorak with the stub PATH and a neutral environment,
+# capturing its combined output and exit status.
+run_dvorak() {
+    set +e
+    output="$(
+        PATH="$stubdir" \
+        STUB_CALLS="$stubdir/calls" \
+        STUB_FCITX="${STUB_FCITX:-no}" \
+        STUB_SET_STATUS="${STUB_SET_STATUS:-0}" \
+        STUB_CURRENT_IM="${STUB_CURRENT_IM:-}" \
+        STUB_READBACK_STATUS="${STUB_READBACK_STATUS:-0}" \
+        TERM=xterm \
+        DISPLAY='' \
+        XDG_CURRENT_DESKTOP='' \
+        IBUS_ADDRESS='' \
+        "$DVORAK" "$@" 2>&1
+    )"
+    status=$?
+    set -e
+    calls="$(cat "$stubdir/calls")"
+}
+
+assert_status() {
+    if test "$status" -ne "$1"; then
+        echo "  FAIL: expected exit status $1, got $status"
+        echo "  output: $output"
+        TEST_FAILED=1
+        return 1
+    fi
+}
+
+assert_output_contains() {
+    case "$output" in
+        *"$1"*) ;;
+        *)
+            echo "  FAIL: output does not contain '$1'"
+            echo "  output: $output"
+            TEST_FAILED=1
+            return 1
+            ;;
+    esac
+}
+
+assert_calls_contain() {
+    case "$calls" in
+        *"$1"*) ;;
+        *)
+            echo "  FAIL: fcitx5-remote was not called with '$1'"
+            echo "  calls: $calls"
+            TEST_FAILED=1
+            return 1
+            ;;
+    esac
+}
+
+assert_no_calls() {
+    if test -n "$calls"; then
+        echo "  FAIL: expected no fcitx5-remote calls, got: $calls"
+        TEST_FAILED=1
+        return 1
+    fi
+}
+
+run_test() {
+    name="$1"
+    func="$2"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    # TEST_FAILED catches asserts that fail mid-test: running "$func" as an
+    # `if` condition disables `set -e` inside it, so a failed assert that is
+    # not the last statement would otherwise be ignored.
+    TEST_FAILED=
+    STUB_FCITX=no
+    STUB_SET_STATUS=0
+    STUB_CURRENT_IM=
+    STUB_READBACK_STATUS=0
+    make_stubs
+    if "$func" && test -z "$TEST_FAILED"; then
+        echo "ok $TESTS_RUN $name"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        echo "not ok $TESTS_RUN $name"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+    cleanup_stubs
+}
+
+# --- fcitx5 tests ---
+
+test_fcitx_not_running_is_left_alone() {
+    STUB_FCITX=no
+    run_dvorak
+    # Nothing else applies either, so dvorak reports total failure.
+    assert_status 1 &&
+    assert_no_calls &&
+    assert_output_contains "could not set Dvorak by any method"
+}
+
+test_fcitx_running_switches_layout() {
+    STUB_FCITX=yes
+    STUB_CURRENT_IM=keyboard-us-dvorak
+    run_dvorak
+    assert_status 0 &&
+    assert_calls_contain "-s keyboard-us-dvorak" &&
+    assert_output_contains "Fcitx5 input method set to US Dvorak"
+}
+
+test_fcitx_switch_command_failing_is_reported() {
+    STUB_FCITX=yes
+    STUB_SET_STATUS=1
+    run_dvorak
+    assert_status 1 &&
+    assert_output_contains "switching to keyboard-us-dvorak failed"
+}
+
+test_fcitx_silent_no_op_is_reported() {
+    # -s exits 0 but the layout isn't in the input method group, so the active
+    # method never changes.
+    STUB_FCITX=yes
+    STUB_CURRENT_IM=keyboard-us
+    run_dvorak
+    assert_status 1 &&
+    assert_output_contains "Fcitx5 still on keyboard-us" &&
+    assert_output_contains "could not set Dvorak by any method"
+}
+
+test_unsupported_readback_is_reported() {
+    # Older fcitx5-remote has no -n: it exits non-zero with nothing on stdout.
+    STUB_FCITX=yes
+    STUB_CURRENT_IM=
+    STUB_READBACK_STATUS=1
+    run_dvorak
+    assert_status 0 &&
+    assert_output_contains "reading the active method back failed"
+}
+
+test_empty_readback_is_reported() {
+    # -n exits 0 but names no method, so there is still nothing to verify
+    # against; the switch must not be reported as confirmed.
+    STUB_FCITX=yes
+    STUB_CURRENT_IM=
+    STUB_READBACK_STATUS=0
+    run_dvorak
+    assert_status 0 &&
+    assert_output_contains "reading the active method back failed"
+}
+
+# --- cli tests ---
+
+test_help_lists_fcitx() {
+    run_dvorak --help
+    assert_status 0 &&
+    assert_output_contains "Fcitx5"
+}
+
+test_unexpected_argument_exits_two() {
+    run_dvorak --nonesuch
+    assert_status 2 &&
+    assert_output_contains "unexpected argument"
+}
+
+# --- run ---
+
+run_test "fcitx5 that is not running is left alone" test_fcitx_not_running_is_left_alone
+run_test "running fcitx5 switches to Dvorak" test_fcitx_running_switches_layout
+run_test "failing fcitx5 switch is reported" test_fcitx_switch_command_failing_is_reported
+run_test "fcitx5 switch that does not take is reported" test_fcitx_silent_no_op_is_reported
+run_test "fcitx5 without -n reports the missing confirmation" test_unsupported_readback_is_reported
+run_test "empty readback reports the missing confirmation" test_empty_readback_is_reported
+run_test "help lists fcitx5" test_help_lists_fcitx
+run_test "unexpected argument exits 2" test_unexpected_argument_exits_two
+
+echo
+echo "$TESTS_RUN tests, $TESTS_PASSED passed, $TESTS_FAILED failed"
+test "$TESTS_FAILED" -eq 0


### PR DESCRIPTION
## What

Adds the one keyboard layer `dvorak` was missing: a running **Fcitx5**. It already covered the Linux console, X11, GNOME, KDE and IBus, but left Fcitx5 on whatever input method it had — so on a Fcitx5 desktop the keys kept producing QWERTY even though every other layer had switched.

This is the Fcitx5 handler from mikelward/mesh#175, which was opened against the wrong repository (mesh is the language repo and has no `scripts/` directory). That PR is closed; everything else in it was already covered by #150.

## How

`maybe_fcitx` switches the active input method with `fcitx5-remote -s keyboard-us-dvorak`, gated on `pgrep -x fcitx5` so a daemon that isn't already running is **never started** — the same rule `maybe_ibus` follows.

`-s` exits 0 even when the layout isn't in the current input method group, so the active method is read back with `fcitx5-remote -n`. A switch that silently did nothing is reported as a failure rather than counted as applied:

```
dvorak: Fcitx5 still on keyboard-us -- add US (Dvorak) to your input method group
```

When the readback gives no answer at all, that is reported too rather than passed off as a verified switch:

```
dvorak: Fcitx5 switched to US Dvorak, but reading the active method back failed
```

An older `fcitx5-remote` without `-n` and a `-n` that fails on the session bus both exit non-zero with empty stdout, so they can't be told apart from the caller — neither is treated as confirmation. This case still counts as applied, since `-s` did succeed and only the confirmation is missing.

`--help` lists the new method alongside the others.

## Tests

There was no `dvorak_test`, so this adds one (and lists it in the `Makefile`). It runs the script against a stub `PATH` holding only the tools it may use — `cat`, `dirname`, `readlink`, plus stub `pgrep` and `fcitx5-remote` — so each layer's outcome is fixed by the test rather than by whatever is installed on the machine running it.

Eight tests: daemon not running (never invoked at all), successful switch, failing `-s`, `-s` that succeeds without taking effect, `-n` unsupported, `-n` succeeding but naming no method, `--help`, and the exit-2 argument check.

`make test` passes in full, and `shellcheck` is clean on both files.

## Cost and reliability

Zero — `fcitx5-remote` is a local DBus call to a daemon that must already be running, no network and no new dependency. If Fcitx5 isn't installed or isn't running, the layer skips exactly as before.