### PR TITLE
Cross-pollinate the offline-sandbox git rule; bound the output exemption

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,8 @@ stopping at the file you opened.
 - **Script output is not one of those artifacts.** It prints on the user's own
   terminal, and naming hosts, paths and remotes is usually the point of the
   message. Redact only secrets: tokens, keys, and passwords embedded in URLs.
+  Quoting that output into a commit, PR, or fixture republishes it, and the
+  bullet above governs again — paraphrase or use a placeholder there.
 
 ## Language and spelling
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,17 @@ stopping at the file you opened.
   isn't disturbed by work on another.
 - **These rules assume an `origin` remote.** Without one you can't fetch,
   branch from `origin/main`, push, or open a PR — say so and stop rather than
-  improvising a local substitute.
+  improvising a local substitute. **Exception:** in a sandbox that
+  intentionally provides no remote Git support (Codex cloud, say), follow the
+  normal branch rules from the current `HEAD` — a pre-created working branch
+  counts — commit locally, and report that fetch, push, and pull requests are
+  unavailable, using the sandbox's own PR handoff if it has one. That exception
+  outranks every `origin`-dependent step below it — the merge-cue fetch, cutting
+  a branch off `origin/main`, the closing PR link — so work from the current
+  `HEAD` and name what wasn't possible instead of faking it. One limit: a merge
+  cue needs a base that *contains* the merge, and an offline sandbox can't fetch
+  one. Say the follow-up needs a fresh sandbox or a synced checkout rather than
+  branching off a `HEAD` whose commits just landed upstream.
 - **Branch naming.** Feature branches are prefixed with the agent's own short
   name: `<agent>/<short-topic>` (`claude/...` for Claude Code, `codex/...`
   for Codex, and so on). The placeholder `<agent>` stands in for whichever
@@ -152,7 +162,9 @@ stopping at the file you opened.
   (anthropics/claude-code#46625).
 - End every reply with the open-PR link (or `.../compare/main...<branch>`
   until a PR exists). Never link to a closed or merged PR — except when the
-  reply *is* post-merge follow-up on that PR, where linking it is correct.
+  reply *is* post-merge follow-up on that PR, where linking it is correct. In an
+  offline sandbox with no `origin` there's no URL to end with — say that, rather
+  than inventing a link that resolves to nothing.
 
 ## Reviews
 


### PR DESCRIPTION
Cross-pollination pass over `AGENTS.md` across the five repos. Two commits.

## Offline sandboxes without an `origin` remote

`vcs` and `mesh` grew an exception to the assume-an-`origin` rule — some
sandboxes intentionally ship no remote Git support, and telling an agent to stop
there throws away work it could have committed locally and handed off. They
worded it two different ways; this brings the exception here on the wording now
shared by all five repos:

> follow the normal branch rules from the current `HEAD` — a pre-created working
> branch counts — commit locally, and report that fetch, push, and pull requests
> are unavailable, using the sandbox's own PR handoff if it has one.

A missing `origin` anywhere else still means say so and stop.

Codex noticed the exception collided with the reply-link rule further down: with
no remote there's no URL to end a reply with, so the two rules together left only
"fabricate a link" as a way out. That rule is now waived for the offline case
here, in `vcs`, and in `root` — the three repos that carry it.

## Quoting script output into an artifact still publishes it

"Script output is not one of those artifacts" landed here in b51633e, and is
right for output printed on the user's own terminal. Read alone, though, it also
licenses pasting a diagnostic that names a real host or home path straight into a
commit or PR body — the exemption is about printing, not about republishing.
Reviewing the parallel PRs surfaced the same gap in each, so the boundary is now
stated in all five:

> Quoting that output into a commit, PR, or fixture republishes it, and the
> bullet above governs again — paraphrase or use a placeholder there.

Codex separately argued the exemption should be conditional on the output staying
local (redirects and CI logs persist it). Declined, with reasoning on the threads
in `vcs`/`conf`/`mesh`: the rule is read when *writing* a message, where the
destination is unknowable, so a destination test resolves to sanitize-always —
the exact bug the exemption exists to fix. Republishing is a choice the author
controls, which is why that's where the line went.

## Sibling PRs

- https://github.com/mikelward/vcs/pull/56
- https://github.com/mikelward/conf/pull/233
- https://github.com/mikelward/mesh/pull/304
- https://github.com/mikelward/root/pull/30

## Testing

Documentation only, so no test added, per the rule about not manufacturing test
churn. `make test` passes, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UqKFQQtAQE92fdLbW2ds9i