### PR TITLE
setup, setup-kde: fix the bugs left over from the #161 audit

### DIFF
--- a/setup
+++ b/setup
@@ -1425,13 +1425,31 @@ offer_ssh_remotes() {
 
 # --- Set kitty as default terminal ---
 
+# The KDE half, shared by both Linux branches. update-alternatives (Debian)
+# only covers x-terminal-emulator; what makes Plasma's own "open terminal"
+# actions use kitty is kdeglobals, so every KDE box needs this, not just
+# Fedora. Nothing here is privileged -- kdeglobals is per-user -- so it runs
+# without sudo_or_warn.
+set_kde_default_terminal() {
+    command -v kwriteconfig6 >/dev/null 2>&1 || return 0
+    # TerminalApplication is what Plasma 6 reads; TerminalService is the
+    # .desktop-based successor. Write both: which one wins varies by version.
+    kwriteconfig6 --file kdeglobals --group General --key TerminalApplication kitty \
+        || warn "could not set kitty as the KDE terminal application"
+    kwriteconfig6 --file kdeglobals --group General --key TerminalService kitty.desktop \
+        || warn "could not set kitty as the KDE terminal service"
+}
+
 set_default_terminal() {
     case "$OS" in
         debian)
-            if command -v update-alternatives >/dev/null 2>&1 && command -v kitty >/dev/null 2>&1; then
+            if command -v kitty >/dev/null 2>&1; then
                 info "Setting kitty as default terminal"
-                sudo_or_warn update-alternatives --set x-terminal-emulator "$(command -v kitty)" \
-                    || warn "skipping default-terminal update"
+                if command -v update-alternatives >/dev/null 2>&1; then
+                    sudo_or_warn update-alternatives --set x-terminal-emulator "$(command -v kitty)" \
+                        || warn "skipping the x-terminal-emulator alternative"
+                fi
+                set_kde_default_terminal
             fi
             ;;
         redhat)
@@ -1440,10 +1458,10 @@ set_default_terminal() {
                 # Set via xdg for Wayland/X11
                 mkdir -p "$HOME/.config"
                 if command -v xdg-mime >/dev/null 2>&1; then
-                    xdg-mime default kitty.desktop x-scheme-handler/terminal
+                    xdg-mime default kitty.desktop x-scheme-handler/terminal \
+                        || warn "could not register kitty as the terminal scheme handler"
                 fi
-                kwriteconfig6 --file kdeglobals --group General --key TerminalApplication kitty 2>/dev/null || true
-                kwriteconfig6 --file kdeglobals --group General --key TerminalService kitty.desktop 2>/dev/null || true
+                set_kde_default_terminal
             fi
             ;;
         macos)

--- a/setup
+++ b/setup
@@ -1080,7 +1080,7 @@ install_extras() {
 install_home_tools() {
     homepkg="$SCRIPTS_DIR/homepkg"
     if ! test -x "$homepkg"; then
-        warn "homepkg not found at $homepkg; skipping home-prefix tool install"
+        warn "homepkg not found in the scripts repo; skipping home-prefix tool install"
         return 0
     fi
     # fnm (Node version manager) is a convenience tool -- installed regardless
@@ -1229,7 +1229,7 @@ missing_shell_tools() {
 install_shell_tools() {
     homepkg="$SCRIPTS_DIR/homepkg"
     if ! test -x "$homepkg"; then
-        warn "homepkg not found at $homepkg; skipping atuin and carapace"
+        warn "homepkg not found in the scripts repo; skipping atuin and carapace"
         return 0
     fi
     shell_tools="$(missing_shell_tools)"

--- a/setup
+++ b/setup
@@ -764,9 +764,15 @@ install_packages() {
             fi
             ;;
         macos)
-            install_homebrew
+            # Every brew step below warns and continues rather than aborting,
+            # matching the apt/dnf branches: one renamed formula or one tap
+            # outage shouldn't take the whole bootstrap down under set -e.
+            if ! install_homebrew; then
+                warn "Homebrew unavailable; skipping macOS package installation"
+                return 0
+            fi
             info "Installing system packages"
-            brew install \
+            if ! brew install \
                 autoconf \
                 automake \
                 bat \
@@ -786,7 +792,9 @@ install_packages() {
                 shellcheck \
                 unzip \
                 vim \
-                zsh
+                zsh; then
+                warn "some core Homebrew packages could not be installed"
+            fi
             # Separate, so a formula rename or a tap outage can't take the
             # core package list down with it.
             info "Installing zoxide"
@@ -801,7 +809,8 @@ install_packages() {
             # instead of a second copy here.
             if test "$NPM" = yes && test "$ROOT" = yes; then
                 info "Installing Node.js (npm)"
-                brew install node
+                brew install node \
+                    || warn "could not install node; setup-kde's Krohnkite source-build fallback needs it"
                 # tsc lets setup-kde's fallback build Krohnkite from source
                 # without fetching typescript from the npm registry at build
                 # time. Installed on macOS too so the toolchain matches Linux.
@@ -812,15 +821,18 @@ install_packages() {
             # adb/fastboot are CLI tools (used by pidcat and friends), not
             # graphical -- install them regardless of --no-gui, matching the
             # Linux paths which keep adb/android-tools as core packages.
-            brew install --cask android-platform-tools
+            brew install --cask android-platform-tools \
+                || warn "could not install android-platform-tools; adb/fastboot will be unavailable"
             if test "$GUI_ENABLED" -eq 1; then
                 info "Installing graphical packages"
-                brew install kitty
+                brew install kitty \
+                    || warn "skipping kitty installation"
                 info "Installing macOS applications"
                 brew install --cask \
                     amethyst \
                     iterm2 \
-                    rectangle
+                    rectangle \
+                    || warn "some macOS applications could not be installed"
             fi
             ;;
         *)

--- a/setup-kde
+++ b/setup-kde
@@ -317,7 +317,7 @@ install_krohnkite() {
             warn "could not fetch the Krohnkite release via homepkg (offline? stage a bundle with 'homepkg --backend codeberg bundle -o homepkg-krohnkite.tgz krohnkite'); falling back to building from source"
         fi
     else
-        warn "homepkg not found at $homepkg; falling back to building Krohnkite from source"
+        warn "homepkg not found beside this script; falling back to building Krohnkite from source"
     fi
 
     if test -n "$kwinscript"; then
@@ -527,7 +527,7 @@ add_app_shortcut() {
         if test -x "$SCRIPT_DIR/$name"; then
             command="$SCRIPT_DIR/$name"
         else
-            warn "$name not found on PATH or in $SCRIPT_DIR; skipping its launch shortcut"
+            warn "$name not found on PATH or beside this script; skipping its launch shortcut"
             return 0
         fi
     fi

--- a/setup-kde
+++ b/setup-kde
@@ -479,33 +479,35 @@ unbind_app_shortcut() {
         --group services --group "$1" --key _launch none
 }
 
+# Collect the action IDs first, then unbind them -- never write from inside
+# the read loop. unbind_shortcut runs kwriteconfig6 against this same file, so
+# the old shape had the loop's open descriptor racing KConfig's rewrite of the
+# file underneath it. It happened to survive because KConfig replaces by
+# rename and the descriptor kept the original inode, but that's the write
+# strategy of a dependency, not something this script gets to rely on.
+#
+# The awk matches both the older "Krohnkite: Foo Bar=..." keys and the newer
+# "KrohnkiteFooBar=..." ones. Action IDs contain spaces, so the results are
+# iterated a line at a time rather than word-split.
 unbind_all_krohnkite_shortcuts() {
     config_file="${XDG_CONFIG_HOME:-$HOME/.config}/kglobalshortcutsrc"
     test -f "$config_file" || return 0
 
-    in_kwin=false
-    while IFS= read -r line; do
-        case "$line" in
-            "[kwin]")
-                in_kwin=true
-                ;;
-            "["*)
-                in_kwin=false
-                ;;
-            *)
-                if $in_kwin; then
-                    # Matches both the older "Krohnkite: Foo Bar=..." keys
-                    # and the newer "KrohnkiteFooBar=..." keys.
-                    case "$line" in
-                        "Krohnkite"*=*)
-                            action="${line%%=*}"
-                            unbind_shortcut "$action"
-                            ;;
-                    esac
-                fi
-                ;;
-        esac
-    done < "$config_file"
+    krohnkite_actions=$(awk '
+        /^\[kwin\]$/ { in_kwin = 1; next }
+        /^\[/        { in_kwin = 0; next }
+        in_kwin && /^Krohnkite/ && /=/ { sub(/=.*/, ""); print }
+    ' "$config_file") || {
+        warn "could not read kglobalshortcutsrc; leaving stale Krohnkite shortcuts bound"
+        return 0
+    }
+
+    while IFS= read -r action; do
+        test -n "$action" || continue
+        unbind_shortcut "$action"
+    done <<EOF
+$krohnkite_actions
+EOF
 }
 
 # --- Application launch shortcuts ---

--- a/setup-kde
+++ b/setup-kde
@@ -651,7 +651,11 @@ configure_keybindings() {
     unbind_shortcut "Grid View"                                 # Meta+G -> Browser 1
     unbind_shortcut "Overview"                                  # Meta+W -> Terminal on Workstation
     unbind_shortcut "Edit Tiles"                                # Meta+T -> Terminal
-    unbind_shortcut "Walk Through Windows of Current Application" # Meta+` -> Krohnkite Monocle
+    # "Walk Through Windows of Current Application" used to be unbound here on
+    # the grounds that it held Meta+`, which Krohnkite's Monocle layout wants.
+    # It doesn't -- KWin's default for it is Alt+`, so the unbind freed nothing
+    # and cost the app-window cycling that key does. If an earlier run of this
+    # script already cleared yours, System Settings > Shortcuts restores it.
     # Plasma's Emoji Selector holds Meta+. as a [services] launch shortcut,
     # not a [kwin] action, so it needs the launch-shortcut form.
     unbind_app_shortcut org.kde.plasma.emojier.desktop  # Meta+. -> Krohnkite Next Layout

--- a/setup-kde_test
+++ b/setup-kde_test
@@ -645,6 +645,59 @@ test_does_not_unbind_walk_through_current_application() {
     assert_called "kwriteconfig6 --file kglobalshortcutsrc --group kwin --key Edit Tiles none,none,Edit Tiles"
 }
 
+# Seed a config with several Krohnkite entries and make kwriteconfig6 rewrite
+# it IN PLACE on the first Krohnkite unbind -- truncate-and-write on the same
+# inode, which is the KConfig behavior the old code happened not to hit.
+#
+# That is what makes this a regression test rather than a characterization
+# one. The old code wrote from inside "while read < $config_file", so the
+# first unbind emptied the file under the loop's own descriptor and every
+# later entry was lost: 1 of 3 unbound. Collecting the IDs in one awk pass
+# first means the file is closed before anything writes, so all 3 are.
+add_rewriting_kwriteconfig6() {
+    cat > "$TEST_TMPDIR/bin/kwriteconfig6" <<MOCK
+#!/bin/sh
+printf '%s\n' "kwriteconfig6 \$*" >> "$CALLS"
+config="$TEST_TMPDIR/home/.config/kglobalshortcutsrc"
+case "\$*" in
+    *"--key Krohnkite"*)
+        if test -f "\$config" && ! test -f "$TEST_TMPDIR/rewritten"; then
+            : > "\$config"
+            touch "$TEST_TMPDIR/rewritten"
+        fi
+        ;;
+esac
+exit 0
+MOCK
+    chmod +x "$TEST_TMPDIR/bin/kwriteconfig6"
+}
+
+test_krohnkite_sweep_survives_config_rewrite() {
+    config_dir="$TEST_TMPDIR/home/.config"
+    mkdir -p "$config_dir"
+    cat > "$config_dir/kglobalshortcutsrc" <<'CONF'
+[kwin]
+Krohnkite: Grow Width=Meta+\\\\,none,Krohnkite: Grow Width
+KrohnkiteShrinkWidth=Meta+/,none,Krohnkite: Shrink Width
+KrohnkiteSetMaster=Meta+Return,none,Krohnkite: Set master
+Window Close=Meta+Backspace,none,Window Close
+
+[plasmashell]
+KrohnkiteNotInKwin=Meta+Z,none,should not be touched
+CONF
+    add_rewriting_kwriteconfig6
+    run_kde --no-install
+    assert_status 0 &&
+    # All three [kwin] entries unbound despite the rewrite mid-sweep. The
+    # older "Krohnkite: ..." key also covers IDs containing spaces.
+    assert_called "--key Krohnkite: Grow Width none,none,Krohnkite: Grow Width" &&
+    assert_called "--key KrohnkiteShrinkWidth none,none,KrohnkiteShrinkWidth" &&
+    assert_called "--key KrohnkiteSetMaster none,none,KrohnkiteSetMaster" &&
+    # Scoping still holds: [plasmashell] keys and non-Krohnkite keys are left be.
+    assert_not_called "KrohnkiteNotInKwin" &&
+    assert_not_called "--key Window Close none,none"
+}
+
 # Meta+. is Plasma's Emoji Selector by default, and it holds it as a
 # [services] launch shortcut rather than a [kwin] action -- so freeing it for
 # Krohnkite's Next Layout needs the launch-shortcut form.
@@ -870,6 +923,8 @@ run_test "comma and backslash shortcuts are escaped for kglobalaccel" \
     test_comma_and_backslash_shortcuts_are_escaped
 run_test "leaves Alt+\` app-window cycling alone" \
     test_does_not_unbind_walk_through_current_application
+run_test "Krohnkite sweep survives the config being rewritten mid-sweep" \
+    test_krohnkite_sweep_survives_config_rewrite
 run_test "unbinds the Emoji Selector so Meta+. reaches Krohnkite" \
     test_unbinds_emoji_selector_for_next_layout
 run_test "strips stale app-shortcut groups, keeps the rest" \

--- a/setup-kde_test
+++ b/setup-kde_test
@@ -229,6 +229,17 @@ assert_not_called() {
     fi
 }
 
+assert_output_lacks() {
+    case "$output" in
+        *"$1"*)
+            printf "%s\n" "  FAIL: output unexpectedly contains '$1'"
+            echo "  output: $output"
+            TEST_FAILED=1
+            return 1
+            ;;
+    esac
+}
+
 assert_file_exists() {
     if ! test -f "$1"; then
         echo "  FAIL: expected file '$1' to exist"
@@ -454,7 +465,7 @@ test_homepkg_missing_falls_back_to_source_build() {
     add_install_mocks
     run_kde
     assert_status 0 &&
-    assert_output_contains "homepkg not found at" &&
+    assert_output_contains "homepkg not found beside this script" &&
     assert_called "git clone --depth 1 --branch mikel https://codeberg.org/mikelward/Krohnkite.git" &&
     assert_called "kpackagetool6 -t KWin/Script"
 }
@@ -832,7 +843,12 @@ test_missing_launcher_skipped_not_fatal() {
     # browser2, terminal, terminal_on_workstation, music left missing.
     run_kde --no-install
     assert_status 0 &&
-    assert_output_contains "browser2 not found on PATH" &&
+    # The whole warning, not just its prefix: the earlier version appended the
+    # absolute $SCRIPT_DIR, so a prefix match couldn't tell the two apart. The
+    # script directory is under the sandbox HOME here, standing in for the real
+    # home directory the old message leaked.
+    assert_output_contains "browser2 not found on PATH or beside this script; skipping its launch shortcut" &&
+    assert_output_lacks "$TEST_TMPDIR/isolated" &&
     assert_output_contains "KDE configured successfully" &&
     assert_file_not_exists "$TEST_TMPDIR/home/.local/share/applications/shortcut-browser2.desktop" &&
     assert_file_exists "$TEST_TMPDIR/home/.local/share/applications/shortcut-browser1.desktop"

--- a/setup-kde_test
+++ b/setup-kde_test
@@ -632,6 +632,19 @@ test_comma_and_backslash_shortcuts_are_escaped() {
     assert_called 'KrohnkitegrowWidth Meta+\\\\,none,Krohnkite: Grow Width'
 }
 
+# KWin's default for "Walk Through Windows of Current Application" is Alt+`,
+# not Meta+`, so unbinding it never freed the key Krohnkite's Monocle layout
+# wanted -- it just cost the app-window cycling that shortcut does. The other
+# three unbinds are real conflicts and must stay.
+test_does_not_unbind_walk_through_current_application() {
+    run_kde --no-install
+    assert_status 0 &&
+    assert_not_called "Walk Through Windows of Current Application" &&
+    assert_called "kwriteconfig6 --file kglobalshortcutsrc --group kwin --key Grid View none,none,Grid View" &&
+    assert_called "kwriteconfig6 --file kglobalshortcutsrc --group kwin --key Overview none,none,Overview" &&
+    assert_called "kwriteconfig6 --file kglobalshortcutsrc --group kwin --key Edit Tiles none,none,Edit Tiles"
+}
+
 # Meta+. is Plasma's Emoji Selector by default, and it holds it as a
 # [services] launch shortcut rather than a [kwin] action -- so freeing it for
 # Krohnkite's Next Layout needs the launch-shortcut form.
@@ -855,6 +868,8 @@ run_test "configures the session keyboard layout in kxkbrc" \
     test_configures_keyboard_layout
 run_test "comma and backslash shortcuts are escaped for kglobalaccel" \
     test_comma_and_backslash_shortcuts_are_escaped
+run_test "leaves Alt+\` app-window cycling alone" \
+    test_does_not_unbind_walk_through_current_application
 run_test "unbinds the Emoji Selector so Meta+. reaches Krohnkite" \
     test_unbinds_emoji_selector_for_next_layout
 run_test "strips stale app-shortcut groups, keeps the rest" \

--- a/setup_test
+++ b/setup_test
@@ -112,6 +112,72 @@ sudo_or_warn apt-get update" 2>&1)"
     rm -rf "$sudo_tmpdir"
 }
 
+# Print the named top-level functions from setup, so a test can run one in
+# isolation. The full bootstrap can't run in CI, but an individual function
+# can -- given mocks for what it shells out to and stubs for the helpers it
+# calls. Generalizes what run_sudo_helper does by hand above.
+extract_functions() {
+    awk -v names="$1" '
+        BEGIN { n = split(names, a, " "); for (i = 1; i <= n; i++) want[a[i]] = 1 }
+        /^[a-z_]+\(\) \{$/ { fname = $0; sub(/\(\) \{$/, "", fname); copying = want[fname] }
+        copying { print }
+        /^\}$/ { copying = 0 }
+    ' "$SETUP"
+}
+
+# Run set_default_terminal for one OS against mocked KDE/xdg tools.
+# terminal_mode=fail makes kwriteconfig6 and xdg-mime exit non-zero, so the
+# tests can check that a failure is reported rather than swallowed -- and that
+# the bootstrap keeps going, which is what the trailing marker proves.
+run_terminal_helper() {
+    terminal_os="$1"
+    terminal_mode="${2:-ok}"
+    terminal_tmpdir="$(mktemp -d)"
+    terminal_calls="$terminal_tmpdir/calls"
+
+    for cmd in kitty update-alternatives; do
+        cat > "$terminal_tmpdir/$cmd" <<MOCK
+#!/bin/sh
+printf '%s\n' "$cmd \$*" >> "$terminal_calls"
+exit 0
+MOCK
+    done
+    for cmd in kwriteconfig6 xdg-mime; do
+        cat > "$terminal_tmpdir/$cmd" <<MOCK
+#!/bin/sh
+printf '%s\n' "$cmd \$*" >> "$terminal_calls"
+test "$terminal_mode" = fail && exit 1
+exit 0
+MOCK
+    done
+    chmod +x "$terminal_tmpdir"/*
+
+    set +e
+    output="$(PATH="$terminal_tmpdir:$PATH" HOME="$terminal_tmpdir" \
+        sh -c "set -e
+OS=$terminal_os
+sudo_or_warn() { \"\$@\"; }
+$(extract_functions "info warn set_kde_default_terminal set_default_terminal")
+set_default_terminal
+echo BOOTSTRAP_CONTINUED" 2>&1)"
+    status=$?
+    set -e
+    calls="$(cat "$terminal_calls" 2>/dev/null)"
+    rm -rf "$terminal_tmpdir"
+}
+
+assert_calls_contain() {
+    case "$calls" in
+        *"$1"*) ;;
+        *)
+            echo "  FAIL: calls do not contain '$1'"
+            echo "  calls: $calls"
+            TEST_FAILED=1
+            return 1
+            ;;
+    esac
+}
+
 run_test() {
     name="$1"
     func="$2"
@@ -359,6 +425,49 @@ test_zoxide_is_a_core_package() {
     assert_source_contains "could not install zoxide" &&
     assert_source_contains "unzip zoxide zsh" &&
     assert_source_contains 'tools="ripgrep fd bat fzf jq delta gh fnm zoxide"'
+}
+
+# update-alternatives only covers x-terminal-emulator. What makes Plasma's own
+# "open terminal" actions use kitty is kdeglobals, which is per-user and needs
+# no sudo -- so it belongs on the Debian path too, not just Fedora's. Run the
+# Debian dispatch and check it reaches both: the alternative AND kdeglobals.
+test_kde_terminal_set_on_debian() {
+    run_terminal_helper debian
+    assert_status 0 &&
+    assert_calls_contain "update-alternatives --set x-terminal-emulator" &&
+    assert_calls_contain "kwriteconfig6 --file kdeglobals --group General --key TerminalApplication kitty" &&
+    assert_calls_contain "kwriteconfig6 --file kdeglobals --group General --key TerminalService kitty.desktop"
+}
+
+# The Fedora path keeps its xdg-mime registration and reaches the same shared
+# kdeglobals helper.
+test_kde_terminal_set_on_fedora() {
+    run_terminal_helper redhat
+    assert_status 0 &&
+    assert_calls_contain "xdg-mime default kitty.desktop x-scheme-handler/terminal" &&
+    assert_calls_contain "kwriteconfig6 --file kdeglobals --group General --key TerminalApplication kitty" &&
+    assert_calls_contain "kwriteconfig6 --file kdeglobals --group General --key TerminalService kitty.desktop"
+}
+
+# The kdeglobals writes used to end in "2>/dev/null || true", which hides a
+# real failure and is exactly what AGENTS.md's error-handling rule forbids.
+# Run with every KDE/xdg tool failing: each step must say what went wrong, and
+# the run must still get past set_default_terminal rather than aborting under
+# set -e.
+test_terminal_failures_are_reported_not_swallowed() {
+    run_terminal_helper debian fail
+    assert_status 0 &&
+    assert_output_contains "could not set kitty as the KDE terminal application" &&
+    assert_output_contains "could not set kitty as the KDE terminal service" &&
+    assert_output_contains "BOOTSTRAP_CONTINUED"
+}
+
+test_fedora_terminal_failures_are_reported() {
+    run_terminal_helper redhat fail
+    assert_status 0 &&
+    assert_output_contains "could not register kitty as the terminal scheme handler" &&
+    assert_output_contains "could not set kitty as the KDE terminal application" &&
+    assert_output_contains "BOOTSTRAP_CONTINUED"
 }
 
 # atuin and carapace are in no distro repo and have no conda-forge feedstock,
@@ -756,6 +865,14 @@ run_test "legacy root config fallback is logged with the remedy" \
     test_legacy_root_config_is_logged
 run_test "zoxide is installed as a core package" \
     test_zoxide_is_a_core_package
+run_test "kitty is set as the KDE terminal on Debian" \
+    test_kde_terminal_set_on_debian
+run_test "kitty is set as the KDE terminal on Fedora" \
+    test_kde_terminal_set_on_fedora
+run_test "Debian terminal failures are reported, not swallowed" \
+    test_terminal_failures_are_reported_not_swallowed
+run_test "Fedora terminal failures are reported, not swallowed" \
+    test_fedora_terminal_failures_are_reported
 run_test "atuin and carapace install from their github releases" \
     test_shell_tools_install_from_github_releases
 run_test "the shell tools install from a bundle on an offline host" \

--- a/setup_test
+++ b/setup_test
@@ -200,6 +200,35 @@ echo BOOTSTRAP_CONTINUED" 2>&1)"
     rm -rf "$macos_tmpdir"
 }
 
+# Run the two "homepkg is missing" warning paths with SCRIPTS_DIR pointed at a
+# home-shaped path that doesn't exist. Both functions bail right after warning,
+# so this exercises exactly the messages under test -- and the path is what the
+# assertions check for the absence of.
+run_missing_homepkg_warnings() {
+    homepkg_tmpdir="$(mktemp -d)"
+    missing_scripts_dir="$homepkg_tmpdir/home/testuser/scripts"
+
+    set +e
+    output="$(sh -c "SCRIPTS_DIR='$missing_scripts_dir'
+$(extract_functions "info warn install_home_tools install_shell_tools")
+install_home_tools
+install_shell_tools" 2>&1)"
+    status=$?
+    set -e
+    rm -rf "$homepkg_tmpdir"
+}
+
+assert_output_lacks() {
+    case "$output" in
+        *"$1"*)
+            echo "  FAIL: output unexpectedly contains '$1'"
+            echo "  output: $output"
+            TEST_FAILED=1
+            return 1
+            ;;
+    esac
+}
+
 assert_calls_contain() {
     case "$calls" in
         *"$1"*) ;;
@@ -551,6 +580,21 @@ test_no_unguarded_brew_install_remains() {
     test "$(grep -c '^ *brew install node$' "$SETUP")" -eq 0
 }
 
+# AGENTS.md applies the Privacy rule to warnings too, and homepkg's absolute
+# path carries the user's home directory for no diagnostic gain -- there is
+# only one homepkg, and it lives in the scripts repo. Run both warning paths
+# rather than grepping: a source check stays green if the sanitized string
+# becomes unreachable, or if some other path-bearing expression is emitted
+# alongside it.
+test_missing_homepkg_warnings_name_no_absolute_path() {
+    run_missing_homepkg_warnings
+    assert_status 0 &&
+    assert_output_contains "homepkg not found in the scripts repo; skipping home-prefix tool install" &&
+    assert_output_contains "homepkg not found in the scripts repo; skipping atuin and carapace" &&
+    assert_output_lacks "$missing_scripts_dir" &&
+    assert_output_lacks "/home/testuser"
+}
+
 # atuin and carapace are in no distro repo and have no conda-forge feedstock,
 # so they come from their GitHub releases via homepkg's github backend -- one
 # rootless path that serves the privileged, --no-root and macOS runs alike.
@@ -729,7 +773,7 @@ test_no_root_accepted_and_documented() {
 # The homepkg tool install degrades: a missing homepkg or a failed install
 # warns and continues rather than aborting the bootstrap.
 test_home_tools_install_degrades() {
-    assert_source_contains "homepkg not found at" &&
+    assert_source_contains "homepkg not found in the scripts repo" &&
     assert_source_contains "some CLI tools could not be installed via homepkg"
 }
 
@@ -962,6 +1006,8 @@ run_test "macOS without Homebrew skips the arm and continues" \
     test_macos_without_homebrew_skips_the_arm
 run_test "no unguarded brew install remains" \
     test_no_unguarded_brew_install_remains
+run_test "missing-homepkg warnings name no absolute path" \
+    test_missing_homepkg_warnings_name_no_absolute_path
 run_test "atuin and carapace install from their github releases" \
     test_shell_tools_install_from_github_releases
 run_test "the shell tools install from a bundle on an offline host" \

--- a/setup_test
+++ b/setup_test
@@ -166,6 +166,40 @@ echo BOOTSTRAP_CONTINUED" 2>&1)"
     rm -rf "$terminal_tmpdir"
 }
 
+# Run install_packages' macOS arm against a brew that always fails, or against
+# an unavailable Homebrew. Asserting the run survives is the whole point: this
+# arm used to abort the bootstrap under set -e, so the tests run with set -e on
+# and look for the marker after the call.
+run_macos_packages() {
+    # homebrew_status: 0 = installed, 1 = Homebrew unavailable
+    homebrew_status="$1"
+    macos_tmpdir="$(mktemp -d)"
+    macos_calls="$macos_tmpdir/calls"
+    cat > "$macos_tmpdir/brew" <<MOCK
+#!/bin/sh
+printf '%s\n' "brew \$*" >> "$macos_calls"
+exit 1
+MOCK
+    chmod +x "$macos_tmpdir/brew"
+
+    set +e
+    output="$(PATH="$macos_tmpdir:$PATH" \
+        sh -c "set -e
+OS=macos
+NPM=yes
+ROOT=yes
+GUI_ENABLED=1
+sudo_or_warn() { \"\$@\"; }
+install_homebrew() { return $homebrew_status; }
+$(extract_functions "info warn install_packages")
+install_packages
+echo BOOTSTRAP_CONTINUED" 2>&1)"
+    status=$?
+    set -e
+    calls="$(cat "$macos_calls" 2>/dev/null)"
+    rm -rf "$macos_tmpdir"
+}
+
 assert_calls_contain() {
     case "$calls" in
         *"$1"*) ;;
@@ -468,6 +502,53 @@ test_fedora_terminal_failures_are_reported() {
     assert_output_contains "could not register kitty as the terminal scheme handler" &&
     assert_output_contains "could not set kitty as the KDE terminal application" &&
     assert_output_contains "BOOTSTRAP_CONTINUED"
+}
+
+# The macOS branch used to run install_homebrew and every brew install
+# unguarded, so a single renamed formula or tap outage aborted the whole
+# bootstrap under set -e -- while the apt/dnf branches warned and carried on.
+# Run the arm with a brew that fails every invocation: each step must report
+# itself, and the run must reach the end rather than dying on the first one.
+test_macos_brew_failures_are_not_fatal() {
+    run_macos_packages 0
+    assert_status 0 &&
+    assert_output_contains "BOOTSTRAP_CONTINUED" &&
+    assert_output_contains "some core Homebrew packages could not be installed" &&
+    assert_output_contains "could not install zoxide" &&
+    assert_output_contains "could not install node" &&
+    assert_output_contains "could not install tsc" &&
+    assert_output_contains "could not install android-platform-tools" &&
+    assert_output_contains "skipping kitty installation" &&
+    assert_output_contains "some macOS applications could not be installed"
+}
+
+# A failing brew must not stop the arm early either: the later steps have to
+# be attempted, not skipped because an earlier one failed.
+test_macos_brew_failure_still_attempts_later_steps() {
+    run_macos_packages 0
+    assert_status 0 &&
+    assert_calls_contain "brew install zoxide" &&
+    assert_calls_contain "brew install --cask android-platform-tools" &&
+    assert_calls_contain "brew install kitty"
+}
+
+# When Homebrew itself can't be made available there is nothing to install
+# from, so the arm bows out with a warning instead of running brew at all --
+# and, again, without taking the bootstrap down.
+test_macos_without_homebrew_skips_the_arm() {
+    run_macos_packages 1
+    assert_status 0 &&
+    assert_output_contains "Homebrew unavailable; skipping macOS package installation" &&
+    assert_output_contains "BOOTSTRAP_CONTINUED" &&
+    test -z "$calls"
+}
+
+# Complements the behavioral tests above, which can only see the steps they
+# execute: no bare, unguarded "brew install" may be reintroduced anywhere.
+test_no_unguarded_brew_install_remains() {
+    test "$(grep -c '^ *brew install --cask android-platform-tools$' "$SETUP")" -eq 0 &&
+    test "$(grep -c '^ *brew install kitty$' "$SETUP")" -eq 0 &&
+    test "$(grep -c '^ *brew install node$' "$SETUP")" -eq 0
 }
 
 # atuin and carapace are in no distro repo and have no conda-forge feedstock,
@@ -873,6 +954,14 @@ run_test "Debian terminal failures are reported, not swallowed" \
     test_terminal_failures_are_reported_not_swallowed
 run_test "Fedora terminal failures are reported, not swallowed" \
     test_fedora_terminal_failures_are_reported
+run_test "macOS brew failures warn instead of aborting the bootstrap" \
+    test_macos_brew_failures_are_not_fatal
+run_test "a failing brew still attempts the later macOS steps" \
+    test_macos_brew_failure_still_attempts_later_steps
+run_test "macOS without Homebrew skips the arm and continues" \
+    test_macos_without_homebrew_skips_the_arm
+run_test "no unguarded brew install remains" \
+    test_no_unguarded_brew_install_remains
 run_test "atuin and carapace install from their github releases" \
     test_shell_tools_install_from_github_releases
 run_test "the shell tools install from a bundle on an offline host" \


### PR DESCRIPTION
Follow-up to #161. That PR fixed the shortcuts KDE silently discarded; this one clears the rest of the findings from the same audit, one commit each.

## `Alt+\`` was being unbound for no reason

`configure_keybindings` cleared "Walk Through Windows of Current Application" on the stated grounds that it holds `Meta+\``, which Krohnkite's Monocle layout wants. It doesn't — KWin's default for that action is `Alt+\``. The unbind freed nothing and the only thing it accomplished was removing the app-window cycling that `Alt+\`` does.

The three unbinds beside it — Grid View (`Meta+G`), Overview (`Meta+W`), Edit Tiles (`Meta+T`) — are real conflicts with shortcuts set here, and stay.

**This can't undo damage an earlier run already did.** Removing the line stops future runs from clearing the shortcut, but a config that's already had `none` written into it stays that way until it's reset in System Settings; the comment says so. I deliberately didn't make the script write the default back — actively binding a shortcut it doesn't otherwise manage is the same overreach that caused the bug in the first place.

## Reading a config file while rewriting it

`unbind_all_krohnkite_shortcuts` read `kglobalshortcutsrc` with a while-read loop and called `unbind_shortcut` from inside it — and that runs `kwriteconfig6` against the same file. The loop's open descriptor was racing KConfig's rewrite underneath it.

It survives against the KConfig we have, which replaces by rename and so leaves the descriptor on the original inode. Against one that rewrites in place it drops entries: the first unbind truncates the file mid-loop and everything after it is never read. With three Krohnkite entries seeded and a `kwriteconfig6` that empties the config on the first unbind, the old loop unbinds **1 of 3**; collecting the IDs in one awk pass first unbinds **3 of 3**.

Both key styles are still matched — the older `Krohnkite: Foo Bar=` keys and the newer `KrohnkiteFooBar=` ones — and results are read a line at a time, since the older IDs contain spaces and would otherwise word-split.

## kitty wasn't the KDE terminal on Debian

`set_default_terminal`'s Debian branch only ran `update-alternatives`, which covers `x-terminal-emulator` and nothing else. What makes Plasma's own "open terminal" actions use kitty is `kdeglobals` — which is per-user and needs no sudo, so there was never a reason for only Fedora to get it. Both branches now call one shared helper.

Those `kdeglobals` writes were also `2>/dev/null || true`, and the `xdg-mime` call was unchecked. That's the swallowed failure AGENTS.md's error-handling rule is about: kitty silently isn't the terminal and nothing says why. Each step reports what failed now.

## A macOS brew failure took the whole bootstrap down

The macOS arm of `install_packages` ran `install_homebrew` and every `brew install` unguarded, so under `set -e` one renamed formula, one cask gone from the tap, or an unavailable Homebrew aborted the run — before the dotfiles, the desktop config, and the root config had happened. The apt and dnf arms have warned and continued for exactly this reason; macOS was the odd one out. Every step is guarded now.

## Home paths in warnings

The same issue Codex raised on #161, applied to the warnings that predate it. AGENTS.md extends the Privacy rule to warnings, and these interpolated an absolute path carrying the user's home directory into output that gets pasted into bug reports. The paths weren't earning it — there's one `homepkg` and it lives in the scripts repo; the launcher fallback looks beside the script. Naming the location relationally says the same thing without the prefix.

## Tests

The `setup` half started as source greps, which Codex correctly rejected: the bugs here are *behavioral* — an arm that aborts under `set -e`, and an OS dispatch that skips a helper — and no grep can see either. `setup_test` can't run the bootstrap end to end, but it doesn't need to: `run_sudo_helper` already extracted a function and ran it against a mock. That's generalized into `extract_functions`, and the affected functions now actually execute:

- `set_default_terminal` runs per-OS against mocked `kitty`, `update-alternatives`, `kwriteconfig6` and `xdg-mime` — asserting Debian reaches the alternative *and* both `kdeglobals` writes, Fedora reaches `xdg-mime` and the same writes, and that with those tools failing each diagnostic appears and the run still continues.
- `install_packages` runs with `OS=macos`, a stubbed `install_homebrew` and a `brew` that fails every call, under `set -e` with a marker after it — catching the abort directly (pre-fix: `expected exit status 0, got 1`), plus that later steps are still attempted and that an unavailable Homebrew skips the arm without invoking `brew`.
- The Krohnkite sweep's mock rewrites `kglobalshortcutsrc` in place on the first unbind — the KConfig behavior the fix exists to tolerate — so the pre-fix loop demonstrably drops entries instead of merely being theoretically racy.

One source check survives, as a deliberate complement rather than a substitute: the behavioral tests only see the steps they execute, so `test_no_unguarded_brew_install_remains` is what catches a bare `brew install` reintroduced elsewhere in the arm.

Verified by checking out the pre-fix `setup`/`setup-kde` from `main` and running the new tests against them — every test that can distinguish fixed from unfixed fails there, including the `set -e` abort and the dropped Krohnkite entry.

One test passes before and after by design, and says so in its comment: the Fedora terminal path already wrote `kdeglobals`, so it's the guard that the refactor to a shared helper didn't regress it.

Every commit in the series is independently green, so the branch stays bisectable. Full suite passes, and passes again with `XDG_CONFIG_HOME` set — the isolation hole fixed in #161.