### PR TITLE
setup-kde: apply keyboard shortcuts to the running session

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,4 +17,5 @@ test:
 	./runenv_test
 	./setup_test
 	./setup-kde_test
+	./kdeshortcut_test
 	./dvorak_test

--- a/kdeshortcut.py
+++ b/kdeshortcut.py
@@ -1,0 +1,462 @@
+#!/usr/bin/env python3
+# Apply KDE global shortcuts to the *running* kglobalaccel, so they work
+# without logging out.
+#
+# kwriteconfig6 edits kglobalshortcutsrc behind kglobalaccel's back. The
+# daemon holds the whole shortcut registry in memory and treats the file as
+# its own serialization, so a file edit changes nothing until the daemon
+# reloads it -- which it only does at startup, i.e. at the next login. System
+# Settings doesn't have this problem because it doesn't edit the file: it
+# calls the daemon, which re-grabs the key and then persists.
+#
+# This does the same call System Settings does (setForeignShortcutKeys), then
+# reads the binding back out of the daemon so a shortcut that didn't take is
+# reported now instead of silently deferring to the next login.
+#
+# Usage:
+#     kdeshortcut.py <component> <action> <keys> [label]
+#     kdeshortcut.py --batch [<file>]
+#     kdeshortcut.py --check <component> <action> <keys> [label]
+#
+# --batch reads one shortcut per line from <file> (default stdin) as
+# tab-separated component, action, keys, and optional label; blank lines and
+# #-comments are skipped. --check only reads the daemon back and reports,
+# changing nothing.
+#
+# <keys> is a shortcut in the form KDE writes it -- "Meta+T", "Meta+Shift+F1",
+# and note that KDE records shifted characters as the character produced
+# ("Meta+!", not "Meta+Shift+1"). "none" (or an empty string) unbinds.
+#
+# Exit status:
+#     0  every shortcut is live in the running session
+#     1  at least one shortcut did not take (details on stderr)
+#     2  usage error
+#     3  the daemon can't be reached at all -- no D-Bus binding available, no
+#        session bus, or kglobalaccel not running. The caller should fall back
+#        to telling the user to log out; nothing was changed.
+
+import os
+import re
+import subprocess
+import sys
+
+HELP = """Usage: kdeshortcut.py [--check] [--quiet] <component> <action> <keys> [label]
+       kdeshortcut.py [--check] [--quiet] --batch [<file>]
+
+Apply KDE global shortcuts to the running kglobalaccel, so they take effect
+without logging out.
+
+Arguments:
+  component  kglobalaccel component, e.g. kwin, plasmashell, or a launcher's
+             .desktop file name
+  action     action ID within that component, e.g. "Window Close", _launch
+  keys       shortcut as KDE writes it, e.g. Meta+T, Meta+Shift+F1, Meta+!
+             ("none" or an empty string unbinds)
+  label      optional human-readable name for the action
+
+Options:
+  --batch    read tab-separated component/action/keys/label lines from <file>
+             (default stdin); blank lines and #-comments are skipped
+  --check    report what the daemon currently holds, changing nothing
+  --quiet    only report failures
+  --backend  force a D-Bus backend: gdbus or dbus-python (default: whichever
+             works, gdbus first)
+  -h, --help show this help and exit
+
+Exit status:
+  0  every shortcut is live in the running session
+  1  at least one shortcut did not take
+  2  usage error
+  3  kglobalaccel could not be reached; nothing was changed
+"""
+
+# kglobalaccel's own D-Bus identity. In Plasma 6 the daemon is embedded in
+# KWin, but it still owns this service name -- that's how System Settings
+# reaches it -- so there's nothing KWin-specific to special-case here.
+SERVICE = 'org.kde.kglobalaccel'
+OBJECT = '/kglobalaccel'
+INTERFACE = 'org.kde.KGlobalAccel'
+
+# Qt6 keyboard modifier bits (Qt::KeyboardModifier).
+MODIFIERS = {
+    'shift': 0x02000000,
+    'ctrl': 0x04000000,
+    'control': 0x04000000,
+    'alt': 0x08000000,
+    'meta': 0x10000000,
+    # KDE writes the Super/Windows key as Meta; accept the aliases people
+    # type so a hand-edited batch file doesn't fail for a spelling.
+    'super': 0x10000000,
+    'win': 0x10000000,
+}
+
+# Qt6 Qt::Key values for keys with no printable character. Printable ASCII
+# needs no table -- those Qt::Key values are the character's own code point,
+# which keycode() relies on.
+NAMED_KEYS = {
+    'escape': 0x01000000,
+    'esc': 0x01000000,
+    'tab': 0x01000001,
+    'backtab': 0x01000002,
+    'backspace': 0x01000003,
+    'return': 0x01000004,
+    'enter': 0x01000005,
+    'insert': 0x01000006,
+    'ins': 0x01000006,
+    'delete': 0x01000007,
+    'del': 0x01000007,
+    'pause': 0x01000008,
+    'print': 0x01000009,
+    'sysreq': 0x0100000A,
+    'clear': 0x0100000B,
+    'home': 0x01000010,
+    'end': 0x01000011,
+    'left': 0x01000012,
+    'up': 0x01000013,
+    'right': 0x01000014,
+    'down': 0x01000015,
+    'pageup': 0x01000016,
+    'prior': 0x01000016,
+    'pagedown': 0x01000017,
+    'next': 0x01000017,
+    'space': 0x20,
+    'menu': 0x01000055,
+    'help': 0x01000058,
+}
+
+# Qt::Key_F1; F2..F35 follow consecutively.
+KEY_F1 = 0x01000030
+MAX_FUNCTION_KEY = 35
+
+
+class ShortcutError(Exception):
+    """A shortcut string that can't be turned into Qt keycodes."""
+
+
+def keycode(token):
+    """Map one key name ("T", "Return", "F3", "\\") to its Qt::Key value."""
+    key = token.strip()
+    if not key:
+        raise ShortcutError('empty key name')
+
+    # Shortcuts come through in the form kglobalshortcutsrc holds them, where
+    # a comma or a backslash in the key is backslash-escaped: KConfig reads
+    # the value with readEntry(QStringList), so an unescaped comma would split
+    # the entry into a fourth field and be discarded. The escape belongs to
+    # that file format, not to the key, so drop it before looking the key up.
+    if len(key) == 2 and key.startswith('\\'):
+        key = key[1:]
+
+    lowered = key.lower()
+    if lowered in NAMED_KEYS:
+        return NAMED_KEYS[lowered]
+
+    match = re.fullmatch(r'f([0-9]+)', lowered)
+    if match:
+        number = int(match.group(1))
+        if not 1 <= number <= MAX_FUNCTION_KEY:
+            raise ShortcutError('no such function key: %s' % key)
+        return KEY_F1 + number - 1
+
+    if len(key) == 1:
+        # Qt::Key values for printable ASCII are the code point of the
+        # *uppercase* character: Qt::Key_A is 0x41, and there is no Key_a.
+        # Non-ASCII (a dead key, a national layout character) has no stable
+        # Qt::Key we can compute, so refuse rather than send a wrong code.
+        char = key.upper()
+        if ord(char) > 0x7E:
+            raise ShortcutError('non-ASCII key not supported: %s' % key)
+        return ord(char)
+
+    raise ShortcutError('unrecognized key name: %s' % key)
+
+
+def parse_shortcut(text):
+    """Parse "Meta+Shift+F1" into a list of Qt keycodes (one per sequence).
+
+    Returns [] for an unbind, which is what the daemon wants for "no keys".
+    """
+    shortcut = (text or '').strip()
+    if not shortcut or shortcut.lower() == 'none':
+        return []
+
+    # '+' separates modifiers from the key, but is also a key name itself
+    # ("Meta++"), so a trailing '+' is the key rather than an empty token.
+    if shortcut.endswith('+'):
+        modifier_text, key = shortcut[:-1], '+'
+    else:
+        modifier_text, _, key = shortcut.rpartition('+')
+
+    modifiers = 0
+    for part in modifier_text.split('+'):
+        if not part.strip():
+            continue
+        name = part.strip().lower()
+        if name not in MODIFIERS:
+            raise ShortcutError('unrecognized modifier: %s' % part)
+        modifiers |= MODIFIERS[name]
+
+    return [modifiers | keycode(key)]
+
+
+def format_keys(keys):
+    """Render keycodes back for reporting. Exact spelling doesn't matter --
+    this is only ever shown to a human comparing what was asked vs. what the
+    daemon holds, so the raw codes are more honest than a lossy round trip."""
+    if not keys:
+        return 'none'
+    return '+'.join(str(key) for key in keys)
+
+
+class DbusPythonBackend:
+    """dbus-python: preferred, since it marshals a(ai) natively."""
+
+    name = 'dbus-python'
+
+    def __init__(self):
+        import dbus
+
+        self._dbus = dbus
+        bus = dbus.SessionBus()
+        proxy = bus.get_object(SERVICE, OBJECT)
+        self._iface = dbus.Interface(proxy, INTERFACE)
+
+    def _sequences(self, keys):
+        dbus = self._dbus
+        # a(ai): array of QKeySequence, each a struct wrapping an int array.
+        return dbus.Array(
+            [dbus.Struct((dbus.Array([dbus.Int32(key) for key in keys], signature='i'),))],
+            signature='(ai)',
+        ) if keys else dbus.Array([], signature='(ai)')
+
+    def set_keys(self, action_id, keys):
+        self._iface.setForeignShortcutKeys(
+            self._dbus.Array(action_id, signature='s'), self._sequences(keys))
+
+    def get_keys(self, action_id):
+        result = self._iface.shortcutKeys(self._dbus.Array(action_id, signature='s'))
+        return [int(key) for sequence in result for key in sequence]
+
+
+class GdbusBackend:
+    """gdbus: GVariant's text format can express a(ai), which qdbus6 and
+    dbus-send cannot -- neither can build a struct argument at all."""
+
+    name = 'gdbus'
+
+    def __init__(self):
+        if not which('gdbus'):
+            raise RuntimeError('gdbus not found')
+        # Fail here rather than on the first shortcut, so the caller gets
+        # "can't reach the daemon" instead of a list of failed shortcuts.
+        self._call('org.freedesktop.DBus.Peer.Ping', [])
+
+    def _call(self, method, args):
+        command = ['gdbus', 'call', '--session', '--dest', SERVICE,
+                   '--object-path', OBJECT, '--method', method] + args
+        result = subprocess.run(command, stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE, universal_newlines=True)
+        if result.returncode != 0:
+            raise RuntimeError((result.stderr or result.stdout).strip()
+                               or 'gdbus call failed: %s' % method)
+        return result.stdout
+
+    def _action_id(self, action_id):
+        return '[%s]' % ', '.join(gvariant_string(field) for field in action_id)
+
+    def set_keys(self, action_id, keys):
+        if keys:
+            # A one-element GVariant tuple needs the trailing comma.
+            sequences = '[([%s],)]' % ', '.join(str(key) for key in keys)
+        else:
+            # An empty list is ambiguous in GVariant text; annotate the type.
+            sequences = '@a(ai) []'
+        self._call('%s.setForeignShortcutKeys' % INTERFACE,
+                   [self._action_id(action_id), sequences])
+
+    def get_keys(self, action_id):
+        output = self._call('%s.shortcutKeys' % INTERFACE,
+                            [self._action_id(action_id)])
+        return [int(match) for match in re.findall(r'-?\d+', output)]
+
+
+def gvariant_string(text):
+    """Quote a string for GVariant text format."""
+    return "'%s'" % text.replace('\\', '\\\\').replace("'", "\\'")
+
+
+def which(program):
+    for directory in os.environ.get('PATH', '').split(os.pathsep):
+        candidate = os.path.join(directory, program)
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+
+BACKENDS = (GdbusBackend, DbusPythonBackend)
+
+
+def open_backend(wanted=None):
+    """Return a working D-Bus backend, or raise RuntimeError describing why
+    none is usable. Reasons are collected so the message names every thing
+    that was tried -- "no D-Bus binding" is not actionable on its own.
+
+    gdbus is tried first because it needs no Python D-Bus binding installed,
+    and because it's the path the tests cover; dbus-python is the fallback for
+    a box with the binding but without glib's CLI tools.
+    """
+    reasons = []
+    for factory in BACKENDS:
+        if wanted and factory.name != wanted:
+            continue
+        try:
+            return factory()
+        except ImportError:
+            reasons.append('%s: not installed' % factory.name)
+        except Exception as error:  # noqa: BLE001 - reported, never swallowed
+            reasons.append('%s: %s' % (factory.name, error))
+    if not reasons:
+        raise RuntimeError('unknown backend: %s' % wanted)
+    raise RuntimeError('; '.join(reasons))
+
+
+def apply_shortcut(backend, component, action, keys_text, label, check_only):
+    """Set one shortcut and confirm the daemon holds it. Returns (ok, note)."""
+    wanted = parse_shortcut(keys_text)
+
+    # actionId is kglobalaccel's 4-field identity: unique and friendly names
+    # for both the component and the action. Only the two unique names are
+    # matched against the registry -- the friendly names are display text the
+    # daemon uses when it has to create an entry -- so the component's unique
+    # name stands in for its friendly name, which this script has no way to
+    # know, and the label describes the action.
+    action_id = [component, action, component, label or action]
+
+    if not check_only:
+        backend.set_keys(action_id, wanted)
+
+    live = backend.get_keys(action_id)
+    if live == wanted:
+        return True, format_keys(wanted)
+
+    if not live:
+        # setForeignShortcutKeys only mutates actions already registered in
+        # the session. An action the daemon has never heard of stays absent,
+        # which is the common case for a component that hasn't started yet.
+        return False, ('daemon holds no binding -- action not registered in '
+                       'this session, so it applies at next login')
+    return False, ('daemon holds %s, wanted %s' % (format_keys(live), format_keys(wanted)))
+
+
+def read_batch(stream):
+    """Parse tab-separated component/action/keys/label lines."""
+    entries = []
+    for number, line in enumerate(stream, start=1):
+        text = line.strip()
+        if not text or text.startswith('#'):
+            continue
+        fields = line.rstrip('\n').split('\t')
+        if len(fields) < 3:
+            raise ShortcutError(
+                'line %d: need tab-separated component, action, keys' % number)
+        component, action, keys = fields[0], fields[1], fields[2]
+        label = fields[3] if len(fields) > 3 else ''
+        entries.append((component.strip(), action.strip(), keys.strip(), label.strip()))
+    return entries
+
+
+def usage(message=None):
+    if message:
+        sys.stderr.write('kdeshortcut.py: %s\n' % message)
+    sys.stderr.write(
+        'Usage: kdeshortcut.py [--check] <component> <action> <keys> [label]\n'
+        '       kdeshortcut.py [--check] --batch [<file>]\n')
+    return 2
+
+
+def main(argv):
+    check_only = False
+    batch = False
+    quiet = False
+    wanted_backend = None
+    args = []
+
+    index = 0
+    while index < len(argv):
+        argument = argv[index]
+        if argument == '--check':
+            check_only = True
+        elif argument == '--batch':
+            batch = True
+        elif argument == '--quiet':
+            quiet = True
+        elif argument == '--backend' or argument.startswith('--backend='):
+            if argument == '--backend':
+                index += 1
+                if index >= len(argv):
+                    return usage('--backend needs an argument')
+                wanted_backend = argv[index]
+            else:
+                wanted_backend = argument.split('=', 1)[1]
+        elif argument in ('-h', '--help'):
+            sys.stdout.write(HELP)
+            return 0
+        elif argument.startswith('-') and argument != '-':
+            return usage('unknown option: %s' % argument)
+        else:
+            args.append(argument)
+        index += 1
+
+    try:
+        if batch:
+            if len(args) > 1:
+                return usage('--batch takes at most one file')
+            if args and args[0] != '-':
+                with open(args[0]) as stream:
+                    entries = read_batch(stream)
+            else:
+                entries = read_batch(sys.stdin)
+        else:
+            if not 3 <= len(args) <= 4:
+                return usage('expected <component> <action> <keys> [label]')
+            entries = [(args[0], args[1], args[2], args[3] if len(args) > 3 else '')]
+    except (ShortcutError, OSError) as error:
+        sys.stderr.write('kdeshortcut.py: %s\n' % error)
+        return 2
+
+    if not entries:
+        return 0
+
+    try:
+        backend = open_backend(wanted_backend)
+    except RuntimeError as error:
+        sys.stderr.write('kdeshortcut.py: cannot reach kglobalaccel (%s)\n' % error)
+        return 3
+
+    failures = 0
+    for component, action, keys_text, label in entries:
+        try:
+            ok, note = apply_shortcut(backend, component, action, keys_text,
+                                      label, check_only)
+        except ShortcutError as error:
+            ok, note = False, str(error)
+        except Exception as error:  # noqa: BLE001 - one bad shortcut isn't fatal
+            ok, note = False, str(error)
+
+        if ok:
+            if not quiet:
+                sys.stdout.write('live  %s/%s -> %s\n' % (component, action, note))
+        else:
+            failures += 1
+            sys.stderr.write('FAIL  %s/%s (%s): %s\n'
+                             % (component, action, keys_text, note))
+
+    if failures:
+        sys.stderr.write('kdeshortcut.py: %d of %d shortcut(s) not live in this '
+                         'session\n' % (failures, len(entries)))
+        return 1
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))

--- a/kdeshortcut_test
+++ b/kdeshortcut_test
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+# Tests for kdeshortcut.py: the shortcut -> Qt keycode parser, the D-Bus
+# argument marshalling, and the reporting contract setup-kde relies on (which
+# exit status means "written but not live" versus "couldn't reach the daemon").
+#
+# The gdbus backend is exercised against a stub gdbus on PATH, which is what
+# makes the wire format testable without a session bus: the assertions check
+# the exact GVariant text, since that's the part a live daemon would reject
+# silently. Applying a shortcut to a *real* kglobalaccel can only be verified
+# on a running Plasma session -- kdeshortcut.py's own readback is what reports
+# that, and these tests cover the readback logic, not the daemon.
+
+import importlib.util
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+# Don't drop a __pycache__/ dir in the repo when importing kdeshortcut.py.
+sys.dont_write_bytecode = True
+
+_dir = os.path.dirname(os.path.abspath(__file__))
+_script = os.path.join(_dir, 'kdeshortcut.py')
+_spec = importlib.util.spec_from_file_location('kdeshortcut', _script)
+kdeshortcut = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(kdeshortcut)
+
+tests_run = 0
+failures = 0
+
+# Qt6 modifier bits, spelled out here rather than imported so a typo in the
+# module's table can't agree with itself and pass.
+META = 0x10000000
+SHIFT = 0x02000000
+CTRL = 0x04000000
+ALT = 0x08000000
+
+
+def check(label, expected, actual):
+    global tests_run, failures
+    tests_run += 1
+    if expected == actual:
+        print('ok %d %s' % (tests_run, label))
+    else:
+        print('not ok %d %s' % (tests_run, label))
+        print('  expected: %r' % (expected,))
+        print('  actual:   %r' % (actual,))
+        failures += 1
+
+
+def check_raises(label, exception, call):
+    global tests_run, failures
+    tests_run += 1
+    try:
+        call()
+    except exception:
+        print('ok %d %s' % (tests_run, label))
+        return
+    except Exception as error:  # noqa: BLE001 - wrong exception is a failure
+        print('not ok %d %s' % (tests_run, label))
+        print('  expected %s, raised %r' % (exception.__name__, error))
+        failures += 1
+        return
+    print('not ok %d %s' % (tests_run, label))
+    print('  expected %s, nothing raised' % exception.__name__)
+    failures += 1
+
+
+# --- Shortcut parsing ---
+#
+# Every form setup-kde actually writes, since a keycode that's wrong by a bit
+# is a shortcut that silently does nothing.
+
+check('a plain letter is the uppercase code point, Qt has no Key_a',
+      [META | 0x54], kdeshortcut.parse_shortcut('Meta+T'))
+check('a lowercase letter parses to the same code',
+      [META | 0x54], kdeshortcut.parse_shortcut('meta+t'))
+check('Backspace is a named key, not a character',
+      [META | 0x01000003], kdeshortcut.parse_shortcut('Meta+Backspace'))
+check('Return is a named key', [META | 0x01000004],
+      kdeshortcut.parse_shortcut('Meta+Return'))
+check('a digit is its own code point', [META | 0x31],
+      kdeshortcut.parse_shortcut('Meta+1'))
+check('KDE records a shifted digit as the character produced, with no Shift bit',
+      [META | 0x21], kdeshortcut.parse_shortcut('Meta+!'))
+check('backslash is a single-character key', [META | 0x5C],
+      kdeshortcut.parse_shortcut('Meta+\\'))
+check('comma is a single-character key', [META | 0x2C],
+      kdeshortcut.parse_shortcut('Meta+,'))
+check('backtick is a single-character key', [META | 0x60],
+      kdeshortcut.parse_shortcut('Meta+`'))
+check('slash is a single-character key', [META | 0x2F],
+      kdeshortcut.parse_shortcut('Meta+/'))
+# Regression: setup-kde passes shortcuts in the escaped form
+# kglobalshortcutsrc holds, because KConfig would otherwise split the entry on
+# the comma. The escape isn't part of the key.
+check('an escaped comma is the comma key', [META | 0x2C],
+      kdeshortcut.parse_shortcut('Meta+\\,'))
+check('an escaped backslash is the backslash key', [META | 0x5C],
+      kdeshortcut.parse_shortcut('Meta+\\\\'))
+check('function keys count up from F1', [META | SHIFT | 0x01000032],
+      kdeshortcut.parse_shortcut('Meta+Shift+F3'))
+check('several modifiers OR together', [CTRL | ALT | 0x01000007],
+      kdeshortcut.parse_shortcut('Ctrl+Alt+Delete'))
+check('Super is an alias for Meta', kdeshortcut.parse_shortcut('Meta+T'),
+      kdeshortcut.parse_shortcut('Super+T'))
+check('a trailing + is the plus key, not an empty token', [META | 0x2B],
+      kdeshortcut.parse_shortcut('Meta++'))
+check('"none" is an unbind, not a key', [], kdeshortcut.parse_shortcut('none'))
+check('an empty string is an unbind', [], kdeshortcut.parse_shortcut(''))
+check('surrounding whitespace is ignored', [META | 0x54],
+      kdeshortcut.parse_shortcut('  Meta+T  '))
+
+check_raises('an unknown key name is refused, not guessed',
+             kdeshortcut.ShortcutError,
+             lambda: kdeshortcut.parse_shortcut('Meta+Nonsense'))
+check_raises('an unknown modifier is refused',
+             kdeshortcut.ShortcutError,
+             lambda: kdeshortcut.parse_shortcut('Hyper+T'))
+check_raises('a function key out of range is refused',
+             kdeshortcut.ShortcutError,
+             lambda: kdeshortcut.parse_shortcut('Meta+F99'))
+check_raises('a non-ASCII key has no computable Qt::Key, so it is refused',
+             kdeshortcut.ShortcutError,
+             lambda: kdeshortcut.parse_shortcut('Meta+ä'))
+
+check("a quote in a GVariant string is escaped", r"'it\'s'",
+      kdeshortcut.gvariant_string("it's"))
+check('a backslash in a GVariant string is escaped', r"'a\\b'",
+      kdeshortcut.gvariant_string('a\\b'))
+
+
+# --- Batch parsing ---
+
+def batch(text):
+    return kdeshortcut.read_batch(text.splitlines(True))
+
+
+check('a batch line splits on tabs, so action IDs may contain spaces',
+      [('kwin', 'Switch to Desktop 1', 'Meta+1', 'Switch to Desktop 1')],
+      batch('kwin\tSwitch to Desktop 1\tMeta+1\tSwitch to Desktop 1\n'))
+check('the label is optional', [('kwin', 'Window Close', 'Meta+Backspace', '')],
+      batch('kwin\tWindow Close\tMeta+Backspace\n'))
+check('blank lines and comments are skipped',
+      [('kwin', 'a', 'Meta+A', '')],
+      batch('\n# a comment\nkwin\ta\tMeta+A\n\n'))
+check_raises('a line with too few fields is an error, not a silent skip',
+             kdeshortcut.ShortcutError, lambda: batch('kwin\tonly-two\n'))
+
+
+# --- The gdbus backend, against a stub gdbus ---
+
+STUB = """#!/bin/sh
+printf '%s\\n' "$*" >> "$GDBUS_LOG"
+for arg in "$@"; do
+    case "$arg" in *Peer.Ping) exit 0;; esac
+done
+case "$*" in
+    *shortcutKeys*)
+        if test -n "$STUB_KEYS"; then
+            printf '([([%s],)],)\\n' "$STUB_KEYS"
+        else
+            printf '(@a(ai) [],)\\n'
+        fi
+        ;;
+    *) echo '()';;
+esac
+exit 0
+"""
+
+workdir = tempfile.mkdtemp()
+try:
+    bindir = os.path.join(workdir, 'bin')
+    os.mkdir(bindir)
+    stub = os.path.join(bindir, 'gdbus')
+    with open(stub, 'w') as handle:
+        handle.write(STUB)
+    os.chmod(stub, 0o755)
+    log = os.path.join(workdir, 'gdbus.log')
+
+    def run(args, keys='', path=None, stdin=None):
+        """Run kdeshortcut.py with the stub gdbus, returning (status, out, err,
+        gdbus calls)."""
+        if os.path.exists(log):
+            os.remove(log)
+        env = dict(os.environ,
+                   PATH=path if path is not None else bindir + os.pathsep + os.environ.get('PATH', ''),
+                   GDBUS_LOG=log,
+                   STUB_KEYS=keys)
+        # PYTHONDONTWRITEBYTECODE: no __pycache__ in the repo from a subprocess.
+        env['PYTHONDONTWRITEBYTECODE'] = '1'
+        result = subprocess.run([sys.executable, _script] + args,
+                                capture_output=True, text=True, env=env,
+                                input=stdin)
+        calls = ''
+        if os.path.exists(log):
+            with open(log) as handle:
+                calls = handle.read()
+        return result.returncode, result.stdout, result.stderr, calls
+
+    META_T = str(META | 0x54)
+
+    status, out, err, calls = run(['kwin', 'Window Close', 'Meta+T', 'Close'],
+                                  keys=META_T)
+    check('a shortcut the daemon confirms exits 0', 0, status)
+    check('the daemon is asked to set the shortcut, the way System Settings does',
+          True, 'org.kde.KGlobalAccel.setForeignShortcutKeys' in calls)
+    check('actionId is the 4-field identity, component friendly name included',
+          True, "['kwin', 'Window Close', 'kwin', 'Close']" in calls)
+    check('keys marshal as a(ai): an array of one-element key sequences',
+          True, '[([%s],)]' % META_T in calls)
+    check('the binding is read back out of the daemon, not assumed',
+          True, 'org.kde.KGlobalAccel.shortcutKeys' in calls)
+    check('a confirmed shortcut is reported as live', True, 'live' in out)
+
+    status, out, err, calls = run(['kwin', 'Grid View', 'none'], keys='')
+    check('an unbind exits 0 when the daemon holds no keys', 0, status)
+    check('an empty key list is type-annotated, since GVariant [] is ambiguous',
+          True, '@a(ai) []' in calls)
+
+    status, out, err, calls = run(['kwin', 'Window Close', 'Meta+T'], keys='999')
+    check('a daemon holding different keys is a failure', 1, status)
+    check('the mismatch names both what the daemon holds and what was wanted',
+          True, 'daemon holds 999' in err and 'wanted %s' % META_T in err)
+
+    status, out, err, calls = run(['kwin', 'Bogus Action', 'Meta+T'], keys='')
+    check('an action the daemon does not know is a failure, not a success', 1, status)
+    check('the unregistered case says it applies at next login',
+          True, 'next login' in err)
+
+    status, out, err, calls = run(['--check', 'kwin', 'Window Close', 'Meta+T'],
+                                  keys=META_T)
+    check('--check exits 0 when the daemon already agrees', 0, status)
+    check('--check changes nothing', True,
+          'setForeignShortcutKeys' not in calls)
+
+    status, out, err, calls = run(['--quiet', 'kwin', 'Window Close', 'Meta+T'],
+                                  keys=META_T)
+    check('--quiet says nothing about a shortcut that worked', '', out)
+
+    batch_text = ('kwin\tWindow Close\tMeta+T\tClose\n'
+                  '# comment\n'
+                  '\n'
+                  'kwin\tOther\tMeta+T\tOther\n')
+    status, out, err, calls = run(['--batch'], keys=META_T, stdin=batch_text)
+    check('--batch reads shortcuts from stdin', 0, status)
+    check('--batch applies every entry in one process', 2,
+          calls.count('setForeignShortcutKeys'))
+
+    batch_file = os.path.join(workdir, 'batch')
+    with open(batch_file, 'w') as handle:
+        handle.write('kwin\tWindow Close\tMeta+T\tClose\n')
+    status, out, err, calls = run(['--batch', batch_file], keys=META_T)
+    check('--batch reads shortcuts from a file', 0, status)
+
+    status, out, err, calls = run(['--batch'], keys=META_T,
+                                  stdin='kwin\tWindow Close\tMeta+Nonsense\n')
+    check('an unparseable shortcut fails that entry rather than crashing',
+          1, status)
+    check('the bad shortcut is named', True, 'Nonsense' in err)
+
+    # A batch where one entry works and one doesn't: the exit status has to
+    # report the failure, since setup-kde keys its fallback off it.
+    status, out, err, calls = run(
+        ['--batch'], keys=META_T,
+        stdin='kwin\tWindow Close\tMeta+T\nkwin\tOther\tMeta+X\n')
+    check('one failure in a batch makes the whole run fail', 1, status)
+    check('the summary counts the failures', True, '1 of 2' in err)
+
+    status, out, err, calls = run(['kwin', 'a', 'Meta+T'], path='/nonexistent')
+    check('no usable D-Bus backend exits 3, distinct from a refused shortcut',
+          3, status)
+    check('the unreachable-daemon message names what was tried', True,
+          'gdbus' in err and 'dbus-python' in err)
+    check('nothing is claimed to be live when the daemon is unreachable',
+          '', out)
+
+    status, out, err, calls = run(['--backend', 'nonsense', 'kwin', 'a', 'Meta+T'])
+    check('an unknown --backend is reported, not silently ignored', 3, status)
+
+    status, out, err, calls = run(['--backend=gdbus', 'kwin', 'Window Close',
+                                   'Meta+T'], keys=META_T)
+    check('--backend=value form works', 0, status)
+
+    status, out, err, calls = run(['kwin', 'Window Close'])
+    check('too few arguments is a usage error', 2, status)
+    status, out, err, calls = run(['--nonsense'])
+    check('an unknown option is a usage error', 2, status)
+    status, out, err, calls = run(['--help'])
+    check('--help exits 0 and describes the exit statuses', True,
+          status == 0 and 'Exit status' in out)
+
+    # A gdbus that fails outright: the daemon is there but the call didn't
+    # work, which must not be reported as a live shortcut.
+    with open(stub, 'w') as handle:
+        handle.write('#!/bin/sh\nprintf "%s\\n" "$*" >> "$GDBUS_LOG"\n'
+                     'echo "Error: no such interface" >&2\nexit 1\n')
+    os.chmod(stub, 0o755)
+    status, out, err, calls = run(['kwin', 'Window Close', 'Meta+T'])
+    check('a failing gdbus is reported as unreachable, not as success', 3, status)
+    check('the gdbus error text is passed through', True, 'no such interface' in err)
+finally:
+    shutil.rmtree(workdir)
+
+print()
+print('%d tests, %d passed, %d failed' % (tests_run, tests_run - failures, failures))
+sys.exit(1 if failures else 0)

--- a/setup
+++ b/setup
@@ -689,6 +689,14 @@ install_packages() {
                     kwin-dev \
                     plasma-desktop plasma-sdk \
                     || warn "skipping KDE graphical package installation"
+                # gdbus (glib's D-Bus CLI) is how setup-kde applies keyboard
+                # shortcuts to the running session instead of deferring them to
+                # the next login -- see kdeshortcut.py. Its own step, because
+                # apt rejects a whole transaction on one unknown name, and
+                # because it's usually already pulled in by the desktop.
+                info "Installing gdbus (live shortcut updates)"
+                sudo_or_warn apt-get install -y --install-recommends libglib2.0-bin \
+                    || warn "libglib2.0-bin unavailable via apt; setup-kde will fall back to asking for a logout unless python3-dbus is installed"
                 # yazi (terminal file manager) is often not in the default repos;
                 # install it separately so its absence doesn't block the rest.
                 sudo_or_warn apt-get install -y --install-recommends yazi \
@@ -757,6 +765,13 @@ install_packages() {
                     plasma-desktop \
                     plasma-sdk \
                     || warn "skipping KDE graphical package installation"
+                # gdbus (glib's D-Bus CLI) is how setup-kde applies keyboard
+                # shortcuts to the running session instead of deferring them to
+                # the next login -- see kdeshortcut.py. Its own step so one
+                # unavailable name can't take the desktop packages down with it.
+                info "Installing gdbus (live shortcut updates)"
+                sudo_or_warn dnf install -y glib2 \
+                    || warn "glib2 unavailable via dnf; setup-kde will fall back to asking for a logout unless python3-dbus is installed"
                 # yazi (terminal file manager) may need a COPR; install it
                 # separately so its absence doesn't block the rest.
                 sudo_or_warn dnf install -y yazi \

--- a/setup-kde
+++ b/setup-kde
@@ -8,7 +8,18 @@
 # - Application launch shortcuts (browser, terminal, music)
 # - The session keyboard layout (US Dvorak, Caps Lock as Compose)
 #
+# Every setting applies to the running session -- no logout. The KDE config
+# files this writes are only what the *next* login loads, so each step is
+# paired with the reload that makes the current session pick it up: kwinrc via
+# `kwin reconfigure`, Krohnkite by unloading and reloading the script, and
+# shortcuts via kdeshortcut.py, which hands them to kglobalaccel the way
+# System Settings does and reports any that didn't take. A shortcut that can't
+# be applied live is reported, never assumed -- see apply_shortcuts_live.
+#
 # Requires: kpackagetool6, kwriteconfig6
+# Wants: python3 plus either gdbus or python3-dbus, for applying shortcuts to
+#        the running session (kdeshortcut.py). Without them the shortcuts are
+#        still written, and the script says a logout is needed.
 # This helper does not use sudo: Krohnkite and every KDE setting are installed
 # for the current user, so setup-kde still works when system sudo is restricted.
 # Optional: homepkg (fetches Krohnkite's prebuilt .kwinscript release, the
@@ -63,6 +74,10 @@ INSTALL=yes
 # Whether to keep going past failures. "no" aborts on the first error via
 # set -e; "yes" (via --ignore-errors) leaves it off and pushes through.
 IGNORE_ERRORS=no
+
+# Interpreter for kdeshortcut.py (see apply_shortcuts_live). Overridable for
+# a box where python3 isn't the name of a working Python 3.
+PYTHON="${PYTHON:-python3}"
 
 info() {
     printf "%s\n" "$*"
@@ -132,8 +147,32 @@ if test "$IGNORE_ERRORS" = no; then
     set -e
 fi
 
+# Shortcuts written to kglobalshortcutsrc during this run, collected as
+# they're written so apply_shortcuts_live can hand the whole batch to
+# kdeshortcut.py in one go. See record_live_shortcut.
+#
+# mktemp rather than a $$-derived name: on a shared /tmp a predictable name can
+# be pre-created as a symlink, and record_live_shortcut's >> would append
+# through it to any file this user can write. It also can't collide with a
+# stale batch left behind by a run that was killed before its trap ran, whose
+# obsolete shortcuts would otherwise be appended to and applied.
+#
+# An unusable temp directory isn't fatal -- every config write still works, and
+# only the live apply is lost -- but it can't pass silently either, so the
+# empty value is what apply_shortcuts_live reports on.
+LIVE_SHORTCUTS=""
+if ! LIVE_SHORTCUTS="$(mktemp "${TMPDIR:-/tmp}/setup-kde-shortcuts-XXXXXX")"; then
+    LIVE_SHORTCUTS=""
+    warn "could not create a temporary file for the shortcut batch"
+fi
+
 cleanup() {
     rm -rf "$KROHNKITE_DIR"
+    # An if, not a &&: a false test as the last command would make the EXIT
+    # trap return non-zero.
+    if test -n "$LIVE_SHORTCUTS"; then
+        rm -f "$LIVE_SHORTCUTS"
+    fi
 }
 trap cleanup EXIT
 
@@ -449,18 +488,31 @@ configure_keyboard_layout() {
 # whose action ID is the same as the display name (e.g. "Window Close").
 # Krohnkite's newer action IDs (KrohnkitegrowWidth, ...) differ from
 # their labels ("Krohnkite: Grow Width"), so pass the label explicitly.
+# Record a shortcut for apply_shortcuts_live. Writing kglobalshortcutsrc only
+# changes what the *next* login loads -- kglobalaccel holds the live registry
+# in memory and never re-reads the file -- so every write below is paired with
+# a line here, and the whole batch is pushed into the running daemon at the
+# end of the run. Tab-separated because action IDs contain spaces.
+record_live_shortcut() {
+    # No batch file means mktemp failed above, which was already reported.
+    test -n "$LIVE_SHORTCUTS" || return 0
+    printf '%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "${4:-$2}" >> "$LIVE_SHORTCUTS"
+}
+
 set_shortcut() {
     action="$1"
     shortcut="$2"
     label="${3:-$action}"
     kwriteconfig6 --file kglobalshortcutsrc --group kwin \
         --key "$action" "$shortcut,none,$label"
+    record_live_shortcut kwin "$action" "$shortcut" "$label"
 }
 
 unbind_shortcut() {
     action="$1"
     kwriteconfig6 --file kglobalshortcutsrc --group kwin \
         --key "$action" "none,none,$action"
+    record_live_shortcut kwin "$action" none "$action"
 }
 
 unbind_shortcut_in() {
@@ -468,6 +520,7 @@ unbind_shortcut_in() {
     action="$2"
     kwriteconfig6 --file kglobalshortcutsrc --group "$group" \
         --key "$action" "none,none,$action"
+    record_live_shortcut "$group" "$action" none "$action"
 }
 
 # Clear a launch shortcut held by a KDE-shipped .desktop component. These live
@@ -478,6 +531,7 @@ unbind_shortcut_in() {
 unbind_app_shortcut() {
     kwriteconfig6 --file kglobalshortcutsrc \
         --group services --group "$1" --key _launch "none,none,$2"
+    record_live_shortcut "$1" _launch none "$2"
 }
 
 # Collect the action IDs first, then unbind them -- never write from inside
@@ -541,6 +595,15 @@ add_app_shortcut() {
     # a launch-shortcut component; without it, kglobalaccel won't register
     # the _launch entry, the shortcut never grabs, and the keypress falls
     # through to the focused window.
+    #
+    # X-KDE-Shortcuts is what makes the shortcut go live without a logout.
+    # kglobalaccel rebuilds its service components when the sycoca database
+    # changes (GlobalShortcutsRegistry watches KSycoca::databaseChanged), and
+    # the rebuild finds launchers by querying for exactly this property --
+    # a .desktop without it is invisible to that scan no matter what
+    # kglobalshortcutsrc says. The binding itself still comes from
+    # kglobalshortcutsrc, which is written below; this only gets the component
+    # registered, so kbuildsycoca6 in the main flow is what completes it.
     cat > "$desktop_dir/$desktop_file" <<EOF
 [Desktop Entry]
 Type=Application
@@ -549,6 +612,7 @@ Exec=$command
 NoDisplay=true
 StartupNotify=false
 X-KDE-GlobalAccel-CommandShortcut=true
+X-KDE-Shortcuts=$shortcut
 EOF
 
     # Nested group [services][foo.desktop] is what kglobalaccel reads for
@@ -571,6 +635,7 @@ EOF
     kwriteconfig6 --file kglobalshortcutsrc \
         --group services --group "$desktop_file" \
         --key _k_friendly_name "$name"
+    record_live_shortcut "$desktop_file" _launch "$shortcut" "$name"
 }
 
 # An earlier version of this script wrote app-launch shortcuts under a
@@ -743,10 +808,13 @@ reload_krohnkite() {
     qdbus6 org.kde.KWin /Scripting org.kde.kwin.Scripting.start >/dev/null 2>&1 || true
 }
 
+# Last resort when the shortcuts couldn't be pushed into the running daemon.
+#
 # In Plasma 6, kglobalaccel is embedded in kwin — the systemd service is a
 # no-op stub. On X11 we can safely replace kwin in-session to reload
 # kglobalshortcutsrc; on Wayland kwin_wayland *is* the compositor, so
-# replacing it kills every client. Just tell the user to log out.
+# replacing it kills every client. Then the only way to reload the file is a
+# fresh login.
 reload_kglobalaccel() {
     case "$XDG_SESSION_TYPE" in
         x11)
@@ -758,6 +826,66 @@ reload_kglobalaccel() {
             ;;
         *)
             warn "unknown session type '$XDG_SESSION_TYPE'; log out and back in to pick up shortcuts"
+            ;;
+    esac
+}
+
+# Push every shortcut written above into the running kglobalaccel, so they
+# work now instead of at the next login.
+#
+# kwriteconfig6 writes the file, which is only what the next login loads: the
+# daemon keeps the live registry in memory and never re-reads the file after
+# startup. kdeshortcut.py makes the same D-Bus call System Settings makes and
+# reads each binding back, so a shortcut that didn't take is reported now.
+#
+# Both halves are kept: the file is what survives a reboot, the D-Bus call is
+# what makes this session agree with it.
+apply_shortcuts_live() {
+    # Without a batch file the shortcuts were written but can't be applied, so
+    # the session still needs the old treatment.
+    if test -z "$LIVE_SHORTCUTS"; then
+        warn "no shortcut batch was recorded, so shortcuts can't be applied to the running session"
+        reload_kglobalaccel
+        return 0
+    fi
+
+    # Nothing recorded means no shortcut was written -- there is nothing to
+    # apply, and no failure to report.
+    test -s "$LIVE_SHORTCUTS" || return 0
+
+    helper="$SCRIPT_DIR/kdeshortcut.py"
+    # Run the interpreter explicitly rather than executing the helper
+    # directly: this reports a missing interpreter as such, and still works if
+    # the file came out of a checkout without its executable bit.
+    if ! is_command "$PYTHON" || ! test -f "$helper"; then
+        if ! is_command "$PYTHON"; then
+            warn "$PYTHON not found, so shortcuts can't be applied to the running session"
+        else
+            warn "kdeshortcut.py not found beside this script, so shortcuts can't be applied to the running session"
+        fi
+        reload_kglobalaccel
+        return 0
+    fi
+
+    info "Applying shortcuts to the running session"
+    status=0
+    "$PYTHON" "$helper" --quiet --batch "$LIVE_SHORTCUTS" || status=$?
+    case "$status" in
+        0)
+            info "Shortcuts are live; no logout needed"
+            ;;
+        1)
+            # The helper already named each shortcut it couldn't apply.
+            warn "some shortcuts could not be applied to the running session"
+            reload_kglobalaccel
+            ;;
+        3)
+            warn "could not reach kglobalaccel; shortcuts are written but not live"
+            reload_kglobalaccel
+            ;;
+        *)
+            warn "kdeshortcut.py failed (status $status); shortcuts are written but not live"
+            reload_kglobalaccel
             ;;
     esac
 }
@@ -779,15 +907,20 @@ configure_keyboard_layout
 reload_kwin
 configure_keybindings
 configure_app_shortcuts
-# Rebuild service database so KDE picks up the new .desktop files
+# Rebuild the service database so KDE picks up the new .desktop files. This
+# also registers them with the running kglobalaccel: it rebuilds its service
+# components when sycoca changes, which is what lets apply_shortcuts_live bind
+# the launch shortcuts below.
 if command -v kbuildsycoca6 >/dev/null 2>&1; then
     kbuildsycoca6
 fi
-# Reload to apply all changes
+# Reload to apply all changes. Order matters for the last step: Krohnkite has
+# to be loaded before its shortcuts can be pushed into the daemon, since
+# kglobalaccel only accepts keys for actions that are registered.
 reload_kwin
 reload_krohnkite
 reload_diminactive_effect
-reload_kglobalaccel
+apply_shortcuts_live
 
 if is_command setup-kde.local; then
     info "Sourcing setup-kde.local"

--- a/setup-kde_test
+++ b/setup-kde_test
@@ -805,8 +805,8 @@ test_stale_group_sweep_needs_no_python3() {
 [scripts-browser1.desktop]
 _launch=Meta+G
 CONF
-    # Shadow python3 with a mock that always fails: reaching it at all is the
-    # regression, and it comes first on the test PATH.
+    # Shadow python3 with a mock that always fails: reaching it for the sweep
+    # is the regression, and it comes first on the test PATH.
     cat > "$TEST_TMPDIR/bin/python3" <<MOCK
 #!/bin/sh
 printf "%s\\n" "python3 \$*" >> "$CALLS"
@@ -815,9 +815,155 @@ MOCK
     chmod +x "$TEST_TMPDIR/bin/python3"
     run_kde --no-install
     assert_status 0 &&
-    assert_not_called "python3" &&
     assert_output_contains "KDE configured successfully" &&
+    # python3 is legitimate for kdeshortcut.py, which applies the shortcuts to
+    # the running session -- so this can't assert python3 went unused, only
+    # that the sweep itself didn't reach for it.
+    ! grep '^python3 ' "$CALLS" | grep -qv 'kdeshortcut\.py' &&
     ! grep -q '^\[scripts-browser1\.desktop\]' "$config_dir/kglobalshortcutsrc"
+}
+
+# --- Applying shortcuts to the running session ---
+#
+# Writing kglobalshortcutsrc only changes what the next login loads, so
+# setup-kde also pushes every shortcut into the running kglobalaccel via
+# kdeshortcut.py. These tests mock python3 to capture that hand-off: the
+# batch file is deleted on exit, so the mock copies it aside first.
+
+# Mock python3 so it records its arguments, saves the batch file it was handed,
+# and exits with $1 (0 = every shortcut went live).
+mock_python3() {
+    cat > "$TEST_TMPDIR/bin/python3" <<MOCK
+#!/bin/sh
+printf "%s\\n" "python3 \$*" >> "$CALLS"
+# The last argument is the batch file; keep a copy for the assertions.
+for arg in "\$@"; do batch="\$arg"; done
+if test -f "\$batch"; then
+    cp "\$batch" "$TEST_TMPDIR/batch"
+fi
+exit ${1:-0}
+MOCK
+    chmod +x "$TEST_TMPDIR/bin/python3"
+}
+
+assert_batch_contains() {
+    if ! grep -qF -- "$(printf "$1")" "$TEST_TMPDIR/batch" 2>/dev/null; then
+        printf "%s\n" "  FAIL: batch does not contain '$1'"
+        printf "%s\n" "  batch: $(cat "$TEST_TMPDIR/batch" 2>/dev/null)"
+        TEST_FAILED=1
+        return 1
+    fi
+}
+
+# Every shortcut written to the config is also handed to kdeshortcut.py, with
+# the component, action, keys and label the config got -- tab-separated,
+# because action IDs contain spaces.
+test_shortcuts_pushed_to_running_session() {
+    add_launcher browser1
+    mock_python3 0
+    run_kde --no-install
+    assert_status 0 &&
+    assert_called "kdeshortcut.py --quiet --batch" &&
+    assert_batch_contains 'kwin\tWindow Close\tMeta+Backspace' &&
+    assert_batch_contains 'kwin\tSwitch to Desktop 1\tMeta+1' &&
+    assert_batch_contains 'kwin\tKrohnkiteSetMaster\tMeta+Return' &&
+    # Unbinds go live too, or the key stays grabbed by its old owner.
+    assert_batch_contains 'kwin\tGrid View\tnone' &&
+    assert_batch_contains 'plasmashell\tactivate task manager entry 1\tnone' &&
+    # Launch shortcuts are [services] components keyed by .desktop name.
+    assert_batch_contains 'shortcut-browser1.desktop\t_launch\tMeta+G\tbrowser1' &&
+    assert_output_contains "Shortcuts are live; no logout needed"
+}
+
+# The batch file is created with mktemp, not from the PID: a predictable name
+# in a shared /tmp can be pre-created as a symlink, and the >> that appends
+# each shortcut would write through it. Asserted via the path the mock python3
+# is handed, since that's the only place the name is observable.
+test_batch_file_name_is_unpredictable() {
+    mock_python3 0
+    run_kde --no-install
+    batch_arg="$(sed -n 's/.*--batch //p' "$CALLS" | head -1)"
+    assert_status 0 &&
+    case "$batch_arg" in
+        *setup-kde-shortcuts-$$) echo "  FAIL: batch file is named from the PID"
+            TEST_FAILED=1; return 1 ;;
+        */setup-kde-shortcuts-??????) ;;
+        *) echo "  FAIL: unexpected batch file name '$batch_arg'"
+            TEST_FAILED=1; return 1 ;;
+    esac
+}
+
+# An unusable TMPDIR loses the live apply, but must not lose the config writes
+# or pass silently -- mktemp failing is exactly when the old advice applies.
+test_unusable_tmpdir_falls_back_to_logout_advice() {
+    mock_python3 0
+    set +e
+    output="$(HOME="$TEST_TMPDIR/home" \
+        XDG_CONFIG_HOME="$TEST_TMPDIR/home/.config" \
+        XDG_SESSION_TYPE=wayland \
+        PATH="$TEST_TMPDIR/bin:/usr/local/bin:/usr/bin:/bin" \
+        TMPDIR="$TEST_TMPDIR/no-such-dir" \
+        "$KDE_SCRIPT" --no-install 2>&1)"
+    status=$?
+    set -e
+    assert_status 0 &&
+    assert_output_contains "could not create a temporary file" &&
+    assert_output_contains "shortcuts take effect after logging out" &&
+    assert_output_contains "KDE configured successfully" &&
+    # The config writes are the part that must survive.
+    assert_called "kwriteconfig6 --file kglobalshortcutsrc --group kwin --key Window Close"
+}
+
+# The whole point is not having to log out, so a successful run must not tell
+# the user to.
+test_live_apply_does_not_advise_logout() {
+    mock_python3 0
+    run_kde --no-install
+    assert_status 0 &&
+    assert_output_lacks "logging out" &&
+    assert_output_lacks "log out"
+}
+
+# A missing interpreter can't be fatal, and it can't be silent either: the
+# shortcuts are written but not live, which is exactly when the old advice
+# applies. $PYTHON stands in for hiding the system python3, which the test
+# PATH can't do -- the mock bin comes first, but an absent entry there just
+# falls through to /usr/bin.
+test_missing_python3_falls_back_to_logout_advice() {
+    set +e
+    output="$(HOME="$TEST_TMPDIR/home" \
+        XDG_CONFIG_HOME="$TEST_TMPDIR/home/.config" \
+        XDG_SESSION_TYPE=wayland \
+        PATH="$TEST_TMPDIR/bin:/usr/local/bin:/usr/bin:/bin" \
+        PYTHON=no-such-python3 \
+        "$KDE_SCRIPT" --no-install 2>&1)"
+    status=$?
+    set -e
+    assert_status 0 &&
+    assert_output_contains "no-such-python3 not found" &&
+    assert_output_contains "shortcuts take effect after logging out" &&
+    assert_output_contains "KDE configured successfully"
+}
+
+# A shortcut the daemon refuses (status 1) is reported, not swallowed, and the
+# run still succeeds -- the config on disk is correct either way.
+test_failed_live_apply_warns_and_continues() {
+    mock_python3 1
+    run_kde --no-install
+    assert_status 0 &&
+    assert_output_contains "some shortcuts could not be applied" &&
+    assert_output_contains "shortcuts take effect after logging out" &&
+    assert_output_contains "KDE configured successfully"
+}
+
+# kglobalaccel unreachable (status 3) is a different message: nothing was
+# changed in the session, rather than some shortcut being rejected.
+test_unreachable_daemon_warns_and_continues() {
+    mock_python3 3
+    run_kde --no-install
+    assert_status 0 &&
+    assert_output_contains "could not reach kglobalaccel" &&
+    assert_output_contains "KDE configured successfully"
 }
 
 # A launcher that exists on PATH gets a .desktop file and a [services] _launch
@@ -836,6 +982,11 @@ test_app_shortcut_created_for_present_launcher() {
     assert_file_exists "$desktop" &&
     grep -q "Exec=$TEST_TMPDIR/bin/browser1" "$desktop" &&
     grep -q "X-KDE-GlobalAccel-CommandShortcut=true" "$desktop" &&
+    # X-KDE-Shortcuts is how the running kglobalaccel finds the launcher when
+    # sycoca changes: its service-component rebuild queries for this property,
+    # and a .desktop without it stays invisible to that scan -- which is what
+    # would force a logout for launch shortcuts specifically.
+    grep -q "X-KDE-Shortcuts=Meta+G" "$desktop" &&
     assert_called "kwriteconfig6 --file kglobalshortcutsrc --group services --group shortcut-browser1.desktop --key _launch Meta+G,none,browser1" &&
     assert_called "kwriteconfig6 --file kglobalshortcutsrc --group services --group shortcut-browser1.desktop --key _k_friendly_name browser1" &&
     # No one-field value may survive: that is the shape kglobalaccel drops.
@@ -960,6 +1111,20 @@ run_test "stale-group sweep rewrites through a symlink" \
     test_stale_group_sweep_follows_symlink
 run_test "stale-group sweep needs no python3" \
     test_stale_group_sweep_needs_no_python3
+run_test "shortcuts are pushed to the running session" \
+    test_shortcuts_pushed_to_running_session
+run_test "the shortcut batch file name is unpredictable" \
+    test_batch_file_name_is_unpredictable
+run_test "an unusable TMPDIR falls back to the logout advice" \
+    test_unusable_tmpdir_falls_back_to_logout_advice
+run_test "a successful live apply doesn't advise logging out" \
+    test_live_apply_does_not_advise_logout
+run_test "missing python3 falls back to the logout advice" \
+    test_missing_python3_falls_back_to_logout_advice
+run_test "a refused shortcut warns and the run continues" \
+    test_failed_live_apply_warns_and_continues
+run_test "an unreachable daemon warns and the run continues" \
+    test_unreachable_daemon_warns_and_continues
 run_test "app shortcut created for present launcher" \
     test_app_shortcut_created_for_present_launcher
 run_test "missing launcher is skipped, not fatal" \


### PR DESCRIPTION
Shortcuts set by `setup-kde` needed a logout before they worked. They now apply to the running session, and a shortcut that can't be applied is reported per shortcut instead of silently deferring.

## Why a logout was needed

`kwriteconfig6` writes `kglobalshortcutsrc` behind kglobalaccel's back. The daemon holds the live shortcut registry in memory and reads that file only at startup, so a file edit changed nothing until the next login. System Settings doesn't have this problem because it doesn't edit the file — it calls the daemon, which re-grabs the key and *then* persists.

Everything else `setup-kde` writes was already applied live (`kwinrc` via `kwin reconfigure`, `kxkbrc` via the keyboard daemon's own file watch, Krohnkite by unload/reload), so shortcuts were the last thing forcing a relogin.

## What changed

**`kdeshortcut.py`** (new) makes the same call System Settings makes — `setForeignShortcutKeys` — then reads each binding back out of the daemon, so a shortcut that didn't take is reported now rather than at the next login. Exit status is the contract `setup-kde` keys its fallback off: `0` all live, `1` some refused, `3` daemon unreachable, `2` usage.

Backend is `gdbus`, because the keys argument is `a(ai)` (an array of `QKeySequence` structs) and GVariant's text format can express it — `qdbus6` and `dbus-send` cannot build a struct argument at all. `python3-dbus` is the fallback for a box with the binding but without glib's CLI.

**`setup-kde`** records every shortcut as it writes it and hands the whole batch over at the end of the run, after KWin and Krohnkite are reloaded — kglobalaccel only accepts keys for actions that are already registered. The config writes are unchanged: they're what survives a reboot, and the D-Bus call is what makes the current session agree with them.

**Launch shortcuts needed one more thing.** kglobalaccel rebuilds its service components when the sycoca database changes, but it discovers launchers by querying for `X-KDE-Shortcuts`, which the generated `.desktop` files never carried — so they were invisible to that scan no matter what `kglobalshortcutsrc` said. Writing the property lets the `kbuildsycoca6` call already in the script complete them.

**Graceful degradation.** No `python3`, no D-Bus binding, an unreachable daemon, or an unusable `TMPDIR` each report what failed and fall back to the previous advice (`kwin_x11 --replace` on X11, log out on Wayland). The shortcuts are still written either way; what's never done is letting the user believe they're live when they aren't.

**Dependency.** Adds glib's `gdbus` CLI (`libglib2.0-bin` / `glib2`) to the KDE package paths as its own best-effort step, since apt fails a whole transaction on one unknown name. Distro packages, no cost, and only touched during setup — nothing new on an interactive hot path.

## Testing

`make test` — 19 suites green. `setup-kde_test` 37 → 44, plus 61 new in `kdeshortcut_test`.

New coverage: the batch hand-off (component, action, keys and label as written, unbinds included); `X-KDE-Shortcuts` in the generated `.desktop`; the batch file's name being unpredictable; and each fallback path (missing interpreter, refused shortcut, unreachable daemon, unusable `TMPDIR`). `kdeshortcut_test` covers the parser against every shortcut form `setup-kde` actually writes and asserts the exact GVariant text on the wire via a stub `gdbus` — that's the part a live daemon would reject silently.

A `PYTHON` override was added to `setup-kde` so the missing-interpreter branch is testable; the test PATH can't hide the system `python3`.

## Limits worth knowing

The live apply is **not** verified against a real kglobalaccel — the sandbox has no Plasma and no session bus. It was exercised end-to-end against a stateful stub daemon, where all 43 shortcuts round-trip with the correct keycodes, but a stub agrees by construction. The readback is what reports the truth on a real session.

That end-to-end run did catch one genuine bug the unit tests missed: the escaped `Meta+\,` and `Meta+\\` forms `kglobalshortcutsrc` requires are not valid key names, so the parser has to undo the escaping. Fixed, with regression tests.

One thing to watch on a real run: whether Krohnkite's actions are registered at the moment the batch is applied. The script reloads Krohnkite first for exactly that reason, but if the reload is asynchronous the first run may report those as not registered, and a second run would show them live.

## Review

Codex raised one P2 on the first push: the shortcut batch used a predictable `$$`-derived `/tmp` name, which a symlink planted in a shared `/tmp` could redirect (`record_live_shortcut` appends with `>>`), and which a PID-recycled successor to a killed run would append to rather than create. Both were real; it now uses `mktemp`, with the failure path reported rather than skipped.