### PR TITLE
setup-kde: fix KDE shortcuts and keyboard layout that silently never applied

### DIFF
--- a/setup
+++ b/setup
@@ -1459,6 +1459,10 @@ set_default_terminal() {
 
 # --- Configure keyboard ---
 
+# System-level only: the console keymap, the persistent X11 config, and a live
+# setxkbmap. Plasma overrides the layout at login from kxkbrc, so the matching
+# session-level config is setup-kde's configure_keyboard_layout -- change both
+# or the two drift apart.
 configure_keyboard() {
     case "$OS" in
         debian)

--- a/setup-kde
+++ b/setup-kde
@@ -438,6 +438,15 @@ unbind_shortcut_in() {
         --key "$action" "none,none,$action"
 }
 
+# Clear a launch shortcut held by a KDE-shipped .desktop component. These live
+# under the nested [services][NAME.desktop] group and carry the bare shortcut
+# as their value, the same shape add_app_shortcut writes -- not the
+# "shortcut,default,name" triple the [kwin] actions use.
+unbind_app_shortcut() {
+    kwriteconfig6 --file kglobalshortcutsrc \
+        --group services --group "$1" --key _launch none
+}
+
 unbind_all_krohnkite_shortcuts() {
     config_file="${XDG_CONFIG_HOME:-$HOME/.config}/kglobalshortcutsrc"
     test -f "$config_file" || return 0
@@ -519,17 +528,63 @@ EOF
 # An earlier version of this script wrote app-launch shortcuts under a
 # top-level [scripts-foo.desktop] group, which kglobalaccel ignores. Strip
 # any such stale groups before we rewrite them under [services].
+#
+# awk, not python3: this script's prerequisites are the KDE tools, and a box
+# without python3 would otherwise abort the whole run here under set -e --
+# right before the app shortcuts are written. The nested [services][...]
+# groups we do want are untouched: their header line starts with [services].
 remove_stale_app_shortcut_groups() {
     config_file="${XDG_CONFIG_HOME:-$HOME/.config}/kglobalshortcutsrc"
     test -f "$config_file" || return 0
-    python3 - "$config_file" <<'PY'
-import re, sys, pathlib
-p = pathlib.Path(sys.argv[1])
-text = p.read_text()
-new = re.sub(r'(?m)^\[(scripts|shortcut)-[^\]]+\.desktop\]\n(?:(?!\[).*\n?)*', '', text)
-if new != text:
-    p.write_text(new)
-PY
+
+    # A dotfiles-managed kglobalshortcutsrc is usually a symlink into the conf
+    # repo. The atomic replace below renames onto its path, which would swap
+    # the link itself for a regular file and quietly disconnect KDE's future
+    # writes from the managed target -- so resolve it first and replace the
+    # target instead. This also keeps the scratch copy on the target's own
+    # filesystem, where mv is a rename rather than a copy.
+    if test -L "$config_file"; then
+        resolved=$(readlink -f "$config_file") || resolved=""
+        if test -z "$resolved"; then
+            warn "could not resolve the kglobalshortcutsrc symlink; leaving stale app-shortcut groups in place"
+            return 0
+        fi
+        config_file="$resolved"
+    fi
+
+    # cp -p seeds the scratch copy with the original's mode so the rename can't
+    # loosen it; awk then rewrites that copy in place. Renaming onto the
+    # original -- rather than copying over it -- keeps the replace atomic: a
+    # failure anywhere below leaves the live config exactly as it was, never
+    # truncated, which is what makes warn-and-continue the honest response.
+    # Stale groups surviving a run is the state this function was added to
+    # clean up, not a corruption of the config.
+    #
+    # The warnings name the file, not its path: the location is
+    # ${XDG_CONFIG_HOME:-$HOME/.config} and there is only one of these, so the
+    # absolute path adds nothing but a home directory to leak.
+    stripped="$config_file.setup-kde.$$"
+    if ! cp -p "$config_file" "$stripped"; then
+        rm -f "$stripped"
+        warn "could not copy kglobalshortcutsrc; leaving stale app-shortcut groups in place"
+        return 0
+    fi
+    if ! awk '
+        /^\[/ { skip = ($0 ~ /^\[(scripts|shortcut)-[^]]+\.desktop\]$/) }
+        !skip
+    ' "$config_file" > "$stripped"; then
+        rm -f "$stripped"
+        warn "could not strip stale app-shortcut groups from kglobalshortcutsrc"
+        return 0
+    fi
+    if cmp -s "$stripped" "$config_file"; then
+        rm -f "$stripped"
+        return 0
+    fi
+    mv "$stripped" "$config_file" || {
+        rm -f "$stripped"
+        warn "could not replace kglobalshortcutsrc; stale app-shortcut groups remain"
+    }
 }
 
 configure_app_shortcuts() {
@@ -565,6 +620,9 @@ configure_keybindings() {
     unbind_shortcut "Overview"                                  # Meta+W -> Terminal on Workstation
     unbind_shortcut "Edit Tiles"                                # Meta+T -> Terminal
     unbind_shortcut "Walk Through Windows of Current Application" # Meta+` -> Krohnkite Monocle
+    # Plasma's Emoji Selector holds Meta+. as a [services] launch shortcut,
+    # not a [kwin] action, so it needs the launch-shortcut form.
+    unbind_app_shortcut org.kde.plasma.emojier.desktop  # Meta+. -> Krohnkite Next Layout
     n=1
     while test "$n" -le 9; do
         # Meta+1..9 -> Switch to Desktop N (plasmashell grabs these by default).
@@ -588,9 +646,15 @@ configure_keybindings() {
     set_shortcut KrohnkitegrowWidth "Meta+\\\\" "Krohnkite: Grow Width"
     set_shortcut KrohnkiteShrinkWidth "Meta+/" "Krohnkite: Shrink Width"
 
-    # Layouts
+    # Layouts. Meta+, is written "Meta+\," because kglobalaccel reads each
+    # entry back with readEntry(QStringList) and drops any entry that doesn't
+    # split into exactly three fields -- a bare comma in the shortcut makes
+    # four, so the binding is silently discarded. The backslash survives to
+    # the file as "\\" (KConfig doubles it on write, halves it on read), which
+    # is the escape deserializeList needs to keep the comma out of the split.
+    # Meta+\ above needs two backslashes for the same round trip.
     set_shortcut KrohnkiteMonocleLayout "Meta+\`" "Krohnkite: Select Layout - Monocle"
-    set_shortcut KrohnkitePreviousLayout "Meta+," "Krohnkite: Previous Layout"
+    set_shortcut KrohnkitePreviousLayout "Meta+\\," "Krohnkite: Previous Layout"
     set_shortcut KrohnkiteNextLayout "Meta+." "Krohnkite: Next Layout"
 
     # Set master

--- a/setup-kde
+++ b/setup-kde
@@ -6,6 +6,7 @@
 # - Focus follows mouse (mouse precedence)
 # - Window management and desktop switching keybindings
 # - Application launch shortcuts (browser, terminal, music)
+# - The session keyboard layout (US Dvorak, Caps Lock as Compose)
 #
 # Requires: kpackagetool6, kwriteconfig6
 # This helper does not use sudo: Krohnkite and every KDE setting are installed
@@ -410,6 +411,32 @@ configure_desktops() {
     kwriteconfig6 --file kwinrc --group Desktops --key Rows 1
 }
 
+# --- Configure the keyboard layout ---
+
+# setup already writes the layout at the system level (/etc/default/keyboard
+# or localectl, plus a live setxkbmap), but that isn't enough on Plasma: once
+# kxkbrc has Use=true, Plasma's keyboard daemon reapplies its own layout at
+# every login and the system setting silently loses. Write the session layout
+# here so the two agree.
+#
+# Options/ResetOldOptions mirror setup's "setxkbmap -option '' -option
+# compose:caps": without them Plasma would reapply the layout and leave the
+# XKB options to chance. Setting them explicitly is what keeps Caps Lock as
+# Compose across a relogin.
+#
+# The daemon watches kxkbrc and re-reads it on change, so there's no dbus call
+# here. (Deliberately not org.kde.KeyboardLayouts.setLayout: it takes a layout
+# name rather than an index and its behavior varies across Plasma versions --
+# same reasoning as the dvorak script.)
+configure_keyboard_layout() {
+    info "Configuring keyboard layout: US Dvorak, Caps Lock as Compose"
+    kwriteconfig6 --file kxkbrc --group Layout --key Use true
+    kwriteconfig6 --file kxkbrc --group Layout --key LayoutList us
+    kwriteconfig6 --file kxkbrc --group Layout --key VariantList dvorak
+    kwriteconfig6 --file kxkbrc --group Layout --key Options compose:caps
+    kwriteconfig6 --file kxkbrc --group Layout --key ResetOldOptions true
+}
+
 # --- Configure keybindings ---
 
 # Third arg is the human-readable label written into the value's third
@@ -722,6 +749,7 @@ configure_krohnkite
 configure_focus_follows_mouse
 configure_dim_inactive
 configure_desktops
+configure_keyboard_layout
 # Reload so Krohnkite registers its default shortcuts in kglobalshortcutsrc
 reload_kwin
 configure_keybindings

--- a/setup-kde_test
+++ b/setup-kde_test
@@ -573,6 +573,20 @@ test_configures_nine_desktops() {
 # escaped ("Meta+\,") -- the backslash reaches the file as "\\", which is the
 # escape the list parser needs. Meta+\ (Grow Width) needs two backslashes for
 # the same round trip.
+# setup configures the layout at the system level, but Plasma reapplies its
+# own from kxkbrc at every login, so the session copy has to be written too or
+# the Dvorak setup silently reverts. Options/ResetOldOptions are what keep
+# Caps Lock as Compose across that reapply.
+test_configures_keyboard_layout() {
+    run_kde --no-install
+    assert_status 0 &&
+    assert_called "kwriteconfig6 --file kxkbrc --group Layout --key Use true" &&
+    assert_called "kwriteconfig6 --file kxkbrc --group Layout --key LayoutList us" &&
+    assert_called "kwriteconfig6 --file kxkbrc --group Layout --key VariantList dvorak" &&
+    assert_called "kwriteconfig6 --file kxkbrc --group Layout --key Options compose:caps" &&
+    assert_called "kwriteconfig6 --file kxkbrc --group Layout --key ResetOldOptions true"
+}
+
 test_comma_and_backslash_shortcuts_are_escaped() {
     run_kde --no-install
     assert_status 0 &&
@@ -798,6 +812,8 @@ run_test "missing git errors clearly once the fallback is reached" \
 run_test "enables and configures Krohnkite" test_enables_and_configures_krohnkite
 run_test "configures focus follows mouse" test_configures_focus_follows_mouse
 run_test "configures nine desktops" test_configures_nine_desktops
+run_test "configures the session keyboard layout in kxkbrc" \
+    test_configures_keyboard_layout
 run_test "comma and backslash shortcuts are escaped for kglobalaccel" \
     test_comma_and_backslash_shortcuts_are_escaped
 run_test "unbinds the Emoji Selector so Meta+. reaches Krohnkite" \

--- a/setup-kde_test
+++ b/setup-kde_test
@@ -160,9 +160,16 @@ MOCK
 # Run setup-kde in the sandbox: fresh HOME, and a PATH of just the mock bin
 # plus the system directories -- so the real ~/scripts (if it's on the
 # caller's PATH) can't satisfy the launcher lookups.
+#
+# XDG_CONFIG_HOME is pinned, not just inherited: setup-kde resolves
+# kglobalshortcutsrc as ${XDG_CONFIG_HOME:-$HOME/.config}, so on a machine
+# that exports it, overriding HOME alone leaves the script reading -- and
+# remove_stale_app_shortcut_groups rewriting -- the caller's real KDE config
+# while the assertions look at the sandbox.
 run_kde() {
     set +e
     output="$(HOME="$TEST_TMPDIR/home" \
+        XDG_CONFIG_HOME="$TEST_TMPDIR/home/.config" \
         XDG_SESSION_TYPE=wayland \
         PATH="$TEST_TMPDIR/bin:/usr/local/bin:/usr/bin:/bin" \
         "$KDE_SCRIPT" "$@" 2>&1)"
@@ -175,6 +182,7 @@ run_kde() {
 run_kde_relative() {
     set +e
     output="$(cd "$(dirname "$KDE_SCRIPT")" && HOME="$TEST_TMPDIR/home" \
+        XDG_CONFIG_HOME="$TEST_TMPDIR/home/.config" \
         XDG_SESSION_TYPE=wayland \
         PATH="$TEST_TMPDIR/bin:/usr/local/bin:/usr/bin:/bin" \
         ./setup-kde "$@" 2>&1)"

--- a/setup-kde_test
+++ b/setup-kde_test
@@ -25,7 +25,7 @@ setup() {
     for cmd in kwriteconfig6 qdbus6 qdbus kbuildsycoca6; do
         cat > "$TEST_TMPDIR/bin/$cmd" <<MOCK
 #!/bin/sh
-echo "$cmd \$*" >> "$CALLS"
+printf "%s\\n" "$cmd \$*" >> "$CALLS"
 exit 0
 MOCK
     done
@@ -67,7 +67,7 @@ add_release_mocks() {
     isolate_script
     cat > "$TEST_TMPDIR/isolated/homepkg" <<MOCK
 #!/bin/sh
-echo "homepkg \$*" >> "$CALLS"
+printf "%s\\n" "homepkg \$*" >> "$CALLS"
 if test "\$1" = "--backend" && test "\$2" = codeberg \\
         && test "\$3" = install && test "\$4" = krohnkite; then
     dir="\$HOME/.local/share/homepkg/assets/krohnkite"
@@ -79,14 +79,14 @@ MOCK
     chmod +x "$TEST_TMPDIR/isolated/homepkg"
     cat > "$TEST_TMPDIR/bin/kpackagetool6" <<MOCK
 #!/bin/sh
-echo "kpackagetool6 \$*" >> "$CALLS"
+printf "%s\\n" "kpackagetool6 \$*" >> "$CALLS"
 exit 0
 MOCK
     chmod +x "$TEST_TMPDIR/bin/kpackagetool6"
     for cmd in git npm go-task tsc; do
         cat > "$TEST_TMPDIR/bin/$cmd" <<MOCK
 #!/bin/sh
-echo "$cmd \$*" >> "$CALLS"
+printf "%s\\n" "$cmd \$*" >> "$CALLS"
 exit 1
 MOCK
         chmod +x "$TEST_TMPDIR/bin/$cmd"
@@ -104,7 +104,7 @@ add_install_mocks() {
     isolate_script
     cat > "$TEST_TMPDIR/bin/git" <<MOCK
 #!/bin/sh
-echo "git \$*" >> "$CALLS"
+printf "%s\\n" "git \$*" >> "$CALLS"
 if test "\$1" = clone; then
     for arg in "\$@"; do dir="\$arg"; done
     mkdir -p "\$dir"
@@ -115,7 +115,7 @@ MOCK
     for cmd in npm kpackagetool6; do
         cat > "$TEST_TMPDIR/bin/$cmd" <<MOCK
 #!/bin/sh
-echo "$cmd \$*" >> "$CALLS"
+printf "%s\\n" "$cmd \$*" >> "$CALLS"
 exit 0
 MOCK
     done
@@ -133,7 +133,7 @@ add_source_build_mocks() {
     add_install_mocks
     cat > "$TEST_TMPDIR/bin/git" <<MOCK
 #!/bin/sh
-echo "git \$*" >> "$CALLS"
+printf "%s\\n" "git \$*" >> "$CALLS"
 if test "\$1" = clone; then
     for arg in "\$@"; do dir="\$arg"; done
     mkdir -p "\$dir"
@@ -142,7 +142,7 @@ exit 0
 MOCK
     cat > "$TEST_TMPDIR/bin/go-task" <<MOCK
 #!/bin/sh
-echo "go-task \$*" >> "$CALLS"
+printf "%s\\n" "go-task \$*" >> "$CALLS"
 npm install --save-dev || exit 1
 npm run tsc -- --strict || exit 1
 touch krohnkite.kwinscript
@@ -150,7 +150,7 @@ exit 0
 MOCK
     cat > "$TEST_TMPDIR/bin/tsc" <<MOCK
 #!/bin/sh
-echo "tsc \$*" >> "$CALLS"
+printf "%s\\n" "tsc \$*" >> "$CALLS"
 exit 0
 MOCK
     chmod +x "$TEST_TMPDIR/bin/git" "$TEST_TMPDIR/bin/go-task" \
@@ -195,7 +195,7 @@ assert_output_contains() {
     case "$output" in
         *"$1"*) ;;
         *)
-            echo "  FAIL: output does not contain '$1'"
+            printf "%s\n" "  FAIL: output does not contain '$1'"
             echo "  output: $output"
             TEST_FAILED=1
             return 1
@@ -205,8 +205,8 @@ assert_output_contains() {
 
 assert_called() {
     if ! grep -q -- "$1" "$CALLS" 2>/dev/null; then
-        echo "  FAIL: expected call '$1' not found"
-        echo "  calls: $(cat "$CALLS" 2>/dev/null)"
+        printf "%s\n" "  FAIL: expected call '$1' not found"
+        printf "%s\n" "  calls: $(cat "$CALLS" 2>/dev/null)"
         TEST_FAILED=1
         return 1
     fi
@@ -214,8 +214,8 @@ assert_called() {
 
 assert_not_called() {
     if grep -q -- "$1" "$CALLS" 2>/dev/null; then
-        echo "  FAIL: unexpected call '$1' found"
-        echo "  calls: $(cat "$CALLS" 2>/dev/null)"
+        printf "%s\n" "  FAIL: unexpected call '$1' found"
+        printf "%s\n" "  calls: $(cat "$CALLS" 2>/dev/null)"
         TEST_FAILED=1
         return 1
     fi
@@ -280,7 +280,7 @@ test_no_sudo_accepted_noop() {
 test_failing_sudo_is_not_used() {
     cat > "$TEST_TMPDIR/bin/sudo" <<MOCK
 #!/bin/sh
-echo "sudo \$*" >> "$CALLS"
+printf "%s\\n" "sudo \$*" >> "$CALLS"
 echo "sudo: permission denied" >&2
 exit 1
 MOCK
@@ -327,7 +327,7 @@ test_release_bundle_used_when_online_fetch_fails() {
     add_release_mocks
     cat > "$TEST_TMPDIR/isolated/homepkg" <<MOCK
 #!/bin/sh
-echo "homepkg \$*" >> "$CALLS"
+printf "%s\\n" "homepkg \$*" >> "$CALLS"
 if test "\$1" = install-bundle; then
     dir="\$HOME/.local/share/homepkg/assets/krohnkite"
     mkdir -p "\$dir"
@@ -353,7 +353,7 @@ test_stale_cached_release_used_when_refresh_fails() {
     add_release_mocks
     cat > "$TEST_TMPDIR/isolated/homepkg" <<MOCK
 #!/bin/sh
-echo "homepkg \$*" >> "$CALLS"
+printf "%s\\n" "homepkg \$*" >> "$CALLS"
 exit 1
 MOCK
     chmod +x "$TEST_TMPDIR/isolated/homepkg"
@@ -371,7 +371,7 @@ test_homepkg_krohnkite_bundle_env_override() {
     add_release_mocks
     cat > "$TEST_TMPDIR/isolated/homepkg" <<MOCK
 #!/bin/sh
-echo "homepkg \$*" >> "$CALLS"
+printf "%s\\n" "homepkg \$*" >> "$CALLS"
 if test "\$1" = install-bundle; then
     dir="\$HOME/.local/share/homepkg/assets/krohnkite"
     mkdir -p "\$dir"
@@ -428,7 +428,7 @@ test_homepkg_release_fetch_fails_falls_back_to_source_build() {
     add_install_mocks
     cat > "$TEST_TMPDIR/isolated/homepkg" <<MOCK
 #!/bin/sh
-echo "homepkg \$*" >> "$CALLS"
+printf "%s\\n" "homepkg \$*" >> "$CALLS"
 exit 1
 MOCK
     chmod +x "$TEST_TMPDIR/isolated/homepkg"
@@ -567,6 +567,131 @@ test_configures_nine_desktops() {
     assert_called "kwriteconfig6 --file kwinrc --group Desktops --key Number 9"
 }
 
+# kglobalaccel reads each [kwin] entry with readEntry(QStringList) and drops
+# any that doesn't split into exactly three fields. A bare comma in the
+# shortcut makes four, so Previous Layout must be written with the comma
+# escaped ("Meta+\,") -- the backslash reaches the file as "\\", which is the
+# escape the list parser needs. Meta+\ (Grow Width) needs two backslashes for
+# the same round trip.
+test_comma_and_backslash_shortcuts_are_escaped() {
+    run_kde --no-install
+    assert_status 0 &&
+    assert_called 'KrohnkitePreviousLayout Meta+\\,,none,Krohnkite: Previous Layout' &&
+    assert_not_called 'KrohnkitePreviousLayout Meta+,,none' &&
+    assert_called 'KrohnkitegrowWidth Meta+\\\\,none,Krohnkite: Grow Width'
+}
+
+# Meta+. is Plasma's Emoji Selector by default, and it holds it as a
+# [services] launch shortcut rather than a [kwin] action -- so freeing it for
+# Krohnkite's Next Layout needs the launch-shortcut form.
+test_unbinds_emoji_selector_for_next_layout() {
+    run_kde --no-install
+    assert_status 0 &&
+    assert_called "kwriteconfig6 --file kglobalshortcutsrc --group services --group org.kde.plasma.emojier.desktop --key _launch none" &&
+    assert_called "kwriteconfig6 --file kglobalshortcutsrc --group kwin --key KrohnkiteNextLayout Meta+."
+}
+
+# Stale top-level [scripts-foo.desktop] / [shortcut-foo.desktop] groups from
+# older versions of this script are stripped; everything else -- including the
+# nested [services][...] groups that hold the real launch shortcuts -- stays.
+test_strips_stale_app_shortcut_groups() {
+    config_dir="$TEST_TMPDIR/home/.config"
+    mkdir -p "$config_dir"
+    cat > "$config_dir/kglobalshortcutsrc" <<'CONF'
+[kwin]
+Window Close=Meta+Backspace,none,Window Close
+
+[scripts-browser1.desktop]
+_k_friendly_name=browser1
+_launch=Meta+G
+
+[shortcut-music.desktop]
+_launch=Meta+Y
+
+[services][shortcut-terminal.desktop]
+_launch=Meta+T
+CONF
+    run_kde --no-install
+    assert_status 0 &&
+    ! grep -q '^\[scripts-browser1\.desktop\]' "$config_dir/kglobalshortcutsrc" &&
+    ! grep -q '^_k_friendly_name=browser1' "$config_dir/kglobalshortcutsrc" &&
+    ! grep -q '^\[shortcut-music\.desktop\]' "$config_dir/kglobalshortcutsrc" &&
+    grep -q '^\[services\]\[shortcut-terminal\.desktop\]' "$config_dir/kglobalshortcutsrc" &&
+    grep -q '^Window Close=Meta+Backspace,none,Window Close' "$config_dir/kglobalshortcutsrc"
+}
+
+# The sweep replaces the config by rename, so it has to carry the original's
+# mode across rather than leave the scratch copy's behind -- a shortcut config
+# that silently turns world-readable is not an acceptable way to clean it up.
+# No scratch file may survive the run either.
+test_stale_group_sweep_preserves_mode() {
+    config_dir="$TEST_TMPDIR/home/.config"
+    mkdir -p "$config_dir"
+    cat > "$config_dir/kglobalshortcutsrc" <<'CONF'
+[scripts-browser1.desktop]
+_launch=Meta+G
+
+[kwin]
+Window Close=Meta+Backspace,none,Window Close
+CONF
+    chmod 600 "$config_dir/kglobalshortcutsrc"
+    run_kde --no-install
+    assert_status 0 &&
+    ! grep -q '^\[scripts-browser1\.desktop\]' "$config_dir/kglobalshortcutsrc" &&
+    test -n "$(find "$config_dir/kglobalshortcutsrc" -perm 600)" &&
+    test -z "$(find "$config_dir" -name 'kglobalshortcutsrc.setup-kde.*')"
+}
+
+# A dotfiles-managed config is a symlink into the conf repo. The sweep has to
+# rewrite the link's target, not rename a regular file over the link itself --
+# doing the latter strips the groups from a fresh local copy while leaving the
+# managed file untouched, and silently disconnects KDE's later writes from it.
+test_stale_group_sweep_follows_symlink() {
+    config_dir="$TEST_TMPDIR/home/.config"
+    managed_dir="$TEST_TMPDIR/home/conf"
+    mkdir -p "$config_dir" "$managed_dir"
+    cat > "$managed_dir/kglobalshortcutsrc" <<'CONF'
+[scripts-browser1.desktop]
+_launch=Meta+G
+
+[kwin]
+Window Close=Meta+Backspace,none,Window Close
+CONF
+    ln -s "$managed_dir/kglobalshortcutsrc" "$config_dir/kglobalshortcutsrc"
+    run_kde --no-install
+    assert_status 0 &&
+    test -L "$config_dir/kglobalshortcutsrc" &&
+    test "$(readlink "$config_dir/kglobalshortcutsrc")" = "$managed_dir/kglobalshortcutsrc" &&
+    ! grep -q '^\[scripts-browser1\.desktop\]' "$managed_dir/kglobalshortcutsrc" &&
+    grep -q '^Window Close=' "$managed_dir/kglobalshortcutsrc" &&
+    test -z "$(find "$TEST_TMPDIR/home" -name 'kglobalshortcutsrc.setup-kde.*')"
+}
+
+# The stale-group sweep must not depend on python3: setup-kde's prerequisites
+# are the KDE tools, and a box without python3 used to abort the whole run
+# here under set -e, right before the app shortcuts were written.
+test_stale_group_sweep_needs_no_python3() {
+    config_dir="$TEST_TMPDIR/home/.config"
+    mkdir -p "$config_dir"
+    cat > "$config_dir/kglobalshortcutsrc" <<'CONF'
+[scripts-browser1.desktop]
+_launch=Meta+G
+CONF
+    # Shadow python3 with a mock that always fails: reaching it at all is the
+    # regression, and it comes first on the test PATH.
+    cat > "$TEST_TMPDIR/bin/python3" <<MOCK
+#!/bin/sh
+printf "%s\\n" "python3 \$*" >> "$CALLS"
+exit 1
+MOCK
+    chmod +x "$TEST_TMPDIR/bin/python3"
+    run_kde --no-install
+    assert_status 0 &&
+    assert_not_called "python3" &&
+    assert_output_contains "KDE configured successfully" &&
+    ! grep -q '^\[scripts-browser1\.desktop\]' "$config_dir/kglobalshortcutsrc"
+}
+
 # A launcher that exists on PATH gets a .desktop file and a [services] _launch
 # shortcut pointing at its resolved path.
 test_app_shortcut_created_for_present_launcher() {
@@ -673,6 +798,18 @@ run_test "missing git errors clearly once the fallback is reached" \
 run_test "enables and configures Krohnkite" test_enables_and_configures_krohnkite
 run_test "configures focus follows mouse" test_configures_focus_follows_mouse
 run_test "configures nine desktops" test_configures_nine_desktops
+run_test "comma and backslash shortcuts are escaped for kglobalaccel" \
+    test_comma_and_backslash_shortcuts_are_escaped
+run_test "unbinds the Emoji Selector so Meta+. reaches Krohnkite" \
+    test_unbinds_emoji_selector_for_next_layout
+run_test "strips stale app-shortcut groups, keeps the rest" \
+    test_strips_stale_app_shortcut_groups
+run_test "stale-group sweep preserves the config's mode" \
+    test_stale_group_sweep_preserves_mode
+run_test "stale-group sweep rewrites through a symlink" \
+    test_stale_group_sweep_follows_symlink
+run_test "stale-group sweep needs no python3" \
+    test_stale_group_sweep_needs_no_python3
 run_test "app shortcut created for present launcher" \
     test_app_shortcut_created_for_present_launcher
 run_test "missing launcher is skipped, not fatal" \


### PR DESCRIPTION
Four bugs in the KDE setup, all of the same shape: the script wrote configuration that KDE then quietly ignored, and reported success.

## Shortcuts kglobalaccel discards

**`Meta+,` (Krohnkite Previous Layout) never bound.** kglobalaccel reads each `[kwin]` entry with `readEntry(QStringList)` and skips any entry that doesn't split into exactly three fields. A bare comma in the shortcut makes four, so the entry was dropped wholesale. Written as `"Meta+\,"` now — KConfig doubles the backslash on the way to the file and halves it on the way back, which is the escape the list parser needs to keep the comma out of the split.

The neighbouring `"Meta+\\\\"` for Grow Width turned out to be **correct** for the same round trip, so it's unchanged; a comment now records why the two look different. This closes the TODO that 0913fb3 deleted without resolving.

**`Meta+.` collided with Plasma's Emoji Selector**, which was never unbound — unlike Meta+G/W/T, which are. The emojier holds it as a `[services]` launch shortcut rather than a `[kwin]` action, so it needs a different unbind shape (`unbind_app_shortcut`).

## The keyboard layout didn't survive a login

`setup` configures Dvorak at the system level (`/etc/default/keyboard` or `localectl`, plus a live `setxkbmap`), but that isn't the layer Plasma reads. Once `kxkbrc` has `Use=true`, Plasma's keyboard daemon reapplies its own layout at every login and the system setting loses — the machine comes back up in US QWERTY.

`setup-kde` now writes the session layout too. `Options`/`ResetOldOptions` mirror `setup`'s `setxkbmap -option '' -option compose:caps`; without them Plasma reapplies the layout and leaves the XKB options to chance, which is what drops Caps Lock as Compose. No dbus call — the daemon watches the file. `org.kde.KeyboardLayouts.setLayout` is deliberately avoided for the reason the `dvorak` script already documents. The two halves cross-reference each other so they aren't changed independently.

## An undocumented python3 dependency could abort the run

`remove_stale_app_shortcut_groups` shelled out to `python3`, which is neither a documented prerequisite nor guaranteed present. On a box without it, `set -e` aborted the whole run immediately before the app-launch shortcuts were written. Rewritten in awk.

The rewrite is careful about the file it edits, which took a couple of review rounds to get right:

- A symlinked config — the dotfiles-managed case, which is what this repo does — is resolved first, so the sweep rewrites the link's **target** and leaves the link intact rather than replacing it with a regular file and disconnecting KDE's later writes.
- The replace is atomic: `cp -p` seeds the scratch copy with the original's mode, awk rewrites it in place, `mv` renames it over. A failure anywhere leaves the live config exactly as it was rather than truncated. Resolving the symlink first also keeps the scratch copy on the target's own filesystem, where `mv` really is a rename.
- Warnings name the file rather than an absolute `$HOME` path.

## Tests

The mocks recorded argv with `echo`, which mangles backslashes and made escaping unassertable; switched to `printf`, along with the pattern diagnostics.

`XDG_CONFIG_HOME` is now pinned to the sandbox alongside `HOME`. `setup-kde` resolves the config as `${XDG_CONFIG_HOME:-$HOME/.config}`, so on a machine that exports it the script read — and the sweep rewrote — the caller's **real** KDE config while assertions checked the sandbox. That leak predates this branch (the python3 version wrote to the same path); it stayed hidden because every earlier test asserts on mocked argv rather than file contents, so nothing had ever read or written the real file.

Seven new tests cover the escaping, the emojier unbind, the kxkbrc writes, the sweep's keep-the-rest / mode-preservation / symlink-following behaviour, and its independence from python3. Each fails against the unfixed script. Full suite green with `XDG_CONFIG_HOME` both set and unset.

## Found but not changed

Reported for separate branches rather than folded in here: `Walk Through Windows of Current Application` is unbound on the stated grounds that it holds `Meta+\`` when KWin's default is `Alt+\``; `set_default_terminal` swallows errors on the redhat path and never sets `kdeglobals` on the debian one; the macOS `brew install` chain is unguarded where the apt/dnf branches warn and continue; `unbind_all_krohnkite_shortcuts` reads `kglobalshortcutsrc` while writing to it inside the loop; and several pre-existing warnings interpolate absolute paths, the same issue as the one fixed above.