### PR TITLE
setup: install the extras from release artifacts instead of building them

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ repo's shell config wires up — are in no distro repo and have no conda-forge
 package, so every `setup` run installs them from their GitHub releases with
 `homepkg --backend github`, regardless of profile or privilege.
 
+The heavyweight extras (`helix jj nu`) come the same way on a privileged box
+without Homebrew: `setup` fetches the release artifacts rather than building
+them from source, so no Rust toolchain is installed. `--brew` (the default
+where `brew` is available, and on macOS) uses bottles instead; `--release`
+forces the release artifacts. `shpool` publishes no prebuilt artifact and is
+no longer installed by `setup` — sessions still prefer it when it's on `PATH`
+from somewhere else, and otherwise fall back to `tmux`.
+
 On a host with no internet, stage a bundle instead. The one-shot bundle below
 covers them along with everything else, which is all a `--no-root` machine
 needs. On a privileged machine the distro packages come from apt/dnf and that

--- a/homepkg
+++ b/homepkg
@@ -68,6 +68,11 @@ import zipfile
 #              conda package is unpacked whole (bin/lib/share); for github we
 #              locate these names in the extracted asset. Omitted for codeberg
 #              tools, which aren't CLI binaries -- see krohnkite below.
+# payload:     non-binary directories to keep out of a github release asset,
+#              {directory in the asset: destination relative to the prefix}.
+#              The github backend otherwise copies out only "bins" and drops
+#              the rest of the archive, which isn't enough for a tool whose
+#              binary needs data files at run time -- see helix below.
 TOOLS = {
     "ripgrep": {"conda": "ripgrep",   "github": "BurntSushi/ripgrep", "bins": ["rg"]},
     "fd":      {"conda": "fd",         "github": "sharkdp/fd",         "bins": ["fd"]},
@@ -76,7 +81,14 @@ TOOLS = {
     "jq":      {"conda": "jq",         "github": "jqlang/jq",          "bins": ["jq"]},
     "delta":   {"conda": "git-delta",  "github": "dandavison/delta",   "bins": ["delta"]},
     "gh":      {"conda": "gh",         "github": "cli/cli",            "bins": ["gh"]},
-    "helix":   {"conda": "helix",      "github": "helix-editor/helix", "bins": ["hx"]},
+    # helix's release tarball carries the hx binary and the runtime/ tree of
+    # grammars, queries, and themes that hx loads at run time. Keep both: an
+    # hx with no runtime starts, but with no highlighting and no language
+    # support. hx searches <config dir>/runtime ahead of anything relative to
+    # the binary, so whoever installs it points that at share/helix/runtime
+    # (setup's link_helix_runtime does).
+    "helix":   {"conda": "helix",      "github": "helix-editor/helix", "bins": ["hx"],
+                "payload": {"runtime": "share/helix/runtime"}},
     "jj":      {"conda": "jujutsu",    "github": "jj-vcs/jj",          "bins": ["jj"]},
     "nu":      {"conda": "nushell",    "github": "nushell/nushell",    "bins": ["nu"]},
     "uv":      {"conda": "uv",         "github": "astral-sh/uv",       "bins": ["uv", "uvx"]},
@@ -364,6 +376,145 @@ def _require_basename(name, what):
         raise HomepkgError(f"unsafe {what} in bundle: {name!r}")
 
 
+# Payloads are data files, so they go under share/ -- and never under
+# share/homepkg/, which is homepkg's own state (the mamba env, the cached
+# assets). Widen this when a tool genuinely needs another root.
+_PAYLOAD_ROOT = "share"
+_HOMEPKG_DIR = "homepkg"
+
+
+def _require_payload_dest(path, prefix, what):
+    """Reject a payload destination that isn't somewhere a payload belongs.
+
+    Staying inside the prefix isn't enough. _replace_dir replaces its
+    destination wholesale, so a destination of "bin" would move every installed
+    executable aside and delete it -- while the install reported success -- and
+    "share/homepkg/env" would take out the mamba environment the same way. Since
+    a destination can come from a bundle manifest, and a bundle can be tampered
+    with (see _require_basename), the shape is constrained rather than trusted:
+    at least two components, the first share/, and not share/homepkg/.
+    """
+    parts = path.split("/") if path else []
+    if (not path or os.path.isabs(path) or len(parts) < 2
+            or any(p in ("", ".", "..") for p in parts)
+            or parts[0] != _PAYLOAD_ROOT or parts[1] == _HOMEPKG_DIR
+            or not _within(os.path.realpath(prefix), os.path.join(prefix, path))):
+        raise HomepkgError(f"unsafe {what}: {path!r}")
+
+
+def _rm_any(path):
+    """Remove a file, symlink, or directory tree, if it's there at all."""
+    if os.path.islink(path) or os.path.isfile(path):
+        os.remove(path)
+    elif os.path.isdir(path):
+        shutil.rmtree(path)
+
+
+def _place_binary(src, dest, backup=None):
+    """Copy the file `src` to `dest`, replacing whatever is there.
+
+    Clears dest first rather than copying onto it: on a prefix the mamba
+    backend has also managed, <prefix>/bin/<tool> is a symlink into its
+    environment, and copying through that symlink would overwrite the
+    conda-managed executable in place -- leaving the environment's metadata
+    describing a file it no longer has, for a later mamba update to replace
+    underneath us. A release install owns the name in <prefix>/bin, not
+    whatever the name currently points at.
+
+    With `backup`, whatever was at dest is moved there instead of removed, so a
+    caller that fails later can put it back -- see _publish_release. That leaves
+    the same one-rename window _replace_dir has, and it's closed the same way:
+    a backup found with nothing at dest is what an earlier run killed mid-swap
+    left behind, so put it back before doing anything else.
+    """
+    if backup is not None:
+        if os.path.exists(backup) and not (os.path.islink(dest) or os.path.exists(dest)):
+            os.rename(backup, dest)
+        if os.path.islink(dest) or os.path.exists(dest):
+            _rm_any(backup)
+            os.rename(dest, backup)
+        else:
+            _rm_any(backup)
+    else:
+        _rm_any(dest)
+    shutil.copy2(src, dest)
+    _ensure_executable(dest)
+
+
+def _publish_release(found_bins, payload_src, prefix, bindir):
+    """Install a tool's binaries and its payload, or neither.
+
+    Only for tools that have a payload, where the two have to match. Both are
+    already known to be in the asset by the time this runs, but being there is
+    not the same as landing: the payload copy is the big, slow half (helix's
+    runtime runs to a couple of hundred megabytes), and it's the one that fails
+    when a disk fills. So the binaries go first and are moved aside rather than
+    overwritten, and if publishing the payload then fails partway they go back
+    -- leaving the tool as it was, instead of a new binary reading the previous
+    release's data files.
+
+    A binary's own copy can fail the same way, so each destination is registered
+    for rollback before it's touched rather than after: the rollback has to cover
+    the call that raised, not just the ones that returned.
+
+    Rolling back means putting back what was there, which on a first install is
+    nothing -- so the new binary is removed rather than left behind. "Both or
+    neither" has to hold for a fresh prefix too, where an hx with no runtime is
+    exactly the editor-with-no-language-support this payload exists to prevent.
+    """
+    backups = {}
+    try:
+        for b, src in found_bins.items():
+            dest = os.path.join(bindir, b)
+            backups[dest] = dest + ".prev"
+            _place_binary(src, dest, backup=dest + ".prev")
+        for src_name, src, dest_rel in payload_src:
+            _replace_dir(src, os.path.join(prefix, dest_rel))
+            info(f"  installed {src_name}/ into {prefix}/{os.path.dirname(dest_rel)}")
+    except BaseException:
+        for dest, backup in backups.items():
+            _rm_any(dest)
+            if os.path.exists(backup):
+                os.rename(backup, dest)
+        raise
+    for backup in backups.values():
+        _rm_any(backup)
+
+
+def _replace_dir(src, dest):
+    """Copy the directory `src` to `dest`, replacing whatever is there.
+
+    Copies alongside the destination and swaps, rather than clearing dest
+    first: an install interrupted partway through (Ctrl-C, a full disk, a
+    truncated asset) then leaves the previous contents in place instead of a
+    half-populated tree. Both temp names are siblings of dest, so each rename
+    is atomic within the one filesystem.
+
+    Two renames means one window -- after dest is moved aside and before its
+    replacement lands -- where an interruption leaves nothing at dest and the
+    previous contents at dest.old. There's no portable way to swap two
+    directories in one step, so instead of widening the promise this closes it
+    from the other end: the next call puts dest.old back before doing anything
+    else, so the previous payload survives even an interruption inside that
+    window.
+    """
+    os.makedirs(os.path.dirname(dest), exist_ok=True)
+    new, old = dest + ".new", dest + ".old"
+    # Recover from an earlier run interrupted mid-swap, then clear leftovers.
+    if os.path.isdir(old) and not os.path.exists(dest):
+        os.rename(old, dest)
+    _rm_any(new)
+    _rm_any(old)
+    shutil.copytree(src, new)
+    if os.path.isdir(dest) and not os.path.islink(dest):
+        os.rename(dest, old)
+        os.rename(new, dest)
+        shutil.rmtree(old)
+    else:
+        _rm_any(dest)  # a stale file or symlink where the directory goes
+        os.rename(new, dest)
+
+
 def _safe_extract_tar(tf, dest):
     """Extract a tar treating members as untrusted. Only directories and
     regular files are created, each validated to stay within dest; special
@@ -393,10 +544,18 @@ def _safe_extract_zip(zf, dest):
     zf.extractall(dest)
 
 
-def github_extract(asset_path, name, prefix, bins):
-    """Unpack an asset and copy the wanted binaries into prefix/bin."""
+def github_extract(asset_path, name, prefix, bins, payload=None):
+    """Unpack an asset and copy the wanted binaries into prefix/bin.
+
+    `payload` (the registry key of the same name) additionally keeps whole
+    directories out of the archive, {directory in the asset: destination
+    relative to prefix}, for a tool that needs data files next to its binary.
+    """
     for b in bins:
         _require_basename(b, "binary name")
+    for src_name, dest_rel in (payload or {}).items():
+        _require_basename(src_name, "payload directory")
+        _require_payload_dest(dest_rel, prefix, "payload destination")
     bindir = os.path.join(prefix, "bin")
     os.makedirs(bindir, exist_ok=True)
     low = name.lower()
@@ -409,27 +568,51 @@ def github_extract(asset_path, name, prefix, bins):
         root = os.path.join(os.path.dirname(asset_path), "x")
         with zipfile.ZipFile(asset_path) as zf:
             _safe_extract_zip(zf, root)
-    if root is not None:
+    # A binary and the data files it loads at run time have to match, so for a
+    # tool with a payload nothing is installed until every part has been located
+    # in the asset -- in either direction. Publishing a new binary and only then
+    # finding no runtime for it, or a new runtime the old binary then reads,
+    # leaves a mismatched pair: worse than not updating, and unlike a missing
+    # binary it can't be left half-done for the next reinstall to finish,
+    # because the half-done state runs -- wrongly. A tool with no payload keeps
+    # the partial-install policy below.
+    payload_src = []
+    if payload:
+        if root is None:
+            # Nothing to unpack, so there's nowhere for a payload to come from.
+            raise HomepkgError(
+                f"{name} can't carry {', '.join(s + '/' for s in payload)}; "
+                "kept the previous install")
+        found_bins = {b: _find_file(root, b) for b in bins}
+        found_payload = {s: _find_dir(root, s) for s in payload}
+        missing = [b for b, found in found_bins.items() if found is None]
+        missing += [s + "/" for s, found in found_payload.items() if found is None]
+        if missing:
+            raise HomepkgError(
+                f"{name} doesn't contain {', '.join(missing)}; "
+                "kept the previous install")
+        payload_src = [(s, found_payload[s], payload[s]) for s in payload]
+    if payload:
+        # Both halves published together, or neither -- everything above only
+        # established that they're in the asset, not that they land.
+        _publish_release(found_bins, payload_src, prefix, bindir)
+        placed = list(bins)
+    elif root is not None:
         placed = []
         for b in bins:
             src = _find_file(root, b)
             if src is None:
                 continue
-            dest = os.path.join(bindir, b)
-            shutil.copy2(src, dest)
-            _ensure_executable(dest)
+            _place_binary(src, os.path.join(bindir, b))
             placed.append(b)
     else:
         # Raw single binary (e.g. jq-linux-amd64): treat the asset as bins[0].
-        dest = os.path.join(bindir, bins[0])
-        shutil.copy2(asset_path, dest)
-        _ensure_executable(dest)
+        _place_binary(asset_path, os.path.join(bindir, bins[0]))
         placed = [bins[0]]
-    # An asset that doesn't carry everything the registry says it does --
-    # a changed release layout, an asset picked by the wrong token -- is a
-    # failed tool, not a warning: the caller has to know to get it another
-    # way. Whatever was found stays, since it works and the reinstall
-    # replaces it.
+    # An asset that doesn't carry every binary the registry says it does -- a
+    # changed release layout, an asset picked by the wrong token -- is a failed
+    # tool, not a warning: the caller has to know to get it another way.
+    # Whatever was found stays, since it works and the reinstall replaces it.
     missing = [b for b in bins if b not in placed]
     if missing:
         raise HomepkgError(
@@ -441,6 +624,13 @@ def github_extract(asset_path, name, prefix, bins):
 def _find_file(root, name):
     for dirpath, _dirs, files in os.walk(root):
         if name in files:
+            return os.path.join(dirpath, name)
+    return None
+
+
+def _find_dir(root, name):
+    for dirpath, dirs, _files in os.walk(root):
+        if name in dirs:
             return os.path.join(dirpath, name)
     return None
 
@@ -459,7 +649,8 @@ def install_github(tool, meta, prefix, plat, dry_run):
         return
     with tempfile.TemporaryDirectory() as td:
         asset_path = download(url, os.path.join(td, name))
-        placed = github_extract(asset_path, name, prefix, meta["bins"])
+        placed = github_extract(asset_path, name, prefix, meta["bins"],
+                                meta.get("payload"))
     info(f"  installed {', '.join(placed)} into {prefix}/bin")
 
 
@@ -913,6 +1104,9 @@ def _stage_github(tools, plat, td, skip_unavailable=False):
             continue
         name, url = picked
         download(url, os.path.join(adir, name))
+        # The payload isn't recorded: replaying a bundle takes it from the
+        # registry instead, so a tampered manifest can't choose which
+        # directories an install replaces (see _install_bundle_github).
         entries.append({"tool": t, "asset": name, "bins": TOOLS[t]["bins"]})
     return entries
 
@@ -1101,7 +1295,13 @@ def _install_bundle_github(td, manifest, prefix, dry_run):
         if dry_run:
             continue
         try:
-            github_extract(asset, e["asset"], prefix, e["bins"])
+            # The payload comes from the registry, never from the manifest: it
+            # decides which directories are replaced wholesale, and a bundle can
+            # be tampered with. A bundle for a tool that needs one but is
+            # unknown here installs its binaries and fails, which github_extract
+            # reports, rather than silently landing an incomplete tool.
+            github_extract(asset, e["asset"], prefix, e["bins"],
+                           TOOLS.get(e["tool"], {}).get("payload"))
         except Exception as exc:  # extraction, permissions, truncated asset
             warn(f"{e['tool']}: {exc}; skipping it")
             failed.append(e["tool"])

--- a/homepkg_test
+++ b/homepkg_test
@@ -600,6 +600,396 @@ with tempfile.TemporaryDirectory() as td:
     check("github_extract says what it kept",
           _err is not None and "hx" in str(_err).split("kept")[-1])
 
+# --- github payload (non-binary release contents) -----------------------------
+#
+# helix's release asset carries hx plus the runtime/ tree it loads grammars and
+# queries from; keeping only the binary would install an editor with no
+# language support. The registry's "payload" key names those directories.
+
+_HELIX_PAYLOAD = {"runtime": "share/helix/runtime"}
+
+check("registry keeps helix's runtime payload from its release",
+      hp.TOOLS["helix"].get("payload") == _HELIX_PAYLOAD)
+
+with tempfile.TemporaryDirectory() as td:
+    prefix = os.path.join(td, "prefix")
+    asset = os.path.join(td, "helix-x86_64-linux.tar.gz")
+    _make_targz(asset, {
+        "helix-25.07/hx": b"#!/bin/sh\necho hx\n",
+        "helix-25.07/runtime/queries/rust/highlights.scm": b"; rust\n",
+        "helix-25.07/runtime/themes/dark.toml": b"# dark\n",
+        "helix-25.07/README.md": b"docs\n"})
+    placed = hp.github_extract(asset, os.path.basename(asset), prefix, ["hx"],
+                               _HELIX_PAYLOAD)
+    runtime = os.path.join(prefix, "share", "helix", "runtime")
+    check("github_extract places the binary alongside its payload",
+          placed == ["hx"] and os.access(os.path.join(prefix, "bin", "hx"), os.X_OK))
+    check("github_extract installs the payload directory at its destination",
+          os.path.exists(os.path.join(runtime, "queries", "rust", "highlights.scm"))
+          and os.path.exists(os.path.join(runtime, "themes", "dark.toml")))
+    _kept = [f for _dir, _subdirs, files in os.walk(prefix) for f in files]
+    check("github_extract keeps only the binary and the payload",
+          "README.md" not in _kept)
+
+    # Reinstalling replaces the payload rather than merging into it: a grammar
+    # or query dropped upstream must not linger and shadow the new release.
+    with open(os.path.join(runtime, "queries", "stale.scm"), "w") as f:
+        f.write("; removed upstream\n")
+    hp.github_extract(asset, os.path.basename(asset), prefix, ["hx"], _HELIX_PAYLOAD)
+    check("reinstalling the payload drops files the new asset doesn't have",
+          not os.path.exists(os.path.join(runtime, "queries", "stale.scm"))
+          and os.path.exists(os.path.join(runtime, "themes", "dark.toml")))
+    check("replacing the payload leaves no swap directories behind",
+          not os.path.exists(runtime + ".new") and not os.path.exists(runtime + ".old"))
+
+# A payload the asset doesn't carry fails the tool, for the same reason a
+# missing binary does: the caller has to know to get it another way rather
+# than be told an unusable helix installed fine. Unlike a missing binary it
+# fails before installing anything, since a new hx paired with the previous
+# release's runtime runs -- wrongly -- where a missing binary just isn't there.
+with tempfile.TemporaryDirectory() as td:
+    prefix = os.path.join(td, "prefix")
+    runtime = os.path.join(prefix, "share", "helix", "runtime")
+    os.makedirs(runtime)
+    os.makedirs(os.path.join(prefix, "bin"))
+    with open(os.path.join(runtime, "previous.toml"), "w") as f:
+        f.write("# the runtime already installed\n")
+    with open(os.path.join(prefix, "bin", "hx"), "w") as f:
+        f.write("previous hx\n")
+    asset = os.path.join(td, "helix-x86_64-linux.tar.gz")
+    _make_targz(asset, {"helix-25.07/hx": b"#!/bin/sh\necho hx\n"})
+    _err = None
+    try:
+        hp.github_extract(asset, os.path.basename(asset), prefix, ["hx"],
+                          _HELIX_PAYLOAD)
+    except hp.HomepkgError as e:
+        _err = e
+    check("github_extract fails when the asset lacks a payload directory",
+          _err is not None and "runtime/" in str(_err))
+    check("a missing payload leaves the previous binary in place",
+          open(os.path.join(prefix, "bin", "hx")).read() == "previous hx\n")
+    check("a missing payload leaves the previous payload in place",
+          os.path.exists(os.path.join(runtime, "previous.toml")))
+    check("a missing payload says the previous install was kept",
+          _err is not None and "kept the previous install" in str(_err))
+
+# A raw single-binary asset can't carry a payload at all -- there's nothing to
+# unpack -- so asking for one is a failure, not a silently skipped step, and
+# again not one that replaces the binary on the way out.
+with tempfile.TemporaryDirectory() as td:
+    prefix = os.path.join(td, "prefix")
+    os.makedirs(os.path.join(prefix, "bin"))
+    with open(os.path.join(prefix, "bin", "hx"), "w") as f:
+        f.write("previous hx\n")
+    asset = os.path.join(td, "hx-linux-amd64")
+    with open(asset, "wb") as f:
+        f.write(b"#!/bin/sh\necho hx\n")
+    _err = None
+    try:
+        hp.github_extract(asset, os.path.basename(asset), prefix, ["hx"],
+                          _HELIX_PAYLOAD)
+    except hp.HomepkgError as e:
+        _err = e
+    check("a payload asked of an unpackable asset is a failure",
+          _err is not None and "runtime/" in str(_err))
+    check("an unpackable asset leaves the previous binary in place",
+          open(os.path.join(prefix, "bin", "hx")).read() == "previous hx\n")
+
+# The mirror of the case above: the asset carries the runtime but not the
+# binary. Publishing the runtime and only then reporting the missing binary
+# would leave the previous hx reading a runtime from a different release, so
+# nothing is installed here either.
+with tempfile.TemporaryDirectory() as td:
+    prefix = os.path.join(td, "prefix")
+    runtime = os.path.join(prefix, "share", "helix", "runtime")
+    os.makedirs(runtime)
+    os.makedirs(os.path.join(prefix, "bin"))
+    with open(os.path.join(runtime, "previous.toml"), "w") as f:
+        f.write("# the runtime already installed\n")
+    with open(os.path.join(prefix, "bin", "hx"), "w") as f:
+        f.write("previous hx\n")
+    asset = os.path.join(td, "helix-x86_64-linux.tar.gz")
+    _make_targz(asset, {"helix-25.07/runtime/themes/dark.toml": b"# dark\n"})
+    _err = None
+    try:
+        hp.github_extract(asset, os.path.basename(asset), prefix, ["hx"],
+                          _HELIX_PAYLOAD)
+    except hp.HomepkgError as e:
+        _err = e
+    check("github_extract fails when a payload asset lacks the binary",
+          _err is not None and "hx" in str(_err))
+    check("a missing binary leaves the previous payload in place",
+          os.path.exists(os.path.join(runtime, "previous.toml"))
+          and not os.path.exists(os.path.join(runtime, "themes", "dark.toml")))
+
+# A prefix the mamba backend has also managed has <prefix>/bin/<tool> as a
+# symlink into its environment. Copying onto that symlink would follow it and
+# overwrite the conda-managed executable in place, leaving the environment
+# describing a file it no longer has; a release install owns the name in bin/,
+# not whatever the name currently points at.
+with tempfile.TemporaryDirectory() as td:
+    prefix = os.path.join(td, "prefix")
+    env_bin = os.path.join(prefix, "share", "homepkg", "env", "bin")
+    os.makedirs(env_bin)
+    os.makedirs(os.path.join(prefix, "bin"))
+    managed = os.path.join(env_bin, "rg")
+    with open(managed, "w") as f:
+        f.write("the conda-managed rg\n")
+    os.symlink(managed, os.path.join(prefix, "bin", "rg"))
+    asset = os.path.join(td, "rg-x86_64-unknown-linux-musl.tar.gz")
+    _make_targz(asset, {"ripgrep-14.1.0/rg": b"#!/bin/sh\necho release rg\n"})
+    hp.github_extract(asset, os.path.basename(asset), prefix, ["rg"])
+    check("github_extract replaces a managed symlink with a regular file",
+          not os.path.islink(os.path.join(prefix, "bin", "rg")))
+    check("github_extract doesn't write through to the managed binary",
+          open(managed).read() == "the conda-managed rg\n")
+
+# Being in the asset isn't landing on disk: the payload copy is the big half and
+# the one a full disk fails, so a failure there has to take the new binary back
+# out with it rather than leave it reading the previous release's data files.
+with tempfile.TemporaryDirectory() as td:
+    prefix = os.path.join(td, "prefix")
+    runtime = os.path.join(prefix, "share", "helix", "runtime")
+    os.makedirs(runtime)
+    os.makedirs(os.path.join(prefix, "bin"))
+    with open(os.path.join(runtime, "previous.toml"), "w") as f:
+        f.write("# the runtime already installed\n")
+    with open(os.path.join(prefix, "bin", "hx"), "w") as f:
+        f.write("previous hx\n")
+    asset = os.path.join(td, "helix-x86_64-linux.tar.gz")
+    _make_targz(asset, {"helix-25.07/hx": b"#!/bin/sh\necho hx\n",
+                        "helix-25.07/runtime/themes/dark.toml": b"# dark\n"})
+    _real_replace_dir = hp._replace_dir
+
+    def _failing_replace_dir(src, dest):
+        raise OSError(28, "No space left on device")
+
+    hp._replace_dir = _failing_replace_dir
+    _err = None
+    try:
+        hp.github_extract(asset, os.path.basename(asset), prefix, ["hx"],
+                          _HELIX_PAYLOAD)
+    except OSError as e:
+        _err = e
+    finally:
+        hp._replace_dir = _real_replace_dir
+    check("a payload that fails to publish is reported", _err is not None)
+    check("a failed payload publish puts the previous binary back",
+          open(os.path.join(prefix, "bin", "hx")).read() == "previous hx\n")
+    check("a failed payload publish leaves no binary backup behind",
+          not os.path.exists(os.path.join(prefix, "bin", "hx.prev")))
+
+# A binary's own copy can fail the same way the payload's can, and the rollback
+# has to cover the call that raised -- not just the ones that returned -- or the
+# working binary is stranded at .prev with nothing at the destination.
+with tempfile.TemporaryDirectory() as td:
+    prefix = os.path.join(td, "prefix")
+    bindir = os.path.join(prefix, "bin")
+    os.makedirs(bindir)
+    with open(os.path.join(bindir, "hx"), "w") as f:
+        f.write("previous hx\n")
+    _err = None
+    try:
+        # A source that isn't there fails the copy after the live binary has
+        # already been moved aside.
+        hp._publish_release({"hx": os.path.join(td, "absent")}, [], prefix, bindir)
+    except OSError as e:
+        _err = e
+    check("a binary copy that fails is reported", _err is not None)
+    check("a failed binary copy puts the previous binary back",
+          open(os.path.join(bindir, "hx")).read() == "previous hx\n")
+    check("a failed binary copy strands nothing at .prev",
+          not os.path.exists(os.path.join(bindir, "hx.prev")))
+
+# On a first install there's nothing to put back, so rolling back means removing
+# the binary that did land: "both or neither" has to hold for a fresh prefix too,
+# and a fresh hx with no runtime is the editor-with-no-language-support this
+# payload exists to prevent.
+with tempfile.TemporaryDirectory() as td:
+    prefix = os.path.join(td, "prefix")
+    bindir = os.path.join(prefix, "bin")
+    os.makedirs(bindir)
+    src = os.path.join(td, "hx")
+    with open(src, "w") as f:
+        f.write("#!/bin/sh\n")
+    _real_replace_dir = hp._replace_dir
+
+    def _failing_replace_dir(src, dest):
+        raise OSError(28, "No space left on device")
+
+    hp._replace_dir = _failing_replace_dir
+    try:
+        hp._publish_release({"hx": src}, [("runtime", os.path.join(td, "rt"),
+                                           "share/helix/runtime")], prefix, bindir)
+    except OSError:
+        pass
+    finally:
+        hp._replace_dir = _real_replace_dir
+    check("a rollback on a fresh prefix removes the binary that landed",
+          not os.path.exists(os.path.join(bindir, "hx")))
+    check("a rollback on a fresh prefix leaves no backup behind",
+          not os.path.exists(os.path.join(bindir, "hx.prev")))
+
+# And the same window across runs: a run killed between the rename and the copy
+# leaves the binary at .prev with nothing at the destination, so the next call
+# puts it back before touching anything.
+with tempfile.TemporaryDirectory() as td:
+    prefix = os.path.join(td, "prefix")
+    bindir = os.path.join(prefix, "bin")
+    os.makedirs(bindir)
+    with open(os.path.join(bindir, "hx.prev"), "w") as f:
+        f.write("previous hx\n")
+    try:
+        hp._publish_release({"hx": os.path.join(td, "absent")}, [], prefix, bindir)
+    except OSError:
+        pass
+    check("a binary stranded at .prev by an earlier run is recovered",
+          os.path.exists(os.path.join(bindir, "hx"))
+          and open(os.path.join(bindir, "hx")).read() == "previous hx\n")
+
+# ...and a run that gets all the way through leaves no backup either.
+with tempfile.TemporaryDirectory() as td:
+    prefix = os.path.join(td, "prefix")
+    os.makedirs(os.path.join(prefix, "bin"))
+    with open(os.path.join(prefix, "bin", "hx"), "w") as f:
+        f.write("previous hx\n")
+    asset = os.path.join(td, "helix-x86_64-linux.tar.gz")
+    _make_targz(asset, {"helix-25.07/hx": b"#!/bin/sh\necho hx\n",
+                        "helix-25.07/runtime/themes/dark.toml": b"# dark\n"})
+    hp.github_extract(asset, os.path.basename(asset), prefix, ["hx"], _HELIX_PAYLOAD)
+    check("a successful publish replaces the binary and clears the backup",
+          open(os.path.join(prefix, "bin", "hx")).read() != "previous hx\n"
+          and not os.path.exists(os.path.join(prefix, "bin", "hx.prev")))
+
+# The swap in _replace_dir has one window -- dest moved aside, replacement not
+# yet renamed in -- that an interruption can land in, leaving the payload at
+# .old with nothing at dest. The next call has to put it back, not delete it,
+# or the tool stays without its data files until some later install succeeds.
+with tempfile.TemporaryDirectory() as td:
+    dest = os.path.join(td, "runtime")
+    old = dest + ".old"
+    os.makedirs(old)
+    with open(os.path.join(old, "themes.toml"), "w") as f:
+        f.write("previous\n")
+    # A source that isn't there fails the copy, standing in for the disk filling
+    # up or a Ctrl-C during it -- so recovery is all this call gets to do.
+    try:
+        hp._replace_dir(os.path.join(td, "absent"), dest)
+    except OSError:
+        pass
+    check("_replace_dir recovers a payload an interrupted swap left at .old",
+          os.path.exists(os.path.join(dest, "themes.toml")))
+
+# Recovered and then replaced in one call: the backup is gone afterwards, and
+# what's at dest is the new payload rather than the recovered one.
+with tempfile.TemporaryDirectory() as td:
+    src = os.path.join(td, "src")
+    os.makedirs(src)
+    with open(os.path.join(src, "new.toml"), "w") as f:
+        f.write("new\n")
+    dest = os.path.join(td, "runtime")
+    os.makedirs(dest + ".old")
+    with open(os.path.join(dest + ".old", "themes.toml"), "w") as f:
+        f.write("previous\n")
+    hp._replace_dir(src, dest)
+    check("a recovered payload is still replaced by the new one",
+          os.path.exists(os.path.join(dest, "new.toml"))
+          and not os.path.exists(os.path.join(dest, "themes.toml"))
+          and not os.path.exists(dest + ".old"))
+
+# A payload destination decides which directory gets replaced wholesale, so its
+# shape is constrained rather than trusted: inside the prefix isn't enough. "bin"
+# would move every installed executable aside and delete it; "share/homepkg/..."
+# would do the same to the mamba env; "share" alone would take out both.
+for _bad in ("../../evil", "/etc/evil", "", ".", "bin", "bin/hx", "share",
+             "share/homepkg", "share/homepkg/env", "share/./helix",
+             "lib/helix/runtime"):
+    with tempfile.TemporaryDirectory() as td:
+        prefix = os.path.join(td, "prefix")
+        asset = os.path.join(td, "tool-x86_64-linux.tar.gz")
+        _make_targz(asset, {"tool-1.0/hx": b"#!/bin/sh\n",
+                            "tool-1.0/runtime/x": b"x\n"})
+        _err = None
+        try:
+            hp.github_extract(asset, os.path.basename(asset), prefix, ["hx"],
+                              {"runtime": _bad})
+        except hp.HomepkgError as e:
+            _err = e
+        check(f"github_extract rejects the payload destination {_bad!r}",
+              _err is not None and "payload destination" in str(_err))
+        check(f"nothing is installed for the destination {_bad!r}",
+              not os.path.exists(os.path.join(prefix, "bin", "hx")))
+
+# The concrete damage the shape check prevents: "bin" as a destination would
+# replace the directory every installed executable lives in, and report success.
+with tempfile.TemporaryDirectory() as td:
+    prefix = os.path.join(td, "prefix")
+    bindir = os.path.join(prefix, "bin")
+    os.makedirs(bindir)
+    for _tool in ("rg", "fd", "uv"):
+        with open(os.path.join(bindir, _tool), "w") as f:
+            f.write("#!/bin/sh\n")
+    asset = os.path.join(td, "helix-x86_64-linux.tar.gz")
+    _make_targz(asset, {"helix-25.07/hx": b"#!/bin/sh\n",
+                        "helix-25.07/runtime/themes/dark.toml": b"# dark\n"})
+    _err = None
+    try:
+        hp.github_extract(asset, os.path.basename(asset), prefix, ["hx"],
+                          {"runtime": "bin"})
+    except hp.HomepkgError as e:
+        _err = e
+    check("a payload destination of bin is refused", _err is not None)
+    check("the other installed executables are untouched",
+          sorted(os.listdir(bindir)) == ["fd", "rg", "uv"])
+
+# ...and a manifest can't ask for it in the first place: replaying a bundle takes
+# the payload from the registry, so the only destination that can reach
+# _replace_dir is the one this repo ships.
+with tempfile.TemporaryDirectory() as td:
+    src = os.path.join(td, "src")
+    os.makedirs(os.path.join(src, "assets"))
+    asset = "helix-x86_64-linux.tar.gz"
+    _make_targz(os.path.join(src, "assets", asset),
+                {"helix-25.07/hx": b"#!/bin/sh\n",
+                 "helix-25.07/runtime/themes/dark.toml": b"# dark\n"})
+    with open(os.path.join(src, "manifest.json"), "w") as f:
+        json.dump({"format": 1, "backend": "github", "platform": "linux/x86_64",
+                   "tools": [{"tool": "helix", "asset": asset, "bins": ["hx"],
+                              "payload": {"runtime": "bin"}}]}, f)
+    bundle = os.path.join(td, "tampered.tar.gz")
+    hp._write_bundle(bundle, src)
+    prefix = os.path.join(td, "prefix")
+    os.makedirs(os.path.join(prefix, "bin"))
+    with open(os.path.join(prefix, "bin", "rg"), "w") as f:
+        f.write("#!/bin/sh\n")
+    hp.install_bundle(bundle, prefix, ("linux", "x86_64"), False)
+    check("a manifest's payload destination is ignored for the registry's",
+          os.path.exists(os.path.join(prefix, "share", "helix", "runtime",
+                                      "themes", "dark.toml")))
+    check("a tampered manifest can't replace the binary directory",
+          os.path.exists(os.path.join(prefix, "bin", "rg"))
+          and os.path.exists(os.path.join(prefix, "bin", "hx")))
+
+# _replace_dir has to cope with whatever is already at the destination: a
+# stale symlink (what setup's old cargo path left at ~/.config/helix/runtime),
+# or a plain file.
+for _existing in ("symlink", "file"):
+    with tempfile.TemporaryDirectory() as td:
+        src = os.path.join(td, "src")
+        os.makedirs(src)
+        with open(os.path.join(src, "new"), "w") as f:
+            f.write("new\n")
+        dest = os.path.join(td, "dest")
+        if _existing == "symlink":
+            os.symlink(os.path.join(td, "elsewhere"), dest)
+        else:
+            with open(dest, "w") as f:
+                f.write("old\n")
+        hp._replace_dir(src, dest)
+        check(f"_replace_dir replaces an existing {_existing} at the destination",
+              os.path.isdir(dest) and not os.path.islink(dest)
+              and os.path.exists(os.path.join(dest, "new")))
+
 # --- conda extraction (.tar.bz2, no zstd needed) -----------------------------
 
 with tempfile.TemporaryDirectory() as td:
@@ -858,6 +1248,27 @@ with tempfile.TemporaryDirectory() as td:
     hp.install_bundle(bundle, prefix, ("linux", "x86_64"), False)
     check("install-bundle (combined) unpacks the github half offline",
           os.access(os.path.join(prefix, "bin", "rg"), os.X_OK))
+
+# A bundle built before the payload key existed records only the binaries, so
+# replaying it falls back to the registry's payload -- otherwise an old bundle
+# would install an hx with no runtime and report success.
+with tempfile.TemporaryDirectory() as td:
+    src = os.path.join(td, "src")
+    os.makedirs(os.path.join(src, "assets"))
+    asset = "helix-x86_64-linux.tar.gz"
+    _make_targz(os.path.join(src, "assets", asset),
+                {"helix-25.07/hx": b"#!/bin/sh\necho hx\n",
+                 "helix-25.07/runtime/themes/dark.toml": b"# dark\n"})
+    with open(os.path.join(src, "manifest.json"), "w") as f:
+        json.dump({"format": 1, "backend": "github", "platform": "linux/x86_64",
+                   "tools": [{"tool": "helix", "asset": asset, "bins": ["hx"]}]}, f)
+    bundle = os.path.join(td, "legacy.tar.gz")
+    hp._write_bundle(bundle, src)
+    prefix = os.path.join(td, "prefix")
+    hp.install_bundle(bundle, prefix, ("linux", "x86_64"), False)
+    check("a bundle with no payload recorded falls back to the registry's",
+          os.path.exists(os.path.join(prefix, "share", "helix", "runtime",
+                                      "themes", "dark.toml")))
 
 # A bundle that lost an asset -- built when the release had none for this
 # platform, or truncated in transit -- still installs everything else, and

--- a/setup
+++ b/setup
@@ -18,15 +18,15 @@
 # installed only when a display server is detected. Pass --gui to force
 # them on, or --no-gui to skip them (e.g. on a headless server).
 #
-# The heavyweight extras install from Homebrew bottles when brew is available
-# (or on macOS), and otherwise build from source via a Rust toolchain (rustup
-# + cargo). The brew path covers helix/jj/nushell; shpool has no tap bottle
-# yet, so it stays on the --cargo path for now. Pass --brew to force Homebrew
-# (installing it if needed) -- bottles skip the slow builds and the disk a
-# Rust toolchain needs -- or --cargo to force the from-source path. The extras
-# are skipped when the disk is small (see MIN_DISK_GB). Pass --minimal to
-# force that lean profile, or --full to install everything. To pass flags
-# through a pipe:
+# The heavyweight extras (helix, jj, nushell) install from Homebrew bottles
+# when brew is available (or on macOS), and otherwise from each project's
+# GitHub release artifacts, fetched into ~/.local by homepkg. Nothing is built
+# from source, so no Rust toolchain is installed either way. Pass --brew to
+# force Homebrew (installing it if needed) or --release to force the release
+# artifacts. shpool is no longer installed at all -- see the shpool note by
+# install_extras. The extras are skipped when the disk is small (see
+# MIN_DISK_GB). Pass --minimal to force that lean profile, or --full to
+# install everything. To pass flags through a pipe:
 #     curl -fsSL https://mikelward.com/setup | sh -s -- --no-gui --minimal
 #
 # Pass --no-install to skip all software installation (packages, fonts,
@@ -167,13 +167,13 @@ SUDO="${SUDO:-yes}"
 # Override with --root / --no-root, or by exporting ROOT before running.
 ROOT="${ROOT:-yes}"
 
-# Which backend installs the heavyweight extras (helix, jj, shpool, nushell).
-# One of:
-#   auto  - Homebrew when brew is available or on macOS; else cargo (default)
-#   brew  - install them from Homebrew bottles (fast, prebuilt, no Rust
-#           toolchain or large build dirs), installing Homebrew if needed
-#   cargo - build them from source via rustup + cargo
-# Override with --brew / --cargo.
+# Which backend installs the heavyweight extras (helix, jj, nushell). One of:
+#   auto    - Homebrew when brew is available or on macOS; else the release
+#             artifacts (default)
+#   brew    - install them from Homebrew bottles, installing Homebrew if needed
+#   release - install the prebuilt binaries from each project's GitHub releases
+#             into ~/.local via homepkg (no root, no build)
+# Override with --brew / --release.
 EXTRAS=auto
 
 usage() {
@@ -189,14 +189,13 @@ Options:
   --no-gui         Skip all graphical packages and desktop configuration
   --kde            Accepted for compatibility; KDE Plasma + Krohnkite is the
                    only desktop setup installs/configures (Linux)
-  --minimal        Skip heavyweight extras (Rust toolchain, helix, jj, shpool,
-                   nushell), installing only core packages, tools, and dotfiles
+  --minimal        Skip heavyweight extras (helix, jj, nushell), installing
+                   only core packages, tools, and dotfiles
   --full           Install everything, even when disk space looks tight
   --brew           Install the heavyweight extras (helix, jj, nushell) from
-                   Homebrew bottles instead of building them from source (fast,
-                   no Rust toolchain or large build dirs); installs Homebrew if
-                   needed. shpool has no bottle yet, so use --cargo for it
-  --cargo          Build the heavyweight extras from source via rustup + cargo
+                   Homebrew bottles, installing Homebrew if needed
+  --release        Install the heavyweight extras from their GitHub release
+                   artifacts into ~/.local via homepkg
   --no-install     Skip every install step (packages, fonts, uv, extras, root
                    config) and only (re)apply config. Forwarded to setup-kde/macos
   --no-sudo        Run no sudo at all: every privileged command (package
@@ -228,10 +227,10 @@ Options:
   -h, --help       Show this help and exit
 
 By default graphical components are installed only when a display server
-(X11 or Wayland) is detected, and the heavyweight source-built extras are
-skipped when free disk space is below MIN_DISK_GB (default 15GB), so this
-runs sensibly on headless and small-disk machines. An SSH key is generated
-only when one isn't already loaded in the agent or present on disk.
+(X11 or Wayland) is detected, and the heavyweight extras are skipped when
+free disk space is below MIN_DISK_GB (default 15GB), so this runs sensibly
+on headless and small-disk machines. An SSH key is generated only when one
+isn't already loaded in the agent or present on disk.
 USAGE
 }
 
@@ -408,8 +407,15 @@ while test $# -gt 0; do
         --brew)
             EXTRAS=brew
             ;;
+        --release)
+            EXTRAS=release
+            ;;
         --cargo)
-            EXTRAS=cargo
+            # Kept so an existing invocation still runs: there is no
+            # from-source path left to select, and the release artifacts are
+            # what --cargo was a slower way of getting.
+            warn "--cargo is gone; installing the extras from their release artifacts instead"
+            EXTRAS=release
             ;;
         --install)
             INSTALL=yes
@@ -680,18 +686,19 @@ resolve_minimal() {
     esac
 }
 
-# Resolve $EXTRAS (auto/brew/cargo) into EXTRAS_BACKEND. Auto picks brew when
-# it's available or on macOS, else cargo -- preserving the previous default on
-# Linux without Homebrew. Must run after detect_os.
+# Resolve $EXTRAS (auto/brew/release) into EXTRAS_BACKEND. Auto picks brew when
+# it's available or on macOS, else the release artifacts -- which is also where
+# Linux boxes without Homebrew used to get a Rust toolchain and a source build.
+# Must run after detect_os.
 resolve_extras() {
     case "$EXTRAS" in
         brew)
             EXTRAS_BACKEND=brew
             info "Extras backend: Homebrew (--brew)"
             ;;
-        cargo)
-            EXTRAS_BACKEND=cargo
-            info "Extras backend: cargo/source (--cargo)"
+        release)
+            EXTRAS_BACKEND=release
+            info "Extras backend: GitHub release artifacts (--release)"
             ;;
         *)
             if command -v brew >/dev/null 2>&1; then
@@ -701,8 +708,8 @@ resolve_extras() {
                 EXTRAS_BACKEND=brew
                 info "Extras backend: Homebrew (macOS)"
             else
-                EXTRAS_BACKEND=cargo
-                info "Extras backend: cargo/source (no Homebrew; use --brew to override)"
+                EXTRAS_BACKEND=release
+                info "Extras backend: GitHub release artifacts (no Homebrew; use --brew to override)"
             fi
             ;;
     esac
@@ -731,7 +738,7 @@ install_homebrew() {
         fi
     done
     # Return status reflects whether brew is now usable, so callers can fall
-    # back (e.g. to the cargo source builds) rather than assume success.
+    # back (e.g. to the release artifacts) rather than assume success.
     command -v brew >/dev/null 2>&1
 }
 
@@ -1010,21 +1017,61 @@ install_fonts() {
 
 # --- Start services ---
 
+# Whether there's a systemd user manager to talk to at all. Without one every
+# --user query fails identically ("Failed to connect to bus"), so asking about a
+# unit can't tell "no such unit" from "couldn't ask" -- and nothing could be
+# enabled anyway. Checked with a query that doesn't name a unit, so the only
+# thing its failure can mean is that there's no manager.
+systemd_user_available() {
+    systemctl --user show --property=Version >/dev/null 2>&1
+}
+
+# True when an shpool.service already exists in any form: a distro package's
+# unit, one a previous setup run wrote, or one that's merely loaded (a generated
+# or transient unit with no file behind it). Whatever set it up owns it -- and a
+# unit setup writes into the user config directory silently overrides a packaged
+# one, since user config outranks /usr/lib -- so leave it alone.
+#
+# Both probes need a user manager, and callers check for one first. Asking
+# systemd beats reimplementing its unit load path: that path varies by version,
+# includes places easy to forget ($XDG_DATA_HOME/systemd/user, the generator
+# directories), and a local copy of it would quietly rot.
+#
+# They're questions rather than operations: for a unit systemd has never heard
+# of, systemctl exits non-zero and says "No files found", which is the negative
+# answer and not a failure to report.
+shpool_service_exists() {
+    if systemctl --user cat shpool.service >/dev/null 2>&1; then
+        return 0
+    fi
+    # cat only sees file-backed units, so ask about loaded ones separately.
+    test -n "$(systemctl --user list-units --all --plain --no-legend \
+        shpool.service 2>/dev/null)"
+}
+
 start_services() {
     case "$OS" in
         debian|redhat)
-            # Enable shpool as a systemd user service. Use the resolved
-            # shpool path in ExecStart rather than hard-coding
-            # %h/.cargo/bin/shpool: under --minimal we skip the cargo
-            # install, and shpool may instead come from a distro/Nix
-            # package elsewhere on PATH. Pointing the unit at a
-            # nonexistent ~/.cargo/bin/shpool would make `enable --now`
-            # fail and abort the whole bootstrap under set -e.
+            # setup doesn't install shpool at all (see the note by
+            # install_extras), so all this does is give a systemd user service
+            # to an shpool that arrived some other way -- a distro/Nix package,
+            # or a hand-run cargo install -- and only when nothing has set one
+            # up already. Use the resolved shpool path in ExecStart rather than
+            # hard-coding %h/.cargo/bin/shpool: pointing the unit at a
+            # nonexistent binary would just make `enable --now` fail.
             if command -v shpool >/dev/null 2>&1 && command -v systemctl >/dev/null 2>&1; then
-                shpool_bin=$(command -v shpool)
-                shpool_service_dir="$HOME/.config/systemd/user"
-                shpool_service="$shpool_service_dir/shpool.service"
-                if ! test -f "$shpool_service"; then
+                if ! systemd_user_available; then
+                    # Asked first, because the probes below can't answer without
+                    # a manager. Nothing could be enabled here anyway, and
+                    # writing a unit blind would leave an override shadowing
+                    # whatever a packaged unit turns out to be once there is one.
+                    warn "no systemd user manager to query; leaving shpool.service alone rather than write an override blind"
+                elif shpool_service_exists; then
+                    info "shpool.service is already set up; leaving it alone"
+                else
+                    shpool_bin=$(command -v shpool)
+                    shpool_service_dir="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+                    shpool_service="$shpool_service_dir/shpool.service"
                     info "Creating shpool systemd user service"
                     mkdir -p "$shpool_service_dir"
                     cat > "$shpool_service" <<SERVICE
@@ -1039,10 +1086,19 @@ Restart=on-failure
 [Install]
 WantedBy=default.target
 SERVICE
-                    systemctl --user daemon-reload
+                    # Both steps are best-effort even though a manager answered
+                    # a moment ago: an optional session daemon must not take the
+                    # bootstrap down with it. The unit file stays either way --
+                    # it's valid, and nothing shadows it, since we only get here
+                    # when no other shpool.service exists.
+                    if systemctl --user daemon-reload; then
+                        info "Enabling and starting shpool service"
+                        systemctl --user enable --now shpool.service \
+                            || warn "wrote the shpool service but could not enable it; sessions fall back to tmux"
+                    else
+                        warn "wrote the shpool service but could not reload the systemd user manager, so it is not enabled"
+                    fi
                 fi
-                info "Enabling and starting shpool service"
-                systemctl --user enable --now shpool.service
             fi
             ;;
         macos)
@@ -1052,88 +1108,63 @@ SERVICE
     esac
 }
 
-# --- Install or update Rust, cargo, and rustup, using rustup ---
+# --- The Helix runtime ---
 
-install_rust() {
-    # Ensure cargo/rustup are on PATH even if profile hasn't been sourced
-    if test -f "$HOME/.cargo/env"; then
-        # shellcheck source=/dev/null
-        . "$HOME/.cargo/env"
-    fi
+# hx loads grammars, queries, and themes from a runtime directory, and searches
+# <config dir>/runtime ahead of both $HELIX_RUNTIME and anything beside the
+# binary. Each install path below brings its own runtime, so a symlink one of
+# them left in the config directory shadows the next one's -- these two keep
+# that straight.
 
-    if command -v rustup >/dev/null 2>&1; then
-        info "Updating Rust toolchain"
-        rustup update
-    else
-        info "Installing Rust via rustup"
-        # -y runs unattended; --no-modify-path keeps rustup out of the shell
-        # rc/profile files, since PATH is managed by the conf repo. We source
-        # ~/.cargo/env below so cargo is on PATH for the rest of this run.
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path
-        # shellcheck source=/dev/null
-        . "$HOME/.cargo/env"
-    fi
-}
-
-# --- Install jj (Jujutsu) ---
-
-install_jj() {
-    if ! command -v cargo >/dev/null 2>&1; then
-        warn "cargo not found, skipping jj installation"
+# Point ~/.config/helix/runtime at the runtime tree homepkg unpacked from the
+# release asset, replacing whatever an earlier install path left there.
+link_helix_runtime() {
+    helix_runtime_src="$1/share/helix/runtime"
+    if ! test -d "$helix_runtime_src"; then
+        warn "hx is installed but its runtime directory is missing; it will start with no grammars or queries"
         return
     fi
-
-    info "Installing/updating jj via cargo"
-    cargo install --locked jj-cli
-}
-
-# --- Install shpool ---
-
-install_shpool() {
-    if ! command -v cargo >/dev/null 2>&1; then
-        warn "cargo not found, skipping shpool installation"
-        return
-    fi
-
-    info "Installing/updating shpool via cargo"
-    cargo install --locked shpool
-}
-
-# --- Install Helix editor ---
-
-install_helix() {
-    if ! command -v cargo >/dev/null 2>&1; then
-        warn "cargo not found, skipping helix installation"
-        return
-    fi
-
-    helix_dir="$SRC_DIR/helix"
-    clone_or_pull "https://github.com/helix-editor/helix" "$helix_dir"
-    info "Installing/updating helix via cargo"
-    cargo install --path "$helix_dir/helix-term" --locked
-
-    # Link runtime files so hx can find grammars and queries
     helix_config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/helix"
     mkdir -p "$helix_config_dir"
-    ln -sfn "$helix_dir/runtime" "$helix_config_dir/runtime"
+    info "Pointing the Helix runtime at the installed release runtime"
+    ln -sfn "$helix_runtime_src" "$helix_config_dir/runtime"
 }
 
-# --- Install Nushell ---
-
-install_nushell() {
-    if ! command -v cargo >/dev/null 2>&1; then
-        warn "cargo not found, skipping nushell installation"
-        return
-    fi
-
-    info "Installing/updating nushell via cargo"
-    cargo install --locked nu
+# Drop ~/.config/helix/runtime when it points at a runtime tree setup itself
+# put there -- the old cargo source checkout, or a release install's payload --
+# so the hx being installed now uses the runtime that came with it. Anything
+# else (a hand-made symlink, a real directory) is left alone.
+#
+# One exception: the release install's hx is a plain file in ~/.local/bin, which
+# no other install path removes, and ~/.local/bin is on PATH. While that binary
+# is still there it may well be the hx that runs, and taking its runtime away
+# leaves it with no grammars at all -- a worse outcome than the version skew of
+# leaving it in place, since the config directory runtime shadows every hx on
+# the box and only one of the two can be right. Keep it, and say so; removing
+# the superseded binary is the user's call, not this script's.
+clear_managed_helix_runtime() {
+    helix_runtime="${XDG_CONFIG_HOME:-$HOME/.config}/helix/runtime"
+    test -L "$helix_runtime" || return 0
+    helix_release_runtime="$HOME/.local/share/helix/runtime"
+    case "$(readlink "$helix_runtime")" in
+        "$SRC_DIR/helix/runtime")
+            ;;
+        "$helix_release_runtime")
+            if test -f "$HOME/.local/bin/hx" && ! test -L "$HOME/.local/bin/hx"; then
+                warn "keeping the Helix runtime: the release hx in ~/.local/bin still needs it. Remove that binary if you want the hx just installed to own the runtime"
+                return 0
+            fi
+            ;;
+        *) return 0 ;;
+    esac
+    info "Removing the Helix runtime symlink left by a previous install path"
+    rm -f "$helix_runtime"
 }
 
 # --- Install the heavyweight extras ---
 
 # helix, jj, and nushell live in homebrew-core with prebuilt Linux/macOS
-# bottles. shpool isn't in core; it ships from the shell-pool/shpool tap.
+# bottles, each bottle carrying its own helix runtime.
 install_extras_brew() {
     # One formula at a time so a single failure doesn't block the rest.
     helix_installed=no
@@ -1145,46 +1176,68 @@ install_extras_brew() {
             warn "could not install $formula via Homebrew"
         fi
     done
-    # A prior cargo run points ~/.config/helix/runtime at the source checkout,
-    # and hx searches that before the bottle's bundled runtime -- so drop the
-    # symlink (only the one install_helix created) to avoid stale grammars.
-    # Only when brew actually installed helix: otherwise a prior cargo hx would
-    # lose the runtime it still needs.
-    helix_runtime="${XDG_CONFIG_HOME:-$HOME/.config}/helix/runtime"
-    if test "$helix_installed" = yes \
-            && test -L "$helix_runtime" \
-            && test "$(readlink "$helix_runtime")" = "$SRC_DIR/helix/runtime"; then
-        info "Removing stale Helix runtime symlink from the cargo build"
-        rm -f "$helix_runtime"
+    # Only when brew actually installed helix: otherwise an hx from another
+    # path would lose the runtime it still needs.
+    if test "$helix_installed" = yes; then
+        clear_managed_helix_runtime
     fi
-    # TODO (follow-up PR): re-add shpool here optimistically -- attempt the
-    # install and warn on failure. It has no brew bottle, but should be
-    # available via apt on the system path.
-    warn "shpool is not installed on the brew path yet; use --cargo (or apt) for shpool"
 }
 
-# The from-source path: rustup + cargo builds of every extra. Slower and
-# disk-heavy, but needs no Homebrew.
-install_extras_cargo() {
-    install_rust
-    install_helix
-    install_jj
-    install_shpool
-    install_nushell
+# The release-artifact path: the prebuilt binaries each project publishes with
+# its own GitHub releases, fetched by homepkg into ~/.local. No Homebrew and no
+# root -- and no build, which is what this used to spend a Rust toolchain and
+# several minutes per box on.
+#
+# helix's asset carries the hx binary and the runtime/ tree hx needs at run
+# time; homepkg installs both (its registry's "payload" key) and
+# link_helix_runtime points hx at the result.
+install_extras_release() {
+    homepkg="$SCRIPTS_DIR/homepkg"
+    if ! test -x "$homepkg"; then
+        warn "homepkg not found in the scripts repo; skipping helix, jj, and nushell"
+        return 0
+    fi
+    info "Installing helix, jj, and nushell from their GitHub release artifacts"
+    "$homepkg" --backend github install helix jj nu \
+        || warn "some of helix, jj, and nushell could not be installed from their releases (offline?)"
+    # A partial run can still have landed helix, so wire up its runtime on the
+    # strength of the binary being there rather than of homepkg's exit status.
+    # A release hx is a plain file; an hx that's a symlink is homepkg's, pointing
+    # into its conda env, and it carries its own runtime -- so a failed release
+    # install on a box provisioned that way must not point that hx at a release
+    # payload left over from before.
+    if test -f "$HOME/.local/bin/hx" && ! test -L "$HOME/.local/bin/hx"; then
+        link_helix_runtime "$HOME/.local"
+    fi
 }
 
 # Dispatch to the resolved extras backend. When Homebrew is requested but
-# can't be made available, fall back to the cargo/source builds.
+# can't be made available, fall back to the release artifacts.
 install_extras() {
     if test "$EXTRAS_BACKEND" = brew; then
         if install_homebrew; then
             install_extras_brew
             return
         fi
-        warn "Homebrew unavailable; building the extras from source with cargo instead"
+        warn "Homebrew unavailable; installing the extras from their release artifacts instead"
     fi
-    install_extras_cargo
+    install_extras_release
 }
+
+# --- shpool ---
+#
+# setup doesn't install shpool. It publishes no release artifact, isn't in
+# homebrew-core or the shell-pool tap as a bottle, and has no conda-forge
+# feedstock, so a cargo build was the only way to get it -- and building from
+# source is what this script no longer does.
+#
+# Sessions still prefer shpool wherever something else has put it on PATH (a
+# distro package, a manual cargo install): sessionlib picks it over tmux, and
+# start_services enables a systemd user service for whichever shpool it finds.
+#
+# TODO: install shpool again once there's a prebuilt artifact to fetch --
+# upstream release binaries, a brew bottle, or a conda-forge feedstock (which
+# would give the --no-root homepkg path a way to provide it too).
 
 # --- Install CLI tools into a home prefix (--no-root) ---
 
@@ -1217,10 +1270,11 @@ install_home_tools() {
     fi
     if test "$MINIMAL_ENABLED" -eq 0; then
         tools="$tools helix jj nu"
-        # shpool is source-only (no conda-forge/prebuilt artifact), so neither
-        # the homepkg nor the brew path can provide it. start_services skips its
-        # user service when shpool is absent, so the shell falls back to tmux.
-        warn "shpool is not available on the homepkg path (source-only); sessions fall back to tmux"
+        # shpool has no prebuilt artifact anywhere, so none of setup's install
+        # paths can provide it (see the shpool note by install_extras).
+        # start_services skips its user service when shpool is absent, so the
+        # shell falls back to tmux.
+        warn "shpool is not installed by setup (no prebuilt artifact); sessions fall back to tmux unless it's installed some other way"
     fi
 
     # Optimistic provisioning. On a FRESH env, prefer a prebuilt bundle (which
@@ -1300,17 +1354,19 @@ install_home_tools() {
         *) PATH="$HOME/.local/bin:$PATH" ;;
     esac
 
-    # A prior cargo run points ~/.config/helix/runtime at the source checkout,
-    # and hx searches that before the prebuilt runtime -- so drop the stale
-    # symlink (only the one install_helix created). Gate on hx actually being
-    # installed by homepkg (which links it into ~/.local/bin) rather than the
-    # minimal profile: a full bundle can install helix even under --minimal.
-    helix_runtime="${XDG_CONFIG_HOME:-$HOME/.config}/helix/runtime"
-    if test -x "$HOME/.local/bin/hx" \
-            && test -L "$helix_runtime" \
-            && test "$(readlink "$helix_runtime")" = "$SRC_DIR/helix/runtime"; then
-        info "Removing stale Helix runtime symlink from the cargo build"
-        rm -f "$helix_runtime"
+    # This path's helix comes from conda-forge, with its runtime inside the
+    # homepkg env, so a symlink left in the config directory by another install
+    # path has to go -- hx searches there first. Gate on the hx that will
+    # actually run being the env's, not merely on some hx existing: homepkg
+    # links the env's binaries into ~/.local/bin but deliberately leaves a
+    # conflicting regular file alone, so on a box that installed the release hx
+    # first, that release binary is still what runs -- and clearing the runtime
+    # symlink would take its grammars away. Gating on the link rather than on
+    # the minimal profile also covers a full bundle, which can install helix
+    # even under --minimal.
+    if test -L "$HOME/.local/bin/hx" \
+            && test "$(readlink "$HOME/.local/bin/hx")" = "$env_dir/bin/hx"; then
+        clear_managed_helix_runtime
     fi
 }
 
@@ -1732,17 +1788,17 @@ if test -f "$CONF_DIR/vcs/Makefile"; then
 fi
 
 if test "$INSTALL" = no; then
-    info "Skipping heavyweight extras (helix, jj, shpool, nushell); --no-install"
+    info "Skipping heavyweight extras (helix, jj, nushell); --no-install"
 elif test "$ROOT" = no; then
     # Unprivileged (--no-root): apt/dnf were skipped, so install the CLI tools
     # (the core distro package set plus the extras) into a home prefix with
     # homepkg instead. --no-sudo alone (ROOT=yes) leaves this to install_extras
-    # below, whose cargo/brew builds are themselves rootless.
+    # below, whose brew and release installs are themselves rootless.
     install_home_tools
 elif test "$MINIMAL_ENABLED" -eq 0; then
     install_extras
 else
-    info "Skipping heavyweight extras (helix, jj, shpool, nushell); minimal profile"
+    info "Skipping heavyweight extras (helix, jj, nushell); minimal profile"
 fi
 
 # atuin/carapace are small static binaries with no packaged build, so they're
@@ -1775,11 +1831,12 @@ fi
 if test "$INSTALL" = yes; then
     mkdir -p "$SRC_DIR"
     clone_or_pull "$ROOT_REPO" "$ROOT_DIR" yes
-    # The default root config builds helper tools that require cargo. When
-    # cargo isn't available -- the --brew extras path skips the Rust toolchain,
-    # as does --minimal -- install the legacy config from the legacy/ subdir
-    # instead. Source ~/.cargo/env first so a previously installed toolchain
-    # still counts as available even on a run that skipped install_rust.
+    # The default root config builds helper tools that require cargo. setup
+    # installs no Rust toolchain of its own any more (the extras come prebuilt
+    # from Homebrew or from release artifacts), so this uses whatever toolchain
+    # the machine already has and installs the legacy config from the legacy/
+    # subdir when there is none. Source ~/.cargo/env first so a rustup
+    # toolchain counts as available even in a non-login shell.
     if test -f "$HOME/.cargo/env"; then
         # shellcheck source=/dev/null
         . "$HOME/.cargo/env"
@@ -1790,7 +1847,7 @@ if test "$INSTALL" = yes; then
             || warn "skipping root config installation"
     else
         info "cargo unavailable; installing the legacy root config from $ROOT_DIR/legacy"
-        info "(no Rust toolchain this run; use --cargo, --full, or 'brew install rust' for the primary Rust root config)"
+        info "(install a Rust toolchain -- rustup, or 'brew install rust' -- for the primary Rust root config)"
         sudo_or_warn make -C "$ROOT_DIR/legacy" install \
             || warn "skipping legacy root config installation"
     fi

--- a/setup_test
+++ b/setup_test
@@ -210,12 +210,274 @@ run_missing_homepkg_warnings() {
 
     set +e
     output="$(sh -c "SCRIPTS_DIR='$missing_scripts_dir'
-$(extract_functions "info warn install_home_tools install_shell_tools")
+$(extract_functions "info warn install_home_tools install_shell_tools install_extras_release")
 install_home_tools
-install_shell_tools" 2>&1)"
+install_shell_tools
+install_extras_release" 2>&1)"
     status=$?
     set -e
     rm -rf "$homepkg_tmpdir"
+}
+
+# Run one of the Helix runtime helpers against a sandboxed HOME, so the tests
+# check what it did to ~/.config/helix/runtime rather than what the source says.
+#   $1  the call to make, e.g. clear_managed_helix_runtime
+#   $2  what's at the config runtime path to begin with:
+#       cargo (a symlink to the old source checkout) | release (a symlink to
+#       the release payload) | foreign (someone else's symlink) | none
+#   $3  whether the release payload exists in the prefix (default yes)
+#   $4  what ~/.local/bin/hx is: none (default) | release-file (the plain file a
+#       release install leaves, which no other path removes) | env-link
+# Leaves $helix_link_target set to what the symlink points at afterwards, or
+# empty when there's no symlink there.
+run_helix_runtime_helper() {
+    helix_call="$1"
+    helix_existing="$2"
+    helix_payload="${3:-yes}"
+    helix_hx="${4:-none}"
+    helix_tmpdir="$(mktemp -d)"
+    helix_home="$helix_tmpdir/home"
+    helix_config="$helix_home/.config"
+    helix_link="$helix_config/helix/runtime"
+    mkdir -p "$helix_config/helix" "$helix_home/src/helix/runtime" "$helix_home/.local/bin"
+    if test "$helix_payload" = yes; then
+        mkdir -p "$helix_home/.local/share/helix/runtime"
+    fi
+    case "$helix_existing" in
+        cargo)   ln -sfn "$helix_home/src/helix/runtime" "$helix_link" ;;
+        release) ln -sfn "$helix_home/.local/share/helix/runtime" "$helix_link" ;;
+        foreign) ln -sfn "$helix_tmpdir/elsewhere" "$helix_link" ;;
+        none)    ;;
+    esac
+    case "$helix_hx" in
+        release-file)
+            printf '#!/bin/sh\n' > "$helix_home/.local/bin/hx"
+            chmod +x "$helix_home/.local/bin/hx"
+            ;;
+        env-link)
+            mkdir -p "$helix_home/.local/share/homepkg/env/bin"
+            printf '#!/bin/sh\n' > "$helix_home/.local/share/homepkg/env/bin/hx"
+            chmod +x "$helix_home/.local/share/homepkg/env/bin/hx"
+            ln -sfn "$helix_home/.local/share/homepkg/env/bin/hx" "$helix_home/.local/bin/hx"
+            ;;
+        none)
+            ;;
+    esac
+
+    set +e
+    # XDG_CONFIG_HOME is set explicitly rather than unset: the helpers fall back
+    # to $HOME/.config, and a real one in the environment running the tests
+    # would otherwise send them at the developer's own config directory.
+    output="$(sh -c "set -e
+HOME='$helix_home'
+XDG_CONFIG_HOME='$helix_config'
+SRC_DIR='$helix_home/src'
+$(extract_functions "info warn link_helix_runtime clear_managed_helix_runtime")
+$helix_call
+echo BOOTSTRAP_CONTINUED" 2>&1)"
+    status=$?
+    set -e
+    if test -L "$helix_link"; then
+        helix_link_target="$(readlink "$helix_link")"
+    else
+        helix_link_target=""
+    fi
+    rm -rf "$helix_tmpdir"
+}
+
+# Run install_extras_release against a mock homepkg, so the tests check the
+# command it issues and what it does with the result.
+#   $1  exit status for the mock homepkg
+#   $2  what ~/.local/bin/hx is afterwards: yes (a release plain file, i.e.
+#       helix installed) | no (nothing) | env-link (homepkg's symlink into its
+#       conda env, from an earlier --no-root run)
+# Leaves $calls set to the homepkg invocations and $helix_link_target to what
+# ~/.config/helix/runtime points at afterwards.
+run_install_extras_release() {
+    release_status="$1"
+    release_hx="$2"
+    release_tmpdir="$(mktemp -d)"
+    release_home="$release_tmpdir/home"
+    release_link="$release_home/.config/helix/runtime"
+    mkdir -p "$release_home/.local/bin" "$release_home/scripts" "$release_home/.config"
+    cat > "$release_home/scripts/homepkg" <<MOCK
+#!/bin/sh
+printf '%s\n' "homepkg \$*" >> "$release_tmpdir/calls"
+exit $release_status
+MOCK
+    chmod +x "$release_home/scripts/homepkg"
+    case "$release_hx" in
+        yes)
+            mkdir -p "$release_home/.local/share/helix/runtime"
+            printf '#!/bin/sh\n' > "$release_home/.local/bin/hx"
+            chmod +x "$release_home/.local/bin/hx"
+            ;;
+        env-link)
+            # A release payload left on disk from before, with hx now homepkg's
+            # symlink into its env -- which brings its own runtime.
+            mkdir -p "$release_home/.local/share/helix/runtime" \
+                "$release_home/.local/share/homepkg/env/bin"
+            printf '#!/bin/sh\n' > "$release_home/.local/share/homepkg/env/bin/hx"
+            chmod +x "$release_home/.local/share/homepkg/env/bin/hx"
+            ln -sfn "$release_home/.local/share/homepkg/env/bin/hx" \
+                "$release_home/.local/bin/hx"
+            ;;
+        no)
+            ;;
+    esac
+
+    set +e
+    output="$(sh -c "set -e
+HOME='$release_home'
+XDG_CONFIG_HOME='$release_home/.config'
+SRC_DIR='$release_home/src'
+SCRIPTS_DIR='$release_home/scripts'
+$(extract_functions "info warn link_helix_runtime install_extras_release")
+install_extras_release
+echo BOOTSTRAP_CONTINUED" 2>&1)"
+    status=$?
+    set -e
+    calls="$(cat "$release_tmpdir/calls" 2>/dev/null)"
+    if test -L "$release_link"; then
+        helix_link_target="$(readlink "$release_link")"
+    else
+        helix_link_target=""
+    fi
+    rm -rf "$release_tmpdir"
+}
+
+# Run start_services' Linux arm against mocked shpool and systemctl, so the
+# tests check what it does about the service rather than what the source says.
+#   $1  what systemd already knows about shpool.service:
+#       cat (a unit file it can show) | loaded (listed, but no file to show) |
+#       none
+#   $2  how the mock systemctl behaves (default ok):
+#       ok | nobus (no user manager: every --user query fails alike) |
+#       enable-fails
+#   $3  whether a unit file is already in the sandboxed user unit directory
+#       (default no), to check an existing one is never rewritten
+# Leaves $calls set to the systemctl invocations, $services_unit_written to
+# whether a unit file is there afterwards, and $services_unit_body to its
+# contents, so a test can tell "left alone" from "rewritten".
+run_start_services() {
+    services_known="$1"
+    services_mode="${2:-ok}"
+    services_seed_unit="${3:-no}"
+    services_tmpdir="$(mktemp -d)"
+    services_home="$services_tmpdir/home"
+    services_calls="$services_tmpdir/calls"
+    services_unit="$services_home/.config/systemd/user/shpool.service"
+    mkdir -p "$services_home/.config/systemd/user"
+    if test "$services_seed_unit" = yes; then
+        printf 'the unit that was already here\n' > "$services_unit"
+    fi
+    printf '#!/bin/sh\n' > "$services_tmpdir/shpool"
+    cat > "$services_tmpdir/systemctl" <<MOCK
+#!/bin/sh
+printf '%s\n' "systemctl \$*" >> "$services_calls"
+# With no user manager every --user query fails identically -- the case that
+# must not be read as "systemd has never heard of that unit".
+test "$services_mode" = nobus && exit 1
+for arg in "\$@"; do
+    case "\$arg" in
+        show)
+            exit 0
+            ;;
+        cat)
+            # Non-zero for a unit systemd has never heard of, like the real one.
+            test "$services_known" = cat
+            exit \$?
+            ;;
+        list-units)
+            if test "$services_known" = loaded; then
+                echo "  shpool.service loaded active running shpool session manager"
+            fi
+            exit 0
+            ;;
+        enable)
+            test "$services_mode" = enable-fails && exit 1
+            exit 0
+            ;;
+    esac
+done
+exit 0
+MOCK
+    chmod +x "$services_tmpdir/shpool" "$services_tmpdir/systemctl"
+
+    set +e
+    output="$(PATH="$services_tmpdir:$PATH" \
+        sh -c "set -e
+OS=debian
+HOME='$services_home'
+XDG_CONFIG_HOME='$services_home/.config'
+$(extract_functions "info warn systemd_user_available shpool_service_exists start_services")
+start_services
+echo BOOTSTRAP_CONTINUED" 2>&1)"
+    status=$?
+    set -e
+    calls="$(cat "$services_calls" 2>/dev/null)"
+    services_unit_body=""
+    if test -f "$services_unit"; then
+        services_unit_written=yes
+        services_unit_body="$(cat "$services_unit")"
+    else
+        services_unit_written=no
+    fi
+    rm -rf "$services_tmpdir"
+}
+
+# Run install_home_tools against a mock homepkg, with the config runtime symlink
+# already pointing at a release payload, so the tests can check whether it's
+# cleared on the strength of which hx would actually run.
+#   $1  what ~/.local/bin/hx is: env-link (homepkg's symlink into its env) |
+#       release-file (a regular file the release path installed, which homepkg
+#       leaves alone) | absent
+# Leaves $helix_link_target set to what ~/.config/helix/runtime points at.
+run_home_tools_helix() {
+    ht_kind="$1"
+    ht_tmpdir="$(mktemp -d)"
+    ht_home="$ht_tmpdir/home"
+    ht_env_bin="$ht_home/.local/share/homepkg/env/bin"
+    ht_payload="$ht_home/.local/share/helix/runtime"
+    ht_link="$ht_home/.config/helix/runtime"
+    mkdir -p "$ht_home/.local/bin" "$ht_env_bin" "$ht_home/.config/helix" \
+        "$ht_home/scripts" "$ht_payload"
+    printf '#!/bin/sh\nexit 0\n' > "$ht_home/scripts/homepkg"
+    printf '#!/bin/sh\n' > "$ht_env_bin/hx"
+    chmod +x "$ht_home/scripts/homepkg" "$ht_env_bin/hx"
+    # The state a previous release-path run leaves behind.
+    ln -sfn "$ht_payload" "$ht_link"
+    case "$ht_kind" in
+        env-link)
+            ln -sfn "$ht_env_bin/hx" "$ht_home/.local/bin/hx"
+            ;;
+        release-file)
+            printf '#!/bin/sh\n' > "$ht_home/.local/bin/hx"
+            chmod +x "$ht_home/.local/bin/hx"
+            ;;
+        absent)
+            ;;
+    esac
+
+    set +e
+    output="$(sh -c "set -e
+HOME='$ht_home'
+XDG_CONFIG_HOME='$ht_home/.config'
+SRC_DIR='$ht_home/src'
+SCRIPTS_DIR='$ht_home/scripts'
+MINIMAL_ENABLED=0
+NPM=yes
+$(extract_functions "info warn install_home_tools clear_managed_helix_runtime")
+install_home_tools
+echo BOOTSTRAP_CONTINUED" 2>&1)"
+    status=$?
+    set -e
+    if test -L "$ht_link"; then
+        helix_link_target="$(readlink "$ht_link")"
+    else
+        helix_link_target=""
+    fi
+    rm -rf "$ht_tmpdir"
 }
 
 assert_output_lacks() {
@@ -371,14 +633,18 @@ test_fnm_installed() {
     assert_source_not_contains "fnm use lts-latest"
 }
 
-# --- Rust / cargo ---
+# --- No source builds ---
 
-# rustup edits the shell rc/profile files by default to put ~/.cargo/bin on
-# PATH. --no-modify-path keeps it out of them, since PATH is managed by the
-# conf repo, not setup. -y still runs the install unattended.
-test_rust_installs_without_modifying_path() {
-    assert_source_contains "sh -s -- -y --no-modify-path" &&
-    assert_source_not_contains "sh.rustup.rs | sh -s -- -y$"
+# The extras arrive prebuilt now -- Homebrew bottles or release artifacts -- so
+# setup builds nothing from source and installs no Rust toolchain of its own.
+# (The yazi hints still name a cargo command for the user to run by hand; those
+# are messages, not installs.)
+test_no_source_builds() {
+    assert_source_not_contains "sh.rustup.rs" &&
+    assert_source_not_contains "rustup update" &&
+    assert_source_not_contains "cargo install --locked jj-cli" &&
+    assert_source_not_contains "cargo install --locked shpool" &&
+    assert_source_not_contains "cargo install --path"
 }
 
 # --- uv ---
@@ -398,17 +664,27 @@ test_uv_installs_without_modifying_path() {
     assert_source_contains "could not install uv"
 }
 
-# --- Homebrew extras backend ---
+# --- Extras backends ---
 
-# The heavyweight extras (helix, jj, shpool, nushell) can install from Homebrew
-# bottles instead of building from source. --brew / --cargo pick the backend,
-# resolved via EXTRAS_BACKEND, and install_extras dispatches to it.
+# The heavyweight extras (helix, jj, nushell) install from Homebrew bottles or
+# from release artifacts. --brew / --release pick the backend, resolved via
+# EXTRAS_BACKEND, and install_extras dispatches to it.
 test_extras_backend_flags() {
     assert_source_contains '[-]-brew)' &&
-    assert_source_contains '[-]-cargo)' &&
+    assert_source_contains '[-]-release)' &&
     assert_source_contains "EXTRAS_BACKEND" &&
     assert_source_contains "resolve_extras" &&
     assert_source_contains "install_extras"
+}
+
+# --cargo used to select the source builds, which no longer exist. It still
+# parses -- an existing invocation shouldn't die on an unknown option -- and
+# says what it did instead of silently meaning something else.
+test_cargo_flag_is_accepted_and_reported() {
+    run_setup --cargo --help
+    assert_status 0 &&
+    assert_output_contains "--cargo is gone" &&
+    assert_output_contains "release artifacts"
 }
 
 # The brew path installs helix/jj/nushell from homebrew-core, each on its own
@@ -418,20 +694,131 @@ test_extras_brew_formulae() {
     assert_source_contains 'brew install "$formula"'
 }
 
-# The shell-pool/shpool tap has no bottle (source-only), which would defeat
-# the brew path, so shpool is omitted from the brew extras with a TODO to add
-# it back. It still installs on the cargo path via install_shpool.
-test_shpool_omitted_from_brew_with_todo() {
+# shpool has no prebuilt artifact anywhere -- no release binaries, no bottle,
+# no conda-forge package -- and building from source is the one thing setup no
+# longer does, so nothing installs it, with a TODO to pick it up again once
+# there's an artifact. What stays is the setup for a shpool that got here some
+# other way: the systemd user service, gated on finding the binary.
+test_shpool_not_installed_with_todo() {
     assert_source_not_contains "shell-pool/shpool/shpool" &&
-    assert_source_contains "re-add shpool" &&
-    assert_source_contains "install_shpool"
+    assert_source_not_contains "install_shpool" &&
+    assert_source_contains "TODO: install shpool again" &&
+    assert_source_contains 'command -v shpool' &&
+    assert_source_contains 'shpool_bin=$(command -v shpool)' &&
+    assert_source_contains "Enabling and starting shpool service"
 }
 
-# When Homebrew can't be made available, the brew path falls back to building
-# the extras from source with cargo/rustup.
-test_extras_brew_falls_back_to_cargo() {
-    assert_source_contains "install_extras_cargo" &&
-    assert_source_contains "Homebrew unavailable; building the extras from source"
+# --- The shpool systemd user service ---
+
+# A unit file systemd can show belongs to whatever installed it -- typically a
+# distro package under /usr/lib/systemd/user. Writing one into
+# ~/.config/systemd/user would override it, since user config outranks /usr/lib,
+# so setup writes nothing and enables nothing.
+test_shpool_service_skipped_when_a_unit_file_exists() {
+    run_start_services cat
+    assert_status 0 &&
+    assert_eq "$services_unit_written" no &&
+    assert_output_contains "already set up; leaving it alone" &&
+    assert_output_lacks "Creating shpool systemd user service"
+}
+
+# `systemctl --user cat` only sees file-backed units, so a service that's merely
+# loaded -- what `list-units` reports on a box where something already set it up
+# -- has to count as existing too.
+test_shpool_service_skipped_when_the_unit_is_loaded() {
+    run_start_services loaded
+    assert_status 0 &&
+    assert_eq "$services_unit_written" no &&
+    assert_output_contains "already set up; leaving it alone"
+}
+
+# With no shpool.service anywhere, setup still provides one for an shpool that
+# got onto PATH some other way -- pointed at that shpool, not at a hard-coded
+# ~/.cargo/bin path.
+test_shpool_service_written_when_absent() {
+    run_start_services none
+    assert_status 0 &&
+    assert_eq "$services_unit_written" yes &&
+    assert_output_contains "Creating shpool systemd user service" &&
+    assert_calls_contain "systemctl --user daemon-reload" &&
+    assert_calls_contain "systemctl --user enable --now shpool.service"
+}
+
+# A box with no systemd user manager (a bare ssh session, a container) fails
+# every --user query, which is indistinguishable from "no such unit". Guessing
+# "no unit" there and writing one would leave an override shadowing whatever a
+# packaged unit turns out to be, and nothing could be enabled anyway -- so skip,
+# and say why.
+test_shpool_service_skipped_without_a_user_manager() {
+    run_start_services none nobus
+    assert_status 0 &&
+    assert_eq "$services_unit_written" no &&
+    assert_output_contains "no systemd user manager to query" &&
+    assert_output_contains "BOOTSTRAP_CONTINUED"
+}
+
+# Same when a unit file is already sitting there: with no manager to ask, an
+# existing unit is left exactly as it was rather than rewritten.
+test_shpool_unit_file_untouched_without_a_user_manager() {
+    run_start_services none nobus yes
+    assert_status 0 &&
+    assert_eq "$services_unit_body" "the unit that was already here" &&
+    assert_output_contains "no systemd user manager to query"
+}
+
+# A manager that answers and then fails the enable anyway must not take the
+# bootstrap down, and the failure has to be reported rather than swallowed.
+test_shpool_service_failure_is_reported_not_fatal() {
+    run_start_services none enable-fails
+    assert_status 0 &&
+    assert_eq "$services_unit_written" yes &&
+    assert_output_contains "could not enable it" &&
+    assert_output_contains "BOOTSTRAP_CONTINUED"
+}
+
+# The release path fetches each project's own release artifacts through
+# homepkg's github backend -- one rootless mechanism, already used for
+# atuin/carapace -- rather than building anything.
+test_extras_release_uses_homepkg_github() {
+    run_install_extras_release 0 yes
+    assert_status 0 &&
+    assert_output_contains "BOOTSTRAP_CONTINUED" &&
+    assert_eq "$calls" "homepkg --backend github install helix jj nu"
+}
+
+# A homepkg failure (a changed release layout, an offline box) warns and the
+# bootstrap carries on: the extras are extras.
+test_extras_release_failure_is_not_fatal() {
+    run_install_extras_release 1 no
+    assert_status 0 &&
+    assert_output_contains "could not be installed from their releases" &&
+    assert_output_contains "BOOTSTRAP_CONTINUED"
+}
+
+# homepkg exits non-zero when any one tool failed, so a run that installed hx
+# but lost jj still has to wire hx's runtime up -- hence the gate on the binary
+# rather than on the exit status.
+test_extras_release_links_runtime_after_partial_failure() {
+    run_install_extras_release 1 yes
+    assert_status 0 &&
+    assert_eq "$helix_link_target" "$release_home/.local/share/helix/runtime"
+}
+
+# ...but "some hx exists" isn't the same as "the release installed one". After a
+# --no-root run, hx is homepkg's symlink into its conda env and carries its own
+# runtime; a failed release install must not point that hx at a release payload
+# left over from an earlier run.
+test_extras_release_leaves_an_env_hx_runtime_alone() {
+    run_install_extras_release 1 env-link
+    assert_status 0 &&
+    assert_eq "$helix_link_target" ""
+}
+
+# When Homebrew can't be made available, the brew path falls back to the
+# release artifacts.
+test_extras_brew_falls_back_to_release() {
+    assert_source_contains "install_extras_release" &&
+    assert_source_contains "Homebrew unavailable; installing the extras from their release artifacts"
 }
 
 # install_homebrew handles the Linuxbrew prefixes too, not just the macOS
@@ -441,17 +828,88 @@ test_homebrew_handles_linux_prefix() {
     assert_source_contains '$HOME/.linuxbrew/bin/brew'
 }
 
-# Switching cargo -> brew leaves ~/.config/helix/runtime pointing at the
-# source checkout, which hx searches before the bottle's runtime. The brew
-# path removes that stale symlink (only the one install_helix created).
-test_brew_clears_stale_helix_runtime() {
-    assert_source_contains 'helix_runtime=' &&
-    assert_source_contains 'readlink "$helix_runtime"' &&
-    assert_source_contains "Removing stale Helix runtime symlink" &&
-    # Removal is gated on brew actually installing helix, so a failed helix
-    # install doesn't strip a prior cargo hx's runtime.
-    assert_source_contains 'helix_installed=yes' &&
-    assert_source_contains 'test "$helix_installed" = yes'
+# --- The Helix runtime ---
+
+# hx searches <config dir>/runtime before anything that ships with the binary,
+# so a symlink one install path left there shadows the next path's runtime.
+# Switching to brew (or to conda-forge under --no-root) has to clear the ones
+# setup itself made: the old cargo source checkout, and a release payload.
+test_clear_helix_runtime_drops_a_cargo_symlink() {
+    run_helix_runtime_helper clear_managed_helix_runtime cargo
+    assert_status 0 &&
+    assert_eq "$helix_link_target" "" &&
+    assert_output_contains "Removing the Helix runtime symlink"
+}
+
+test_clear_helix_runtime_drops_a_release_symlink() {
+    run_helix_runtime_helper clear_managed_helix_runtime release
+    assert_status 0 &&
+    assert_eq "$helix_link_target" ""
+}
+
+# ...unless the release hx is still installed. No other install path removes that
+# plain file from ~/.local/bin, which is on PATH, so it may well still be the hx
+# that runs -- and the config directory runtime shadows every hx on the box, so
+# only one of the two can be right. Leaving it with version skew beats leaving it
+# with no grammars at all; which binary should win is the user's call.
+test_clear_helix_runtime_keeps_a_release_symlink_a_release_hx_needs() {
+    run_helix_runtime_helper clear_managed_helix_runtime release yes release-file
+    assert_status 0 &&
+    assert_eq "$helix_link_target" "$helix_home/.local/share/helix/runtime" &&
+    assert_output_contains "keeping the Helix runtime" &&
+    assert_output_lacks "$helix_home"
+}
+
+# homepkg's own hx is a symlink into its environment and carries its own runtime,
+# so it isn't a reason to keep the release payload's.
+test_clear_helix_runtime_drops_a_release_symlink_for_an_env_hx() {
+    run_helix_runtime_helper clear_managed_helix_runtime release yes env-link
+    assert_status 0 &&
+    assert_eq "$helix_link_target" ""
+}
+
+# Anything setup didn't put there is the user's: a symlink to a runtime they
+# manage themselves stays, and hx keeps using it.
+test_clear_helix_runtime_leaves_a_foreign_symlink() {
+    run_helix_runtime_helper clear_managed_helix_runtime foreign
+    assert_status 0 &&
+    assert_eq "$helix_link_target" "$helix_tmpdir/elsewhere"
+}
+
+# Nothing to clear is the common case (a fresh box), and it must not fail --
+# clear_managed_helix_runtime runs unguarded under set -e.
+test_clear_helix_runtime_with_nothing_there() {
+    run_helix_runtime_helper clear_managed_helix_runtime none
+    assert_status 0 &&
+    assert_output_contains "BOOTSTRAP_CONTINUED"
+}
+
+# The release asset carries hx and its runtime as one artifact; the runtime
+# lands in the prefix and the config directory is pointed at it, which is what
+# makes grammars and queries resolve for a release build.
+test_link_helix_runtime_points_at_the_prefix() {
+    run_helix_runtime_helper 'link_helix_runtime "$HOME/.local"' none
+    assert_status 0 &&
+    assert_eq "$helix_link_target" "$helix_home/.local/share/helix/runtime"
+}
+
+# Repointing, not just removing: a box moving from the cargo path to the
+# release path has a symlink to the source checkout already.
+test_link_helix_runtime_replaces_a_cargo_symlink() {
+    run_helix_runtime_helper 'link_helix_runtime "$HOME/.local"' cargo
+    assert_status 0 &&
+    assert_eq "$helix_link_target" "$helix_home/.local/share/helix/runtime"
+}
+
+# An hx with no runtime starts, but with no highlighting and no language
+# support -- so say so rather than leave it looking installed. Sanitized, like
+# every other warning: no home paths.
+test_link_helix_runtime_reports_a_missing_runtime() {
+    run_helix_runtime_helper 'link_helix_runtime "$HOME/.local"' none no
+    assert_status 0 &&
+    assert_output_contains "its runtime directory is missing" &&
+    assert_output_contains "BOOTSTRAP_CONTINUED" &&
+    assert_output_lacks "$helix_home"
 }
 
 # The brew path skips the Rust toolchain, so the root-config install falls
@@ -591,6 +1049,7 @@ test_missing_homepkg_warnings_name_no_absolute_path() {
     assert_status 0 &&
     assert_output_contains "homepkg not found in the scripts repo; skipping home-prefix tool install" &&
     assert_output_contains "homepkg not found in the scripts repo; skipping atuin and carapace" &&
+    assert_output_contains "homepkg not found in the scripts repo; skipping helix, jj, and nushell" &&
     assert_output_lacks "$missing_scripts_dir" &&
     assert_output_lacks "/home/testuser"
 }
@@ -1023,24 +1482,40 @@ test_home_tools_install_degrades() {
     assert_source_contains "some CLI tools could not be installed via homepkg"
 }
 
-# shpool is source-only, so (like the brew path) the homepkg path can't provide
-# it. The full --no-root run must say so explicitly rather than silently
-# dropping it, since the normal full cargo path installs shpool.
+# shpool has no prebuilt artifact, so the homepkg path can't provide it either.
+# The full --no-root run must say so explicitly rather than silently dropping a
+# tool the shell config expects to prefer.
 test_home_tools_warns_about_shpool() {
-    assert_source_contains "shpool is not available on the homepkg path"
+    assert_source_contains "shpool is not installed by setup"
 }
 
-# Switching a prior cargo hx to the homepkg hx leaves ~/.config/helix/runtime
-# pointing at the source checkout, which hx searches first. The homepkg path
-# removes that stale symlink (only the one install_helix created), same as the
-# brew path -- and only after a successful install so a failed run doesn't strip
-# a still-active cargo hx's runtime.
+# The homepkg hx keeps its runtime inside the conda env, so a symlink another
+# install path left in the config directory -- which hx searches first -- has to
+# go, same as on the brew path. Only after a successful install, so a failed run
+# doesn't strip the runtime of an hx that's still in use.
 test_home_tools_clears_stale_helix_runtime() {
-    # Gated on hx being installed (linked into ~/.local/bin), not on the minimal
-    # profile -- a full bundle can install helix even under --minimal.
-    assert_source_contains 'test -x "$HOME/.local/bin/hx"' &&
-    assert_source_contains 'readlink "$helix_runtime"' &&
-    assert_source_contains "Removing stale Helix runtime symlink"
+    run_home_tools_helix env-link
+    assert_status 0 &&
+    assert_eq "$helix_link_target" "" &&
+    assert_output_contains "Removing the Helix runtime symlink"
+}
+
+# ...but homepkg leaves a conflicting regular file in ~/.local/bin alone, so on a
+# box that installed the release hx first, that release binary is still what
+# runs. Clearing the runtime symlink then takes its grammars away, so the gate is
+# "the env's hx is the one that runs", not "some hx exists".
+test_home_tools_keeps_the_runtime_of_a_release_hx() {
+    run_home_tools_helix release-file
+    assert_status 0 &&
+    assert_eq "$helix_link_target" "$ht_payload"
+}
+
+# Nothing installed helix at all: leave the runtime symlink for whatever hx it
+# belongs to.
+test_home_tools_keeps_the_runtime_when_no_hx_landed() {
+    run_home_tools_helix absent
+    assert_status 0 &&
+    assert_eq "$helix_link_target" "$ht_payload"
 }
 
 # On a fresh env, install_home_tools prefers a prebuilt bundle (which installs
@@ -1261,8 +1736,12 @@ run_test "home-prefix tool install degrades on failure" \
     test_home_tools_install_degrades
 run_test "home-prefix full install warns that shpool is unavailable" \
     test_home_tools_warns_about_shpool
-run_test "home-prefix path clears the stale cargo Helix runtime symlink" \
+run_test "home-prefix path clears the Helix runtime symlink for the env hx" \
     test_home_tools_clears_stale_helix_runtime
+run_test "home-prefix path keeps the runtime of a release hx it left alone" \
+    test_home_tools_keeps_the_runtime_of_a_release_hx
+run_test "home-prefix path keeps the runtime when no hx landed" \
+    test_home_tools_keeps_the_runtime_when_no_hx_landed
 
 run_test "--kde is accepted as a no-op" test_kde_flag_is_a_noop
 run_test "tsc installs from the distro alongside node" \
@@ -1277,8 +1756,8 @@ run_test "successful sudo preserves its stderr" \
     test_sudo_success_preserves_stderr
 run_test "sudo-dependent blocks guard every privileged call" \
     test_sudo_calls_are_guarded
-run_test "rustup installs with --no-modify-path" \
-    test_rust_installs_without_modifying_path
+run_test "setup builds nothing from source" \
+    test_no_source_builds
 run_test "uv installs with --no-modify-path" \
     test_uv_installs_without_modifying_path
 run_test "fnm installs as a tool, not the node provisioner" \
@@ -1292,18 +1771,56 @@ run_test "--ssh overrides the existing-key skip" \
     test_ssh_flag_overrides_existing_key_check
 run_test "setup offers to switch repo remotes to SSH" \
     test_offers_ssh_remote_switch
-run_test "--brew/--cargo select the extras backend" \
+run_test "--brew/--release select the extras backend" \
     test_extras_backend_flags
+run_test "--cargo is accepted and reports what it does instead" \
+    test_cargo_flag_is_accepted_and_reported
 run_test "brew extras install helix/jj/nushell per formula" \
     test_extras_brew_formulae
-run_test "shpool is omitted from the brew path with a TODO" \
-    test_shpool_omitted_from_brew_with_todo
-run_test "brew extras fall back to cargo when Homebrew is unavailable" \
-    test_extras_brew_falls_back_to_cargo
+run_test "shpool is not installed, with a TODO and its service kept" \
+    test_shpool_not_installed_with_todo
+run_test "an existing shpool unit file is left alone" \
+    test_shpool_service_skipped_when_a_unit_file_exists
+run_test "an shpool unit that is only loaded is left alone" \
+    test_shpool_service_skipped_when_the_unit_is_loaded
+run_test "the shpool service is written when there is none" \
+    test_shpool_service_written_when_absent
+run_test "the shpool service is skipped with no user manager to query" \
+    test_shpool_service_skipped_without_a_user_manager
+run_test "an existing shpool unit file is untouched without a user manager" \
+    test_shpool_unit_file_untouched_without_a_user_manager
+run_test "an shpool service failure is reported, not fatal" \
+    test_shpool_service_failure_is_reported_not_fatal
+run_test "the release extras path installs via homepkg's github backend" \
+    test_extras_release_uses_homepkg_github
+run_test "a release extras failure warns instead of aborting" \
+    test_extras_release_failure_is_not_fatal
+run_test "a partial release run still links the Helix runtime" \
+    test_extras_release_links_runtime_after_partial_failure
+run_test "a failed release run leaves an env hx's runtime alone" \
+    test_extras_release_leaves_an_env_hx_runtime_alone
+run_test "brew extras fall back to the release artifacts" \
+    test_extras_brew_falls_back_to_release
 run_test "install_homebrew handles the Linuxbrew prefixes" \
     test_homebrew_handles_linux_prefix
-run_test "brew path clears the stale cargo Helix runtime symlink" \
-    test_brew_clears_stale_helix_runtime
+run_test "a cargo-checkout Helix runtime symlink is cleared" \
+    test_clear_helix_runtime_drops_a_cargo_symlink
+run_test "a release-payload Helix runtime symlink is cleared" \
+    test_clear_helix_runtime_drops_a_release_symlink
+run_test "a release-payload runtime a release hx still needs is kept" \
+    test_clear_helix_runtime_keeps_a_release_symlink_a_release_hx_needs
+run_test "a release-payload runtime is cleared for homepkg's env hx" \
+    test_clear_helix_runtime_drops_a_release_symlink_for_an_env_hx
+run_test "someone else's Helix runtime symlink is left alone" \
+    test_clear_helix_runtime_leaves_a_foreign_symlink
+run_test "clearing the Helix runtime with nothing there is not an error" \
+    test_clear_helix_runtime_with_nothing_there
+run_test "the Helix runtime is linked to the release payload" \
+    test_link_helix_runtime_points_at_the_prefix
+run_test "linking the Helix runtime replaces a cargo symlink" \
+    test_link_helix_runtime_replaces_a_cargo_symlink
+run_test "a missing Helix runtime is reported, sanitized" \
+    test_link_helix_runtime_reports_a_missing_runtime
 run_test "legacy root config fallback is logged with the remedy" \
     test_legacy_root_config_is_logged
 run_test "zoxide is installed as a core package" \


### PR DESCRIPTION
helix, jj, and nushell all publish prebuilt binaries with their GitHub releases, so the rustup + cargo path was building from source what can be downloaded ready to run — a Rust toolchain and several minutes per box. This switches the extras to those artifacts and drops the from-source path.

Rebased on `c519115`.

## homepkg: keep a release asset's non-binary payload

The github backend copied out only the binaries named in the registry and dropped the rest of the archive. That isn't enough for a tool that needs data files at run time: helix's tarball carries `hx` **and** the `runtime/` tree of grammars, queries, and themes it loads, and an `hx` without it starts with no language support at all. It's one artifact, not two — the backend was just discarding most of it.

- New `payload` registry key: directories to keep out of an asset, and where they go under the prefix. helix's `runtime/` → `share/helix/runtime`.
- A destination decides which directory gets replaced **wholesale**, so it comes from the registry alone — never from a bundle manifest, which can be tampered with the same way an asset or binary name can. Its shape is constrained rather than trusted too: at least two components, under `share/`, not under `share/homepkg/`. Inside the prefix isn't enough, since `bin` would move every installed executable aside and delete it while reporting success, and `share/homepkg/env` would do that to the mamba environment.
- A binary and the data files it loads have to match, so for a tool with a payload nothing is installed until **every** part has been located in the asset. Publishing a new `hx` and only then finding no runtime for it — or a new runtime the old `hx` then reads — leaves a mismatched pair, which is worse than not updating: unlike a missing binary it can't be left half-done for the next reinstall to finish, because the half-done state runs, and runs wrongly. Tools with no payload keep the existing partial-install policy.
- Being in the asset isn't landing on disk either, so both halves publish together or neither: the binaries go first and are moved aside rather than overwritten, and a payload copy that fails partway (a full disk) puts them back — or removes them, on a first install where there was nothing to put back.
- Binaries are placed by clearing the destination first rather than copying onto it. On a prefix the mamba backend has also managed, `<prefix>/bin/<tool>` is a symlink into its environment, and `shutil.copy2` would follow it and overwrite the conda-managed executable in place. A release install owns the *name* in `bin/`, not whatever the name currently points at.
- Reinstalling replaces the payload tree instead of merging into it — a grammar dropped upstream shouldn't linger — by copying alongside and swapping. Two renames leave one window an interruption can land in, and no portable call swaps two directories in one step, so the next call puts the backup back before doing anything else instead of deleting it. Same for a binary's own rename-then-copy.

## setup: the release-artifact path

- `install_extras_cargo` (rustup plus four `cargo install` builds) is replaced by `homepkg --backend github install helix jj nu` — the same rootless mechanism that already installs atuin and carapace.
- `~/.config/helix/runtime` is pointed at the runtime homepkg unpacks alongside `hx`, since hx searches the config directory ahead of both `$HELIX_RUNTIME` and anything beside the binary. Verified against the real 25.07.1 tarball: `hx --health rust` reports the tree-sitter parser and the highlight, textobject, and indent queries all resolving.
- The brew and `--no-root` paths bring their own runtime, so both now share one helper for clearing a runtime symlink an earlier path left behind — which also covers the new "release payload" target the old check didn't know about.
- Which `hx` would actually run decides that in both directions, since `~/.local/bin` is on `PATH` and no install path removes another's binary. A release `hx` is a plain file; homepkg's is a symlink into its conda env and carries its own runtime. So the runtime is linked only for a release plain file, and kept — not cleared — while one is still installed, with a warning naming what to delete if you want the newly installed `hx` to own it.
- `--cargo` becomes `--release`. The old flag still parses and reports what it does instead, rather than failing as an unknown option.
- Nothing installs a Rust toolchain any more, so the root config builds with whichever one the machine already has and installs the legacy config otherwise — as it already did on the brew path. The hint text names rustup instead of `--cargo`.

## shpool

shpool has no prebuilt artifact anywhere: no release binaries, no brew bottle, no conda-forge feedstock. A source build was the only way to get it, so setup no longer installs it, with a TODO to pick it back up once there's an artifact to fetch.

Since setup no longer puts shpool on the box, it no longer treats the systemd user service as its to write:

- It skips when an `shpool.service` already exists **in any form** — one systemd can show a file for, or one that's merely loaded (generated, transient). The old check only looked for its own file under `~/.config/systemd/user`, which outranks `/usr/lib/systemd/user` and would therefore quietly override a distro package's unit.
- Both of those questions need a systemd user manager, and without one every `--user` query fails identically, so "no such unit" can't be told from "couldn't ask". Rather than reimplement systemd's unit load path to answer it anyway, setup checks whether there's a manager at all (`systemctl --user show --property=Version`) and skips when there isn't — nothing could be enabled there in any case, so a unit written blind would only shadow whatever the packaged one turns out to be.
- Writing the service where a manager reports none stays, for an shpool that arrived some other way. Nothing else in the repo starts the daemon (`autoshpool` reports "shpool not responding" and exits), and `sessionlib` prefers shpool on the binary alone, so dropping this step would break sessions on a box that has shpool but no enabled service. The unit goes to `$XDG_CONFIG_HOME/systemd/user` when that's set, which is where systemd looks for it.
- Both `systemctl` steps warn instead of aborting the bootstrap.

`sessionlib` still prefers shpool over tmux, so a shpool installed some other way works exactly as before.

## Note

The helix runtime is ~190MB extracted. `MIN_DISK_GB` is still 15, though its stated rationale (cargo build dirs) no longer applies — worth lowering separately.

## Testing

`make test` — all suites green, including 79 in `setup_test` and 200 in `homepkg_test`.

In homepkg: the payload install and replace paths; every rejection path (missing payload, missing binary, unpackable asset, and each unsafe destination — escaping the prefix, `bin`, `share`, `share/homepkg/env`, `.`) asserting the previous install survives; a prefix holding `rg`, `fd`, and `uv` still holding exactly those after a destination of `bin` is refused; a tampered manifest's destination being ignored for the registry's; rollback of a failed publish on both an existing and a fresh prefix; recovery of a binary or payload stranded by an interrupted run; and a managed symlink being replaced rather than written through.

In setup: the homepkg invocation; the partial-failure runtime link; each Helix runtime symlink case (cargo, release, foreign, absent, and release-with-a-release-`hx`-still-installed); which `hx` the release and `--no-root` paths link or clear the runtime for; and each shpool service case (unit file present, unit only loaded, nothing there, no user manager, enable failing) — all run as real functions against mocks and a sandboxed `HOME` rather than checked by grepping the source.

Also verified end to end against the real helix 25.07.1 tarball after each round: asset selection, `bin/` containing exactly `hx`, and `hx --health rust` resolving the parser and all three query sets through the config-directory runtime symlink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TDN8ZvedqZNyRuJRBwAUqi