### PR TITLE
setup-kde: install Krohnkite from its Codeberg release, not a source build

### DIFF
--- a/homepkg
+++ b/homepkg
@@ -12,20 +12,26 @@ For machines where apt/dnf need root. Installs into a home prefix (default
   conda   unpack a single conda-forge package (sha256-verified) -- stateless,
           no dependency resolution; for one-shots and building push-bundles.
   github  unpack a release asset from the tool's GitHub repo -- stateless.
+  codeberg  fetch a release asset from the tool's Codeberg repo -- stateless.
+          For artifacts that aren't a CLI binary (e.g. Krohnkite's
+          .kwinscript): unlike github this saves the raw asset under
+          <prefix>/share/homepkg/assets/<tool>/ instead of unpacking named
+          binaries onto PATH.
 
 Usage:
     homepkg bootstrap                       # fetch micromamba into ~/.local/bin
     homepkg install TOOL...                 # mamba env (default)
     homepkg update [TOOL...]                # native micromamba update (all if none)
     homepkg remove TOOL...
-    homepkg --backend conda|github install TOOL...
+    homepkg --backend conda|github|codeberg install TOOL...
     homepkg list
 
 Push bundles (build on an online host, install on an air-gapped target):
-    homepkg bundle -o tools.tgz                     # online: bundle ALL tools
-    homepkg bundle -o tools.tgz TOOL...            # ...or just the named ones
-    homepkg --backend github bundle -o t.tgz TOOL... # static-asset variant
-    homepkg install-bundle tools.tgz               # target: install offline
+    homepkg bundle -o tools.tgz                       # online: bundle ALL tools
+    homepkg bundle -o tools.tgz TOOL...                # ...or just the named ones
+    homepkg --backend github bundle -o t.tgz TOOL...   # static-asset variant
+    homepkg --backend codeberg bundle -o t.tgz TOOL...   # ditto, Codeberg-hosted
+    homepkg install-bundle tools.tgz                  # target: install offline
 
 A bundle carries whatever each tool needs: the solved conda closure for the
 tools with a conda-forge package, release assets for the ones without, and the
@@ -33,7 +39,7 @@ micromamba to replay the closure with. `bundle` with no tool names covers the
 whole registry, so one file provisions a machine with no network at all.
 
 Tool names are logical (ripgrep, fd, ...); the registry maps each to its conda
-package and GitHub repo.
+package and its GitHub or Codeberg repo.
 """
 
 import argparse
@@ -51,11 +57,17 @@ import zipfile
 
 # --- Tool registry -----------------------------------------------------------
 #
-# conda:  conda-forge package name (verified against current_repodata).
-# github: "owner/repo" for the release backend.
-# bins:   binary basenames to expose on PATH (default: the tool name). A conda
-#         package is unpacked whole (bin/lib/share); for github we locate these
-#         names in the extracted asset.
+# conda:       conda-forge package name (verified against current_repodata).
+# github:      "owner/repo" for the GitHub release backend.
+# codeberg:    "owner/repo" for the Codeberg release backend (mutually
+#              exclusive with github -- a tool has at most one release host).
+# codeberg_tag: pin the codeberg backend to a specific release tag instead of
+#              "latest" (Gitea's /releases/latest excludes prereleases, so a
+#              tool whose current usable build is tagged as one needs this).
+# bins:        binary basenames to expose on PATH (default: the tool name). A
+#              conda package is unpacked whole (bin/lib/share); for github we
+#              locate these names in the extracted asset. Omitted for codeberg
+#              tools, which aren't CLI binaries -- see krohnkite below.
 TOOLS = {
     "ripgrep": {"conda": "ripgrep",   "github": "BurntSushi/ripgrep", "bins": ["rg"]},
     "fd":      {"conda": "fd",         "github": "sharkdp/fd",         "bins": ["fd"]},
@@ -83,6 +95,16 @@ TOOLS = {
     "node":       {"conda": "nodejs",     "github": "nodejs/node",          "bins": ["node", "npm", "npx"]},
     "typescript": {"conda": "typescript", "github": "microsoft/TypeScript", "bins": ["tsc"]},
     "fnm":        {"conda": "fnm",        "github": "Schniz/fnm",           "bins": ["fnm"]},
+    # Krohnkite (KDE KWin tiling script). Not a CLI tool -- it installs via
+    # kpackagetool6, not onto PATH -- so it carries no "bins" and has no
+    # conda-forge feedstock. homepkg only fetches its prebuilt .kwinscript
+    # release asset, from upstream's Codeberg releases; setup-kde does the
+    # actual kpackagetool6 install. No codeberg_tag pin: the codeberg backend
+    # already takes the newest release including prereleases (see
+    # codeberg_release_assets), which is what's wanted here -- upstream's last
+    # stable tag is old and buggy on KWin 6, and Gitea's /releases/latest
+    # would otherwise skip past the current beta straight to that stable one.
+    "krohnkite": {"conda": None, "codeberg": "anametologin/Krohnkite"},
 }
 
 
@@ -109,9 +131,10 @@ def conda_pkgs(tools, skip_missing=False):
     """
     missing = [t for t in tools if not TOOLS[t].get("conda")]
     if missing and not skip_missing:
-        raise HomepkgError(
-            f"no conda-forge package for: {', '.join(missing)}; "
-            f"install with --backend github")
+        backends = sorted({b for t in missing for b in ("github", "codeberg")
+                            if TOOLS[t].get(b)})
+        hint = f"; install with --backend {'/'.join(backends)}" if backends else ""
+        raise HomepkgError(f"no conda-forge package for: {', '.join(missing)}{hint}")
     if missing:
         warn(f"no conda-forge package, skipping: {', '.join(missing)}")
     return [TOOLS[t]["conda"] for t in tools if TOOLS[t].get("conda")]
@@ -440,11 +463,80 @@ def install_github(tool, meta, prefix, plat, dry_run):
     info(f"  installed {', '.join(placed)} into {prefix}/bin")
 
 
+# --- codeberg backend ---------------------------------------------------------
+#
+# Codeberg (Gitea) exposes almost the same release shape as GitHub -- "assets":
+# [{"name", "browser_download_url"}] -- so the fetch is a near copy of the
+# github backend above. What differs is the artifact itself: Krohnkite's
+# release is a single, platform-independent .kwinscript file, not an
+# arch-specific archive with binaries inside, so there's no asset-token
+# matching and nothing to unpack. This backend just caches the raw file under
+# <prefix>/share/homepkg/assets/<tool>/; installing it (kpackagetool6) is
+# setup-kde's job, not homepkg's.
+
+def codeberg_release_assets(repo, tag=None):
+    """(tag_name, [(asset name, url), ...]) for a release.
+
+    `tag=None` (the default) means the single newest published release,
+    prereleases included: Gitea's (like GitHub's) /releases/latest skips
+    prereleases, which would silently pick an old stable release over a
+    newer beta -- exactly what Krohnkite needs to avoid, since its last
+    stable tag predates KWin 6 fixes only shipped in the beta line. The
+    releases list is already sorted newest-first, so ?limit=1 is enough.
+    Pass an explicit tag (registry's codeberg_tag) to pin one instead.
+    """
+    if tag:
+        data = json.loads(http_get(
+            f"https://codeberg.org/api/v1/repos/{repo}/releases/tags/{tag}"))
+    else:
+        releases = json.loads(http_get(
+            f"https://codeberg.org/api/v1/repos/{repo}/releases?limit=1"))
+        if not releases:
+            raise HomepkgError(f"no releases found for {repo}")
+        data = releases[0]
+    return data.get("tag_name", "?"), [
+        (a["name"], a["browser_download_url"]) for a in data.get("assets", [])]
+
+
+def codeberg_pick_kwinscript(assets):
+    for name, url in assets:
+        if name.lower().endswith(".kwinscript"):
+            return name, url
+    return None
+
+
+def codeberg_asset_dir(tool, prefix):
+    return os.path.join(prefix, "share", "homepkg", "assets", tool)
+
+
+def install_codeberg(tool, meta, prefix, plat, dry_run):
+    repo = meta["codeberg"]
+    tag, assets = codeberg_release_assets(repo, meta.get("codeberg_tag"))
+    picked = codeberg_pick_kwinscript(assets)
+    if not picked:
+        raise HomepkgError(f"{tool}: no .kwinscript asset in {repo} {tag}")
+    name, url = picked
+    info(f"{tool}: codeberg {repo} {tag} -> {name}")
+    if dry_run:
+        info(f"  would install from {url}")
+        return
+    dest_dir = codeberg_asset_dir(tool, prefix)
+    # Clear any previous asset first: a version bump changes the filename, and
+    # a consumer (setup-kde) that globs this directory for "the" .kwinscript
+    # needs exactly one file here, not old and new coexisting.
+    if os.path.isdir(dest_dir):
+        shutil.rmtree(dest_dir)
+    os.makedirs(dest_dir, exist_ok=True)
+    download(url, os.path.join(dest_dir, name))
+    info(f"  saved {name} to {dest_dir}")
+
+
 # The per-tool extract backends: fetch one prebuilt artifact and unpack it.
 # Good for one-shot installs and for building push-bundles, but they carry no
 # state and don't resolve dependencies. For the well-lit interactive path use
 # the mamba backend below.
-EXTRACT_BACKENDS = {"conda": install_conda, "github": install_github}
+EXTRACT_BACKENDS = {"conda": install_conda, "github": install_github,
+                     "codeberg": install_codeberg}
 
 
 # --- micromamba backend ------------------------------------------------------
@@ -719,21 +811,50 @@ def _stage_github(tools, plat, td, skip_unavailable=False):
     return entries
 
 
+def _stage_codeberg(tools, td, skip_unavailable=False):
+    """Download a release asset per tool in `tools` into staging dir `td`.
+
+    Krohnkite's release asset is platform-independent, so unlike
+    _stage_github this needs no per-arch token matching.
+    """
+    info(f"collecting codeberg assets for {', '.join(tools)}")
+    adir = os.path.join(td, "codeberg-assets")
+    os.makedirs(adir, exist_ok=True)
+    entries = []
+    for t in tools:
+        repo = TOOLS[t]["codeberg"]
+        tag, assets = codeberg_release_assets(repo, TOOLS[t].get("codeberg_tag"))
+        picked = codeberg_pick_kwinscript(assets)
+        if not picked:
+            msg = f"{t}: no .kwinscript asset in {repo} {tag}"
+            if not skip_unavailable:
+                raise HomepkgError(msg)
+            warn(msg + "; leaving it out of the bundle")
+            continue
+        name, url = picked
+        download(url, os.path.join(adir, name))
+        entries.append({"tool": t, "asset": name})
+    return entries
+
+
 def bundle_all(tools, prefix, plat, out, dry_run, whole_registry=False):
     """Bundle `tools` from wherever each one comes from, in one file.
 
-    Most tools come from conda-forge; the few with no feedstock come from their
-    GitHub releases. Splitting that across two bundles would make the caller
-    track which tool went where, so one bundle carries both payloads and
-    install-bundle replays whichever parts are present.
+    Most tools come from conda-forge; the few with no feedstock come from
+    their GitHub or Codeberg releases. Splitting that across separate bundles
+    would make the caller track which tool went where, so one bundle carries
+    every payload and install-bundle replays whichever parts are present.
     """
     conda_tools = [t for t in tools if TOOLS[t].get("conda")]
     github_tools = [t for t in tools if not TOOLS[t].get("conda")
                     and TOOLS[t].get("github")]
-    unavailable = [t for t in tools if t not in conda_tools and t not in github_tools]
+    codeberg_tools = [t for t in tools if not TOOLS[t].get("conda")
+                      and TOOLS[t].get("codeberg")]
+    unavailable = [t for t in tools if t not in conda_tools
+                   and t not in github_tools and t not in codeberg_tools]
     if unavailable:
         warn(f"no source for: {', '.join(unavailable)}; leaving them out of the bundle")
-    if not conda_tools and not github_tools:
+    if not conda_tools and not github_tools and not codeberg_tools:
         raise HomepkgError("nothing to bundle")
 
     # Report before touching the network so --dry-run needs no micromamba.
@@ -743,6 +864,8 @@ def bundle_all(tools, prefix, plat, out, dry_run, whole_registry=False):
                  f"({conda_subdir(*plat)}) and download it")
         if github_tools:
             info(f"would download github release assets for {', '.join(github_tools)}")
+        if codeberg_tools:
+            info(f"would download codeberg release assets for {', '.join(codeberg_tools)}")
         info(f"would write {out}")
         return
 
@@ -754,6 +877,9 @@ def bundle_all(tools, prefix, plat, out, dry_run, whole_registry=False):
         if github_tools:
             manifest["github"] = {"tools": _stage_github(
                 github_tools, plat, td, skip_unavailable=whole_registry)}
+        if codeberg_tools:
+            manifest["codeberg"] = {"tools": _stage_codeberg(
+                codeberg_tools, td, skip_unavailable=whole_registry)}
         with open(os.path.join(td, "manifest.json"), "w") as fh:
             json.dump(manifest, fh)
         _write_bundle(out, td)
@@ -769,6 +895,20 @@ def bundle_github(tools, prefix, plat, out, dry_run):
         entries = _stage_github(tools, plat, td)
         with open(os.path.join(td, "manifest.json"), "w") as fh:
             json.dump({"format": 1, "backend": "github",
+                       "platform": f"{plat[0]}/{plat[1]}", "tools": entries}, fh)
+        _write_bundle(out, td)
+    info(f"wrote {out} ({os.path.getsize(out) // 1024} KiB)")
+
+
+def bundle_codeberg(tools, plat, out, dry_run):
+    info(f"collecting codeberg assets for {', '.join(tools)}")
+    if dry_run:
+        info(f"  would download release assets and write {out}")
+        return
+    with tempfile.TemporaryDirectory() as td:
+        entries = _stage_codeberg(tools, td)
+        with open(os.path.join(td, "manifest.json"), "w") as fh:
+            json.dump({"format": 1, "backend": "codeberg",
                        "platform": f"{plat[0]}/{plat[1]}", "tools": entries}, fh)
         _write_bundle(out, td)
     info(f"wrote {out} ({os.path.getsize(out) // 1024} KiB)")
@@ -845,6 +985,28 @@ def _install_bundle_github(td, manifest, prefix, dry_run):
     return failed
 
 
+def _install_bundle_codeberg(td, manifest, prefix, dry_run):
+    """Copy each tool's cached asset into place. Returns the tools that
+    couldn't be installed, same contract as _install_bundle_github."""
+    failed = []
+    for e in manifest["tools"]:
+        _require_basename(e["asset"], "asset name")
+        asset = os.path.join(td, "codeberg-assets", e["asset"])
+        if not os.path.exists(asset):
+            warn(f"{e['tool']}: {e['asset']} is not in the bundle; skipping it")
+            failed.append(e["tool"])
+            continue
+        info(f"{e['tool']}: {e['asset']}")
+        if dry_run:
+            continue
+        dest_dir = codeberg_asset_dir(e["tool"], prefix)
+        if os.path.isdir(dest_dir):
+            shutil.rmtree(dest_dir)
+        os.makedirs(dest_dir, exist_ok=True)
+        shutil.copy2(asset, os.path.join(dest_dir, e["asset"]))
+    return failed
+
+
 def install_bundle(bundle_file, prefix, plat, dry_run):
     with tempfile.TemporaryDirectory() as td:
         with tarfile.open(bundle_file) as tf:
@@ -878,10 +1040,15 @@ def install_bundle(bundle_file, prefix, plat, dry_run):
             if "github" in manifest:
                 failed.extend(_install_bundle_github(
                     td, manifest["github"], prefix, dry_run))
+            if "codeberg" in manifest:
+                failed.extend(_install_bundle_codeberg(
+                    td, manifest["codeberg"], prefix, dry_run))
         elif backend == "mamba":
             _install_bundle_mamba(td, manifest, prefix, dry_run)
         elif backend == "github":
             failed.extend(_install_bundle_github(td, manifest, prefix, dry_run))
+        elif backend == "codeberg":
+            failed.extend(_install_bundle_codeberg(td, manifest, prefix, dry_run))
         else:
             raise HomepkgError(f"unknown bundle backend: {backend}")
         if failed:
@@ -912,10 +1079,11 @@ def main(argv=None):
     p = argparse.ArgumentParser(
         prog="homepkg", add_help=True,
         description="Install prebuilt CLI tools into a home prefix, no root.")
-    p.add_argument("--backend", choices=["mamba", "conda", "github"], default="mamba",
+    p.add_argument("--backend", choices=["mamba", "conda", "github", "codeberg"],
+                   default="mamba",
                    help="install backend (default: mamba -- a managed micromamba "
-                        "env with native update/remove; conda/github unpack a "
-                        "single artifact with no state)")
+                        "env with native update/remove; conda/github/codeberg "
+                        "fetch a single artifact with no state)")
     p.add_argument("--prefix", default=os.path.expanduser("~/.local"),
                    help="install prefix (default: ~/.local)")
     p.add_argument("--arch", default=None,
@@ -942,9 +1110,11 @@ def main(argv=None):
         for name in sorted(TOOLS):
             m = TOOLS[name]
             # conda is None for tools with no conda-forge feedstock; show a
-            # dash so `list` says which ones need --backend github.
+            # dash so `list` says which ones need --backend github/codeberg.
             conda = m["conda"] or "-"
-            print(f"{name:10} conda={conda:12} github={m['github']}")
+            release = f"github={m['github']}" if m.get("github") else \
+                      f"codeberg={m['codeberg']}" if m.get("codeberg") else "release=-"
+            print(f"{name:10} conda={conda:12} {release}")
         return 0
 
     if args.command == "bootstrap":
@@ -972,16 +1142,18 @@ def main(argv=None):
         if not args.output:
             p.error("bundle requires -o/--output FILE")
         if args.backend == "conda":
-            p.error("bundle supports --backend mamba (default) or github, not conda")
+            p.error("bundle supports --backend mamba (default), github, or "
+                    "codeberg, not conda")
         whole_registry = not args.tools
         if args.tools:
             tools = args.tools
-        elif args.backend == "github":
-            # No "bundle everything" for the github-only variant: not every
-            # registered tool has a static release asset (typescript is
-            # npm-only), and asking for that variant means asking for those
-            # assets specifically. The default backend covers everything.
-            p.error("bundle --backend github needs explicit tool names "
+        elif args.backend in ("github", "codeberg"):
+            # No "bundle everything" for the static-asset variants: not every
+            # registered tool has a release asset on that host (typescript is
+            # npm-only, most tools aren't on Codeberg), and asking for that
+            # variant means asking for those assets specifically. The default
+            # backend covers everything.
+            p.error(f"bundle --backend {args.backend} needs explicit tool names "
                     "(no-args = all is the default backend)")
         else:
             # No tool names means "bundle everything registered" -- one file
@@ -993,6 +1165,8 @@ def main(argv=None):
         try:
             if args.backend == "github":
                 bundle_github(tools, args.prefix, plat, args.output, args.dry_run)
+            elif args.backend == "codeberg":
+                bundle_codeberg(tools, plat, args.output, args.dry_run)
             else:
                 bundle_all(tools, args.prefix, plat, args.output, args.dry_run,
                            whole_registry=whole_registry)

--- a/homepkg
+++ b/homepkg
@@ -521,13 +521,20 @@ def install_codeberg(tool, meta, prefix, plat, dry_run):
         info(f"  would install from {url}")
         return
     dest_dir = codeberg_asset_dir(tool, prefix)
-    # Clear any previous asset first: a version bump changes the filename, and
-    # a consumer (setup-kde) that globs this directory for "the" .kwinscript
-    # needs exactly one file here, not old and new coexisting.
-    if os.path.isdir(dest_dir):
-        shutil.rmtree(dest_dir)
-    os.makedirs(dest_dir, exist_ok=True)
-    download(url, os.path.join(dest_dir, name))
+    # Download to a temp location first, and only then replace dest_dir: a
+    # consumer (setup-kde) refreshes by calling this on every run and falls
+    # back to whatever's already cached here when the fetch fails (offline).
+    # Clearing dest_dir before the download would destroy that fallback the
+    # moment the network drops mid-refresh, not just when it's absent
+    # entirely. A version bump changes the filename, so dest_dir is still
+    # cleared on success -- old and new must not coexist, since a consumer
+    # globs this directory for "the" .kwinscript.
+    with tempfile.TemporaryDirectory() as td:
+        downloaded = download(url, os.path.join(td, name))
+        if os.path.isdir(dest_dir):
+            shutil.rmtree(dest_dir)
+        os.makedirs(dest_dir, exist_ok=True)
+        shutil.move(downloaded, os.path.join(dest_dir, name))
     info(f"  saved {name} to {dest_dir}")
 
 
@@ -880,6 +887,12 @@ def bundle_all(tools, prefix, plat, out, dry_run, whole_registry=False):
         if codeberg_tools:
             manifest["codeberg"] = {"tools": _stage_codeberg(
                 codeberg_tools, td, skip_unavailable=whole_registry)}
+        # A bundle carrying ONLY codeberg assets has nothing platform-specific
+        # in it (see bundle_codeberg) -- tag it platform-neutral rather than
+        # pinning it to whichever host happened to build it, the same
+        # exemption install_bundle gives bundle_codeberg's own output.
+        if codeberg_tools and not conda_tools and not github_tools:
+            manifest["platform"] = "any"
         with open(os.path.join(td, "manifest.json"), "w") as fh:
             json.dump(manifest, fh)
         _write_bundle(out, td)
@@ -900,7 +913,7 @@ def bundle_github(tools, prefix, plat, out, dry_run):
     info(f"wrote {out} ({os.path.getsize(out) // 1024} KiB)")
 
 
-def bundle_codeberg(tools, plat, out, dry_run):
+def bundle_codeberg(tools, out, dry_run):
     info(f"collecting codeberg assets for {', '.join(tools)}")
     if dry_run:
         info(f"  would download release assets and write {out}")
@@ -908,8 +921,12 @@ def bundle_codeberg(tools, plat, out, dry_run):
     with tempfile.TemporaryDirectory() as td:
         entries = _stage_codeberg(tools, td)
         with open(os.path.join(td, "manifest.json"), "w") as fh:
+            # .kwinscript assets are platform-independent (see
+            # codeberg_release_assets), so this bundle is too -- "any" tells
+            # install_bundle to skip the OS/arch check that would otherwise
+            # tie it to whichever host happened to build it.
             json.dump({"format": 1, "backend": "codeberg",
-                       "platform": f"{plat[0]}/{plat[1]}", "tools": entries}, fh)
+                       "platform": "any", "tools": entries}, fh)
         _write_bundle(out, td)
     info(f"wrote {out} ({os.path.getsize(out) // 1024} KiB)")
 
@@ -991,6 +1008,10 @@ def _install_bundle_codeberg(td, manifest, prefix, dry_run):
     failed = []
     for e in manifest["tools"]:
         _require_basename(e["asset"], "asset name")
+        # e["tool"] feeds codeberg_asset_dir() below, same as asset name --
+        # a tampered manifest with e.g. "../../etc" would otherwise let
+        # rmtree() delete an arbitrary directory outside the prefix.
+        _require_basename(e.get("tool", ""), "tool name")
         asset = os.path.join(td, "codeberg-assets", e["asset"])
         if not os.path.exists(asset):
             warn(f"{e['tool']}: {e['asset']} is not in the bundle; skipping it")
@@ -1015,7 +1036,10 @@ def install_bundle(bundle_file, prefix, plat, dry_run):
         backend = manifest.get("backend")
         want = f"{plat[0]}/{plat[1]}"
         got = manifest.get("platform")
-        if got != want:
+        # "any" marks a bundle with nothing platform-specific in it (a
+        # codeberg-only payload -- see bundle_codeberg/bundle_all), which
+        # installs on any host regardless of what built it.
+        if got != want and got != "any":
             raise HomepkgError(
                 f"bundle is for {got}, but this host is {want} "
                 "(pass --arch to override)")
@@ -1166,7 +1190,7 @@ def main(argv=None):
             if args.backend == "github":
                 bundle_github(tools, args.prefix, plat, args.output, args.dry_run)
             elif args.backend == "codeberg":
-                bundle_codeberg(tools, plat, args.output, args.dry_run)
+                bundle_codeberg(tools, args.output, args.dry_run)
             else:
                 bundle_all(tools, args.prefix, plat, args.output, args.dry_run,
                            whole_registry=whole_registry)

--- a/homepkg_test
+++ b/homepkg_test
@@ -120,6 +120,93 @@ check("github_pick_asset matches single-binary amd64", _pick_jq is not None and 
 check("github_pick_asset returns None when nothing matches",
       hp.github_pick_asset([("tool-win.zip", "x")], _linux) is None)
 
+# --- codeberg asset selection -------------------------------------------------
+
+_kw_assets = [
+    ("krohnkite-0.9.9.3_beta.kwinscript", "k1"),
+    ("krohnkite-0.9.9.3_beta.kwinscript.sha256", "k2"),
+    ("Source code (zip)", "k3"),
+]
+_kw_pick = hp.codeberg_pick_kwinscript(_kw_assets)
+check("codeberg_pick_kwinscript picks the .kwinscript asset",
+      _kw_pick is not None and _kw_pick[1] == "k1")
+check("codeberg_pick_kwinscript ignores the checksum and source archive",
+      _kw_pick[0] == "krohnkite-0.9.9.3_beta.kwinscript")
+check("codeberg_pick_kwinscript returns None when nothing matches",
+      hp.codeberg_pick_kwinscript([("Source code (zip)", "x")]) is None)
+
+# codeberg_release_assets requests /releases/tags/<tag> when a tag is given,
+# and /releases?limit=1 (the single newest release, prereleases included)
+# otherwise -- NOT /releases/latest, which (like GitHub's) skips prereleases
+# and would silently prefer an old stable release over a newer beta.
+_saved_http_get = hp.http_get
+_http_get_urls = []
+def _fake_http_get(url, accept=None):
+    _http_get_urls.append(url)
+    if "/releases/tags/" in url:
+        return json.dumps({"tag_name": "1.2.3",
+                           "assets": [{"name": "krohnkite-1.2.3.kwinscript",
+                                       "browser_download_url": "https://example.invalid/pinned"}]}).encode()
+    return json.dumps([{"tag_name": "0.9.9.3_beta",
+                        "assets": [{"name": "krohnkite-0.9.9.3_beta.kwinscript",
+                                    "browser_download_url": "https://example.invalid/newest"}]},
+                       {"tag_name": "0.9.9.2",
+                        "assets": [{"name": "krohnkite-0.9.9.2.kwinscript",
+                                    "browser_download_url": "https://example.invalid/older"}]}]).encode()
+hp.http_get = _fake_http_get
+try:
+    hp.codeberg_release_assets("anametologin/Krohnkite", "1.2.3")
+    check("codeberg_release_assets requests a pinned tag from /releases/tags",
+          _http_get_urls[-1].endswith("/releases/tags/1.2.3"))
+    tag, assets = hp.codeberg_release_assets("anametologin/Krohnkite")
+    check("codeberg_release_assets with no tag requests /releases?limit=1, not /releases/latest",
+          _http_get_urls[-1].endswith("/releases?limit=1"))
+    check("codeberg_release_assets with no tag takes the newest release, prereleases included",
+          tag == "0.9.9.3_beta" and assets[0][0] == "krohnkite-0.9.9.3_beta.kwinscript")
+finally:
+    hp.http_get = _saved_http_get
+
+# install_codeberg saves the raw asset under share/homepkg/assets/<tool>/ --
+# no unpacking, unlike install_github, and no "bins" needed in meta.
+_saved_cra = hp.codeberg_release_assets
+hp.codeberg_release_assets = lambda repo, tag=None: (
+    "0.9.9.3_beta", [("krohnkite-0.9.9.3_beta.kwinscript", "https://example.invalid/k")])
+try:
+    with tempfile.TemporaryDirectory() as td:
+        prefix = os.path.join(td, "prefix")
+        _saved_download = hp.download
+        hp.download = lambda url, dest: open(dest, "wb").write(b"// kwin script") or dest
+        try:
+            hp.install_codeberg("krohnkite", hp.TOOLS["krohnkite"], prefix,
+                                ("linux", "x86_64"), False)
+        finally:
+            hp.download = _saved_download
+        saved = os.path.join(hp.codeberg_asset_dir("krohnkite", prefix),
+                             "krohnkite-0.9.9.3_beta.kwinscript")
+        check("install_codeberg saves the asset under share/homepkg/assets/<tool>/",
+              os.path.exists(saved) and open(saved, "rb").read() == b"// kwin script")
+    # dry-run must not touch the filesystem or need "bins" in meta.
+    with tempfile.TemporaryDirectory() as td:
+        prefix = os.path.join(td, "prefix")
+        hp.install_codeberg("krohnkite", hp.TOOLS["krohnkite"], prefix,
+                            ("linux", "x86_64"), True)
+        check("install_codeberg --dry-run writes nothing",
+              not os.path.exists(hp.codeberg_asset_dir("krohnkite", prefix)))
+    # No .kwinscript asset in the release -- e.g. upstream renamed or dropped
+    # it -- has to fail loudly rather than silently install nothing.
+    hp.codeberg_release_assets = lambda repo, tag=None: ("9.9.9", [("Source code (zip)", "u")])
+    _err = None
+    try:
+        hp.install_codeberg("krohnkite", hp.TOOLS["krohnkite"],
+                            os.path.join(tempfile.gettempdir(), "hp-cb-noasset"),
+                            ("linux", "x86_64"), False)
+    except hp.HomepkgError as e:
+        _err = e
+    check("install_codeberg errors when the release has no .kwinscript asset",
+          _err is not None and "krohnkite" in str(_err))
+finally:
+    hp.codeberg_release_assets = _saved_cra
+
 # --- github extraction -------------------------------------------------------
 
 def _make_targz(path, members):
@@ -228,6 +315,18 @@ check("registry maps carapace to carapace-bin releases",
       and hp.TOOLS["carapace"]["github"] == "carapace-sh/carapace-bin"
       and hp.TOOLS["carapace"]["bins"] == ["carapace"])
 
+# Krohnkite: no conda-forge feedstock, no GitHub repo -- its release lives on
+# Codeberg, pinned to a specific (beta) tag rather than "latest", and it's not
+# a CLI tool so it carries no "bins".
+check("registry maps krohnkite to its codeberg releases only",
+      hp.TOOLS["krohnkite"]["conda"] is None
+      and hp.TOOLS["krohnkite"]["codeberg"] == "anametologin/Krohnkite")
+check("krohnkite has no tag pinned (codeberg backend already takes newest, "
+      "prereleases included)",
+      "codeberg_tag" not in hp.TOOLS["krohnkite"])
+check("krohnkite carries no bins (not a CLI tool)",
+      "bins" not in hp.TOOLS["krohnkite"])
+
 # conda_pkgs is the gate between the registry and every conda/mamba path.
 check("conda_pkgs maps tools to their conda-forge names",
       hp.conda_pkgs(["ripgrep", "delta"]) == ["ripgrep", "git-delta"])
@@ -240,6 +339,13 @@ check("conda_pkgs errors when a named tool has no conda package",
       _conda_pkgs_raised)
 check("conda_pkgs skips conda-less tools for whole-registry operations",
       hp.conda_pkgs(["ripgrep", "carapace"], skip_missing=True) == ["ripgrep"])
+try:
+    hp.conda_pkgs(["krohnkite"])
+    _conda_pkgs_codeberg_raised = False
+except hp.HomepkgError as e:
+    _conda_pkgs_codeberg_raised = "krohnkite" in str(e) and "--backend codeberg" in str(e)
+check("conda_pkgs names the codeberg backend for a codeberg-only tool",
+      _conda_pkgs_codeberg_raised)
 
 # A conda-less tool named explicitly must fail rather than look installed.
 check("install of a github-only tool on the mamba backend errors",
@@ -276,9 +382,10 @@ check("bundle with no tools targets every registered package",
 check("bundle with no tools also collects the conda-less tools",
       all(t in _bundle_all.stderr
           for t in hp.TOOLS if not hp.TOOLS[t]["conda"]))
-check("bundle with no tools reports both payloads",
+check("bundle with no tools reports every payload",
       "would solve closure" in _bundle_all.stderr
-      and "github release assets" in _bundle_all.stderr)
+      and "github release assets" in _bundle_all.stderr
+      and "codeberg release assets" in _bundle_all.stderr)
 # Naming a conda-less tool works the same way: it lands in the bundle's
 # github payload instead of erroring.
 _bundle_named = _run("bundle", "-o",
@@ -288,11 +395,22 @@ check("bundle covers an explicitly named conda-less tool",
       _bundle_named.returncode == 0
       and "carapace" in _bundle_named.stderr
       and "jq" in _bundle_named.stderr)
+# ...and a codeberg-only tool lands in the codeberg payload.
+_bundle_krohnkite = _run("bundle", "-o",
+                         os.path.join(tempfile.gettempdir(), "hp-bundle-krohnkite.tgz"),
+                         "--dry-run", "krohnkite")
+check("bundle covers an explicitly named codeberg-only tool",
+      _bundle_krohnkite.returncode == 0
+      and "codeberg release assets" in _bundle_krohnkite.stderr
+      and "krohnkite" in _bundle_krohnkite.stderr)
 # ...but no-args "all" is mamba-only: not every tool has a github release asset
 # (typescript is npm-only), so the github backend must require explicit names.
 check("bundle --backend github rejects no-args all-tools",
       _run("--backend", "github", "bundle", "-o",
            os.path.join(tempfile.gettempdir(), "hp-gh-test.tgz")).returncode != 0)
+check("bundle --backend codeberg rejects no-args all-tools",
+      _run("--backend", "codeberg", "bundle", "-o",
+           os.path.join(tempfile.gettempdir(), "hp-cb-test.tgz")).returncode != 0)
 
 # --- micromamba backend: env paths and symlink management --------------------
 
@@ -510,7 +628,8 @@ with tempfile.TemporaryDirectory() as td:
 # The tool split is what makes one bundle enough: everything with a
 # conda-forge package goes through the closure, the rest through releases.
 check("every registered tool has a source for the combined bundle",
-      all(hp.TOOLS[t].get("conda") or hp.TOOLS[t].get("github") for t in hp.TOOLS))
+      all(hp.TOOLS[t].get("conda") or hp.TOOLS[t].get("github")
+          or hp.TOOLS[t].get("codeberg") for t in hp.TOOLS))
 
 # A github bundle round-trips fully offline: build the tarball by hand, then
 # install-bundle unpacks the asset and places the binary -- no network.
@@ -528,6 +647,61 @@ with tempfile.TemporaryDirectory() as td:
     hp.install_bundle(bundle, prefix, ("linux", "x86_64"), False)
     check("install-bundle (github) unpacks the asset offline",
           os.access(os.path.join(prefix, "bin", "rg"), os.X_OK))
+
+# A codeberg bundle round-trips the same way: no unpacking, just the raw
+# .kwinscript asset copied into place under share/homepkg/assets/<tool>/.
+with tempfile.TemporaryDirectory() as td:
+    src = os.path.join(td, "src")
+    os.makedirs(os.path.join(src, "codeberg-assets"))
+    asset = "krohnkite-0.9.9.3_beta.kwinscript"
+    with open(os.path.join(src, "codeberg-assets", asset), "wb") as f:
+        f.write(b"// kwin script")
+    with open(os.path.join(src, "manifest.json"), "w") as f:
+        json.dump({"format": 1, "backend": "codeberg", "platform": "linux/x86_64",
+                   "tools": [{"tool": "krohnkite", "asset": asset}]}, f)
+    bundle = os.path.join(td, "b.tar.gz")
+    hp._write_bundle(bundle, src)
+    prefix = os.path.join(td, "prefix")
+    hp.install_bundle(bundle, prefix, ("linux", "x86_64"), False)
+    installed = os.path.join(hp.codeberg_asset_dir("krohnkite", prefix), asset)
+    check("install-bundle (codeberg) saves the raw asset offline",
+          os.path.exists(installed) and open(installed, "rb").read() == b"// kwin script")
+
+# A combined bundle's codeberg section is replayed alongside the others --
+# install_bundle has to find it under manifest["codeberg"], not top-level.
+with tempfile.TemporaryDirectory() as td:
+    src = os.path.join(td, "src")
+    os.makedirs(os.path.join(src, "codeberg-assets"))
+    asset = "krohnkite-0.9.9.3_beta.kwinscript"
+    with open(os.path.join(src, "codeberg-assets", asset), "wb") as f:
+        f.write(b"// kwin script")
+    with open(os.path.join(src, "manifest.json"), "w") as f:
+        json.dump({"format": 1, "backend": "combined", "platform": "linux/x86_64",
+                   "codeberg": {"tools": [{"tool": "krohnkite", "asset": asset}]}}, f)
+    bundle = os.path.join(td, "combined-codeberg.tar.gz")
+    hp._write_bundle(bundle, src)
+    prefix = os.path.join(td, "prefix")
+    hp.install_bundle(bundle, prefix, ("linux", "x86_64"), False)
+    check("install-bundle (combined) replays the codeberg section",
+          os.path.exists(os.path.join(hp.codeberg_asset_dir("krohnkite", prefix), asset)))
+
+# A codeberg asset missing from the bundle is reported, not silently skipped
+# -- same contract as the equivalent github-side test above.
+with tempfile.TemporaryDirectory() as td:
+    src = os.path.join(td, "src")
+    os.makedirs(os.path.join(src, "codeberg-assets"))
+    with open(os.path.join(src, "manifest.json"), "w") as f:
+        json.dump({"format": 1, "backend": "codeberg", "platform": "linux/x86_64",
+                   "tools": [{"tool": "krohnkite", "asset": "missing.kwinscript"}]}, f)
+    bundle = os.path.join(td, "b.tar.gz")
+    hp._write_bundle(bundle, src)
+    _err = None
+    try:
+        hp.install_bundle(bundle, os.path.join(td, "prefix"), ("linux", "x86_64"), False)
+    except hp.HomepkgError as e:
+        _err = e
+    check("install-bundle (codeberg) reports a missing asset",
+          _err is not None and "krohnkite" in str(_err))
 
 with tempfile.TemporaryDirectory() as td:
     src = os.path.join(td, "src")

--- a/homepkg_test
+++ b/homepkg_test
@@ -175,7 +175,11 @@ try:
     with tempfile.TemporaryDirectory() as td:
         prefix = os.path.join(td, "prefix")
         _saved_download = hp.download
-        hp.download = lambda url, dest: open(dest, "wb").write(b"// kwin script") or dest
+        def _fake_download(url, dest):
+            with open(dest, "wb") as f:
+                f.write(b"// kwin script")
+            return dest
+        hp.download = _fake_download
         try:
             hp.install_codeberg("krohnkite", hp.TOOLS["krohnkite"], prefix,
                                 ("linux", "x86_64"), False)
@@ -703,6 +707,65 @@ with tempfile.TemporaryDirectory() as td:
     check("install-bundle (codeberg) reports a missing asset",
           _err is not None and "krohnkite" in str(_err))
 
+# A tampered codeberg manifest with a path-traversal tool name must be
+# rejected before it's ever joined into a filesystem path -- e["tool"] feeds
+# codeberg_asset_dir(), and dest_dir there gets rmtree'd, so an unvalidated
+# "../../etc"-style value could delete an arbitrary directory.
+with tempfile.TemporaryDirectory() as td:
+    src = os.path.join(td, "src")
+    os.makedirs(os.path.join(src, "codeberg-assets"))
+    asset = "krohnkite-0.9.9.3_beta.kwinscript"
+    with open(os.path.join(src, "codeberg-assets", asset), "wb") as f:
+        f.write(b"// kwin script")
+    with open(os.path.join(src, "manifest.json"), "w") as f:
+        json.dump({"format": 1, "backend": "codeberg", "platform": "linux/x86_64",
+                   "tools": [{"tool": "../../evil", "asset": asset}]}, f)
+    bundle = os.path.join(td, "b.tar.gz")
+    hp._write_bundle(bundle, src)
+    raised = False
+    try:
+        hp.install_bundle(bundle, os.path.join(td, "prefix"), ("linux", "x86_64"), False)
+    except hp.HomepkgError:
+        raised = True
+    check("install-bundle rejects a codeberg manifest tool name that escapes the prefix",
+          raised)
+    check("...and nothing was written outside the prefix",
+          not os.path.exists(os.path.join(td, "evil")))
+
+# install_codeberg downloads to a temp location and only replaces dest_dir on
+# success -- a failed refresh (network drops mid-download) must leave a
+# previously-cached asset intact, since setup-kde falls back to whatever's
+# cached when the online fetch fails.
+with tempfile.TemporaryDirectory() as td:
+    prefix = os.path.join(td, "prefix")
+    dest_dir = hp.codeberg_asset_dir("krohnkite", prefix)
+    os.makedirs(dest_dir)
+    with open(os.path.join(dest_dir, "krohnkite-0.9.9.2.kwinscript"), "wb") as f:
+        f.write(b"old cached release")
+    _saved_cra2 = hp.codeberg_release_assets
+    _saved_dl2 = hp.download
+    hp.codeberg_release_assets = lambda repo, tag=None: (
+        "0.9.9.3_beta", [("krohnkite-0.9.9.3_beta.kwinscript", "https://example.invalid/k")])
+    def _failing_download(url, dest):
+        raise OSError("network unreachable")
+    hp.download = _failing_download
+    try:
+        _err = None
+        try:
+            hp.install_codeberg("krohnkite", hp.TOOLS["krohnkite"], prefix,
+                                ("linux", "x86_64"), False)
+        except OSError as e:
+            _err = e
+        check("install_codeberg propagates a download failure",
+              _err is not None)
+        check("...but leaves the previously cached asset in place",
+              os.path.exists(os.path.join(dest_dir, "krohnkite-0.9.9.2.kwinscript"))
+              and open(os.path.join(dest_dir, "krohnkite-0.9.9.2.kwinscript"), "rb").read()
+              == b"old cached release")
+    finally:
+        hp.codeberg_release_assets = _saved_cra2
+        hp.download = _saved_dl2
+
 with tempfile.TemporaryDirectory() as td:
     src = os.path.join(td, "src")
     os.makedirs(src)
@@ -733,6 +796,67 @@ with tempfile.TemporaryDirectory() as td:
     except hp.HomepkgError:
         raised = True
     check("install-bundle rejects a platform mismatch", raised)
+
+# ...but "any" (a codeberg-only bundle, which carries nothing
+# platform-specific -- see bundle_codeberg) installs regardless of platform.
+with tempfile.TemporaryDirectory() as td:
+    src = os.path.join(td, "src")
+    os.makedirs(os.path.join(src, "codeberg-assets"))
+    asset = "krohnkite-0.9.9.3_beta.kwinscript"
+    with open(os.path.join(src, "codeberg-assets", asset), "wb") as f:
+        f.write(b"// kwin script")
+    with open(os.path.join(src, "manifest.json"), "w") as f:
+        json.dump({"format": 1, "backend": "codeberg", "platform": "any",
+                   "tools": [{"tool": "krohnkite", "asset": asset}]}, f)
+    bundle = os.path.join(td, "b.tar.gz")
+    hp._write_bundle(bundle, src)
+    prefix = os.path.join(td, "prefix")
+    hp.install_bundle(bundle, prefix, ("macos", "aarch64"), False)
+    check("a platform: any bundle installs regardless of the host platform",
+          os.path.exists(os.path.join(hp.codeberg_asset_dir("krohnkite", prefix), asset)))
+
+# bundle_codeberg writes platform: "any" itself, not the builder's platform.
+with tempfile.TemporaryDirectory() as td:
+    _saved_sc = hp._stage_codeberg
+    hp._stage_codeberg = lambda tools, td_: [{"tool": "krohnkite", "asset": "x.kwinscript"}]
+    try:
+        out = os.path.join(td, "b.tgz")
+        hp.bundle_codeberg(["krohnkite"], out, False)
+        with tarfile.open(out) as tf:
+            manifest = json.loads(tf.extractfile("manifest.json").read())
+        check("bundle_codeberg tags its manifest platform: any",
+              manifest["platform"] == "any")
+    finally:
+        hp._stage_codeberg = _saved_sc
+
+# bundle_all does the same when the bundle ends up codeberg-only (no
+# conda/github tools alongside it) -- but NOT when it's mixed with tools
+# that do carry platform-specific data.
+with tempfile.TemporaryDirectory() as td:
+    _saved_sc2 = hp._stage_codeberg
+    hp._stage_codeberg = lambda tools, td_, skip_unavailable=False: [
+        {"tool": "krohnkite", "asset": "x.kwinscript"}]
+    try:
+        out = os.path.join(td, "b.tgz")
+        hp.bundle_all(["krohnkite"], td, ("linux", "x86_64"), out, False)
+        with tarfile.open(out) as tf:
+            manifest = json.loads(tf.extractfile("manifest.json").read())
+        check("bundle_all tags a codeberg-only combined bundle platform: any",
+              manifest["platform"] == "any")
+
+        out2 = os.path.join(td, "b2.tgz")
+        _saved_stage_mamba = hp._stage_mamba
+        hp._stage_mamba = lambda tools, prefix, plat, td_: list(tools)
+        try:
+            hp.bundle_all(["jq", "krohnkite"], td, ("linux", "x86_64"), out2, False)
+        finally:
+            hp._stage_mamba = _saved_stage_mamba
+        with tarfile.open(out2) as tf:
+            manifest2 = json.loads(tf.extractfile("manifest.json").read())
+        check("bundle_all keeps the real platform when mixed with a conda tool",
+              manifest2["platform"] == "linux/x86_64")
+    finally:
+        hp._stage_codeberg = _saved_sc2
 
 # _mamba_solve must pass --platform for the target subdir (so cross-arch
 # bundles solve the right arch) and build from the LINK set, not FETCH (which

--- a/setup
+++ b/setup
@@ -50,11 +50,13 @@
 # agent) or a key file already exists. Pass --ssh to generate one anyway,
 # or --no-ssh to skip it entirely.
 #
-# Node.js (node/npm) and the TypeScript compiler (tsc) are installed because
-# setup-kde needs tsc to build Krohnkite from source without fetching from the
-# npm registry at build time. On privileged boxes they come from the distro
-# package (apt/dnf/brew); under --no-root, where the distro installs are
-# skipped, they come from conda-forge via homepkg instead (rootless). Pass
+# Node.js (node/npm) and the TypeScript compiler (tsc) are installed as a
+# fallback for setup-kde: it normally fetches Krohnkite's prebuilt release,
+# but falls back to building from source (which needs tsc, without fetching
+# from the npm registry at build time) when that release can't be fetched.
+# On privileged boxes they come from the distro package (apt/dnf/brew); under
+# --no-root, where the distro installs are skipped, they come from
+# conda-forge via homepkg instead (rootless). Pass
 # --no-npm to skip them where Node is provided some other way (nvm, fnm,
 # corepack, a system package, etc.) -- then provide tsc yourself.
 #
@@ -120,7 +122,8 @@ IGNORE_ERRORS=no
 SSH=auto
 
 # Whether to install Node.js (node/npm) and the TypeScript compiler (tsc),
-# needed by setup-kde to build Krohnkite. One of:
+# needed by setup-kde's source-build fallback for Krohnkite (its normal path
+# fetches a prebuilt release and needs neither). One of:
 #   yes - install them (the default). Privileged boxes get the distro npm/node
 #         package plus tsc; --no-root boxes get node/npm/tsc from conda-forge
 #         via homepkg instead.
@@ -672,22 +675,23 @@ install_packages() {
             info "Installing zoxide"
             sudo_or_warn apt-get install -y --install-recommends zoxide \
                 || warn "could not install zoxide; z/zi directory jumps will be unavailable"
-            # Node.js + tsc from the distro on the privileged path (setup-kde
-            # needs tsc to build Krohnkite). Under --no-root apt is skipped
-            # above, and these come from conda-forge via homepkg instead
-            # (install_home_tools).
+            # Node.js + tsc from the distro on the privileged path (setup-kde's
+            # source-build fallback for Krohnkite needs tsc; its normal path
+            # fetches a prebuilt release and needs neither). Under --no-root
+            # apt is skipped above, and these come from conda-forge via
+            # homepkg instead (install_home_tools).
             if test "$NPM" = yes; then
                 info "Installing npm"
                 sudo_or_warn apt-get install -y --install-recommends npm \
                     || warn "could not install the distro npm package; continuing with the TypeScript attempt"
-                # tsc lets setup-kde build Krohnkite from source without
-                # fetching typescript from the npm registry at build time.
-                # Debian/Ubuntu package it as node-typescript; fall back to
-                # a one-time global npm install where that's unavailable.
+                # tsc lets setup-kde's fallback build Krohnkite from source
+                # without fetching typescript from the npm registry at build
+                # time. Debian/Ubuntu package it as node-typescript; fall
+                # back to a one-time global npm install where unavailable.
                 info "Installing TypeScript (tsc)"
                 sudo_or_warn apt-get install -y --install-recommends node-typescript \
                     || sudo_or_warn npm install -g typescript \
-                    || warn "could not install tsc; setup-kde needs it to build Krohnkite"
+                    || warn "could not install tsc; setup-kde's Krohnkite source-build fallback needs it"
             fi
             if test "$GUI_ENABLED" -eq 1; then
                 info "Installing kitty"
@@ -796,21 +800,22 @@ install_packages() {
             info "Installing zoxide"
             sudo_or_warn dnf install -y zoxide \
                 || warn "could not install zoxide; z/zi directory jumps will be unavailable"
-            # Node.js + tsc from the distro on the privileged path (setup-kde
-            # needs tsc to build Krohnkite). Under --no-root dnf is skipped
-            # above, and these come from conda-forge via homepkg instead
-            # (install_home_tools).
+            # Node.js + tsc from the distro on the privileged path (setup-kde's
+            # source-build fallback for Krohnkite needs tsc; its normal path
+            # fetches a prebuilt release and needs neither). Under --no-root
+            # dnf is skipped above, and these come from conda-forge via
+            # homepkg instead (install_home_tools).
             if test "$NPM" = yes; then
                 info "Installing npm"
                 sudo_or_warn dnf install -y npm \
                     || warn "could not install the distro npm package; continuing with the TypeScript attempt"
-                # tsc lets setup-kde build Krohnkite from source without
-                # fetching typescript from the npm registry at build time.
-                # Fedora ships no typescript rpm, so this is a one-time
+                # tsc lets setup-kde's fallback build Krohnkite from source
+                # without fetching typescript from the npm registry at build
+                # time. Fedora ships no typescript rpm, so this is a one-time
                 # global npm install during bootstrap.
                 info "Installing TypeScript (tsc)"
                 sudo_or_warn npm install -g typescript \
-                    || warn "could not install tsc; setup-kde needs it to build Krohnkite"
+                    || warn "could not install tsc; setup-kde's Krohnkite source-build fallback needs it"
             fi
             if test "$GUI_ENABLED" -eq 1; then
                 info "Installing kitty"
@@ -926,20 +931,22 @@ install_packages() {
             info "Installing zoxide"
             brew install zoxide \
                 || warn "could not install zoxide; z/zi directory jumps will be unavailable"
-            # Node.js + tsc from Homebrew on the privileged path (setup-kde
-            # needs tsc to build Krohnkite). brew needs no sudo, so unlike the
-            # apt/dnf branches this can't self-skip under --no-root -- gate it on
-            # ROOT so an unprivileged macOS run gets node/tsc from conda-forge
-            # via homepkg (install_home_tools) instead of a second copy here.
+            # Node.js + tsc from Homebrew on the privileged path (setup-kde's
+            # source-build fallback for Krohnkite needs tsc; its normal path
+            # fetches a prebuilt release and needs neither). brew needs no
+            # sudo, so unlike the apt/dnf branches this can't self-skip under
+            # --no-root -- gate it on ROOT so an unprivileged macOS run gets
+            # node/tsc from conda-forge via homepkg (install_home_tools)
+            # instead of a second copy here.
             if test "$NPM" = yes && test "$ROOT" = yes; then
                 info "Installing Node.js (npm)"
                 brew install node
-                # tsc lets setup-kde build Krohnkite from source without
-                # fetching typescript from the npm registry at build time.
-                # Installed on macOS too so the toolchain matches Linux.
+                # tsc lets setup-kde's fallback build Krohnkite from source
+                # without fetching typescript from the npm registry at build
+                # time. Installed on macOS too so the toolchain matches Linux.
                 info "Installing TypeScript (tsc)"
                 brew install typescript \
-                    || warn "could not install tsc; setup-kde needs it to build Krohnkite"
+                    || warn "could not install tsc; setup-kde's Krohnkite source-build fallback needs it"
             fi
             # adb/fastboot are CLI tools (used by pidcat and friends), not
             # graphical -- install them regardless of --no-gui, matching the
@@ -1208,9 +1215,11 @@ install_home_tools() {
     # --no-root, so fnm comes from here instead).
     tools="ripgrep fd bat fzf jq delta gh fnm zoxide"
     if test "$NPM" = yes; then
-        # node/npm + tsc are the actual build toolchain (setup-kde needs tsc to
-        # build Krohnkite), gated on --no-npm. The --no-root counterpart to the
-        # distro npm/tsc install on the privileged path -- no root, no distro pkg.
+        # node/npm + tsc are the actual build toolchain for setup-kde's
+        # Krohnkite source-build fallback (its normal path fetches a
+        # prebuilt release and needs neither), gated on --no-npm. The
+        # --no-root counterpart to the distro npm/tsc install on the
+        # privileged path -- no root, no distro pkg.
         tools="$tools node typescript"
     fi
     if test "$MINIMAL_ENABLED" -eq 0; then
@@ -1290,9 +1299,9 @@ install_home_tools() {
 
     # homepkg links the tools into ~/.local/bin. Put that on PATH for the rest
     # of THIS run so later steps and child processes find them -- notably
-    # setup-kde, which needs tsc on PATH to build Krohnkite. The conf repo
-    # already puts ~/.local/bin on PATH for interactive shells; this covers the
-    # non-interactive bootstrap however setup was invoked.
+    # setup-kde's Krohnkite source-build fallback, which needs tsc on PATH.
+    # The conf repo already puts ~/.local/bin on PATH for interactive shells;
+    # this covers the non-interactive bootstrap however setup was invoked.
     case ":$PATH:" in
         *":$HOME/.local/bin:"*) ;;
         *) PATH="$HOME/.local/bin:$PATH" ;;

--- a/setup-kde
+++ b/setup-kde
@@ -266,11 +266,17 @@ install_krohnkite_from_source() {
 
 # Fetch Krohnkite's prebuilt .kwinscript release from upstream's Codeberg
 # releases (anametologin/Krohnkite) via homepkg's codeberg backend -- no
-# tsc/go-task/make needed. Tries a pre-staged offline bundle first (built
+# tsc/go-task/make needed. Always tries the online fetch first, so a machine
+# that's already installed Krohnkite once still picks up newer releases on
+# later runs rather than reusing whatever it cached the first time. Only
+# when that fails does it fall back to a pre-staged offline bundle (built
 # with 'homepkg --backend codeberg bundle -o homepkg-krohnkite.tgz
 # krohnkite', staged at $HOMEPKG_KROHNKITE_BUNDLE, homepkg-krohnkite.tgz
-# beside this script, or in $HOME), then an online fetch. Falls back to
-# cloning KROHNKITE_REPO and building from source when neither works.
+# beside this script, or in $HOME) or, failing that, whatever homepkg's
+# codeberg backend already has cached from a previous successful fetch (it
+# never wipes that cache on a failed refresh -- see install_codeberg).
+# Falls back to cloning KROHNKITE_REPO and building from source when none of
+# that produces a usable .kwinscript.
 install_krohnkite() {
     kwinscript=""
     homepkg="$SCRIPT_DIR/homepkg"
@@ -279,25 +285,25 @@ install_krohnkite() {
         # it, so the fetched asset always lands here.
         asset_dir="$HOME/.local/share/homepkg/assets/krohnkite"
 
-        bundle=""
-        for cand in "${HOMEPKG_KROHNKITE_BUNDLE:-}" \
-                "$SCRIPT_DIR/homepkg-krohnkite.tgz" \
-                "$HOME/homepkg-krohnkite.tgz"; do
-            if test -n "$cand" && test -f "$cand"; then
-                bundle="$cand"
-                break
-            fi
-        done
-        if test -n "$bundle"; then
-            info "Fetching the Krohnkite release from bundle: $bundle"
-            "$homepkg" install-bundle "$bundle" \
-                || warn "the Krohnkite bundle didn't provide the release; trying the online fetch"
-        fi
-
+        info "Fetching the Krohnkite release via homepkg"
+        "$homepkg" --backend codeberg install krohnkite \
+            || warn "could not fetch the Krohnkite release online; trying a staged bundle or the last cached copy"
         kwinscript=$(find "$asset_dir" -name '*.kwinscript' -print -quit 2>/dev/null || true)
+
         if test -z "$kwinscript"; then
-            info "Fetching the Krohnkite release via homepkg"
-            if "$homepkg" --backend codeberg install krohnkite; then
+            bundle=""
+            for cand in "${HOMEPKG_KROHNKITE_BUNDLE:-}" \
+                    "$SCRIPT_DIR/homepkg-krohnkite.tgz" \
+                    "$HOME/homepkg-krohnkite.tgz"; do
+                if test -n "$cand" && test -f "$cand"; then
+                    bundle="$cand"
+                    break
+                fi
+            done
+            if test -n "$bundle"; then
+                info "Fetching the Krohnkite release from bundle: $bundle"
+                "$homepkg" install-bundle "$bundle" \
+                    || warn "the Krohnkite bundle didn't provide the release either"
                 kwinscript=$(find "$asset_dir" -name '*.kwinscript' -print -quit 2>/dev/null || true)
             fi
         fi

--- a/setup-kde
+++ b/setup-kde
@@ -7,11 +7,12 @@
 # - Window management and desktop switching keybindings
 # - Application launch shortcuts (browser, terminal, music)
 #
-# Requires: git, kpackagetool6, kwriteconfig6
+# Requires: kpackagetool6, kwriteconfig6
 # This helper does not use sudo: Krohnkite and every KDE setting are installed
 # for the current user, so setup-kde still works when system sudo is restricted.
-# Optional: tsc (only to build Krohnkite when the checkout has no prebuilt
-#           .kwinscript), go-task (preferred build tool), p7zip
+# Optional: homepkg (fetches Krohnkite's prebuilt .kwinscript release, the
+#           normal path -- see install_krohnkite), git, tsc, go-task, p7zip
+#           (build-from-source fallback when the release can't be fetched)
 #
 # Usage:
 #     setup-kde [--no-install] [--no-sudo] [--ignore-errors] [-h | --help]
@@ -25,11 +26,18 @@
 # uses no sudo, so it already runs unchanged on a machine with restricted
 # sudo.
 #
-# Krohnkite comes from my fork's mikel branch by default; set KROHNKITE_REPO
-# (any git URL or local path) and/or KROHNKITE_BRANCH to clone something
-# else. The build never talks to the npm registry: a prebuilt .kwinscript
-# committed to the repo installs as-is, and building from source uses the
-# local tsc via an npm shim.
+# Krohnkite normally installs from the prebuilt .kwinscript release asset
+# published on upstream's Codeberg (anametologin/Krohnkite), fetched via
+# homepkg's codeberg backend -- see install_krohnkite. That needs no
+# tsc/go-task/make, and is offline-capable via a homepkg bundle staged at
+# $HOMEPKG_KROHNKITE_BUNDLE, homepkg-krohnkite.tgz beside this script, or in
+# $HOME (build one with 'homepkg --backend codeberg bundle -o
+# homepkg-krohnkite.tgz krohnkite'). If homepkg or the release is unavailable,
+# setup-kde falls back to cloning KROHNKITE_REPO (my fork's mikel branch by
+# default; any git URL or local path, and/or KROHNKITE_BRANCH, override it)
+# and building from source. That build never talks to the npm registry: a
+# prebuilt .kwinscript committed to the checkout installs as-is, and building
+# from source uses the local tsc via an npm shim.
 
 KROHNKITE_DEFAULT_REPO="https://codeberg.org/mikelward/Krohnkite.git"
 KROHNKITE_REPO="${KROHNKITE_REPO:-$KROHNKITE_DEFAULT_REPO}"
@@ -131,19 +139,19 @@ trap cleanup EXIT
 # --- Check prerequisites ---
 
 # kwriteconfig6 is needed for every configuration step, so it's always
-# required. git/kpackagetool6 are only used to fetch and install Krohnkite,
-# so they're only required when actually installing. tsc is checked in
-# build_krohnkite: whether a build is needed at all depends on the checkout
-# (a committed prebuilt .kwinscript installs without one).
+# required. kpackagetool6 installs Krohnkite regardless of where its
+# .kwinscript came from, so it's required whenever actually installing.
+# git/tsc are only needed by the source-build fallback (see
+# install_krohnkite): whether that fallback is even reached depends on
+# whether the prebuilt release can be fetched, so they're warnings, not hard
+# requirements, checked up front only so a fallback failure isn't a surprise.
 command -v kwriteconfig6 >/dev/null 2>&1 || error "kwriteconfig6 is required (KDE Plasma 6)"
 if test "$INSTALL" = yes; then
-    command -v git >/dev/null 2>&1 || error "git is required"
     command -v kpackagetool6 >/dev/null 2>&1 || error "kpackagetool6 is required (KDE Plasma 6)"
-    # Not fatal here: a checkout that ships a prebuilt .kwinscript installs
-    # without any compiler. But if a build turns out to be needed it will
-    # fail on this, so say so before spending time on the clone.
+    command -v git >/dev/null 2>&1 \
+        || warn "git not found; if the Krohnkite release can't be fetched, the source-build fallback will fail"
     command -v tsc >/dev/null 2>&1 \
-        || warn "tsc not found; the install will fail unless $KROHNKITE_REPO ships a prebuilt .kwinscript"
+        || warn "tsc not found; if the Krohnkite release can't be fetched, the source-build fallback will fail unless $KROHNKITE_REPO ships a prebuilt .kwinscript"
 fi
 
 # --- Install Krohnkite ---
@@ -215,7 +223,13 @@ SHIM
     fi
 }
 
-install_krohnkite() {
+# Clone KROHNKITE_REPO/KROHNKITE_BRANCH and either install a prebuilt
+# .kwinscript already in the checkout, or build one from source. Fallback
+# path, used when the prebuilt release can't be fetched (see
+# install_krohnkite below).
+install_krohnkite_from_source() {
+    command -v git >/dev/null 2>&1 \
+        || error "git is required to build Krohnkite from source (the prebuilt release could not be fetched)"
     if test -n "${KROHNKITE_BRANCH:-}"; then
         info "Cloning Krohnkite from $KROHNKITE_REPO ($KROHNKITE_BRANCH)"
         git clone --depth 1 --branch "$KROHNKITE_BRANCH" "$KROHNKITE_REPO" "$KROHNKITE_DIR"
@@ -248,6 +262,60 @@ install_krohnkite() {
             error "Could not find installable Krohnkite package"
         fi
     fi
+}
+
+# Fetch Krohnkite's prebuilt .kwinscript release from upstream's Codeberg
+# releases (anametologin/Krohnkite) via homepkg's codeberg backend -- no
+# tsc/go-task/make needed. Tries a pre-staged offline bundle first (built
+# with 'homepkg --backend codeberg bundle -o homepkg-krohnkite.tgz
+# krohnkite', staged at $HOMEPKG_KROHNKITE_BUNDLE, homepkg-krohnkite.tgz
+# beside this script, or in $HOME), then an online fetch. Falls back to
+# cloning KROHNKITE_REPO and building from source when neither works.
+install_krohnkite() {
+    kwinscript=""
+    homepkg="$SCRIPT_DIR/homepkg"
+    if test -x "$homepkg"; then
+        # homepkg's default --prefix (~/.local); setup-kde doesn't override
+        # it, so the fetched asset always lands here.
+        asset_dir="$HOME/.local/share/homepkg/assets/krohnkite"
+
+        bundle=""
+        for cand in "${HOMEPKG_KROHNKITE_BUNDLE:-}" \
+                "$SCRIPT_DIR/homepkg-krohnkite.tgz" \
+                "$HOME/homepkg-krohnkite.tgz"; do
+            if test -n "$cand" && test -f "$cand"; then
+                bundle="$cand"
+                break
+            fi
+        done
+        if test -n "$bundle"; then
+            info "Fetching the Krohnkite release from bundle: $bundle"
+            "$homepkg" install-bundle "$bundle" \
+                || warn "the Krohnkite bundle didn't provide the release; trying the online fetch"
+        fi
+
+        kwinscript=$(find "$asset_dir" -name '*.kwinscript' -print -quit 2>/dev/null || true)
+        if test -z "$kwinscript"; then
+            info "Fetching the Krohnkite release via homepkg"
+            if "$homepkg" --backend codeberg install krohnkite; then
+                kwinscript=$(find "$asset_dir" -name '*.kwinscript' -print -quit 2>/dev/null || true)
+            fi
+        fi
+        if test -z "$kwinscript"; then
+            warn "could not fetch the Krohnkite release via homepkg (offline? stage a bundle with 'homepkg --backend codeberg bundle -o homepkg-krohnkite.tgz krohnkite'); falling back to building from source"
+        fi
+    else
+        warn "homepkg not found at $homepkg; falling back to building Krohnkite from source"
+    fi
+
+    if test -n "$kwinscript"; then
+        info "Installing Krohnkite from $kwinscript"
+        kpackagetool6 -t KWin/Script -u "$kwinscript" 2>/dev/null ||
+            kpackagetool6 -t KWin/Script -i "$kwinscript"
+        return
+    fi
+
+    install_krohnkite_from_source
 }
 
 # --- Enable Krohnkite ---

--- a/setup-kde_test
+++ b/setup-kde_test
@@ -307,10 +307,23 @@ test_release_install_via_homepkg() {
     assert_not_called "tsc "
 }
 
-# A pre-staged bundle (homepkg-krohnkite.tgz beside the script) is tried
-# before the online fetch; when it provides the release, the online fetch
-# never runs.
-test_release_bundle_used_before_online_fetch() {
+# The online fetch is tried FIRST and, when it succeeds, a pre-staged bundle
+# is never even touched -- refreshing from the network beats reusing
+# whatever a bundle happens to carry, so a machine that already has a bundle
+# staged still gets newer Krohnkite releases as they're published.
+test_online_fetch_preferred_over_staged_bundle() {
+    add_release_mocks
+    touch "$TEST_TMPDIR/isolated/homepkg-krohnkite.tgz"
+    run_kde
+    assert_status 0 &&
+    assert_called "homepkg --backend codeberg install krohnkite" &&
+    assert_not_called "install-bundle" &&
+    assert_called "kpackagetool6 -t KWin/Script"
+}
+
+# When the online fetch fails, a pre-staged bundle (homepkg-krohnkite.tgz
+# beside the script) is tried as a fallback source for the release.
+test_release_bundle_used_when_online_fetch_fails() {
     add_release_mocks
     cat > "$TEST_TMPDIR/isolated/homepkg" <<MOCK
 #!/bin/sh
@@ -327,39 +340,30 @@ MOCK
     touch "$TEST_TMPDIR/isolated/homepkg-krohnkite.tgz"
     run_kde
     assert_status 0 &&
+    assert_called "homepkg --backend codeberg install krohnkite" &&
     assert_called "homepkg install-bundle $TEST_TMPDIR/isolated/homepkg-krohnkite.tgz" &&
-    assert_called "kpackagetool6 -t KWin/Script" &&
-    assert_not_called "--backend codeberg install krohnkite"
+    assert_called "kpackagetool6 -t KWin/Script"
 }
 
-# A bundle that doesn't provide the release (partial/stale) falls through to
-# the online fetch rather than treating the bundle as the final answer.
-test_release_bundle_falls_through_to_online_fetch() {
+# When both the online fetch and the bundle are unavailable, a release
+# cached by an earlier successful run is still used rather than falling all
+# the way back to a source build -- homepkg's codeberg backend never wipes a
+# good cache on a failed refresh (see install_codeberg's atomic replace).
+test_stale_cached_release_used_when_refresh_fails() {
     add_release_mocks
-    touch "$TEST_TMPDIR/isolated/homepkg-krohnkite.tgz"
-    # add_release_mocks' homepkg mock already fails install-bundle (falls
-    # into its final "exit 0" only for the codeberg install case) -- rewrite
-    # it to fail install-bundle explicitly and still succeed the online path.
     cat > "$TEST_TMPDIR/isolated/homepkg" <<MOCK
 #!/bin/sh
 echo "homepkg \$*" >> "$CALLS"
-if test "\$1" = install-bundle; then
-    exit 1
-fi
-if test "\$1" = "--backend" && test "\$2" = codeberg \\
-        && test "\$3" = install && test "\$4" = krohnkite; then
-    dir="\$HOME/.local/share/homepkg/assets/krohnkite"
-    mkdir -p "\$dir"
-    touch "\$dir/krohnkite-0.9.9.3_beta.kwinscript"
-fi
-exit 0
+exit 1
 MOCK
     chmod +x "$TEST_TMPDIR/isolated/homepkg"
+    mkdir -p "$TEST_TMPDIR/home/.local/share/homepkg/assets/krohnkite"
+    touch "$TEST_TMPDIR/home/.local/share/homepkg/assets/krohnkite/krohnkite-0.9.9.2.kwinscript"
     run_kde
     assert_status 0 &&
-    assert_called "homepkg install-bundle $TEST_TMPDIR/isolated/homepkg-krohnkite.tgz" &&
     assert_called "homepkg --backend codeberg install krohnkite" &&
-    assert_called "kpackagetool6 -t KWin/Script"
+    assert_called "kpackagetool6 -t KWin/Script" &&
+    assert_not_called "git clone"
 }
 
 # HOMEPKG_KROHNKITE_BUNDLE overrides the default bundle search locations.
@@ -637,10 +641,12 @@ run_test "failing sudo does not affect user-scoped KDE setup" \
     test_failing_sudo_is_not_used
 run_test "release install via homepkg's codeberg backend" \
     test_release_install_via_homepkg
-run_test "pre-staged release bundle is tried before the online fetch" \
-    test_release_bundle_used_before_online_fetch
-run_test "a release bundle that doesn't provide it falls through online" \
-    test_release_bundle_falls_through_to_online_fetch
+run_test "online fetch is preferred over a pre-staged bundle" \
+    test_online_fetch_preferred_over_staged_bundle
+run_test "release bundle used when the online fetch fails" \
+    test_release_bundle_used_when_online_fetch_fails
+run_test "a stale cached release is used when the refresh fails entirely" \
+    test_stale_cached_release_used_when_refresh_fails
 run_test "HOMEPKG_KROHNKITE_BUNDLE overrides the bundle search" \
     test_homepkg_krohnkite_bundle_env_override
 run_test "missing git warns but doesn't block the release path" \

--- a/setup-kde_test
+++ b/setup-kde_test
@@ -56,12 +56,52 @@ isolate_script() {
     KDE_SCRIPT="$TEST_TMPDIR/isolated/setup-kde"
 }
 
-# Mocks that let the full install path run: git "clones" by creating the
+# Mocks for the release-first install path (the default now): homepkg is
+# looked up beside setup-kde ($SCRIPT_DIR/homepkg), so it must live in the
+# isolated script dir, not on PATH -- isolate_script sets that up. The mock
+# simulates a successful 'homepkg --backend codeberg install krohnkite' by
+# dropping a fake .kwinscript where homepkg's codeberg backend would put it.
+# git/npm/go-task/tsc are canaries: the release path must never reach the
+# source-build fallback.
+add_release_mocks() {
+    isolate_script
+    cat > "$TEST_TMPDIR/isolated/homepkg" <<MOCK
+#!/bin/sh
+echo "homepkg \$*" >> "$CALLS"
+if test "\$1" = "--backend" && test "\$2" = codeberg \\
+        && test "\$3" = install && test "\$4" = krohnkite; then
+    dir="\$HOME/.local/share/homepkg/assets/krohnkite"
+    mkdir -p "\$dir"
+    touch "\$dir/krohnkite-0.9.9.3_beta.kwinscript"
+fi
+exit 0
+MOCK
+    chmod +x "$TEST_TMPDIR/isolated/homepkg"
+    cat > "$TEST_TMPDIR/bin/kpackagetool6" <<MOCK
+#!/bin/sh
+echo "kpackagetool6 \$*" >> "$CALLS"
+exit 0
+MOCK
+    chmod +x "$TEST_TMPDIR/bin/kpackagetool6"
+    for cmd in git npm go-task tsc; do
+        cat > "$TEST_TMPDIR/bin/$cmd" <<MOCK
+#!/bin/sh
+echo "$cmd \$*" >> "$CALLS"
+exit 1
+MOCK
+        chmod +x "$TEST_TMPDIR/bin/$cmd"
+    done
+}
+
+# Mocks for the source-build fallback path: no homepkg beside the isolated
+# script (isolate_script alone leaves it absent), so install_krohnkite skips
+# straight to install_krohnkite_from_source. git "clones" by creating the
 # target directory with a fake prebuilt .kwinscript (the expected shape of
 # the fork), kpackagetool6 just records. npm is mocked purely as a canary:
 # nothing in the install may ever reach it. This exercises
-# install_krohnkite's cd into the checkout.
+# install_krohnkite_from_source's cd into the checkout.
 add_install_mocks() {
+    isolate_script
     cat > "$TEST_TMPDIR/bin/git" <<MOCK
 #!/bin/sh
 echo "git \$*" >> "$CALLS"
@@ -251,9 +291,151 @@ MOCK
     assert_output_contains "KDE configured successfully"
 }
 
-# --- installation (mocked git/kpackagetool6; npm is a never-called canary) ---
+# --- installation: release path (the default; homepkg's codeberg backend) ---
 
-# The clone must come from my Codeberg fork's mikel branch.
+# The common case: homepkg fetches the prebuilt release and setup-kde
+# installs it directly -- no clone, no build tool ever runs.
+test_release_install_via_homepkg() {
+    add_release_mocks
+    run_kde
+    assert_status 0 &&
+    assert_called "homepkg --backend codeberg install krohnkite" &&
+    assert_called "kpackagetool6 -t KWin/Script" &&
+    assert_not_called "git" &&
+    assert_not_called "npm" &&
+    assert_not_called "go-task" &&
+    assert_not_called "tsc "
+}
+
+# A pre-staged bundle (homepkg-krohnkite.tgz beside the script) is tried
+# before the online fetch; when it provides the release, the online fetch
+# never runs.
+test_release_bundle_used_before_online_fetch() {
+    add_release_mocks
+    cat > "$TEST_TMPDIR/isolated/homepkg" <<MOCK
+#!/bin/sh
+echo "homepkg \$*" >> "$CALLS"
+if test "\$1" = install-bundle; then
+    dir="\$HOME/.local/share/homepkg/assets/krohnkite"
+    mkdir -p "\$dir"
+    touch "\$dir/krohnkite-0.9.9.3_beta.kwinscript"
+    exit 0
+fi
+exit 1
+MOCK
+    chmod +x "$TEST_TMPDIR/isolated/homepkg"
+    touch "$TEST_TMPDIR/isolated/homepkg-krohnkite.tgz"
+    run_kde
+    assert_status 0 &&
+    assert_called "homepkg install-bundle $TEST_TMPDIR/isolated/homepkg-krohnkite.tgz" &&
+    assert_called "kpackagetool6 -t KWin/Script" &&
+    assert_not_called "--backend codeberg install krohnkite"
+}
+
+# A bundle that doesn't provide the release (partial/stale) falls through to
+# the online fetch rather than treating the bundle as the final answer.
+test_release_bundle_falls_through_to_online_fetch() {
+    add_release_mocks
+    touch "$TEST_TMPDIR/isolated/homepkg-krohnkite.tgz"
+    # add_release_mocks' homepkg mock already fails install-bundle (falls
+    # into its final "exit 0" only for the codeberg install case) -- rewrite
+    # it to fail install-bundle explicitly and still succeed the online path.
+    cat > "$TEST_TMPDIR/isolated/homepkg" <<MOCK
+#!/bin/sh
+echo "homepkg \$*" >> "$CALLS"
+if test "\$1" = install-bundle; then
+    exit 1
+fi
+if test "\$1" = "--backend" && test "\$2" = codeberg \\
+        && test "\$3" = install && test "\$4" = krohnkite; then
+    dir="\$HOME/.local/share/homepkg/assets/krohnkite"
+    mkdir -p "\$dir"
+    touch "\$dir/krohnkite-0.9.9.3_beta.kwinscript"
+fi
+exit 0
+MOCK
+    chmod +x "$TEST_TMPDIR/isolated/homepkg"
+    run_kde
+    assert_status 0 &&
+    assert_called "homepkg install-bundle $TEST_TMPDIR/isolated/homepkg-krohnkite.tgz" &&
+    assert_called "homepkg --backend codeberg install krohnkite" &&
+    assert_called "kpackagetool6 -t KWin/Script"
+}
+
+# HOMEPKG_KROHNKITE_BUNDLE overrides the default bundle search locations.
+test_homepkg_krohnkite_bundle_env_override() {
+    add_release_mocks
+    cat > "$TEST_TMPDIR/isolated/homepkg" <<MOCK
+#!/bin/sh
+echo "homepkg \$*" >> "$CALLS"
+if test "\$1" = install-bundle; then
+    dir="\$HOME/.local/share/homepkg/assets/krohnkite"
+    mkdir -p "\$dir"
+    touch "\$dir/krohnkite-0.9.9.3_beta.kwinscript"
+    exit 0
+fi
+exit 1
+MOCK
+    chmod +x "$TEST_TMPDIR/isolated/homepkg"
+    touch "$TEST_TMPDIR/custom-bundle.tgz"
+    export HOMEPKG_KROHNKITE_BUNDLE="$TEST_TMPDIR/custom-bundle.tgz"
+    run_kde
+    unset HOMEPKG_KROHNKITE_BUNDLE
+    assert_status 0 &&
+    assert_called "homepkg install-bundle $TEST_TMPDIR/custom-bundle.tgz"
+}
+
+# git not being installed is a warning, not a hard error, when the release
+# path doesn't need it at all. Skipped when the host itself has git on the
+# test PATH -- the script would legitimately find the real one and not warn.
+test_missing_git_warns_but_release_path_still_installs() {
+    if PATH="$TEST_TMPDIR/bin:/usr/local/bin:/usr/bin:/bin" \
+            command -v git >/dev/null 2>&1; then
+        echo "  skip: git present on test PATH"
+        return 0
+    fi
+    add_release_mocks
+    rm "$TEST_TMPDIR/bin/git"
+    run_kde
+    assert_status 0 &&
+    assert_output_contains "git not found" &&
+    assert_called "kpackagetool6 -t KWin/Script"
+}
+
+# --- installation: source-build fallback (release unavailable) ---
+#
+# Mocked git/kpackagetool6; npm is a never-called canary.
+
+# When homepkg itself isn't present, install_krohnkite warns and falls
+# straight to install_krohnkite_from_source -- which, by default, clones my
+# Codeberg fork's mikel branch.
+test_homepkg_missing_falls_back_to_source_build() {
+    add_install_mocks
+    run_kde
+    assert_status 0 &&
+    assert_output_contains "homepkg not found at" &&
+    assert_called "git clone --depth 1 --branch mikel https://codeberg.org/mikelward/Krohnkite.git" &&
+    assert_called "kpackagetool6 -t KWin/Script"
+}
+
+# When homepkg is present but can't fetch the release (offline, no
+# matching asset, ...), the same fallback runs.
+test_homepkg_release_fetch_fails_falls_back_to_source_build() {
+    add_install_mocks
+    cat > "$TEST_TMPDIR/isolated/homepkg" <<MOCK
+#!/bin/sh
+echo "homepkg \$*" >> "$CALLS"
+exit 1
+MOCK
+    chmod +x "$TEST_TMPDIR/isolated/homepkg"
+    run_kde
+    assert_status 0 &&
+    assert_output_contains "could not fetch the Krohnkite release via homepkg" &&
+    assert_called "git clone --depth 1 --branch mikel https://codeberg.org/mikelward/Krohnkite.git" &&
+    assert_called "kpackagetool6 -t KWin/Script"
+}
+
+# The fallback's clone must come from my Codeberg fork's mikel branch.
 test_clones_fork_by_default() {
     add_install_mocks
     run_kde
@@ -261,8 +443,8 @@ test_clones_fork_by_default() {
     assert_called "git clone --depth 1 --branch mikel https://codeberg.org/mikelward/Krohnkite.git"
 }
 
-# KROHNKITE_REPO and KROHNKITE_BRANCH override the clone source (any git
-# URL or local path) and branch.
+# KROHNKITE_REPO and KROHNKITE_BRANCH override the fallback's clone source
+# (any git URL or local path) and branch.
 test_krohnkite_repo_env_overrides_clone_source() {
     add_install_mocks
     export KROHNKITE_REPO="https://example.test/me/krohnkite.git"
@@ -341,6 +523,23 @@ test_source_build_without_tsc_errors() {
     run_kde
     assert_status 1 &&
     assert_output_contains "tsc is required to build Krohnkite without remote npm"
+}
+
+# Without git at all, the fallback fails with a clear error rather than a
+# raw "command not found" -- but only once the fallback is actually reached
+# (git isn't required up front; see test_missing_git_warns_but_release_path_still_installs).
+# Skipped when the host itself has git on the test PATH, same as above.
+test_missing_git_fallback_errors_clearly() {
+    if PATH="$TEST_TMPDIR/bin:/usr/local/bin:/usr/bin:/bin" \
+            command -v git >/dev/null 2>&1; then
+        echo "  skip: git present on test PATH"
+        return 0
+    fi
+    add_install_mocks
+    rm "$TEST_TMPDIR/bin/git"
+    run_kde
+    assert_status 1 &&
+    assert_output_contains "git is required to build Krohnkite from source"
 }
 
 # --- configuration (with --no-install so nothing is cloned/built) ---
@@ -436,19 +635,35 @@ run_test "unknown option errors" test_unknown_option
 run_test "--no-sudo is accepted as a no-op" test_no_sudo_accepted_noop
 run_test "failing sudo does not affect user-scoped KDE setup" \
     test_failing_sudo_is_not_used
-run_test "clones my krohnkite fork by default" test_clones_fork_by_default
-run_test "KROHNKITE_REPO overrides the clone source" \
+run_test "release install via homepkg's codeberg backend" \
+    test_release_install_via_homepkg
+run_test "pre-staged release bundle is tried before the online fetch" \
+    test_release_bundle_used_before_online_fetch
+run_test "a release bundle that doesn't provide it falls through online" \
+    test_release_bundle_falls_through_to_online_fetch
+run_test "HOMEPKG_KROHNKITE_BUNDLE overrides the bundle search" \
+    test_homepkg_krohnkite_bundle_env_override
+run_test "missing git warns but doesn't block the release path" \
+    test_missing_git_warns_but_release_path_still_installs
+run_test "homepkg missing falls back to the source build" \
+    test_homepkg_missing_falls_back_to_source_build
+run_test "release fetch failure falls back to the source build" \
+    test_homepkg_release_fetch_fails_falls_back_to_source_build
+run_test "clones my krohnkite fork by default (fallback)" test_clones_fork_by_default
+run_test "KROHNKITE_REPO overrides the clone source (fallback)" \
     test_krohnkite_repo_env_overrides_clone_source
-run_test "repo override alone doesn't force the mikel branch" \
+run_test "repo override alone doesn't force the mikel branch (fallback)" \
     test_repo_override_does_not_force_mikel_branch
-run_test "prebuilt package installs without npm" \
+run_test "prebuilt package installs without npm (fallback)" \
     test_prebuilt_package_installs_without_npm
-run_test "source build uses local tsc, never remote npm" \
+run_test "source build uses local tsc, never remote npm (fallback)" \
     test_source_build_uses_local_tsc_not_remote_npm
-run_test "missing tsc warns up front but prebuilt still installs" \
+run_test "missing tsc warns up front but prebuilt still installs (fallback)" \
     test_missing_tsc_warns_but_prebuilt_still_installs
-run_test "source build without tsc errors instead of remote npm" \
+run_test "source build without tsc errors instead of remote npm (fallback)" \
     test_source_build_without_tsc_errors
+run_test "missing git errors clearly once the fallback is reached" \
+    test_missing_git_fallback_errors_clearly
 run_test "enables and configures Krohnkite" test_enables_and_configures_krohnkite
 run_test "configures focus follows mouse" test_configures_focus_follows_mouse
 run_test "configures nine desktops" test_configures_nine_desktops


### PR DESCRIPTION
## Summary

- Krohnkite normally installed by cloning a git checkout and building the `.kwinscript` from source (tsc/go-task/make). `setup-kde` now fetches the prebuilt release from upstream's Codeberg releases (`anametologin/Krohnkite`) instead, and only falls back to the git-clone-and-build path when the release can't be fetched.
- Added a `codeberg` backend to `homepkg` (parallel to the existing `github` backend, but saving the raw asset under `<prefix>/share/homepkg/assets/<tool>/` instead of unpacking CLI binaries onto PATH) and registered `krohnkite` against it. It always takes the newest release including prereleases — upstream's last stable tag is old and buggy on KWin 6, and Gitea's `/releases/latest` would otherwise skip past the current beta straight to that stable release.
- `setup-kde` always tries the online fetch first (so a machine that's already installed Krohnkite still picks up newer releases on later runs), falling back to a pre-staged offline bundle (built with `homepkg --backend codeberg bundle -o homepkg-krohnkite.tgz krohnkite`, the same pattern as the existing atuin/carapace shell-tools bundle) and finally to whatever's already cached from a previous successful fetch — `install_codeberg` downloads to a temp location and swaps it in atomically, so a failed refresh never destroys a good cached copy. Krohnkite is also included in the default whole-registry `homepkg bundle`.
- Codeberg-only bundles are tagged `platform: "any"` (a `.kwinscript` is architecture-independent), so they can be staged on any host regardless of what built them.
- `git`/`tsc` move from hard prerequisites to warnings in `setup-kde`, since the source-build fallback is the only thing that still needs them.
- A bundle manifest's `tool` field is now validated the same way its `asset` field already was, closing a path-traversal hole a tampered Codeberg bundle could otherwise use to delete an arbitrary directory via `rmtree`.

## Test plan

- [x] `make test` — all suites pass (see `homepkg_test` and `setup-kde_test`, extended with coverage for the release-first/fallback/bundle/refresh/platform-neutral/traversal behavior)
- [x] `python3 homepkg list` / `--help` sanity-checked manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Thxxh6LMNduKmtw2LWjXGP