### PR TITLE
homepkg, setup-kde: address second review pass on the Krohnkite backend

### DIFF
--- a/homepkg
+++ b/homepkg
@@ -509,6 +509,40 @@ def codeberg_asset_dir(tool, prefix):
     return os.path.join(prefix, "share", "homepkg", "assets", tool)
 
 
+def _replace_codeberg_asset(dest_dir, name, populate):
+    """Atomically replace dest_dir's cached asset with `name`, written by
+    calling populate(tmp_path). Used by both install_codeberg (populate
+    downloads) and _install_bundle_codeberg (populate copies from the
+    bundle), so a failed refresh -- from either source -- can't destroy a
+    previously good cache.
+
+    populate() writes to a temp file inside dest_dir first; only the final
+    os.replace() (atomic on a single filesystem, and dest_dir/tmp_path always
+    share one) touches the name a consumer actually looks for. If populate()
+    raises, dest_dir's existing contents are exactly as they were before this
+    call. Only once the new file is confirmed in place are older-version
+    files in dest_dir cleared out, so old and new never coexist.
+    """
+    os.makedirs(dest_dir, exist_ok=True)
+    tmp_path = os.path.join(dest_dir, f".{name}.part")
+    final_path = os.path.join(dest_dir, name)
+    try:
+        populate(tmp_path)
+        os.replace(tmp_path, final_path)
+    except BaseException:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+        raise
+    for existing in os.listdir(dest_dir):
+        if existing == name:
+            continue
+        p = os.path.join(dest_dir, existing)
+        if os.path.isdir(p) and not os.path.islink(p):
+            shutil.rmtree(p)
+        else:
+            os.remove(p)
+
+
 def install_codeberg(tool, meta, prefix, plat, dry_run):
     repo = meta["codeberg"]
     tag, assets = codeberg_release_assets(repo, meta.get("codeberg_tag"))
@@ -516,25 +550,18 @@ def install_codeberg(tool, meta, prefix, plat, dry_run):
     if not picked:
         raise HomepkgError(f"{tool}: no .kwinscript asset in {repo} {tag}")
     name, url = picked
+    # name comes straight from the Codeberg API response, not from our own
+    # registry -- validate it the same way a bundle-manifest asset name is,
+    # so a compromised/malicious release can't smuggle a ".."-traversal name
+    # (still ending in .kwinscript, so codeberg_pick_kwinscript would accept
+    # it) into a filesystem path.
+    _require_basename(name, "asset name")
     info(f"{tool}: codeberg {repo} {tag} -> {name}")
     if dry_run:
         info(f"  would install from {url}")
         return
     dest_dir = codeberg_asset_dir(tool, prefix)
-    # Download to a temp location first, and only then replace dest_dir: a
-    # consumer (setup-kde) refreshes by calling this on every run and falls
-    # back to whatever's already cached here when the fetch fails (offline).
-    # Clearing dest_dir before the download would destroy that fallback the
-    # moment the network drops mid-refresh, not just when it's absent
-    # entirely. A version bump changes the filename, so dest_dir is still
-    # cleared on success -- old and new must not coexist, since a consumer
-    # globs this directory for "the" .kwinscript.
-    with tempfile.TemporaryDirectory() as td:
-        downloaded = download(url, os.path.join(td, name))
-        if os.path.isdir(dest_dir):
-            shutil.rmtree(dest_dir)
-        os.makedirs(dest_dir, exist_ok=True)
-        shutil.move(downloaded, os.path.join(dest_dir, name))
+    _replace_codeberg_asset(dest_dir, name, lambda tmp: download(url, tmp))
     info(f"  saved {name} to {dest_dir}")
 
 
@@ -839,6 +866,10 @@ def _stage_codeberg(tools, td, skip_unavailable=False):
             warn(msg + "; leaving it out of the bundle")
             continue
         name, url = picked
+        # Same reasoning as install_codeberg: validate a release-supplied
+        # name before it becomes a filesystem path, here inside the bundle's
+        # staging directory.
+        _require_basename(name, "asset name")
         download(url, os.path.join(adir, name))
         entries.append({"tool": t, "asset": name})
     return entries
@@ -1021,10 +1052,8 @@ def _install_bundle_codeberg(td, manifest, prefix, dry_run):
         if dry_run:
             continue
         dest_dir = codeberg_asset_dir(e["tool"], prefix)
-        if os.path.isdir(dest_dir):
-            shutil.rmtree(dest_dir)
-        os.makedirs(dest_dir, exist_ok=True)
-        shutil.copy2(asset, os.path.join(dest_dir, e["asset"]))
+        _replace_codeberg_asset(dest_dir, e["asset"],
+                                lambda tmp, src=asset: shutil.copy2(src, tmp))
     return failed
 
 

--- a/homepkg
+++ b/homepkg
@@ -509,6 +509,9 @@ def codeberg_asset_dir(tool, prefix):
     return os.path.join(prefix, "share", "homepkg", "assets", tool)
 
 
+_CODEBERG_ASSET_LOCK = ".lock"
+
+
 def _replace_codeberg_asset(dest_dir, name, populate):
     """Atomically replace dest_dir's cached asset with `name`, written by
     calling populate(tmp_path). Used by both install_codeberg (populate
@@ -522,25 +525,43 @@ def _replace_codeberg_asset(dest_dir, name, populate):
     raises, dest_dir's existing contents are exactly as they were before this
     call. Only once the new file is confirmed in place are older-version
     files in dest_dir cleared out, so old and new never coexist.
+
+    The whole populate/replace/cleanup sequence runs under a per-dest_dir
+    flock: two overlapping refreshes of the same tool (e.g. a manual
+    `homepkg install` racing setup-kde's own fetch) would otherwise each
+    list dest_dir mid-flight and delete the *other* one's just-placed final
+    file -- both report success, but the cache ends up empty. Serializing
+    means the second call only ever sees the first call's fully-finished
+    result. The lock file itself is never removed by the cleanup loop below;
+    deleting it while a process still holds it open would let a later opener
+    take a lock on a different, discarded inode and silently stop
+    contending for it.
     """
+    import fcntl  # POSIX-only, matching this file's Linux/macOS-only scope
     os.makedirs(dest_dir, exist_ok=True)
-    tmp_path = os.path.join(dest_dir, f".{name}.part")
-    final_path = os.path.join(dest_dir, name)
-    try:
-        populate(tmp_path)
-        os.replace(tmp_path, final_path)
-    except BaseException:
-        if os.path.exists(tmp_path):
-            os.remove(tmp_path)
-        raise
-    for existing in os.listdir(dest_dir):
-        if existing == name:
-            continue
-        p = os.path.join(dest_dir, existing)
-        if os.path.isdir(p) and not os.path.islink(p):
-            shutil.rmtree(p)
-        else:
-            os.remove(p)
+    lock_path = os.path.join(dest_dir, _CODEBERG_ASSET_LOCK)
+    with open(lock_path, "a+") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            tmp_path = os.path.join(dest_dir, f".{name}.part")
+            final_path = os.path.join(dest_dir, name)
+            try:
+                populate(tmp_path)
+                os.replace(tmp_path, final_path)
+            except BaseException:
+                if os.path.exists(tmp_path):
+                    os.remove(tmp_path)
+                raise
+            for existing in os.listdir(dest_dir):
+                if existing in (name, _CODEBERG_ASSET_LOCK):
+                    continue
+                p = os.path.join(dest_dir, existing)
+                if os.path.isdir(p) and not os.path.islink(p):
+                    shutil.rmtree(p)
+                else:
+                    os.remove(p)
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
 
 
 def install_codeberg(tool, meta, prefix, plat, dry_run):

--- a/homepkg
+++ b/homepkg
@@ -475,7 +475,7 @@ def install_github(tool, meta, prefix, plat, dry_run):
 # setup-kde's job, not homepkg's.
 
 def codeberg_release_assets(repo, tag=None):
-    """(tag_name, [(asset name, url), ...]) for a release.
+    """(tag_name, published_at, [(asset name, url), ...]) for a release.
 
     `tag=None` (the default) means the single newest published release,
     prereleases included: Gitea's (like GitHub's) /releases/latest skips
@@ -484,6 +484,11 @@ def codeberg_release_assets(repo, tag=None):
     stable tag predates KWin 6 fixes only shipped in the beta line. The
     releases list is already sorted newest-first, so ?limit=1 is enough.
     Pass an explicit tag (registry's codeberg_tag) to pin one instead.
+
+    published_at is Codeberg's own RFC3339 timestamp for the release --
+    server-authoritative, unlike any local machine's clock, and lexically
+    comparable as a plain string. It's the freshness signal
+    _replace_codeberg_asset uses instead of filesystem mtimes.
     """
     if tag:
         data = json.loads(http_get(
@@ -494,8 +499,9 @@ def codeberg_release_assets(repo, tag=None):
         if not releases:
             raise HomepkgError(f"no releases found for {repo}")
         data = releases[0]
-    return data.get("tag_name", "?"), [
-        (a["name"], a["browser_download_url"]) for a in data.get("assets", [])]
+    published_at = data.get("published_at") or data.get("created_at")
+    return (data.get("tag_name", "?"), published_at,
+            [(a["name"], a["browser_download_url"]) for a in data.get("assets", [])])
 
 
 def codeberg_pick_kwinscript(assets):
@@ -510,9 +516,10 @@ def codeberg_asset_dir(tool, prefix):
 
 
 _CODEBERG_ASSET_LOCK = ".lock"
+_CODEBERG_ASSET_META = ".meta.json"
 
 
-def _replace_codeberg_asset(dest_dir, name, populate):
+def _replace_codeberg_asset(dest_dir, name, populate, freshness=None):
     """Atomically replace dest_dir's cached asset with `name`, written by
     calling populate(tmp_path). Used by both install_codeberg (populate
     downloads) and _install_bundle_codeberg (populate copies from the
@@ -524,27 +531,33 @@ def _replace_codeberg_asset(dest_dir, name, populate):
     share one) touches the name a consumer actually looks for. If populate()
     raises, dest_dir's existing contents are exactly as they were before this
     call. Only once the new file is confirmed in place are older-version
-    files in dest_dir cleared out, so old and new never coexist.
+    files (including any orphaned .part left by a process that was killed
+    mid-populate) cleared out, so nothing but the current asset, the lock,
+    and the freshness sidecar ever remain.
 
-    The whole populate/replace/cleanup sequence runs under a per-dest_dir
-    flock: two overlapping refreshes of the same tool (e.g. a manual
-    `homepkg install` racing setup-kde's own fetch) would otherwise each
-    list dest_dir mid-flight and delete the *other* one's just-placed final
-    file -- both report success, but the cache ends up empty. Serializing
-    means the second call only ever sees the first call's fully-finished
-    result. The lock file itself is never removed by the cleanup loop below;
-    deleting it while a process still holds it open would let a later opener
-    take a lock on a different, discarded inode and silently stop
-    contending for it.
+    The whole sequence runs under a per-dest_dir flock: two overlapping
+    refreshes of the same tool (e.g. a manual `homepkg install` racing
+    setup-kde's own fetch) would otherwise each list dest_dir mid-flight and
+    delete the *other* one's just-placed final file -- both report success,
+    but the cache ends up empty. Serializing means the second call only ever
+    sees the first call's fully-finished result. The lock file itself is
+    never removed by the cleanup below; deleting it while a process still
+    holds it open would let a later opener take a lock on a different,
+    discarded inode and silently stop contending for it.
 
-    If dest_dir already holds an asset newer (by mtime) than the one
-    populate() just produced, the existing asset is kept and this returns
-    False instead of replacing it -- a staged bundle, built at some earlier
-    point, must not downgrade a cache that was refreshed more recently
-    online. download() always writes with the current time, so the online
-    path never loses this comparison; a bundle's asset mtime survives from
-    whenever the bundle was built (preserved through tarfile extraction and
-    shutil.copy2), so it can correctly lose to a fresher cache. Returns True
+    `freshness` is an opaque, lexicographically-comparable token -- in
+    practice Codeberg's release `published_at` (RFC3339, sorts correctly as
+    a plain string) -- persisted in a small sidecar file next to the asset.
+    If the sidecar's stored value is already >= `freshness`, populate() is
+    skipped entirely (no download/copy) and this returns False: a bundle
+    built at some earlier point must not downgrade a cache that was
+    refreshed more recently online. This deliberately does NOT use local
+    file mtimes: a bundle built on one host and installed on another has no
+    shared clock, so an older bundle from a host with a clock skewed ahead
+    could otherwise look newer than a genuinely fresher cache -- and worse,
+    a bogus future mtime could then block every later legitimate refresh
+    until the local clock caught up to it. `freshness=None` (unknown) always
+    applies, matching the old no-comparison-possible behavior. Returns True
     if the new asset was applied.
     """
     import fcntl  # POSIX-only, matching this file's Linux/macOS-only scope
@@ -553,25 +566,31 @@ def _replace_codeberg_asset(dest_dir, name, populate):
     with open(lock_path, "a+") as lock_file:
         fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
         try:
+            meta_path = os.path.join(dest_dir, _CODEBERG_ASSET_META)
+            existing_freshness = None
+            if os.path.exists(meta_path):
+                try:
+                    with open(meta_path) as f:
+                        existing_freshness = json.load(f).get("published_at")
+                except (OSError, ValueError):
+                    existing_freshness = None
+            if (existing_freshness is not None and freshness is not None
+                    and existing_freshness >= freshness):
+                return False
+
             tmp_path = os.path.join(dest_dir, f".{name}.part")
             final_path = os.path.join(dest_dir, name)
             try:
                 populate(tmp_path)
+                os.replace(tmp_path, final_path)
             except BaseException:
                 if os.path.exists(tmp_path):
                     os.remove(tmp_path)
                 raise
-            others = [f for f in os.listdir(dest_dir)
-                      if f not in (name, _CODEBERG_ASSET_LOCK, os.path.basename(tmp_path))]
-            newest_existing = max(
-                (os.path.getmtime(os.path.join(dest_dir, f)) for f in others),
-                default=None)
-            if newest_existing is not None and newest_existing > os.path.getmtime(tmp_path):
-                os.remove(tmp_path)
-                return False
-            os.replace(tmp_path, final_path)
+            with open(meta_path, "w") as f:
+                json.dump({"published_at": freshness}, f)
             for existing in os.listdir(dest_dir):
-                if existing in (name, _CODEBERG_ASSET_LOCK):
+                if existing in (name, _CODEBERG_ASSET_LOCK, _CODEBERG_ASSET_META):
                     continue
                 p = os.path.join(dest_dir, existing)
                 if os.path.isdir(p) and not os.path.islink(p):
@@ -585,7 +604,7 @@ def _replace_codeberg_asset(dest_dir, name, populate):
 
 def install_codeberg(tool, meta, prefix, plat, dry_run):
     repo = meta["codeberg"]
-    tag, assets = codeberg_release_assets(repo, meta.get("codeberg_tag"))
+    tag, published_at, assets = codeberg_release_assets(repo, meta.get("codeberg_tag"))
     picked = codeberg_pick_kwinscript(assets)
     if not picked:
         raise HomepkgError(f"{tool}: no .kwinscript asset in {repo} {tag}")
@@ -601,10 +620,10 @@ def install_codeberg(tool, meta, prefix, plat, dry_run):
         info(f"  would install from {url}")
         return
     dest_dir = codeberg_asset_dir(tool, prefix)
-    if _replace_codeberg_asset(dest_dir, name, lambda tmp: download(url, tmp)):
+    if _replace_codeberg_asset(dest_dir, name, lambda tmp: download(url, tmp), published_at):
         info(f"  saved {name} to {dest_dir}")
     else:
-        info(f"  {dest_dir} already has a newer asset; keeping it")
+        info(f"  {dest_dir} already has a release at least as recent; keeping it")
 
 
 # The per-tool extract backends: fetch one prebuilt artifact and unpack it.
@@ -899,7 +918,7 @@ def _stage_codeberg(tools, td, skip_unavailable=False):
     entries = []
     for t in tools:
         repo = TOOLS[t]["codeberg"]
-        tag, assets = codeberg_release_assets(repo, TOOLS[t].get("codeberg_tag"))
+        tag, published_at, assets = codeberg_release_assets(repo, TOOLS[t].get("codeberg_tag"))
         picked = codeberg_pick_kwinscript(assets)
         if not picked:
             msg = f"{t}: no .kwinscript asset in {repo} {tag}"
@@ -913,7 +932,10 @@ def _stage_codeberg(tools, td, skip_unavailable=False):
         # staging directory.
         _require_basename(name, "asset name")
         download(url, os.path.join(adir, name))
-        entries.append({"tool": t, "asset": name})
+        # published_at rides along in the manifest so install-bundle can
+        # compare it against whatever's already cached at install time,
+        # without needing network access to look it up again.
+        entries.append({"tool": t, "asset": name, "published_at": published_at})
     return entries
 
 
@@ -1095,7 +1117,8 @@ def _install_bundle_codeberg(td, manifest, prefix, dry_run):
             continue
         dest_dir = codeberg_asset_dir(e["tool"], prefix)
         if not _replace_codeberg_asset(dest_dir, e["asset"],
-                                       lambda tmp, src=asset: shutil.copy2(src, tmp)):
+                                       lambda tmp, src=asset: shutil.copy2(src, tmp),
+                                       e.get("published_at")):
             # Not a failure: the tool still has a valid (just newer) asset --
             # this bundle's copy simply lost to a fresher cache.
             info(f"  {e['tool']}: keeping the newer cached asset over this bundle's")

--- a/homepkg
+++ b/homepkg
@@ -548,16 +548,20 @@ def _replace_codeberg_asset(dest_dir, name, populate, freshness=None):
     `freshness` is an opaque, lexicographically-comparable token -- in
     practice Codeberg's release `published_at` (RFC3339, sorts correctly as
     a plain string) -- persisted in a small sidecar file next to the asset.
-    If the sidecar's stored value is already >= `freshness`, populate() is
-    skipped entirely (no download/copy) and this returns False: a bundle
-    built at some earlier point must not downgrade a cache that was
-    refreshed more recently online. This deliberately does NOT use local
-    file mtimes: a bundle built on one host and installed on another has no
-    shared clock, so an older bundle from a host with a clock skewed ahead
-    could otherwise look newer than a genuinely fresher cache -- and worse,
-    a bogus future mtime could then block every later legitimate refresh
-    until the local clock caught up to it. `freshness=None` (unknown) always
-    applies, matching the old no-comparison-possible behavior. Returns True
+    If the sidecar records a known freshness and the candidate isn't clearly
+    newer (its own freshness is unknown, or known but not later), populate()
+    is skipped entirely (no download/copy) and this returns False: a bundle
+    built at some earlier point -- or a legacy bundle from before this
+    mechanism existed, whose manifest carries no freshness at all -- must
+    not downgrade a cache with a known, established freshness. This
+    deliberately does NOT use local file mtimes: a bundle built on one host
+    and installed on another has no shared clock, so an older bundle from a
+    host with a clock skewed ahead could otherwise look newer than a
+    genuinely fresher cache -- and worse, a bogus future mtime could then
+    block every later legitimate refresh until the local clock caught up to
+    it. Only when the EXISTING asset's freshness is itself unknown (nothing
+    to compare against -- e.g. a cache from before this mechanism existed)
+    does an unknown-freshness candidate apply unconditionally. Returns True
     if the new asset was applied.
     """
     import fcntl  # POSIX-only, matching this file's Linux/macOS-only scope
@@ -574,8 +578,8 @@ def _replace_codeberg_asset(dest_dir, name, populate, freshness=None):
                         existing_freshness = json.load(f).get("published_at")
                 except (OSError, ValueError):
                     existing_freshness = None
-            if (existing_freshness is not None and freshness is not None
-                    and existing_freshness >= freshness):
+            if existing_freshness is not None and (
+                    freshness is None or existing_freshness >= freshness):
                 return False
 
             tmp_path = os.path.join(dest_dir, f".{name}.part")

--- a/homepkg
+++ b/homepkg
@@ -526,14 +526,17 @@ def _replace_codeberg_asset(dest_dir, name, populate, freshness=None):
     bundle), so a failed refresh -- from either source -- can't destroy a
     previously good cache.
 
-    populate() writes to a temp file inside dest_dir first; only the final
-    os.replace() (atomic on a single filesystem, and dest_dir/tmp_path always
-    share one) touches the name a consumer actually looks for. If populate()
-    raises, dest_dir's existing contents are exactly as they were before this
-    call. Only once the new file is confirmed in place are older-version
-    files (including any orphaned .part left by a process that was killed
-    mid-populate) cleared out, so nothing but the current asset, the lock,
-    and the freshness sidecar ever remain.
+    populate() writes to a temp file inside dest_dir first, and the freshness
+    sidecar is fully written and validated to its own temp file too, before
+    either is renamed into place -- if populate() or the metadata write
+    raises (e.g. the disk fills partway through), dest_dir's existing asset
+    and sidecar are exactly as they were before this call; a consumer never
+    observes a new asset paired with a missing or stale sidecar, or vice
+    versa. Only once both renames succeed (each an atomic os.replace() on a
+    single filesystem, and dest_dir/tmp_path always share one) are
+    older-version files (including any orphaned .part left by a process that
+    was killed mid-populate) cleared out, so nothing but the current asset,
+    the lock, and the freshness sidecar ever remain.
 
     The whole sequence runs under a per-dest_dir flock: two overlapping
     refreshes of the same tool (e.g. a manual `homepkg install` racing
@@ -584,15 +587,19 @@ def _replace_codeberg_asset(dest_dir, name, populate, freshness=None):
 
             tmp_path = os.path.join(dest_dir, f".{name}.part")
             final_path = os.path.join(dest_dir, name)
+            meta_tmp_path = os.path.join(dest_dir, f".{_CODEBERG_ASSET_META}.part")
             try:
                 populate(tmp_path)
+                with open(meta_tmp_path, "w") as f:
+                    json.dump({"published_at": freshness}, f)
                 os.replace(tmp_path, final_path)
+                os.replace(meta_tmp_path, meta_path)
             except BaseException:
                 if os.path.exists(tmp_path):
                     os.remove(tmp_path)
+                if os.path.exists(meta_tmp_path):
+                    os.remove(meta_tmp_path)
                 raise
-            with open(meta_path, "w") as f:
-                json.dump({"published_at": freshness}, f)
             for existing in os.listdir(dest_dir):
                 if existing in (name, _CODEBERG_ASSET_LOCK, _CODEBERG_ASSET_META):
                     continue

--- a/homepkg
+++ b/homepkg
@@ -536,6 +536,16 @@ def _replace_codeberg_asset(dest_dir, name, populate):
     deleting it while a process still holds it open would let a later opener
     take a lock on a different, discarded inode and silently stop
     contending for it.
+
+    If dest_dir already holds an asset newer (by mtime) than the one
+    populate() just produced, the existing asset is kept and this returns
+    False instead of replacing it -- a staged bundle, built at some earlier
+    point, must not downgrade a cache that was refreshed more recently
+    online. download() always writes with the current time, so the online
+    path never loses this comparison; a bundle's asset mtime survives from
+    whenever the bundle was built (preserved through tarfile extraction and
+    shutil.copy2), so it can correctly lose to a fresher cache. Returns True
+    if the new asset was applied.
     """
     import fcntl  # POSIX-only, matching this file's Linux/macOS-only scope
     os.makedirs(dest_dir, exist_ok=True)
@@ -547,11 +557,19 @@ def _replace_codeberg_asset(dest_dir, name, populate):
             final_path = os.path.join(dest_dir, name)
             try:
                 populate(tmp_path)
-                os.replace(tmp_path, final_path)
             except BaseException:
                 if os.path.exists(tmp_path):
                     os.remove(tmp_path)
                 raise
+            others = [f for f in os.listdir(dest_dir)
+                      if f not in (name, _CODEBERG_ASSET_LOCK, os.path.basename(tmp_path))]
+            newest_existing = max(
+                (os.path.getmtime(os.path.join(dest_dir, f)) for f in others),
+                default=None)
+            if newest_existing is not None and newest_existing > os.path.getmtime(tmp_path):
+                os.remove(tmp_path)
+                return False
+            os.replace(tmp_path, final_path)
             for existing in os.listdir(dest_dir):
                 if existing in (name, _CODEBERG_ASSET_LOCK):
                     continue
@@ -560,6 +578,7 @@ def _replace_codeberg_asset(dest_dir, name, populate):
                     shutil.rmtree(p)
                 else:
                     os.remove(p)
+            return True
         finally:
             fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
 
@@ -582,8 +601,10 @@ def install_codeberg(tool, meta, prefix, plat, dry_run):
         info(f"  would install from {url}")
         return
     dest_dir = codeberg_asset_dir(tool, prefix)
-    _replace_codeberg_asset(dest_dir, name, lambda tmp: download(url, tmp))
-    info(f"  saved {name} to {dest_dir}")
+    if _replace_codeberg_asset(dest_dir, name, lambda tmp: download(url, tmp)):
+        info(f"  saved {name} to {dest_dir}")
+    else:
+        info(f"  {dest_dir} already has a newer asset; keeping it")
 
 
 # The per-tool extract backends: fetch one prebuilt artifact and unpack it.
@@ -1073,8 +1094,11 @@ def _install_bundle_codeberg(td, manifest, prefix, dry_run):
         if dry_run:
             continue
         dest_dir = codeberg_asset_dir(e["tool"], prefix)
-        _replace_codeberg_asset(dest_dir, e["asset"],
-                                lambda tmp, src=asset: shutil.copy2(src, tmp))
+        if not _replace_codeberg_asset(dest_dir, e["asset"],
+                                       lambda tmp, src=asset: shutil.copy2(src, tmp)):
+            # Not a failure: the tool still has a valid (just newer) asset --
+            # this bundle's copy simply lost to a fresher cache.
+            info(f"  {e['tool']}: keeping the newer cached asset over this bundle's")
     return failed
 
 

--- a/homepkg_test
+++ b/homepkg_test
@@ -16,7 +16,6 @@ import subprocess
 import sys
 import tarfile
 import tempfile
-import threading
 import time
 
 # Load the extensionless homepkg script as a module without running main().
@@ -147,13 +146,13 @@ _http_get_urls = []
 def _fake_http_get(url, accept=None):
     _http_get_urls.append(url)
     if "/releases/tags/" in url:
-        return json.dumps({"tag_name": "1.2.3",
+        return json.dumps({"tag_name": "1.2.3", "published_at": "2026-06-01T00:00:00Z",
                            "assets": [{"name": "krohnkite-1.2.3.kwinscript",
                                        "browser_download_url": "https://example.invalid/pinned"}]}).encode()
-    return json.dumps([{"tag_name": "0.9.9.3_beta",
+    return json.dumps([{"tag_name": "0.9.9.3_beta", "published_at": "2026-07-01T00:00:00Z",
                         "assets": [{"name": "krohnkite-0.9.9.3_beta.kwinscript",
                                     "browser_download_url": "https://example.invalid/newest"}]},
-                       {"tag_name": "0.9.9.2",
+                       {"tag_name": "0.9.9.2", "published_at": "2026-01-01T00:00:00Z",
                         "assets": [{"name": "krohnkite-0.9.9.2.kwinscript",
                                     "browser_download_url": "https://example.invalid/older"}]}]).encode()
 hp.http_get = _fake_http_get
@@ -161,11 +160,13 @@ try:
     hp.codeberg_release_assets("anametologin/Krohnkite", "1.2.3")
     check("codeberg_release_assets requests a pinned tag from /releases/tags",
           _http_get_urls[-1].endswith("/releases/tags/1.2.3"))
-    tag, assets = hp.codeberg_release_assets("anametologin/Krohnkite")
+    tag, published_at, assets = hp.codeberg_release_assets("anametologin/Krohnkite")
     check("codeberg_release_assets with no tag requests /releases?limit=1, not /releases/latest",
           _http_get_urls[-1].endswith("/releases?limit=1"))
     check("codeberg_release_assets with no tag takes the newest release, prereleases included",
           tag == "0.9.9.3_beta" and assets[0][0] == "krohnkite-0.9.9.3_beta.kwinscript")
+    check("codeberg_release_assets returns the release's published_at",
+          published_at == "2026-07-01T00:00:00Z")
 finally:
     hp.http_get = _saved_http_get
 
@@ -173,7 +174,8 @@ finally:
 # no unpacking, unlike install_github, and no "bins" needed in meta.
 _saved_cra = hp.codeberg_release_assets
 hp.codeberg_release_assets = lambda repo, tag=None: (
-    "0.9.9.3_beta", [("krohnkite-0.9.9.3_beta.kwinscript", "https://example.invalid/k")])
+    "0.9.9.3_beta", "2026-07-01T00:00:00Z",
+    [("krohnkite-0.9.9.3_beta.kwinscript", "https://example.invalid/k")])
 try:
     with tempfile.TemporaryDirectory() as td:
         prefix = os.path.join(td, "prefix")
@@ -201,7 +203,8 @@ try:
               not os.path.exists(hp.codeberg_asset_dir("krohnkite", prefix)))
     # No .kwinscript asset in the release -- e.g. upstream renamed or dropped
     # it -- has to fail loudly rather than silently install nothing.
-    hp.codeberg_release_assets = lambda repo, tag=None: ("9.9.9", [("Source code (zip)", "u")])
+    hp.codeberg_release_assets = lambda repo, tag=None: (
+        "9.9.9", "2026-07-01T00:00:00Z", [("Source code (zip)", "u")])
     _err = None
     try:
         hp.install_codeberg("krohnkite", hp.TOOLS["krohnkite"],
@@ -217,7 +220,8 @@ try:
     # ends in .kwinscript must be rejected before it becomes a path, the same
     # way a bundle-manifest asset name already is.
     hp.codeberg_release_assets = lambda repo, tag=None: (
-        "9.9.9", [("../../evil.kwinscript", "https://example.invalid/evil")])
+        "9.9.9", "2026-07-01T00:00:00Z",
+        [("../../evil.kwinscript", "https://example.invalid/evil")])
     with tempfile.TemporaryDirectory() as td:
         prefix = os.path.join(td, "prefix")
         _err = None
@@ -247,6 +251,8 @@ finally:
 
 # The new asset must land under its final name and any older-version file
 # must be gone -- but only after populate() (the download/copy) succeeds.
+# Neither call here passes a freshness token, so the swap is unconditional
+# (freshness=None always applies -- "can't compare, so just take it").
 with tempfile.TemporaryDirectory() as td:
     dest_dir = os.path.join(td, "assets", "krohnkite")
     os.makedirs(dest_dir)
@@ -262,7 +268,8 @@ with tempfile.TemporaryDirectory() as td:
           not os.path.exists(os.path.join(dest_dir, "krohnkite-0.9.9.2.kwinscript")))
     check("_replace_codeberg_asset leaves no stray temp file",
           sorted(os.listdir(dest_dir))
-          == sorted(["krohnkite-0.9.9.3_beta.kwinscript", hp._CODEBERG_ASSET_LOCK]))
+          == sorted(["krohnkite-0.9.9.3_beta.kwinscript",
+                     hp._CODEBERG_ASSET_LOCK, hp._CODEBERG_ASSET_META]))
 
 # If populate() fails, the old asset must be untouched and no partial temp
 # file left behind -- the swap only happens after populate() succeeds.
@@ -293,23 +300,34 @@ with tempfile.TemporaryDirectory() as td:
 
 # A staged bundle, built at some earlier point, must not downgrade a cache
 # that was refreshed more recently online -- e.g. the cache holds 0.9.9.3
-# (fetched today) but a bootstrap bundle sitting around still carries
-# 0.9.9.2 (built weeks ago). populate() here simulates a bundle-copy that
-# preserves the source's (older) mtime, the same way shutil.copy2 does.
+# (fetched today, published_at recorded in the sidecar) but a bootstrap
+# bundle sitting around still carries 0.9.9.2 (built weeks ago, an OLDER
+# published_at). This is deliberately NOT a local-mtime comparison: a bundle
+# built on one host and installed on another share no clock, so an older
+# bundle from a host with a skewed-ahead clock could otherwise look newer
+# than a genuinely fresher cache.
 with tempfile.TemporaryDirectory() as td:
     dest_dir = os.path.join(td, "assets", "krohnkite")
     os.makedirs(dest_dir)
     newer_path = os.path.join(dest_dir, "krohnkite-0.9.9.3_beta.kwinscript")
     with open(newer_path, "wb") as f:
         f.write(b"newer, already cached")
+    with open(os.path.join(dest_dir, hp._CODEBERG_ASSET_META), "w") as f:
+        json.dump({"published_at": "2026-07-01T00:00:00Z"}, f)
 
-    def _populate_older(tmp):
-        with open(tmp, "wb") as f:
-            f.write(b"older, from a stale bundle")
-        os.utime(tmp, (time.time() - 3600, time.time() - 3600))  # 1h in the past
+    def _populate_should_not_run(tmp):
+        raise AssertionError("populate() must not be called for an already-stale candidate")
 
-    applied = hp._replace_codeberg_asset(
-        dest_dir, "krohnkite-0.9.9.2.kwinscript", _populate_older)
+    try:
+        applied = hp._replace_codeberg_asset(
+            dest_dir, "krohnkite-0.9.9.2.kwinscript", _populate_should_not_run,
+            "2026-01-01T00:00:00Z")
+        _populate_wrongly_called = False
+    except AssertionError:
+        applied = False
+        _populate_wrongly_called = True
+    check("_replace_codeberg_asset never calls populate() for an already-stale candidate",
+          not _populate_wrongly_called)
     check("_replace_codeberg_asset reports the older asset was not applied",
           applied is False)
     check("_replace_codeberg_asset keeps the newer cached asset",
@@ -317,39 +335,81 @@ with tempfile.TemporaryDirectory() as td:
     check("_replace_codeberg_asset doesn't leave the older asset behind either",
           not os.path.exists(os.path.join(dest_dir, "krohnkite-0.9.9.2.kwinscript")))
 
-# ...but the online path is never blocked by this: download() always writes
-# with the current time, so a genuinely fresh fetch always wins even if it
-# happens to resolve to a name that would sort "older" as a plain string.
+# ...a genuinely newer release (later published_at) correctly supersedes it.
 with tempfile.TemporaryDirectory() as td:
     dest_dir = os.path.join(td, "assets", "krohnkite")
     os.makedirs(dest_dir)
     with open(os.path.join(dest_dir, "krohnkite-0.9.9.9.kwinscript"), "wb") as f:
         f.write(b"cached")
+    with open(os.path.join(dest_dir, hp._CODEBERG_ASSET_META), "w") as f:
+        json.dump({"published_at": "2026-01-01T00:00:00Z"}, f)
     applied = hp._replace_codeberg_asset(
         dest_dir, "krohnkite-0.9.9.10.kwinscript",
-        lambda tmp: open(tmp, "wb").write(b"freshly fetched"))
-    check("a freshly-populated asset (current mtime) always applies",
+        lambda tmp: open(tmp, "wb").write(b"freshly fetched"),
+        "2026-07-01T00:00:00Z")
+    check("a release with a later published_at applies over an older cache",
           applied is True
           and open(os.path.join(dest_dir, "krohnkite-0.9.9.10.kwinscript"), "rb").read()
           == b"freshly fetched")
 
+# An unknown freshness (no sidecar yet, e.g. a cache from before this
+# mechanism existed) can't be compared, so the new asset always applies --
+# matching the old no-comparison-possible behavior.
+with tempfile.TemporaryDirectory() as td:
+    dest_dir = os.path.join(td, "assets", "krohnkite")
+    os.makedirs(dest_dir)
+    with open(os.path.join(dest_dir, "krohnkite-0.9.9.2.kwinscript"), "wb") as f:
+        f.write(b"legacy cache, no sidecar")
+    applied = hp._replace_codeberg_asset(
+        dest_dir, "krohnkite-0.9.9.3_beta.kwinscript",
+        lambda tmp: open(tmp, "wb").write(b"new"), "2026-07-01T00:00:00Z")
+    check("no existing sidecar means the new asset always applies",
+          applied is True)
 
-def _concurrent_replace_worker(dest_dir, name, barrier, barrier_q, outcome_q):
+# A process killed mid-populate() (e.g. SIGKILL) leaves an orphaned
+# .NAME.part behind -- its cleanup-on-exception path never runs. That orphan
+# must not count as "an existing asset" for freshness purposes (its recent
+# mtime could otherwise make a legitimate, genuinely newer replacement look
+# like a downgrade and get discarded) and should be swept up as ordinary
+# clutter the next time the lock is held.
+with tempfile.TemporaryDirectory() as td:
+    dest_dir = os.path.join(td, "assets", "krohnkite")
+    os.makedirs(dest_dir)
+    orphan = os.path.join(dest_dir, ".krohnkite-0.9.9.2.kwinscript.part")
+    with open(orphan, "wb") as f:
+        f.write(b"leftover from a killed process")
+    applied = hp._replace_codeberg_asset(
+        dest_dir, "krohnkite-0.9.9.3_beta.kwinscript",
+        lambda tmp: open(tmp, "wb").write(b"new"), "2026-07-01T00:00:00Z")
+    check("an orphaned .part file doesn't block a legitimate replacement",
+          applied is True)
+    check("the orphan is swept up, not left behind",
+          not os.path.exists(orphan))
+    check("only the new asset, lock, and sidecar remain",
+          sorted(os.listdir(dest_dir))
+          == sorted(["krohnkite-0.9.9.3_beta.kwinscript",
+                     hp._CODEBERG_ASSET_LOCK, hp._CODEBERG_ASSET_META]))
+
+
+def _concurrent_replace_worker(dest_dir, name, start_barrier, active_count, max_seen, outcome_q):
+    start_barrier.wait()  # both processes begin racing for the flock together
     def populate(tmp):
+        # Directly, atomically observe how many workers are inside
+        # populate() at once -- not inferred from timeouts or sleep
+        # ordering, which can give a false "exclusive" reading purely from
+        # scheduler delay. If the lock holds, max_seen can never exceed 1,
+        # full stop, regardless of timing; if it were missing, two workers
+        # synchronized by start_barrier are very likely to be here together
+        # and max_seen would show it.
+        with active_count.get_lock():
+            active_count.value += 1
+            with max_seen.get_lock():
+                max_seen.value = max(max_seen.value, active_count.value)
         with open(tmp, "wb") as f:
             f.write(name.encode())
-        # If the lock holds, only one worker is ever inside populate() at a
-        # time, so its partner can never reach this barrier concurrently and
-        # wait() must time out (BrokenBarrierError). If the lock were
-        # missing, both workers would be here together and the barrier would
-        # release normally for both -- that's the race, detected
-        # deterministically instead of via sleep timing that CI scheduling
-        # could make miss the overlap entirely.
-        try:
-            barrier.wait(timeout=2)
-            barrier_q.put("released")
-        except threading.BrokenBarrierError:
-            barrier_q.put("timed-out")
+        time.sleep(0.1)  # widen the window a broken lock would need to be caught in
+        with active_count.get_lock():
+            active_count.value -= 1
     try:
         hp._replace_codeberg_asset(dest_dir, name, populate)
         outcome_q.put("ok")
@@ -359,36 +419,40 @@ def _concurrent_replace_worker(dest_dir, name, barrier, barrier_q, outcome_q):
 
 # _replace_codeberg_asset locks per dest_dir: two overlapping installs of the
 # same tool must not run their populate() calls concurrently (proven above
-# via the barrier), and the overall operation must still behave correctly:
-# neither call may raise, and exactly one final asset must remain (the
-# lock's serialization makes the later call supersede the earlier one, same
-# as two sequential refreshes would -- without the lock this reproduces as
-# either both final files vanishing, each call's cleanup deleting the
+# via the shared counter), and the overall operation must still behave
+# correctly: neither call may raise, and exactly one final asset must remain
+# (the lock's serialization makes the later call supersede the earlier one,
+# same as two sequential refreshes would -- without the lock this reproduces
+# as either both final files vanishing, each call's cleanup deleting the
 # other's just-placed file, or a crash from one call's cleanup deleting the
 # other's still-in-flight temp file). Real subprocesses (fork), so the OS
-# flock and the barrier are both actually contended, not same-process no-ops.
+# flock and the shared counter are both actually contended, not
+# same-process no-ops.
 with tempfile.TemporaryDirectory() as td:
     dest_dir = os.path.join(td, "assets", "krohnkite")
     ctx = multiprocessing.get_context("fork")
-    barrier = ctx.Barrier(2)
-    barrier_q = ctx.Queue()
+    start_barrier = ctx.Barrier(2)
+    active_count = ctx.Value('i', 0)
+    max_seen = ctx.Value('i', 0)
     outcome_q = ctx.Queue()
     p1 = ctx.Process(target=_concurrent_replace_worker,
-                     args=(dest_dir, "krohnkite-a.kwinscript", barrier, barrier_q, outcome_q))
+                     args=(dest_dir, "krohnkite-a.kwinscript", start_barrier,
+                           active_count, max_seen, outcome_q))
     p2 = ctx.Process(target=_concurrent_replace_worker,
-                     args=(dest_dir, "krohnkite-b.kwinscript", barrier, barrier_q, outcome_q))
+                     args=(dest_dir, "krohnkite-b.kwinscript", start_barrier,
+                           active_count, max_seen, outcome_q))
     p1.start()
     p2.start()
-    barrier_signals = sorted([barrier_q.get(timeout=10), barrier_q.get(timeout=10)])
     outcomes = sorted([outcome_q.get(timeout=10), outcome_q.get(timeout=10)])
     p1.join(timeout=10)
     p2.join(timeout=10)
     check("the lock keeps populate() calls from ever overlapping "
-          "(neither finds a partner at the barrier)",
-          barrier_signals == ["timed-out", "timed-out"])
+          "(a shared counter never observes more than 1 concurrently)",
+          max_seen.value == 1)
     check("neither concurrent _replace_codeberg_asset call raises",
           outcomes == ["ok", "ok"])
-    remaining = sorted(f for f in os.listdir(dest_dir) if f != hp._CODEBERG_ASSET_LOCK)
+    remaining = sorted(f for f in os.listdir(dest_dir)
+                       if f not in (hp._CODEBERG_ASSET_LOCK, hp._CODEBERG_ASSET_META))
     check("concurrent _replace_codeberg_asset calls don't both vanish",
           remaining in (["krohnkite-a.kwinscript"], ["krohnkite-b.kwinscript"]))
 
@@ -870,6 +934,37 @@ with tempfile.TemporaryDirectory() as td:
     check("install-bundle (combined) replays the codeberg section",
           os.path.exists(os.path.join(hp.codeberg_asset_dir("krohnkite", prefix), asset)))
 
+# End-to-end: a bundle manifest's published_at (recorded by _stage_codeberg
+# at build time) has to actually block install-bundle from downgrading a
+# cache that's already newer -- not just work at the _replace_codeberg_asset
+# unit level.
+with tempfile.TemporaryDirectory() as td:
+    prefix = os.path.join(td, "prefix")
+    dest_dir = hp.codeberg_asset_dir("krohnkite", prefix)
+    os.makedirs(dest_dir)
+    newer_asset = os.path.join(dest_dir, "krohnkite-0.9.9.3_beta.kwinscript")
+    with open(newer_asset, "wb") as f:
+        f.write(b"newer, already cached")
+    with open(os.path.join(dest_dir, hp._CODEBERG_ASSET_META), "w") as f:
+        json.dump({"published_at": "2026-07-01T00:00:00Z"}, f)
+
+    src = os.path.join(td, "src")
+    os.makedirs(os.path.join(src, "codeberg-assets"))
+    older_asset_name = "krohnkite-0.9.9.2.kwinscript"
+    with open(os.path.join(src, "codeberg-assets", older_asset_name), "wb") as f:
+        f.write(b"older, from a stale bundle")
+    with open(os.path.join(src, "manifest.json"), "w") as f:
+        json.dump({"format": 1, "backend": "codeberg", "platform": "linux/x86_64",
+                   "tools": [{"tool": "krohnkite", "asset": older_asset_name,
+                              "published_at": "2026-01-01T00:00:00Z"}]}, f)
+    bundle = os.path.join(td, "stale.tar.gz")
+    hp._write_bundle(bundle, src)
+
+    hp.install_bundle(bundle, prefix, ("linux", "x86_64"), False)
+    check("install-bundle (codeberg) doesn't downgrade a newer cache end-to-end",
+          open(newer_asset, "rb").read() == b"newer, already cached"
+          and not os.path.exists(os.path.join(dest_dir, older_asset_name)))
+
 # A codeberg asset missing from the bundle is reported, not silently skipped
 # -- same contract as the equivalent github-side test above.
 with tempfile.TemporaryDirectory() as td:
@@ -926,7 +1021,8 @@ with tempfile.TemporaryDirectory() as td:
     _saved_cra2 = hp.codeberg_release_assets
     _saved_dl2 = hp.download
     hp.codeberg_release_assets = lambda repo, tag=None: (
-        "0.9.9.3_beta", [("krohnkite-0.9.9.3_beta.kwinscript", "https://example.invalid/k")])
+        "0.9.9.3_beta", "2026-07-01T00:00:00Z",
+        [("krohnkite-0.9.9.3_beta.kwinscript", "https://example.invalid/k")])
     def _failing_download(url, dest):
         raise OSError("network unreachable")
     hp.download = _failing_download

--- a/homepkg_test
+++ b/homepkg_test
@@ -208,8 +208,83 @@ try:
         _err = e
     check("install_codeberg errors when the release has no .kwinscript asset",
           _err is not None and "krohnkite" in str(_err))
+
+    # A release asset name is attacker-influenced (whoever can publish to the
+    # Codeberg repo), not our own registry -- a traversal name that still
+    # ends in .kwinscript must be rejected before it becomes a path, the same
+    # way a bundle-manifest asset name already is.
+    hp.codeberg_release_assets = lambda repo, tag=None: (
+        "9.9.9", [("../../evil.kwinscript", "https://example.invalid/evil")])
+    with tempfile.TemporaryDirectory() as td:
+        prefix = os.path.join(td, "prefix")
+        _err = None
+        try:
+            hp.install_codeberg("krohnkite", hp.TOOLS["krohnkite"], prefix,
+                                ("linux", "x86_64"), False)
+        except hp.HomepkgError as e:
+            _err = e
+        check("install_codeberg rejects a traversal asset name from the release",
+              _err is not None)
+        check("...and writes nothing outside the prefix",
+              not os.path.exists(os.path.join(td, "evil.kwinscript")))
+
+    # _stage_codeberg (used when building a bundle) validates the same way.
+    with tempfile.TemporaryDirectory() as td:
+        _err = None
+        try:
+            hp._stage_codeberg(["krohnkite"], td)
+        except hp.HomepkgError as e:
+            _err = e
+        check("_stage_codeberg rejects a traversal asset name from the release",
+              _err is not None)
 finally:
     hp.codeberg_release_assets = _saved_cra
+
+# --- _replace_codeberg_asset: atomic swap ------------------------------------
+
+# The new asset must land under its final name and any older-version file
+# must be gone -- but only after populate() (the download/copy) succeeds.
+with tempfile.TemporaryDirectory() as td:
+    dest_dir = os.path.join(td, "assets", "krohnkite")
+    os.makedirs(dest_dir)
+    with open(os.path.join(dest_dir, "krohnkite-0.9.9.2.kwinscript"), "wb") as f:
+        f.write(b"old")
+    hp._replace_codeberg_asset(
+        dest_dir, "krohnkite-0.9.9.3_beta.kwinscript",
+        lambda tmp: open(tmp, "wb").write(b"new"))
+    check("_replace_codeberg_asset writes the new asset under its final name",
+          open(os.path.join(dest_dir, "krohnkite-0.9.9.3_beta.kwinscript"), "rb").read()
+          == b"new")
+    check("_replace_codeberg_asset removes the older-version file",
+          not os.path.exists(os.path.join(dest_dir, "krohnkite-0.9.9.2.kwinscript")))
+    check("_replace_codeberg_asset leaves no stray temp file",
+          os.listdir(dest_dir) == ["krohnkite-0.9.9.3_beta.kwinscript"])
+
+# If populate() fails, the old asset must be untouched and no partial temp
+# file left behind -- the swap only happens after populate() succeeds.
+with tempfile.TemporaryDirectory() as td:
+    dest_dir = os.path.join(td, "assets", "krohnkite")
+    os.makedirs(dest_dir)
+    with open(os.path.join(dest_dir, "krohnkite-0.9.9.2.kwinscript"), "wb") as f:
+        f.write(b"old")
+
+    def _failing_populate(tmp):
+        with open(tmp, "wb") as f:
+            f.write(b"partial")
+        raise OSError("network unreachable")
+
+    _err = None
+    try:
+        hp._replace_codeberg_asset(
+            dest_dir, "krohnkite-0.9.9.3_beta.kwinscript", _failing_populate)
+    except OSError as e:
+        _err = e
+    check("_replace_codeberg_asset propagates a populate() failure", _err is not None)
+    check("...and leaves the old asset untouched",
+          open(os.path.join(dest_dir, "krohnkite-0.9.9.2.kwinscript"), "rb").read()
+          == b"old")
+    check("...and cleans up the partial temp file",
+          os.listdir(dest_dir) == ["krohnkite-0.9.9.2.kwinscript"])
 
 # --- github extraction -------------------------------------------------------
 

--- a/homepkg_test
+++ b/homepkg_test
@@ -423,6 +423,28 @@ with tempfile.TemporaryDirectory() as td:
                      hp._CODEBERG_ASSET_LOCK, hp._CODEBERG_ASSET_META]))
 
 
+def _wait_for_attempts(attempts, needed, deadline_seconds):
+    """Busy-wait for the shared `attempts` counter to reach `needed`.
+
+    The deadline is purely an infra hang-guard (a process that never even
+    reaches the barrier), not a tunable "probably long enough" threshold --
+    if it's ever hit, the handshake this is meant to prove didn't happen, so
+    this raises instead of letting the caller silently proceed as if it had.
+    A caller that swallowed a timed-out wait here would degrade back into
+    exactly the kind of unproven, timing-dependent pass this handshake
+    exists to rule out.
+    """
+    deadline = time.monotonic() + deadline_seconds
+    while attempts.value < needed and time.monotonic() < deadline:
+        pass
+    if attempts.value < needed:
+        raise RuntimeError(
+            f"concurrency test handshake timed out waiting for "
+            f"attempts>={needed} (got {attempts.value}); this is a test "
+            f"infrastructure problem (e.g. a starved process), not a "
+            f"real assertion about the lock")
+
+
 def _concurrent_replace_worker(dest_dir, name, start_barrier, attempts,
                                 active_count, max_seen, outcome_q):
     start_barrier.wait()  # both processes begin racing for the flock together
@@ -442,12 +464,10 @@ def _concurrent_replace_worker(dest_dir, name, start_barrier, attempts,
         # allowed to finish and release the flock. Since "attempts" is set
         # before either worker even tries the lock (above), this condition
         # is already true almost immediately in the overwhelmingly common
-        # case; the deadline exists purely as an infra hang-guard (a process
-        # that never even reaches the barrier), not as a tunable "probably
-        # long enough" pass/fail threshold like a fixed sleep would be.
-        deadline = time.monotonic() + 10
-        while attempts.value < 2 and time.monotonic() < deadline:
-            pass
+        # case. If it's ever NOT true within the deadline, that's a broken
+        # test environment, not a passing run -- _wait_for_attempts raises
+        # rather than letting this fall through as a false "ok".
+        _wait_for_attempts(attempts, 2, 10)
         with open(tmp, "wb") as f:
             f.write(name.encode())
         with active_count.get_lock():
@@ -457,6 +477,32 @@ def _concurrent_replace_worker(dest_dir, name, start_barrier, attempts,
         outcome_q.put("ok")
     except Exception as e:  # noqa: BLE001 -- reporting to the parent, not handling
         outcome_q.put(f"error: {e}")
+
+
+# Prove _wait_for_attempts' raise-on-timeout directly, with a short deadline,
+# rather than only ever exercising it indirectly through the full 10-second
+# multiprocess handshake below -- a broken version that swallows the timeout
+# (as an earlier round of this test did) would otherwise only show up as a
+# rare, load-dependent false pass in the slow test, not a reliable failure
+# here.
+class _FakeCounter:
+    def __init__(self, value):
+        self.value = value
+
+
+_start = time.monotonic()
+try:
+    _wait_for_attempts(_FakeCounter(0), 2, 0.2)
+    check("_wait_for_attempts raises when the target is never reached", False)
+except RuntimeError:
+    check("_wait_for_attempts raises when the target is never reached", True)
+check("_wait_for_attempts doesn't overrun its own deadline",
+      time.monotonic() - _start < 2)
+
+_start = time.monotonic()
+_wait_for_attempts(_FakeCounter(2), 2, 5)
+check("_wait_for_attempts returns immediately once the target is already met",
+      time.monotonic() - _start < 1)
 
 
 # _replace_codeberg_asset locks per dest_dir: two overlapping installs of the

--- a/homepkg_test
+++ b/homepkg_test
@@ -366,6 +366,38 @@ with tempfile.TemporaryDirectory() as td:
     check("no existing sidecar means the new asset always applies",
           applied is True)
 
+# ...but the reverse must NOT hold: a candidate with unknown freshness (a
+# legacy bundle manifest from before _stage_codeberg recorded published_at)
+# must not downgrade a cache whose sidecar proves a known freshness. Only
+# "unknown vs unknown" defaults to applying; "unknown vs known" must keep
+# the known-good one.
+with tempfile.TemporaryDirectory() as td:
+    dest_dir = os.path.join(td, "assets", "krohnkite")
+    os.makedirs(dest_dir)
+    known_good = os.path.join(dest_dir, "krohnkite-0.9.9.3_beta.kwinscript")
+    with open(known_good, "wb") as f:
+        f.write(b"known-fresh cache")
+    with open(os.path.join(dest_dir, hp._CODEBERG_ASSET_META), "w") as f:
+        json.dump({"published_at": "2026-07-01T00:00:00Z"}, f)
+
+    def _populate_should_not_run2(tmp):
+        raise AssertionError("populate() must not run for an unknown-freshness "
+                              "candidate against a known-fresh cache")
+
+    try:
+        applied = hp._replace_codeberg_asset(
+            dest_dir, "krohnkite-0.9.9.2.kwinscript", _populate_should_not_run2,
+            None)  # unknown freshness, e.g. a legacy bundle
+        _wrongly_called = False
+    except AssertionError:
+        applied = False
+        _wrongly_called = True
+    check("an unknown-freshness candidate never calls populate() against a known-fresh cache",
+          not _wrongly_called)
+    check("an unknown-freshness candidate does not replace a known-fresh cache",
+          applied is False
+          and open(known_good, "rb").read() == b"known-fresh cache")
+
 # A process killed mid-populate() (e.g. SIGKILL) leaves an orphaned
 # .NAME.part behind -- its cleanup-on-exception path never runs. That orphan
 # must not count as "an existing asset" for freshness purposes (its recent
@@ -391,23 +423,33 @@ with tempfile.TemporaryDirectory() as td:
                      hp._CODEBERG_ASSET_LOCK, hp._CODEBERG_ASSET_META]))
 
 
-def _concurrent_replace_worker(dest_dir, name, start_barrier, active_count, max_seen, outcome_q):
+def _concurrent_replace_worker(dest_dir, name, start_barrier, attempts,
+                                active_count, max_seen, outcome_q):
     start_barrier.wait()  # both processes begin racing for the flock together
+    # Signal "attempting" immediately, entirely independent of the flock:
+    # this increment doesn't wait to win any lock, so it lands for both
+    # workers within microseconds of leaving the barrier, regardless of
+    # which one (if either) ends up holding the flock. It's the handshake
+    # populate() waits on below.
+    with attempts.get_lock():
+        attempts.value += 1
     def populate(tmp):
-        # Directly, atomically observe how many workers are inside
-        # populate() at once -- not inferred from timeouts or sleep
-        # ordering, which can give a false "exclusive" reading purely from
-        # scheduler delay. If the lock holds, max_seen can never exceed 1,
-        # full stop, regardless of timing; if it were missing, two workers
-        # synchronized by start_barrier are very likely to be here together
-        # and max_seen would show it.
         with active_count.get_lock():
             active_count.value += 1
             with max_seen.get_lock():
                 max_seen.value = max(max_seen.value, active_count.value)
+        # Prove the OTHER worker has also attempted entry before this one is
+        # allowed to finish and release the flock. Since "attempts" is set
+        # before either worker even tries the lock (above), this condition
+        # is already true almost immediately in the overwhelmingly common
+        # case; the deadline exists purely as an infra hang-guard (a process
+        # that never even reaches the barrier), not as a tunable "probably
+        # long enough" pass/fail threshold like a fixed sleep would be.
+        deadline = time.monotonic() + 10
+        while attempts.value < 2 and time.monotonic() < deadline:
+            pass
         with open(tmp, "wb") as f:
             f.write(name.encode())
-        time.sleep(0.1)  # widen the window a broken lock would need to be caught in
         with active_count.get_lock():
             active_count.value -= 1
     try:
@@ -419,33 +461,38 @@ def _concurrent_replace_worker(dest_dir, name, start_barrier, active_count, max_
 
 # _replace_codeberg_asset locks per dest_dir: two overlapping installs of the
 # same tool must not run their populate() calls concurrently (proven above
-# via the shared counter), and the overall operation must still behave
-# correctly: neither call may raise, and exactly one final asset must remain
-# (the lock's serialization makes the later call supersede the earlier one,
-# same as two sequential refreshes would -- without the lock this reproduces
-# as either both final files vanishing, each call's cleanup deleting the
-# other's just-placed file, or a crash from one call's cleanup deleting the
-# other's still-in-flight temp file). Real subprocesses (fork), so the OS
-# flock and the shared counter are both actually contended, not
-# same-process no-ops.
+# via the shared counter -- and, since "attempts" proves the second worker
+# had genuinely started racing for the flock before the first was allowed to
+# leave populate(), this holds regardless of scheduling: if the lock were
+# missing, the second worker -- already known to be attempting -- would have
+# nothing to gate it and would show up in max_seen too), and the overall
+# operation must still behave correctly: neither call may raise, and exactly
+# one final asset must remain (the lock's serialization makes the later call
+# supersede the earlier one, same as two sequential refreshes would --
+# without the lock this reproduces as either both final files vanishing,
+# each call's cleanup deleting the other's just-placed file, or a crash from
+# one call's cleanup deleting the other's still-in-flight temp file). Real
+# subprocesses (fork), so the OS flock and the shared counters are all
+# actually contended, not same-process no-ops.
 with tempfile.TemporaryDirectory() as td:
     dest_dir = os.path.join(td, "assets", "krohnkite")
     ctx = multiprocessing.get_context("fork")
     start_barrier = ctx.Barrier(2)
+    attempts = ctx.Value('i', 0)
     active_count = ctx.Value('i', 0)
     max_seen = ctx.Value('i', 0)
     outcome_q = ctx.Queue()
     p1 = ctx.Process(target=_concurrent_replace_worker,
                      args=(dest_dir, "krohnkite-a.kwinscript", start_barrier,
-                           active_count, max_seen, outcome_q))
+                           attempts, active_count, max_seen, outcome_q))
     p2 = ctx.Process(target=_concurrent_replace_worker,
                      args=(dest_dir, "krohnkite-b.kwinscript", start_barrier,
-                           active_count, max_seen, outcome_q))
+                           attempts, active_count, max_seen, outcome_q))
     p1.start()
     p2.start()
-    outcomes = sorted([outcome_q.get(timeout=10), outcome_q.get(timeout=10)])
-    p1.join(timeout=10)
-    p2.join(timeout=10)
+    outcomes = sorted([outcome_q.get(timeout=15), outcome_q.get(timeout=15)])
+    p1.join(timeout=15)
+    p2.join(timeout=15)
     check("the lock keeps populate() calls from ever overlapping "
           "(a shared counter never observes more than 1 concurrently)",
           max_seen.value == 1)
@@ -964,6 +1011,36 @@ with tempfile.TemporaryDirectory() as td:
     check("install-bundle (codeberg) doesn't downgrade a newer cache end-to-end",
           open(newer_asset, "rb").read() == b"newer, already cached"
           and not os.path.exists(os.path.join(dest_dir, older_asset_name)))
+
+# End-to-end: a LEGACY bundle manifest (built before _stage_codeberg recorded
+# published_at, so the tool entry has no "published_at" key at all) must not
+# downgrade a cache with a known freshness either -- e.get("published_at")
+# resolves to None, and unknown-vs-known must keep the known-good cache.
+with tempfile.TemporaryDirectory() as td:
+    prefix = os.path.join(td, "prefix")
+    dest_dir = hp.codeberg_asset_dir("krohnkite", prefix)
+    os.makedirs(dest_dir)
+    newer_asset = os.path.join(dest_dir, "krohnkite-0.9.9.3_beta.kwinscript")
+    with open(newer_asset, "wb") as f:
+        f.write(b"newer, already cached")
+    with open(os.path.join(dest_dir, hp._CODEBERG_ASSET_META), "w") as f:
+        json.dump({"published_at": "2026-07-01T00:00:00Z"}, f)
+
+    src = os.path.join(td, "src")
+    os.makedirs(os.path.join(src, "codeberg-assets"))
+    legacy_asset_name = "krohnkite-0.9.9.2.kwinscript"
+    with open(os.path.join(src, "codeberg-assets", legacy_asset_name), "wb") as f:
+        f.write(b"from a legacy bundle with no published_at")
+    with open(os.path.join(src, "manifest.json"), "w") as f:
+        json.dump({"format": 1, "backend": "codeberg", "platform": "linux/x86_64",
+                   "tools": [{"tool": "krohnkite", "asset": legacy_asset_name}]}, f)
+    bundle = os.path.join(td, "legacy.tar.gz")
+    hp._write_bundle(bundle, src)
+
+    hp.install_bundle(bundle, prefix, ("linux", "x86_64"), False)
+    check("install-bundle (codeberg) doesn't let a legacy bundle downgrade a known-fresh cache",
+          open(newer_asset, "rb").read() == b"newer, already cached"
+          and not os.path.exists(os.path.join(dest_dir, legacy_asset_name)))
 
 # A codeberg asset missing from the bundle is reported, not silently skipped
 # -- same contract as the equivalent github-side test above.

--- a/homepkg_test
+++ b/homepkg_test
@@ -10,11 +10,13 @@ locally built archives so the suite needs no network.
 
 import io
 import json
+import multiprocessing
 import os
 import subprocess
 import sys
 import tarfile
 import tempfile
+import time
 
 # Load the extensionless homepkg script as a module without running main().
 _here = os.path.dirname(os.path.abspath(__file__))
@@ -258,7 +260,8 @@ with tempfile.TemporaryDirectory() as td:
     check("_replace_codeberg_asset removes the older-version file",
           not os.path.exists(os.path.join(dest_dir, "krohnkite-0.9.9.2.kwinscript")))
     check("_replace_codeberg_asset leaves no stray temp file",
-          os.listdir(dest_dir) == ["krohnkite-0.9.9.3_beta.kwinscript"])
+          sorted(os.listdir(dest_dir))
+          == sorted(["krohnkite-0.9.9.3_beta.kwinscript", hp._CODEBERG_ASSET_LOCK]))
 
 # If populate() fails, the old asset must be untouched and no partial temp
 # file left behind -- the swap only happens after populate() succeeds.
@@ -284,7 +287,50 @@ with tempfile.TemporaryDirectory() as td:
           open(os.path.join(dest_dir, "krohnkite-0.9.9.2.kwinscript"), "rb").read()
           == b"old")
     check("...and cleans up the partial temp file",
-          os.listdir(dest_dir) == ["krohnkite-0.9.9.2.kwinscript"])
+          sorted(os.listdir(dest_dir))
+          == sorted(["krohnkite-0.9.9.2.kwinscript", hp._CODEBERG_ASSET_LOCK]))
+
+
+def _concurrent_replace_worker(dest_dir, name, delay, q):
+    def populate(tmp):
+        with open(tmp, "wb") as f:
+            f.write(name.encode())
+        time.sleep(delay)  # widen the window so the two calls actually overlap
+    try:
+        hp._replace_codeberg_asset(dest_dir, name, populate)
+        q.put("ok")
+    except Exception as e:  # noqa: BLE001 -- reporting to the parent, not handling
+        q.put(f"error: {e}")
+
+
+# _replace_codeberg_asset locks per dest_dir: two overlapping installs of the
+# same tool must not race. Without the lock this reproduces as either both
+# final files vanishing (each call's cleanup deletes the other's just-placed
+# file) or a crash (one call's cleanup deletes the other's still-in-flight
+# temp file out from under it, an os.replace FileNotFoundError) -- so the
+# check covers both: neither worker may raise, AND exactly one final asset
+# must remain (the lock's serialization makes the later call supersede the
+# earlier one, same as two sequential refreshes would). Real subprocesses
+# (fork), so the OS flock is actually contended rather than a same-process
+# no-op.
+with tempfile.TemporaryDirectory() as td:
+    dest_dir = os.path.join(td, "assets", "krohnkite")
+    ctx = multiprocessing.get_context("fork")
+    q = ctx.Queue()
+    p1 = ctx.Process(target=_concurrent_replace_worker,
+                     args=(dest_dir, "krohnkite-a.kwinscript", 0.2, q))
+    p2 = ctx.Process(target=_concurrent_replace_worker,
+                     args=(dest_dir, "krohnkite-b.kwinscript", 0.05, q))
+    p1.start()
+    p2.start()
+    results = [q.get(timeout=10), q.get(timeout=10)]
+    p1.join(timeout=10)
+    p2.join(timeout=10)
+    check("neither concurrent _replace_codeberg_asset call raises",
+          results == ["ok", "ok"])
+    remaining = sorted(f for f in os.listdir(dest_dir) if f != hp._CODEBERG_ASSET_LOCK)
+    check("concurrent _replace_codeberg_asset calls don't both vanish",
+          remaining in (["krohnkite-a.kwinscript"], ["krohnkite-b.kwinscript"]))
 
 # --- github extraction -------------------------------------------------------
 

--- a/homepkg_test
+++ b/homepkg_test
@@ -16,6 +16,7 @@ import subprocess
 import sys
 import tarfile
 import tempfile
+import threading
 import time
 
 # Load the extensionless homepkg script as a module without running main().
@@ -290,44 +291,103 @@ with tempfile.TemporaryDirectory() as td:
           sorted(os.listdir(dest_dir))
           == sorted(["krohnkite-0.9.9.2.kwinscript", hp._CODEBERG_ASSET_LOCK]))
 
+# A staged bundle, built at some earlier point, must not downgrade a cache
+# that was refreshed more recently online -- e.g. the cache holds 0.9.9.3
+# (fetched today) but a bootstrap bundle sitting around still carries
+# 0.9.9.2 (built weeks ago). populate() here simulates a bundle-copy that
+# preserves the source's (older) mtime, the same way shutil.copy2 does.
+with tempfile.TemporaryDirectory() as td:
+    dest_dir = os.path.join(td, "assets", "krohnkite")
+    os.makedirs(dest_dir)
+    newer_path = os.path.join(dest_dir, "krohnkite-0.9.9.3_beta.kwinscript")
+    with open(newer_path, "wb") as f:
+        f.write(b"newer, already cached")
 
-def _concurrent_replace_worker(dest_dir, name, delay, q):
+    def _populate_older(tmp):
+        with open(tmp, "wb") as f:
+            f.write(b"older, from a stale bundle")
+        os.utime(tmp, (time.time() - 3600, time.time() - 3600))  # 1h in the past
+
+    applied = hp._replace_codeberg_asset(
+        dest_dir, "krohnkite-0.9.9.2.kwinscript", _populate_older)
+    check("_replace_codeberg_asset reports the older asset was not applied",
+          applied is False)
+    check("_replace_codeberg_asset keeps the newer cached asset",
+          open(newer_path, "rb").read() == b"newer, already cached")
+    check("_replace_codeberg_asset doesn't leave the older asset behind either",
+          not os.path.exists(os.path.join(dest_dir, "krohnkite-0.9.9.2.kwinscript")))
+
+# ...but the online path is never blocked by this: download() always writes
+# with the current time, so a genuinely fresh fetch always wins even if it
+# happens to resolve to a name that would sort "older" as a plain string.
+with tempfile.TemporaryDirectory() as td:
+    dest_dir = os.path.join(td, "assets", "krohnkite")
+    os.makedirs(dest_dir)
+    with open(os.path.join(dest_dir, "krohnkite-0.9.9.9.kwinscript"), "wb") as f:
+        f.write(b"cached")
+    applied = hp._replace_codeberg_asset(
+        dest_dir, "krohnkite-0.9.9.10.kwinscript",
+        lambda tmp: open(tmp, "wb").write(b"freshly fetched"))
+    check("a freshly-populated asset (current mtime) always applies",
+          applied is True
+          and open(os.path.join(dest_dir, "krohnkite-0.9.9.10.kwinscript"), "rb").read()
+          == b"freshly fetched")
+
+
+def _concurrent_replace_worker(dest_dir, name, barrier, barrier_q, outcome_q):
     def populate(tmp):
         with open(tmp, "wb") as f:
             f.write(name.encode())
-        time.sleep(delay)  # widen the window so the two calls actually overlap
+        # If the lock holds, only one worker is ever inside populate() at a
+        # time, so its partner can never reach this barrier concurrently and
+        # wait() must time out (BrokenBarrierError). If the lock were
+        # missing, both workers would be here together and the barrier would
+        # release normally for both -- that's the race, detected
+        # deterministically instead of via sleep timing that CI scheduling
+        # could make miss the overlap entirely.
+        try:
+            barrier.wait(timeout=2)
+            barrier_q.put("released")
+        except threading.BrokenBarrierError:
+            barrier_q.put("timed-out")
     try:
         hp._replace_codeberg_asset(dest_dir, name, populate)
-        q.put("ok")
+        outcome_q.put("ok")
     except Exception as e:  # noqa: BLE001 -- reporting to the parent, not handling
-        q.put(f"error: {e}")
+        outcome_q.put(f"error: {e}")
 
 
 # _replace_codeberg_asset locks per dest_dir: two overlapping installs of the
-# same tool must not race. Without the lock this reproduces as either both
-# final files vanishing (each call's cleanup deletes the other's just-placed
-# file) or a crash (one call's cleanup deletes the other's still-in-flight
-# temp file out from under it, an os.replace FileNotFoundError) -- so the
-# check covers both: neither worker may raise, AND exactly one final asset
-# must remain (the lock's serialization makes the later call supersede the
-# earlier one, same as two sequential refreshes would). Real subprocesses
-# (fork), so the OS flock is actually contended rather than a same-process
-# no-op.
+# same tool must not run their populate() calls concurrently (proven above
+# via the barrier), and the overall operation must still behave correctly:
+# neither call may raise, and exactly one final asset must remain (the
+# lock's serialization makes the later call supersede the earlier one, same
+# as two sequential refreshes would -- without the lock this reproduces as
+# either both final files vanishing, each call's cleanup deleting the
+# other's just-placed file, or a crash from one call's cleanup deleting the
+# other's still-in-flight temp file). Real subprocesses (fork), so the OS
+# flock and the barrier are both actually contended, not same-process no-ops.
 with tempfile.TemporaryDirectory() as td:
     dest_dir = os.path.join(td, "assets", "krohnkite")
     ctx = multiprocessing.get_context("fork")
-    q = ctx.Queue()
+    barrier = ctx.Barrier(2)
+    barrier_q = ctx.Queue()
+    outcome_q = ctx.Queue()
     p1 = ctx.Process(target=_concurrent_replace_worker,
-                     args=(dest_dir, "krohnkite-a.kwinscript", 0.2, q))
+                     args=(dest_dir, "krohnkite-a.kwinscript", barrier, barrier_q, outcome_q))
     p2 = ctx.Process(target=_concurrent_replace_worker,
-                     args=(dest_dir, "krohnkite-b.kwinscript", 0.05, q))
+                     args=(dest_dir, "krohnkite-b.kwinscript", barrier, barrier_q, outcome_q))
     p1.start()
     p2.start()
-    results = [q.get(timeout=10), q.get(timeout=10)]
+    barrier_signals = sorted([barrier_q.get(timeout=10), barrier_q.get(timeout=10)])
+    outcomes = sorted([outcome_q.get(timeout=10), outcome_q.get(timeout=10)])
     p1.join(timeout=10)
     p2.join(timeout=10)
+    check("the lock keeps populate() calls from ever overlapping "
+          "(neither finds a partner at the barrier)",
+          barrier_signals == ["timed-out", "timed-out"])
     check("neither concurrent _replace_codeberg_asset call raises",
-          results == ["ok", "ok"])
+          outcomes == ["ok", "ok"])
     remaining = sorted(f for f in os.listdir(dest_dir) if f != hp._CODEBERG_ASSET_LOCK)
     check("concurrent _replace_codeberg_asset calls don't both vanish",
           remaining in (["krohnkite-a.kwinscript"], ["krohnkite-b.kwinscript"]))

--- a/setup-kde
+++ b/setup-kde
@@ -272,11 +272,14 @@ install_krohnkite_from_source() {
 # when that fails does it fall back to a pre-staged offline bundle (built
 # with 'homepkg --backend codeberg bundle -o homepkg-krohnkite.tgz
 # krohnkite', staged at $HOMEPKG_KROHNKITE_BUNDLE, homepkg-krohnkite.tgz
-# beside this script, or in $HOME) or, failing that, whatever homepkg's
-# codeberg backend already has cached from a previous successful fetch (it
-# never wipes that cache on a failed refresh -- see install_codeberg).
-# Falls back to cloning KROHNKITE_REPO and building from source when none of
-# that produces a usable .kwinscript.
+# beside this script, or in $HOME) -- tried unconditionally on a failed
+# fetch, even if something's already cached, since a staged bundle may carry
+# a newer release than whatever's left over from an earlier run. Only once
+# neither the online fetch nor a bundle produced anything does it fall back
+# to reusing whatever homepkg's codeberg backend already has cached from an
+# earlier successful fetch (it never wipes that cache on a failed refresh --
+# see install_codeberg). Falls back to cloning KROHNKITE_REPO and building
+# from source when none of that produces a usable .kwinscript.
 install_krohnkite() {
     kwinscript=""
     homepkg="$SCRIPT_DIR/homepkg"
@@ -286,11 +289,10 @@ install_krohnkite() {
         asset_dir="$HOME/.local/share/homepkg/assets/krohnkite"
 
         info "Fetching the Krohnkite release via homepkg"
-        "$homepkg" --backend codeberg install krohnkite \
-            || warn "could not fetch the Krohnkite release online; trying a staged bundle or the last cached copy"
-        kwinscript=$(find "$asset_dir" -name '*.kwinscript' -print -quit 2>/dev/null || true)
-
-        if test -z "$kwinscript"; then
+        if "$homepkg" --backend codeberg install krohnkite; then
+            kwinscript=$(find "$asset_dir" -name '*.kwinscript' -print -quit 2>/dev/null || true)
+        else
+            warn "could not fetch the Krohnkite release online; trying a staged bundle"
             bundle=""
             for cand in "${HOMEPKG_KROHNKITE_BUNDLE:-}" \
                     "$SCRIPT_DIR/homepkg-krohnkite.tgz" \
@@ -304,8 +306,11 @@ install_krohnkite() {
                 info "Fetching the Krohnkite release from bundle: $bundle"
                 "$homepkg" install-bundle "$bundle" \
                     || warn "the Krohnkite bundle didn't provide the release either"
-                kwinscript=$(find "$asset_dir" -name '*.kwinscript' -print -quit 2>/dev/null || true)
             fi
+            # Whatever's on disk now -- fresh from the bundle, or whatever
+            # was already cached from an earlier successful fetch if the
+            # bundle didn't provide it either (or wasn't staged at all).
+            kwinscript=$(find "$asset_dir" -name '*.kwinscript' -print -quit 2>/dev/null || true)
         fi
         if test -z "$kwinscript"; then
             warn "could not fetch the Krohnkite release via homepkg (offline? stage a bundle with 'homepkg --backend codeberg bundle -o homepkg-krohnkite.tgz krohnkite'); falling back to building from source"

--- a/setup-kde_test
+++ b/setup-kde_test
@@ -366,6 +366,35 @@ MOCK
     assert_not_called "git clone"
 }
 
+# A staged bundle must still be tried when the online fetch fails, even if
+# something's already cached from an earlier run -- a stale cache sitting
+# there must not short-circuit the bundle check and reinstall the old
+# release when a fresher one is staged and ready.
+test_staged_bundle_tried_even_with_a_stale_cache_present() {
+    add_release_mocks
+    cat > "$TEST_TMPDIR/isolated/homepkg" <<MOCK
+#!/bin/sh
+echo "homepkg \$*" >> "$CALLS"
+if test "\$1" = install-bundle; then
+    dir="\$HOME/.local/share/homepkg/assets/krohnkite"
+    rm -f "\$dir"/*.kwinscript
+    touch "\$dir/krohnkite-0.9.9.3_beta.kwinscript"
+    exit 0
+fi
+exit 1
+MOCK
+    chmod +x "$TEST_TMPDIR/isolated/homepkg"
+    touch "$TEST_TMPDIR/isolated/homepkg-krohnkite.tgz"
+    mkdir -p "$TEST_TMPDIR/home/.local/share/homepkg/assets/krohnkite"
+    touch "$TEST_TMPDIR/home/.local/share/homepkg/assets/krohnkite/krohnkite-0.9.9.2.kwinscript"
+    run_kde
+    assert_status 0 &&
+    assert_called "homepkg --backend codeberg install krohnkite" &&
+    assert_called "homepkg install-bundle $TEST_TMPDIR/isolated/homepkg-krohnkite.tgz" &&
+    assert_called "kpackagetool6 -t KWin/Script -u $TEST_TMPDIR/home/.local/share/homepkg/assets/krohnkite/krohnkite-0.9.9.3_beta.kwinscript" &&
+    assert_not_called "krohnkite-0.9.9.2.kwinscript"
+}
+
 # HOMEPKG_KROHNKITE_BUNDLE overrides the default bundle search locations.
 test_homepkg_krohnkite_bundle_env_override() {
     add_release_mocks
@@ -647,6 +676,8 @@ run_test "release bundle used when the online fetch fails" \
     test_release_bundle_used_when_online_fetch_fails
 run_test "a stale cached release is used when the refresh fails entirely" \
     test_stale_cached_release_used_when_refresh_fails
+run_test "a staged bundle is tried even with a stale cache present" \
+    test_staged_bundle_tried_even_with_a_stale_cache_present
 run_test "HOMEPKG_KROHNKITE_BUNDLE overrides the bundle search" \
     test_homepkg_krohnkite_bundle_env_override
 run_test "missing git warns but doesn't block the release path" \


### PR DESCRIPTION
## Summary

Follow-up to #158 (merged), which added `setup-kde`'s Codeberg-release-first Krohnkite install and homepkg's `codeberg` backend. Five rounds of Codex re-review on this branch's own fix commits found further issues, all addressed here:

- `install_krohnkite` checked its local cache right after a failed online fetch, so a stale cached release would short-circuit the staged-bundle check entirely. Only accept the cache once neither the online fetch nor a staged bundle produced anything.
- A Codeberg release's asset name is attacker-influenced (whoever can publish to that repo), not our own registry, so `install_codeberg` and `_stage_codeberg` now validate it with `_require_basename` before using it as a path.
- Replaced a "download to temp, then rmtree+move" swap (which still deleted the old cache before the move) with a real atomic swap (`_replace_codeberg_asset`): the new asset is renamed into its final name via `os.replace`, and only once that succeeds are older-version files cleared out.
- That swap wasn't safe against two overlapping refreshes of the same tool: each call's cleanup step could delete the other's just-placed (or still in-flight) file. `_replace_codeberg_asset` now holds a per-dest_dir `flock` around the whole populate/replace/cleanup sequence.
- A staged bundle (built at some earlier point) could downgrade a cache refreshed more recently online — and comparing local file mtimes for this is unsound across hosts with no shared clock. Freshness now comes from Codeberg's own `published_at`/`created_at` timestamp instead, threaded through `install_codeberg` and the bundle manifest and persisted in a small `.meta.json` sidecar next to the cached asset — never a local clock. This also closes an orphaned-`.part`-file hazard the old mtime approach had.
- A legacy bundle manifest (built before `published_at` was recorded at all) could still downgrade a cache with a *known* freshness, since "unknown" defaulted to "always apply." Now only an unknown-vs-unknown comparison applies unconditionally; a known-fresh cache always beats an unknown-freshness candidate.
- The concurrency regression test went through several iterations (sleep delays → barrier timeout → a lock-independent `attempts` handshake) before landing on one with no timing dependency anywhere in its pass/fail signal: both workers signal "attempting" immediately after a start barrier, entirely decoupled from who wins the flock, and `populate()` waits on that signal (not a fixed sleep) before finishing.
- That handshake's own wait still had a silent-timeout escape hatch: if its 10s deadline elapsed without both workers signaling, the wait loop just fell through as if the handshake had succeeded. Extracted into `_wait_for_attempts`, which now raises instead, so an unmet handshake shows up as a test failure rather than a silently weakened, unproven pass.
- `_replace_codeberg_asset` wrote the freshness sidecar directly to its final path *after* the asset's `os.replace()` already landed — a failed sidecar write (e.g. disk full) would leave a live new asset paired with a missing/stale sidecar. The sidecar is now written to its own temp file and fully validated before either the asset or the sidecar is renamed into place, so a failure at any point leaves the existing asset/sidecar pair untouched.

## Test plan

- [x] `make test` — all suites pass (~1.5s for the concurrency tests, no hangs)
- [x] New `homepkg_test` coverage for: bundle-vs-stale-cache ordering, asset-name traversal rejection, atomic-swap/failure-cleanup behavior, the `published_at`-based freshness guard (including orphaned-`.part` and legacy-manifest cases), a real-subprocess concurrency test (atomic-counter + attempts-handshake based) with a raise-on-timeout handshake wait, and a crash-safe asset/sidecar swap — each verified to fail against the pre-fix code and pass with the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Thxxh6LMNduKmtw2LWjXGP