### PR TITLE
setup-kde: restore the three-field form of the _launch shortcut value

### DIFF
--- a/setup-kde
+++ b/setup-kde
@@ -471,12 +471,13 @@ unbind_shortcut_in() {
 }
 
 # Clear a launch shortcut held by a KDE-shipped .desktop component. These live
-# under the nested [services][NAME.desktop] group and carry the bare shortcut
-# as their value, the same shape add_app_shortcut writes -- not the
-# "shortcut,default,name" triple the [kwin] actions use.
+# under the nested [services][NAME.desktop] group and take the same
+# "shortcut,default,name" triple as a [kwin] action -- see add_app_shortcut.
+# Writing a bare "none" would be a one-field value, which kglobalaccel skips,
+# leaving the component free to register its .desktop default instead.
 unbind_app_shortcut() {
     kwriteconfig6 --file kglobalshortcutsrc \
-        --group services --group "$1" --key _launch none
+        --group services --group "$1" --key _launch "none,none,$2"
 }
 
 # Collect the action IDs first, then unbind them -- never write from inside
@@ -552,11 +553,24 @@ EOF
 
     # Nested group [services][foo.desktop] is what kglobalaccel reads for
     # desktop-file launch shortcuts; a top-level [foo.desktop] group is
-    # silently ignored. The value is just the shortcut — the ",default,name"
-    # suffix used for [kwin] actions doesn't apply to launch shortcuts.
+    # silently ignored.
+    #
+    # The value needs all three comma-separated fields, exactly like a [kwin]
+    # action: kglobalaccel loads BOTH kinds through Component::loadSettings
+    # (KServiceActionComponent derives from Component), which reads each entry
+    # with readEntry(QStringList) and skips anything that isn't 3 fields. A
+    # bare "Meta+T" is one field, so the entry is dropped, the shortcut never
+    # grabs, and the keypress falls through to the focused window -- the same
+    # failure the X-KDE-GlobalAccel-CommandShortcut flag above fixes, and the
+    # same 3-field rule that Meta+\, needs in configure_keybindings.
     kwriteconfig6 --file kglobalshortcutsrc \
         --group services --group "$desktop_file" \
-        --key _launch "$shortcut"
+        --key _launch "$shortcut,none,$name"
+    # The component's display name in System Settings, written the way KDE
+    # writes it for its own service shortcuts.
+    kwriteconfig6 --file kglobalshortcutsrc \
+        --group services --group "$desktop_file" \
+        --key _k_friendly_name "$name"
 }
 
 # An earlier version of this script wrote app-launch shortcuts under a
@@ -660,7 +674,7 @@ configure_keybindings() {
     # script already cleared yours, System Settings > Shortcuts restores it.
     # Plasma's Emoji Selector holds Meta+. as a [services] launch shortcut,
     # not a [kwin] action, so it needs the launch-shortcut form.
-    unbind_app_shortcut org.kde.plasma.emojier.desktop  # Meta+. -> Krohnkite Next Layout
+    unbind_app_shortcut org.kde.plasma.emojier.desktop "Emoji Selector"  # Meta+. -> Krohnkite Next Layout
     n=1
     while test "$n" -le 9; do
         # Meta+1..9 -> Switch to Desktop N (plasmashell grabs these by default).

--- a/setup-kde_test
+++ b/setup-kde_test
@@ -715,7 +715,7 @@ CONF
 test_unbinds_emoji_selector_for_next_layout() {
     run_kde --no-install
     assert_status 0 &&
-    assert_called "kwriteconfig6 --file kglobalshortcutsrc --group services --group org.kde.plasma.emojier.desktop --key _launch none" &&
+    assert_called "kwriteconfig6 --file kglobalshortcutsrc --group services --group org.kde.plasma.emojier.desktop --key _launch none,none,Emoji Selector" &&
     assert_called "kwriteconfig6 --file kglobalshortcutsrc --group kwin --key KrohnkiteNextLayout Meta+."
 }
 
@@ -822,6 +822,12 @@ MOCK
 
 # A launcher that exists on PATH gets a .desktop file and a [services] _launch
 # shortcut pointing at its resolved path.
+#
+# The _launch value must carry all three comma-separated fields. kglobalaccel
+# loads service shortcuts through the same Component::loadSettings as [kwin]
+# actions, and that skips any entry which isn't 3 fields -- so a bare "Meta+G"
+# is silently dropped and the shortcut never grabs. This assertion previously
+# pinned the one-field form, which is how that regression survived.
 test_app_shortcut_created_for_present_launcher() {
     add_launcher browser1
     run_kde --no-install
@@ -830,7 +836,10 @@ test_app_shortcut_created_for_present_launcher() {
     assert_file_exists "$desktop" &&
     grep -q "Exec=$TEST_TMPDIR/bin/browser1" "$desktop" &&
     grep -q "X-KDE-GlobalAccel-CommandShortcut=true" "$desktop" &&
-    assert_called "kwriteconfig6 --file kglobalshortcutsrc --group services --group shortcut-browser1.desktop --key _launch Meta+G"
+    assert_called "kwriteconfig6 --file kglobalshortcutsrc --group services --group shortcut-browser1.desktop --key _launch Meta+G,none,browser1" &&
+    assert_called "kwriteconfig6 --file kglobalshortcutsrc --group services --group shortcut-browser1.desktop --key _k_friendly_name browser1" &&
+    # No one-field value may survive: that is the shape kglobalaccel drops.
+    assert_not_called "--key _launch Meta+G$"
 }
 
 # A launcher on neither PATH nor beside the script is skipped with a warning;


### PR DESCRIPTION
Fixes the reported symptom: after running `setup-kde`, none of the `Meta+G/H/T/W/Y` app-launch shortcuts grab — the keypress falls through to the focused window.

All five failing at once is the tell. That points at the launch-shortcut mechanism itself, not at individual key conflicts (which is where I'd been looking in #161 and #162).

## Cause

`_launch=Meta+T` is a **one-field** value.

kglobalaccel loads service shortcuts through the same `Component::loadSettings` as `[kwin]` actions — `KServiceActionComponent` derives from `Component` — and that reads each entry with `readEntry(QStringList)` and skips anything that isn't exactly three comma-separated fields. So every `_launch` entry was dropped on load, and nothing was ever registered to grab the key.

```
before:  _launch=Meta+T              -> ['Meta+T']                      1 field  -> SKIPPED
after:   _launch=Meta+T,none,terminal -> ['Meta+T', 'none', 'terminal']  3 fields -> registers
```

## How it got there

8103060 made two changes at once:

1. Added `X-KDE-GlobalAccel-CommandShortcut=true` to the generated `.desktop` files — correct and necessary.
2. Stripped `,none,$name` from the `_launch` value, on the theory that launch shortcuts take a bare keystring.

The second is wrong; 5800752 had the format right to begin with. So that commit fixed one cause of "the shortcut never grabs" and reintroduced the same symptom through a different door, which is why it looked like it had worked.

This is the same rule as the `Meta+\,` fix in 020ed84. That commit established the three-field requirement for `[kwin]` and stopped there — it didn't ask whether `[services]` went through the same loader. It does.

## Changes

- `_launch` carries all three fields again.
- `_k_friendly_name` is written for the component, the way KDE does for its own service shortcuts.
- `unbind_app_shortcut` gets the same treatment. A bare `none` is also a one-field value, so it was skipped too — meaning the Emoji Selector unbind added in #162 wasn't actually suppressing anything, and left the component free to register its `.desktop` default.

## Tests

The existing assertion pinned the broken value verbatim:

```
assert_called "... --key _launch Meta+G"
```

That is why the regression survived two rounds of review on this file — the test encoded the bug as the expectation. It now requires all three fields, asserts `_k_friendly_name`, and rejects the bare one-field form outright.

Both updated tests fail against the version currently on `main`:

```
not ok 29 unbinds the Emoji Selector so Meta+. reaches Krohnkite
  FAIL: expected call '... --key _launch none,none,Emoji Selector' not found
not ok 34 app shortcut created for present launcher
  FAIL: expected call '... --key _launch Meta+G,none,browser1' not found
```

## Verifying

Two things to know when checking this on a real session:

- I can't run Plasma here. This is reasoned from KConfig/kglobalaccel semantics, and it explains all five shortcuts failing together with the git history corroborating it — but it wants confirmation on hardware.
- On Wayland the shortcuts only take effect after logging out and back in, so test after a relog rather than straight after the script run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJzWNKxv2GFAJKaDmQXrcL)_