### PR TITLE
setup: stop assuming github.com over SSH once --github points elsewhere

### DIFF
--- a/setup
+++ b/setup
@@ -68,6 +68,12 @@
 # PREFIX is the part before OWNER/REPO; a bare host is treated as SSH, and its
 # trailing separator (: or /) is supplied for you. GITHUB_PREFIX in the
 # environment does the same, which is handy when piping setup from a mirror.
+#
+# A non-default prefix also stops setup assuming github.com-over-SSH elsewhere:
+# the SSH key instructions name that host instead of github.com, an HTTPS
+# prefix doesn't stop to wait for the key at all (nothing it clones needs one),
+# the end-of-run offer to rewrite remotes to SSH is skipped, and a repo already
+# cloned from somewhere else is reported rather than silently left behind.
 
 # The three repositories setup clones, kept as OWNER/REPO paths. The host and
 # protocol come from GITHUB_PREFIX, which defaults to GitHub over SSH and can be
@@ -78,7 +84,12 @@
 # apart. The path is appended to the prefix; the URLs themselves are assembled
 # after argument parsing (see normalize_github_prefix). Override the default
 # host by exporting GITHUB_PREFIX, or per-run with --github.
-GITHUB_PREFIX="${GITHUB_PREFIX:-git@github.com:}"
+#
+# The default is kept as its own constant so the steps that care whether the
+# repos come from somewhere else -- the SSH key prompt and the offer to rewrite
+# remotes -- can compare against it (see GITHUB_MIRROR below).
+GITHUB_DEFAULT_PREFIX="git@github.com:"
+GITHUB_PREFIX="${GITHUB_PREFIX:-$GITHUB_DEFAULT_PREFIX}"
 SCRIPTS_REPO_PATH="mikelward/scripts.git"
 CONF_REPO_PATH="mikelward/conf.git"
 ROOT_REPO_PATH="mikelward/root.git"
@@ -210,7 +221,9 @@ Options:
                    is the host or full prefix before OWNER/REPO; its protocol is
                    taken as given, e.g. an internal SSH host (git@ghe.corp or
                    git@ghe.corp:) or an HTTPS mirror (https://ghe.corp). A bare
-                   host is treated as SSH. Also settable via the GITHUB_PREFIX
+                   host is treated as SSH. Setting it also points the SSH key
+                   instructions at that host and skips the offer to rewrite the
+                   cloned remotes to SSH. Also settable via the GITHUB_PREFIX
                    environment variable
   -h, --help       Show this help and exit
 
@@ -299,6 +312,59 @@ normalize_github_prefix() {
         *://*)   printf '%s/' "$1" ;;
         *)       printf '%s:' "$1" ;;
     esac
+}
+
+# github_prefix_host PREFIX: print the host from a normalized prefix, for the
+# messages that name where the repos came from. Handles both shapes the prefix
+# can take -- scp-style (git@HOST:) and URL (https://HOST/, ssh://git@HOST/).
+github_prefix_host() {
+    case "$1" in
+        *://*)
+            _prefix_rest=${1#*://}
+            _prefix_rest=${_prefix_rest%%/*}
+            ;;
+        *)
+            _prefix_rest=${1%%:*}
+            ;;
+    esac
+    printf '%s' "${_prefix_rest#*@}"
+}
+
+# redact_url_credentials URL: print URL with any embedded user-info replaced by
+# "***", so a message can name a remote without echoing a secret to the
+# terminal or to a captured bootstrap log. An HTTPS clone URL can carry one --
+# https://USER:TOKEN@host/..., and the token-as-username forms
+# (https://TOKEN@host/..., https://x-access-token:TOKEN@host/...) mean a bare
+# user-info is no safer than a password, so the whole of it goes. scp-style
+# remotes (git@HOST:PATH) are printed unchanged: that syntax has no password
+# field, so its user is a plain SSH login rather than a credential.
+redact_url_credentials() {
+    case "$1" in
+        *://*) ;;
+        *) printf '%s' "$1"; return ;;
+    esac
+    _redact_scheme=${1%%://*}
+    _redact_rest=${1#*://}
+    # User-info is only what precedes the '@' in the authority, i.e. before the
+    # first '/'. An '@' further along is part of the path, not a credential.
+    _redact_authority=${_redact_rest%%/*}
+    case "$_redact_authority" in
+        *@*) ;;
+        *) printf '%s' "$1"; return ;;
+    esac
+    _redact_path=${_redact_rest#"$_redact_authority"}
+    printf '%s://***@%s%s' \
+        "$_redact_scheme" "${_redact_authority##*@}" "$_redact_path"
+}
+
+# canonical_remote URL: print URL with the spellings git treats as
+# interchangeable removed -- a trailing slash and the optional .git suffix --
+# so a checkout cloned as .../OWNER/REPO compares equal to the .../OWNER/REPO.git
+# the repo paths are written as. Protocol and host are deliberately left alone:
+# a difference there is a real one, and reporting it is the point.
+canonical_remote() {
+    _canon=${1%/}
+    printf '%s' "${_canon%.git}"
 }
 
 # require_github_prefix VALUE: abort with the usage error unless VALUE is a
@@ -408,6 +474,28 @@ SCRIPTS_REPO="${GITHUB_PREFIX}${SCRIPTS_REPO_PATH}"
 CONF_REPO="${GITHUB_PREFIX}${CONF_REPO_PATH}"
 ROOT_REPO="${GITHUB_PREFIX}${ROOT_REPO_PATH}"
 
+# Whether the repos come from somewhere other than the default (github.com over
+# SSH), i.e. --github or GITHUB_PREFIX pointed them elsewhere. Compared after
+# normalization, so "--github git@github.com" is recognized as the default
+# rather than mistaken for a mirror. Steps that assume github.com-over-SSH key
+# off this: the SSH key prompt names the right host, and the offer to rewrite
+# remotes to SSH is skipped -- see offer_ssh_remotes.
+if test "$GITHUB_PREFIX" = "$GITHUB_DEFAULT_PREFIX"; then
+    GITHUB_MIRROR=no
+else
+    GITHUB_MIRROR=yes
+fi
+GITHUB_HOST=$(github_prefix_host "$GITHUB_PREFIX")
+
+# Whether cloning from the prefix authenticates with an SSH key. An HTTPS
+# prefix -- an internal mirror served over HTTPS, or github.com itself where a
+# network blocks SSH -- needs no key for any repo setup clones, so
+# generate_ssh_key doesn't stop the bootstrap to wait for one.
+case "$GITHUB_PREFIX" in
+    https://* | http://*) GITHUB_PREFIX_SSH=no ;;
+    *)                    GITHUB_PREFIX_SSH=yes ;;
+esac
+
 # Abort on the first error by default. --ignore-errors leaves set -e off so
 # the bootstrap pushes through failing steps. We toggle this only after
 # parsing args, so an unknown option above still exits non-zero.
@@ -437,9 +525,39 @@ fi
 clone_or_pull() {
     repo="$1"
     dir="$2"
+    # Whether REPO was built from GITHUB_PREFIX. Only for those does an
+    # existing checkout pointing elsewhere mean --github failed to apply; the
+    # helix clone shares this function with a hard-coded upstream URL the flag
+    # never steers, and its origin may legitimately be an SSH URL or a fork.
+    # Default off so a new caller has to opt in rather than inherit the check.
+    from_prefix="${3:-no}"
 
     if test -d "$dir/.git"; then
         info "$dir already exists, pulling latest changes"
+        # The prefix only steers fresh clones; an existing checkout keeps
+        # whatever remote it was cloned with. Say so when they disagree, rather
+        # than letting --github look like it took effect on a re-run. Only
+        # under a non-default prefix: on the default, a repo cloned over HTTPS
+        # differs from the SSH default URL harmlessly, and that's exactly what
+        # offer_ssh_remotes exists to fix.
+        if test "$from_prefix" = yes && test "$GITHUB_MIRROR" = yes; then
+            # config --get, not "remote get-url": we want the raw stored URL,
+            # not one an url.*.insteadOf rule has already rewritten. An unset
+            # key (a local-only checkout with no origin) exits 1 with no
+            # output -- not an error here, just nothing to compare against.
+            existing=$(git -C "$dir" config --get remote.origin.url) || existing=""
+            # Compared canonically, so a checkout cloned without the .git
+            # suffix isn't reported as a mismatch against the same URL with it.
+            if test -n "$existing" \
+                    && test "$(canonical_remote "$existing")" != "$(canonical_remote "$repo")"; then
+                # Both URLs are redacted before they're printed: a stored origin
+                # can carry a token the user has long forgotten, and the prefix
+                # they passed lands in any captured log just the same. In the
+                # ordinary credential-free case nothing changes and the
+                # set-url command below is copy-pasteable as printed.
+                warn "$dir is cloned from $(redact_url_credentials "$existing"), not $(redact_url_credentials "$repo"); leaving the remote as-is (git -C $dir remote set-url origin $(redact_url_credentials "$repo") to change it)"
+            fi
+        fi
         # A failed pull (e.g. no network) must not abort the bootstrap: the
         # existing checkout is enough to keep going. This is also what lets an
         # offline "setup --no-root" reach the homepkg bundle install, which runs
@@ -455,7 +573,9 @@ clone_or_pull() {
         # No existing checkout, so a failed clone stays fatal: there's nothing
         # to fall back to, and later steps (confinst, the root build) need the
         # repo. An offline box must therefore pre-stage the repos it needs.
-        info "Cloning $repo into $dir"
+        # Redacted for the same reason as the mismatch warning above: a prefix
+        # passed with credentials shouldn't be echoed into a bootstrap log.
+        info "Cloning $(redact_url_credentials "$repo") into $dir"
         git clone --recurse-submodules "$repo" "$dir"
     fi
 }
@@ -1372,23 +1492,39 @@ generate_ssh_key() {
     ssh-keygen -t ed25519 -f "$HOME/.ssh/id_ed25519" -N ""
 
     info ""
-    info "Add this SSH public key to GitHub and Codeberg before continuing:"
-    info "  GitHub:   https://github.com/settings/ssh/new"
+    info "Add this SSH public key to $GITHUB_HOST and Codeberg:"
+    if test "$GITHUB_MIRROR" = yes; then
+        # A mirror's web UI lives wherever that deployment puts it, so name the
+        # host rather than guessing at a settings URL that probably 404s.
+        info "  $GITHUB_HOST: add it under your account's SSH keys"
+    else
+        info "  GitHub:   https://github.com/settings/ssh/new"
+    fi
     info "  Codeberg: https://codeberg.org/user/settings/keys"
     info ""
     cat "$HOME/.ssh/id_ed25519.pub"
     info ""
 
+    # Only block on the key when this run's clones actually need it. Under an
+    # HTTPS prefix nothing setup clones authenticates with it (the repos come
+    # over HTTPS, as does Krohnkite), so waiting would stall a bootstrap that
+    # would otherwise finish unattended -- print the key and keep going.
+    if test "$GITHUB_PREFIX_SSH" = no; then
+        info "Cloning from $GITHUB_HOST over HTTPS this run, so setup isn't waiting for the key"
+        return
+    fi
+
     # When run via "curl | sh", stdin is the script itself, so we
     # can't read user input.  Open /dev/tty to read from the terminal.
+    prompt="Press Enter after adding the key to $GITHUB_HOST and Codeberg..."
     if test -t 0; then
-        printf "Press Enter after adding the key to GitHub and Codeberg..."
+        printf "%s" "$prompt"
         read -r _
     elif test -e /dev/tty; then
-        printf "Press Enter after adding the key to GitHub and Codeberg..."
+        printf "%s" "$prompt"
         read -r _ < /dev/tty
     else
-        warn "Cannot prompt for input; add the key to GitHub and Codeberg manually before cloning SSH repos"
+        warn "Cannot prompt for input; add the key to $GITHUB_HOST and Codeberg manually before cloning SSH repos"
     fi
 }
 
@@ -1399,6 +1535,17 @@ generate_ssh_key() {
 # be flipped here so pushes use the key. Defaults to no, so a non-interactive
 # "curl | sh" run never rewrites anything without being asked.
 offer_ssh_remotes() {
+    # A non-default prefix put these remotes where they are deliberately, so
+    # don't offer to move them. Both shapes it can take argue against the
+    # offer: an internal mirror is a host gittossh doesn't rewrite at all (it
+    # only knows github.com and codeberg.org), so the prompt could only ever
+    # answer "nothing to convert"; and an HTTPS prefix was chosen precisely
+    # because SSH isn't the way in, so converting would break the remote.
+    if test "$GITHUB_MIRROR" = yes; then
+        info "Cloned from $GITHUB_HOST; leaving repo remotes as-is"
+        return 0
+    fi
+
     converter="$SCRIPTS_DIR/gittossh"
     test -x "$converter" || return 0
 
@@ -1573,8 +1720,8 @@ if ! command -v make >/dev/null 2>&1; then
     exit 1
 fi
 
-clone_or_pull "$SCRIPTS_REPO" "$SCRIPTS_DIR"
-clone_or_pull "$CONF_REPO" "$CONF_DIR"
+clone_or_pull "$SCRIPTS_REPO" "$SCRIPTS_DIR" yes
+clone_or_pull "$CONF_REPO" "$CONF_DIR" yes
 
 info "Running confinst"
 "$SCRIPTS_DIR/confinst"
@@ -1627,7 +1774,7 @@ fi
 # an install step too: skip it under --no-install.
 if test "$INSTALL" = yes; then
     mkdir -p "$SRC_DIR"
-    clone_or_pull "$ROOT_REPO" "$ROOT_DIR"
+    clone_or_pull "$ROOT_REPO" "$ROOT_DIR" yes
     # The default root config builds helper tools that require cargo. When
     # cargo isn't available -- the --brew extras path skips the Rust toolchain,
     # as does --minimal -- install the legacy config from the legacy/ subdir

--- a/setup_test
+++ b/setup_test
@@ -653,12 +653,13 @@ fi' &&
 
 # The default Krohnkite clone is HTTPS, but other repos (conf, scripts) are
 # cloned over SSH, and pushing anywhere needs a key. Codeberg hosts Krohnkite
-# now, so the key-generation prompt must point at both GitHub and Codeberg,
-# not GitHub alone.
+# now, so the key-generation prompt must point at both the GitHub host and
+# Codeberg, not the GitHub host alone. The GitHub side is named by
+# $GITHUB_HOST so a --github mirror gets its own host rather than github.com's.
 test_ssh_key_prompt_covers_github_and_codeberg() {
     assert_source_contains "https://github.com/settings/ssh/new" &&
     assert_source_contains "https://codeberg.org/user/settings/keys" &&
-    assert_source_contains "add the key to GitHub and Codeberg"
+    assert_source_contains 'add the key to $GITHUB_HOST and Codeberg'
 }
 
 # --ssh promises to generate a key even when one is already available, so
@@ -677,6 +678,251 @@ test_offers_ssh_remote_switch() {
     assert_source_contains "offer_ssh_remotes" &&
     assert_source_contains "gittossh" &&
     assert_source_contains "from HTTPS to SSH?"
+}
+
+# --- --github mirror: SSH key and remote handling ---
+
+# Run offer_ssh_remotes against a recording gittossh stub. Neither call below
+# may reach the prompt, which would block on a terminal: the mirror case
+# returns at the guard under test, and the default case is given no gittossh so
+# it returns at the executable check just after it.
+run_offer_ssh_remotes() {
+    offer_mirror="$1"
+    offer_converter="$2"
+    offer_tmpdir="$(mktemp -d)"
+    offer_calls="$offer_tmpdir/calls"
+    for d in scripts conf src/root; do
+        mkdir -p "$offer_tmpdir/$d/.git"
+    done
+    if test "$offer_converter" = present; then
+        cat > "$offer_tmpdir/scripts/gittossh" <<MOCK
+#!/bin/sh
+printf '%s\n' "gittossh \$*" >> "$offer_calls"
+MOCK
+        chmod +x "$offer_tmpdir/scripts/gittossh"
+    fi
+
+    set +e
+    output="$(sh -c "set -e
+GITHUB_MIRROR=$offer_mirror
+GITHUB_HOST=ghe.corp.example.com
+SCRIPTS_DIR='$offer_tmpdir/scripts'
+CONF_DIR='$offer_tmpdir/conf'
+ROOT_DIR='$offer_tmpdir/src/root'
+$(extract_functions "info warn offer_ssh_remotes")
+offer_ssh_remotes
+echo BOOTSTRAP_CONTINUED" </dev/null 2>&1)"
+    status=$?
+    set -e
+    calls="$(cat "$offer_calls" 2>/dev/null)"
+    rm -rf "$offer_tmpdir"
+}
+
+# A --github prefix put these remotes where they are on purpose: an internal
+# mirror is a host gittossh wouldn't rewrite anyway, and an HTTPS prefix was
+# chosen because SSH isn't the way in. So the offer is skipped outright --
+# gittossh is never run, and the bootstrap continues.
+test_mirror_skips_ssh_remote_offer() {
+    run_offer_ssh_remotes yes present
+    assert_status 0 &&
+    assert_output_contains "Cloned from ghe.corp.example.com" &&
+    assert_output_contains "leaving repo remotes as-is" &&
+    assert_output_contains "BOOTSTRAP_CONTINUED" &&
+    assert_eq "$calls" ""
+}
+
+# Without a mirror prefix the guard must not fire: the function falls through
+# to its converter lookup (absent here, so it returns before the prompt) rather
+# than reporting that it left the remotes alone.
+test_default_prefix_reaches_ssh_remote_offer() {
+    run_offer_ssh_remotes no absent
+    assert_status 0 &&
+    assert_output_lacks "ghe.corp.example.com" &&
+    assert_output_lacks "leaving repo remotes as-is" &&
+    assert_output_contains "BOOTSTRAP_CONTINUED"
+}
+
+# Run generate_ssh_key with a stub ssh-keygen. Only safe for the HTTPS-prefix
+# case, which returns before the "Press Enter" prompt; the SSH paths would
+# block on a terminal. SSH=yes so it skips the auto-mode short circuits and
+# actually reaches the key-instructions block under test.
+run_generate_ssh_key_https() {
+    key_tmpdir="$(mktemp -d)"
+    mkdir -p "$key_tmpdir/bin"
+    cat > "$key_tmpdir/bin/ssh-keygen" <<'MOCK'
+#!/bin/sh
+keyfile=""
+while test $# -gt 0; do
+    case "$1" in
+        -f) keyfile="$2"; shift ;;
+    esac
+    shift
+done
+: > "$keyfile"
+printf 'ssh-ed25519 AAAATESTKEY test\n' > "$keyfile.pub"
+MOCK
+    chmod +x "$key_tmpdir/bin/ssh-keygen"
+
+    set +e
+    output="$(PATH="$key_tmpdir/bin:$PATH" HOME="$key_tmpdir" \
+        sh -c "set -e
+SSH=yes
+GITHUB_MIRROR=yes
+GITHUB_HOST=ghe.corp.example.com
+GITHUB_PREFIX_SSH=no
+$(extract_functions "info warn generate_ssh_key")
+generate_ssh_key
+echo BOOTSTRAP_CONTINUED" </dev/null 2>&1)"
+    status=$?
+    set -e
+    rm -rf "$key_tmpdir"
+}
+
+# Under an HTTPS prefix nothing setup clones authenticates with the key, so the
+# run must not stall at "Press Enter after adding the key" -- it prints the key
+# and continues. The instructions name the prefix's host: a mirror's key
+# settings live wherever that deployment puts them, not at github.com's URL.
+test_https_prefix_key_prompt_does_not_block() {
+    run_generate_ssh_key_https
+    assert_status 0 &&
+    assert_output_contains "ghe.corp.example.com" &&
+    assert_output_contains "ssh-ed25519 AAAATESTKEY" &&
+    assert_output_lacks "https://github.com/settings/ssh/new" &&
+    assert_output_lacks "Press Enter" &&
+    assert_output_contains "BOOTSTRAP_CONTINUED"
+}
+
+# Run clone_or_pull's existing-checkout branch against a stub git, so nothing
+# here touches the network. The stub answers the config lookup with
+# $MOCK_ORIGIN (exiting 1 when it's empty, as git does for an unset key) and
+# succeeds at everything else.
+run_clone_or_pull_existing() {
+    cop_mirror="$1"
+    cop_origin="$2"
+    cop_repo="$3"
+    # Whether the call opts into the mismatch check, i.e. stands in for one of
+    # the three repos whose URL comes from the prefix. Defaults to yes so the
+    # cases below read as the prefixed call sites they model.
+    cop_from_prefix="${4:-yes}"
+    cop_tmpdir="$(mktemp -d)"
+    mkdir -p "$cop_tmpdir/bin" "$cop_tmpdir/scripts/.git"
+    cat > "$cop_tmpdir/bin/git" <<'MOCK'
+#!/bin/sh
+shift 2                     # drop the "-C DIR" clone_or_pull always passes
+case "$1" in
+    config)
+        test -n "${MOCK_ORIGIN:-}" || exit 1
+        printf '%s\n' "$MOCK_ORIGIN"
+        ;;
+esac
+exit 0
+MOCK
+    chmod +x "$cop_tmpdir/bin/git"
+
+    set +e
+    output="$(PATH="$cop_tmpdir/bin:$PATH" MOCK_ORIGIN="$cop_origin" \
+        sh -c "set -e
+GITHUB_MIRROR=$cop_mirror
+$(extract_functions "info warn redact_url_credentials canonical_remote clone_or_pull")
+clone_or_pull '$cop_repo' '$cop_tmpdir/scripts' $cop_from_prefix
+echo BOOTSTRAP_CONTINUED" 2>&1)"
+    status=$?
+    set -e
+    rm -rf "$cop_tmpdir"
+}
+
+# --github steers fresh clones only; a checkout that already exists keeps the
+# remote it was cloned with. Re-running with a mirror prefix over repos cloned
+# from github.com must say the flag didn't apply, not leave it looking like it
+# did -- and must still continue the bootstrap.
+test_existing_checkout_mismatch_warns() {
+    run_clone_or_pull_existing yes \
+        "git@github.com:mikelward/scripts.git" \
+        "https://ghe.corp.example.com/mikelward/scripts.git"
+    assert_status 0 &&
+    assert_output_contains "is cloned from git@github.com:mikelward/scripts.git" &&
+    assert_output_contains "leaving the remote as-is" &&
+    assert_output_contains "remote set-url origin" &&
+    assert_output_contains "BOOTSTRAP_CONTINUED"
+}
+
+# A stored origin can carry a token the user has long forgotten, and the
+# mismatch warning is printed to the terminal and into any captured bootstrap
+# log -- so neither URL may go out with its credentials intact. The host and
+# path still come through, which is all the warning needs to be actionable.
+test_existing_checkout_mismatch_redacts_credentials() {
+    run_clone_or_pull_existing yes \
+        "https://olduser:oldtoken@github.com/mikelward/scripts.git" \
+        "https://newuser:newtoken@ghe.corp.example.com/mikelward/scripts.git"
+    assert_status 0 &&
+    assert_output_lacks "oldtoken" &&
+    assert_output_lacks "newtoken" &&
+    assert_output_lacks "olduser" &&
+    assert_output_lacks "newuser" &&
+    assert_output_contains "https://***@github.com/mikelward/scripts.git" &&
+    assert_output_contains "https://***@ghe.corp.example.com/mikelward/scripts.git"
+}
+
+# Exercise the real canonical_remote: git treats a trailing slash and the .git
+# suffix as interchangeable, so the mismatch check has to as well. Protocol and
+# host differences must survive -- those are the mismatches worth reporting.
+test_canonical_remote() {
+    eval "$(extract_functions "canonical_remote")"
+    assert_eq "$(canonical_remote 'https://ghe.corp.example.com/mikelward/scripts.git')" \
+        "$(canonical_remote 'https://ghe.corp.example.com/mikelward/scripts')" &&
+    assert_eq "$(canonical_remote 'https://ghe.corp.example.com/mikelward/scripts/')" \
+        "$(canonical_remote 'https://ghe.corp.example.com/mikelward/scripts')" &&
+    assert_eq "$(canonical_remote 'git@ghe.corp.example.com:mikelward/scripts.git')" \
+        'git@ghe.corp.example.com:mikelward/scripts' &&
+    # A different protocol on the same host stays a mismatch.
+    test "$(canonical_remote 'https://ghe.corp.example.com/mikelward/scripts.git')" \
+        != "$(canonical_remote 'git@ghe.corp.example.com:mikelward/scripts.git')"
+}
+
+# The repo paths carry a .git suffix, but a checkout cloned by hand often
+# doesn't. Both spell the same repository, so a byte-for-byte comparison would
+# tell the user --github hadn't applied when it had nothing to apply.
+test_existing_checkout_suffix_spelling_is_quiet() {
+    run_clone_or_pull_existing yes \
+        "https://ghe.corp.example.com/mikelward/scripts" \
+        "https://ghe.corp.example.com/mikelward/scripts.git"
+    assert_status 0 &&
+    assert_output_lacks "leaving the remote as-is"
+}
+
+# A checkout that already points at the mirror is the expected state, so the
+# re-run says nothing about it.
+test_existing_checkout_match_is_quiet() {
+    run_clone_or_pull_existing yes \
+        "https://ghe.corp.example.com/mikelward/scripts.git" \
+        "https://ghe.corp.example.com/mikelward/scripts.git"
+    assert_status 0 &&
+    assert_output_lacks "leaving the remote as-is"
+}
+
+# On the default prefix an HTTPS github.com checkout differs from the SSH URL
+# harmlessly -- that's what offer_ssh_remotes is for -- so the mismatch warning
+# must stay quiet rather than nagging on every ordinary re-run.
+test_existing_checkout_quiet_on_default_prefix() {
+    run_clone_or_pull_existing no \
+        "https://github.com/mikelward/scripts.git" \
+        "git@github.com:mikelward/scripts.git"
+    assert_status 0 &&
+    assert_output_lacks "leaving the remote as-is"
+}
+
+# clone_or_pull is shared: install_helix calls it with a hard-coded upstream
+# URL that --github never steers, and that checkout's origin may legitimately
+# be an SSH URL or a fork. Such a caller must not inherit the mismatch check,
+# or a mirror prefix would claim --github asked for a different Helix remote.
+test_unprefixed_caller_skips_the_mismatch_check() {
+    run_clone_or_pull_existing yes \
+        "git@github.com:someone/helix.git" \
+        "https://github.com/helix-editor/helix" \
+        no
+    assert_status 0 &&
+    assert_output_lacks "leaving the remote as-is" &&
+    assert_output_contains "BOOTSTRAP_CONTINUED"
 }
 
 # --- no-sudo mode ---
@@ -884,7 +1130,8 @@ test_github_rejects_empty_equals() {
 # The repos are assembled from GITHUB_PREFIX + path, defaulting to GitHub over
 # SSH, so an unset --github clones from github.com exactly as before.
 test_github_default_and_assembly() {
-    assert_source_contains 'GITHUB_PREFIX="${GITHUB_PREFIX:-git@github.com:}"' &&
+    assert_source_contains 'GITHUB_DEFAULT_PREFIX="git@github.com:"' &&
+    assert_source_contains 'GITHUB_PREFIX="${GITHUB_PREFIX:-$GITHUB_DEFAULT_PREFIX}"' &&
     assert_source_contains 'SCRIPTS_REPO_PATH="mikelward/scripts.git"' &&
     assert_source_contains 'SCRIPTS_REPO="${GITHUB_PREFIX}${SCRIPTS_REPO_PATH}"' &&
     assert_source_contains 'CONF_REPO="${GITHUB_PREFIX}${CONF_REPO_PATH}"' &&
@@ -906,6 +1153,51 @@ test_normalize_github_prefix() {
     assert_eq "$(normalize_github_prefix 'ssh://git@ghe.corp')" 'ssh://git@ghe.corp/'
 }
 
+# GITHUB_MIRROR is what the SSH-key and remote-rewrite steps key off, so it has
+# to be derived from the *normalized* prefix -- otherwise "--github git@github.com"
+# (the default, spelled without its separator) would look like a mirror. The
+# HTTPS check decides whether an SSH key is needed to clone at all.
+test_github_mirror_derived_after_normalizing() {
+    assert_source_contains 'test "$GITHUB_MIRROR" = yes' &&
+    assert_source_contains 'if test "$GITHUB_PREFIX" = "$GITHUB_DEFAULT_PREFIX"; then' &&
+    assert_source_contains 'GITHUB_PREFIX_SSH=no' &&
+    # The GITHUB_MIRROR/GITHUB_PREFIX_SSH block reads the normalized prefix, so
+    # it must come after normalize_github_prefix rewrites it.
+    test "$(grep -n 'GITHUB_PREFIX=$(normalize_github_prefix' "$SETUP" | cut -d: -f1)" \
+        -lt "$(grep -n '^    GITHUB_MIRROR=no$' "$SETUP" | cut -d: -f1)"
+}
+
+# Exercise the real github_prefix_host: both prefix shapes reduce to a bare
+# host, so the SSH-key and remote messages can name where the repos came from.
+test_github_prefix_host() {
+    eval "$(sed -n '/^github_prefix_host() {/,/^}/p' "$SETUP")"
+    assert_eq "$(github_prefix_host 'git@github.com:')" 'github.com' &&
+    assert_eq "$(github_prefix_host 'git@ghe.corp.example.com:')" 'ghe.corp.example.com' &&
+    assert_eq "$(github_prefix_host 'https://ghe.corp.example.com/')" 'ghe.corp.example.com' &&
+    assert_eq "$(github_prefix_host 'ssh://git@ghe.corp.example.com/')" 'ghe.corp.example.com' &&
+    assert_eq "$(github_prefix_host 'https://user@ghe.corp.example.com/')" 'ghe.corp.example.com'
+}
+
+# Exercise the real redact_url_credentials. An HTTPS clone URL can carry a
+# token, and the token-as-username forms mean a bare user-info is no safer than
+# a password, so the whole of it is replaced -- while credential-free URLs and
+# scp-style remotes (no password field in that syntax) print unchanged, so the
+# ordinary case stays readable and copy-pasteable.
+test_redact_url_credentials() {
+    eval "$(sed -n '/^redact_url_credentials() {/,/^}/p' "$SETUP")"
+    assert_eq "$(redact_url_credentials 'https://user:tok@ghe.corp.example.com/mikelward/scripts.git')" \
+        'https://***@ghe.corp.example.com/mikelward/scripts.git' &&
+    assert_eq "$(redact_url_credentials 'https://tok@ghe.corp.example.com/mikelward/scripts.git')" \
+        'https://***@ghe.corp.example.com/mikelward/scripts.git' &&
+    assert_eq "$(redact_url_credentials 'https://ghe.corp.example.com/mikelward/scripts.git')" \
+        'https://ghe.corp.example.com/mikelward/scripts.git' &&
+    assert_eq "$(redact_url_credentials 'git@github.com:mikelward/scripts.git')" \
+        'git@github.com:mikelward/scripts.git' &&
+    # An '@' in the path is not user-info, so it survives untouched.
+    assert_eq "$(redact_url_credentials 'https://ghe.corp.example.com/mikelward/a@b.git')" \
+        'https://ghe.corp.example.com/mikelward/a@b.git'
+}
+
 run_test "--github is accepted and takes an argument" test_github_flag_accepted
 run_test "--github=VALUE form parses" test_github_equals_form_accepted
 run_test "--github without an argument errors" test_github_requires_argument
@@ -916,6 +1208,32 @@ run_test "repos default to github.com over SSH via GITHUB_PREFIX" \
     test_github_default_and_assembly
 run_test "normalize_github_prefix appends the right separator" \
     test_normalize_github_prefix
+run_test "the mirror flags are derived from the normalized prefix" \
+    test_github_mirror_derived_after_normalizing
+run_test "github_prefix_host reduces both prefix shapes to a host" \
+    test_github_prefix_host
+run_test "redact_url_credentials strips embedded user-info" \
+    test_redact_url_credentials
+run_test "a mirror prefix skips the SSH remote-switch offer" \
+    test_mirror_skips_ssh_remote_offer
+run_test "the default prefix still reaches the remote-switch offer" \
+    test_default_prefix_reaches_ssh_remote_offer
+run_test "an HTTPS prefix names its host and doesn't wait for the key" \
+    test_https_prefix_key_prompt_does_not_block
+run_test "a mismatched existing checkout is reported under a mirror prefix" \
+    test_existing_checkout_mismatch_warns
+run_test "the mismatch warning redacts credentials in both URLs" \
+    test_existing_checkout_mismatch_redacts_credentials
+run_test "canonical_remote folds interchangeable URL spellings" \
+    test_canonical_remote
+run_test "a .git-suffix spelling difference is not a mismatch" \
+    test_existing_checkout_suffix_spelling_is_quiet
+run_test "a matching existing checkout is silent under a mirror prefix" \
+    test_existing_checkout_match_is_quiet
+run_test "the default prefix doesn't second-guess an existing remote" \
+    test_existing_checkout_quiet_on_default_prefix
+run_test "a caller whose URL isn't from the prefix skips the check" \
+    test_unprefixed_caller_skips_the_mismatch_check
 
 run_test "--no-sudo is accepted as a known option" test_no_sudo_flag_accepted
 run_test "--no-sudo is documented in usage" test_no_sudo_in_usage


### PR DESCRIPTION
`--github` (and `GITHUB_PREFIX`) only steered the clone URLs; everything downstream still behaved as if the repos came from github.com over SSH.

This derives `GITHUB_MIRROR` / `GITHUB_HOST` / `GITHUB_PREFIX_SSH` from the normalized prefix and uses them in the three places that got it wrong.

## The reported one: the remote-switch offer

The end-of-run "Switch your repo remotes (scripts, conf, root) from HTTPS to SSH?" prompt is skipped under a non-default prefix. Both shapes the prefix can take argue against the offer:

- an internal mirror is a host `gittossh` doesn't rewrite at all (it only knows github.com and codeberg.org), so the prompt could only ever answer "nothing to convert";
- an HTTPS prefix was chosen precisely because SSH isn't the way in, so converting would break the remote.

## Two others with the same root cause

**The SSH key step.** It pointed at `https://github.com/settings/ssh/new`, a URL a mirror deployment doesn't share, and then *blocked* on "Press Enter after adding the key to GitHub and Codeberg". The instructions now name the prefix's host, and under an HTTPS prefix the key is printed without waiting — nothing setup clones authenticates with it (the repos come over HTTPS, as does Krohnkite), so an otherwise unattended bootstrap no longer stalls on a key it never uses.

**Re-runs over an existing checkout.** `clone_or_pull` pulls an existing checkout as-is, so `setup --github https://ghe.corp.example.com` over repos already cloned from github.com silently did nothing at all. It now reports the mismatch and gives the `git remote set-url` that fixes it.

Two things keep that check from crying wolf:

- It only applies to the three repos whose URL comes from the prefix. `clone_or_pull` is shared, and `install_helix` passes a hard-coded upstream URL that `--github` never steers — that checkout's origin may legitimately be an SSH URL or a fork. The function takes an optional third argument saying whether the prefix applies, defaulting to off, so a future caller has to opt in rather than silently inherit the check.
- URLs are compared canonically, so `.../OWNER/REPO` and the `.../OWNER/REPO.git` the repo paths are written as aren't reported as a mismatch. Only the spellings git itself treats as interchangeable are folded — a trailing slash and the `.git` suffix. Protocol and host differences survive, because those are the mismatches worth reporting.

And it stays quiet on the default prefix, where an HTTPS github.com checkout differs from the SSH URL harmlessly — that's what `offer_ssh_remotes` is for.

## Credentials in printed URLs

An HTTPS clone URL can carry a token — as the password, or as the *username* in the token-as-user forms (`https://TOKEN@host/...`, `https://x-access-token:TOKEN@host/...`). A token in output that gets pasted somewhere is immediately usable by whoever reads it, so `redact_url_credentials` replaces the whole user-info with `***` before any URL is printed, including on the pre-existing `Cloning ... into ...` line which had the same hole.

Scope is deliberately just that. Credential-free URLs and scp-style remotes (`git@HOST:PATH`, a syntax with no password field) print unchanged: hosts, paths and remotes are what make these messages useful, nothing captures the output, and none of them are dangerous to a reader.

## Not changed

The third-party GitHub fetches (fonts, the helix clone, the rustup/uv/fnm installers, homepkg's github backend) still go to github.com. `--github` is documented as "clone the scripts/conf/root repos from PREFIX", and a GHE-style mirror generally carries an org's own repos rather than proxying all of github.com, so redirecting those would break more than it fixed.

## Compatibility

The default path is unchanged. The prefix is compared *after* normalization, so `--github git@github.com` is still recognized as the default rather than mistaken for a mirror.

## Testing

`make test` — all suites green, 71 tests in `setup_test`. Eleven new tests, each failing against `main`:

- a mirror prefix skips the remote-switch offer and never runs `gittossh`; the default prefix still falls through to it
- `github_prefix_host` reduces both prefix shapes (scp-style and URL, with or without `user@`) to a bare host
- `redact_url_credentials` strips both credentialed forms, leaves credential-free and scp-style URLs alone, and doesn't mistake an `@` in the *path* for user-info
- `canonical_remote` folds the `.git` suffix and a trailing slash, but not a protocol difference
- the mirror flags are derived after `normalize_github_prefix`, not before
- an HTTPS prefix names its host and returns before the blocking prompt
- the existing-checkout mismatch warns under a mirror prefix and redacts credentials in both URLs, and stays quiet when the remote matches, when only the `.git` spelling differs, on the default prefix, and for a caller whose URL didn't come from the prefix

The quiet-case assertions were mutation-tested — forcing the guard true, and restoring the byte-for-byte URL comparison — to confirm they fail when the behavior regresses rather than passing vacuously. The `clone_or_pull` and `generate_ssh_key` tests run the real functions against stub `git` / `ssh-keygen`, so they touch neither the network nor a terminal.