### PR TITLE
AGENTS.md: say that script output isn't a publishable artifact

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,10 +48,10 @@ stopping at the file you opened.
 ## Error handling
 
 - **Don't silently swallow errors.** A bare `2>/dev/null`, an unchecked exit
-  status, or a `|| true` hides real failures. Report what failed (sanitized —
-  the *Privacy* rule applies to warnings too), clean up what the failed step
-  created, and decide explicitly what the caller sees. To ignore a specific
-  failure, say why in a one-line comment (`# not every host has shpool`).
+  status, or a `|| true` hides real failures. Report what failed, clean up what
+  the failed step created, and decide explicitly what the caller sees. To
+  ignore a specific failure, say why in a one-line comment (`# not every host
+  has shpool`).
 
 ## Privacy
 
@@ -64,6 +64,9 @@ stopping at the file you opened.
   placeholders (`/home/user`, `host1`, `git@example.com:org/repo.git`) in
   examples and fixtures. If a bug report contains any of it, paraphrase in
   the commit / PR — don't quote verbatim. When in doubt, ask before pushing.
+- **Script output is not one of those artifacts.** It prints on the user's own
+  terminal, and naming hosts, paths and remotes is usually the point of the
+  message. Redact only secrets: tokens, keys, and passwords embedded in URLs.
 
 ## Language and spelling
 


### PR DESCRIPTION
The Privacy rule is headed "never put user data in any artifact that **leaves this machine**", and its list — hostnames, internal domains, home paths, SSH aliases — is calibrated for commits, PRs and fixtures. The Error handling rule then pointed warnings at that whole list. So an agent reading it scrubbed the user's own hostname from the user's own terminal.

That's not hypothetical. On #165 it produced four escalating review findings against `setup`, three of which had to be reverted: rendering `$HOME/scripts` as `~/scripts`, dropping both remote URLs from a mismatch warning so it read "cloned from a different remote" with no way to see which, and finally replacing `$GITHUB_HOST` with "the configured mirror" in the instruction *telling the user which host to add their SSH key to*. The reverted wording also took working tests with it — the reworded warning left three negative assertions matching a string the code no longer emitted.

## The change

Two edits, no net growth:

- **Error handling** loses the `(sanitized — the *Privacy* rule applies to warnings too)` parenthetical.
- **Privacy** gains one bullet: script output isn't one of those artifacts; redact only secrets.

## Why it moved rather than being reworded in place

Output isn't only produced on the error path. The reading that prompted this was applied to plain `info` lines — the SSH-key instructions — not warnings at all, even though the rule said "warnings". Putting the correction in an error-handling bullet would repeat the original category error: a privacy statement filed under a heading about failures, governing a subset of the output it actually concerns.

It belongs in Privacy, said once, covering all output.

## What it still forbids

Nothing about the artifact rule changes — commits, PR text, code comments and fixtures are untouched. And the distinction it draws keeps the case that matters: a token embedded in an HTTPS clone URL is immediately usable by whoever reads it, and easy not to notice, so it's still redacted. `setup`'s credential redaction on #165 remains correct under this wording; every other finding it produced does not.

## Testing

`make test` — all suites green. No test added: AGENTS.md is documentation, which the Testing rule explicitly exempts.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G9UAj5S6D5mnU6UQ6NwsJC)_