### PR TITLE
homepkg: don't install release sidecars as the tool binary

### DIFF
--- a/homepkg
+++ b/homepkg
@@ -335,6 +335,60 @@ def github_latest_assets(repo):
         (a["name"], a["browser_download_url"]) for a in data.get("assets", [])]
 
 
+# Non-payload artifacts that sit in a release beside the archives: checksums,
+# signatures, manifests, installer scripts. The cargo-dist updater is here
+# because no extension test can catch it -- it's named <tool>-<triple>-update
+# with no extension at all, so it looks exactly like a bare binary, and it is
+# one; just not the tool's. Left unfiltered it matches the platform tokens as
+# well as the real archive does, and github_extract then installs axoupdater
+# under the tool's name.
+SIDECAR_SUFFIXES = (
+    ".sha256", ".sha512", ".sum", ".asc", ".sig", ".txt", ".sbom", ".json",
+    ".sh", ".ps1", "-update",
+)
+
+# What github_extract knows how to unpack, split the way it opens them. The
+# picker ranks by this rather than a list of its own, so teaching extraction a
+# new format can't leave the two disagreeing about what's installable.
+TAR_SUFFIXES = (".tar.gz", ".tgz", ".tar.xz", ".tar.bz2", ".tar")
+ZIP_SUFFIXES = (".zip",)
+ARCHIVE_SUFFIXES = TAR_SUFFIXES + ZIP_SUFFIXES
+
+
+def _asset_kind(low):
+    """How installable an asset looks, highest first.
+
+    Ranked rather than filtered, because enumerating the formats a release
+    might add is a losing game: goreleaser ships .deb, .rpm *and* .apk beside
+    the tarball, every one of them matching the platform tokens as well as the
+    tarball does. Deciding by what we can actually open needs no such list.
+
+    2  an archive we can unpack
+    1  no extension, so possibly a bare binary (jq-linux-amd64)
+    0  anything else -- a package format we can't open. Still eligible, so a
+       release offering nothing better is reported by github_extract, which
+       knows what it couldn't do with it, rather than as "no matching asset".
+    """
+    if low.endswith(ARCHIVE_SUFFIXES):
+        return 2
+    return 1 if "." not in os.path.basename(low) else 0
+
+
+def _name_prefix_len(low, tokens):
+    """Characters before the platform part of an asset name.
+
+    Only used to break ties. One repo can release several binaries -- atuin
+    ships atuin-<triple>.tar.gz beside atuin-server-<triple>.tar.gz -- and
+    both match every token equally, so otherwise the winner is whichever
+    GitHub happens to list first. The tool's own archive is the one with the
+    least name in front of the triple. It stays a tie-break rather than a
+    match against the tool name because plenty of tools ship under a longer
+    name than their registry key (carapace -> carapace-bin_<ver>_linux_amd64).
+    """
+    at = [low.find(t) for t in tokens["arch"] + tokens["os"] if t in low]
+    return min(at) if at else len(low)
+
+
 def github_pick_asset(assets, tokens):
     """Choose the best asset for this platform from (name, url) pairs."""
     def score(name):
@@ -343,14 +397,19 @@ def github_pick_asset(assets, tokens):
             return None
         if tokens["os"] and not any(t in low for t in tokens["os"]):
             return None
-        # Skip checksums/signatures/source archives.
-        if any(low.endswith(x) for x in (".sha256", ".asc", ".sig", ".txt", ".sbom")):
+        # Skip checksums, signatures, manifests, installers and updaters.
+        # Source archives need no rule of their own: they carry no platform
+        # in the name, so the two token tests above have already dropped them.
+        if low.endswith(SIDECAR_SUFFIXES):
             return None
         s = 0
         for i, pref in enumerate(tokens["prefer"]):
             if pref and pref in low:
                 s = len(tokens["prefer"]) - i
-        return s
+        # Compared as a tuple. Installability leads: a musl .deb is still no
+        # use to us next to a gnu tarball. The name length only settles what
+        # the rest leaves tied.
+        return (_asset_kind(low), s, -_name_prefix_len(low, tokens))
     best = None
     for name, url in assets:
         sc = score(name)
@@ -362,6 +421,17 @@ def github_pick_asset(assets, tokens):
 def _ensure_executable(path):
     if os.path.exists(path):
         os.chmod(path, 0o755)
+
+
+# What a release might ship as a bare, extensionless binary: ELF (Linux),
+# Mach-O 64-bit either endianness and a universal binary (macOS), or a script.
+EXEC_MAGIC = (b"\x7fELF", b"\xcf\xfa\xed\xfe", b"\xfe\xed\xfa\xcf",
+              b"\xca\xfe\xba\xbe", b"#!")
+
+
+def _looks_executable(path):
+    with open(path, "rb") as fh:
+        return fh.read(4).startswith(EXEC_MAGIC)
 
 
 def _within(dest_real, path):
@@ -560,11 +630,11 @@ def github_extract(asset_path, name, prefix, bins, payload=None):
     os.makedirs(bindir, exist_ok=True)
     low = name.lower()
     root = None
-    if low.endswith((".tar.gz", ".tgz", ".tar.xz", ".tar.bz2", ".tar")):
+    if low.endswith(TAR_SUFFIXES):
         root = os.path.join(os.path.dirname(asset_path), "x")
         with tarfile.open(asset_path) as tf:
             _safe_extract_tar(tf, root)
-    elif low.endswith(".zip"):
+    elif low.endswith(ZIP_SUFFIXES):
         root = os.path.join(os.path.dirname(asset_path), "x")
         with zipfile.ZipFile(asset_path) as zf:
             _safe_extract_zip(zf, root)
@@ -607,6 +677,15 @@ def github_extract(asset_path, name, prefix, bins, payload=None):
             placed.append(b)
     else:
         # Raw single binary (e.g. jq-linux-amd64): treat the asset as bins[0].
+        # Nothing in the name proves it is one, and getting this wrong is
+        # silent in the worst way -- the file lands on PATH under the tool's
+        # name and only fails when the user runs it -- so check it looks like
+        # an executable first. Raising before _place_binary leaves the
+        # previous install untouched.
+        if not _looks_executable(asset_path):
+            raise HomepkgError(
+                f"{name} is neither an archive nor an executable; "
+                f"refusing to install it as {bins[0]}")
         _place_binary(asset_path, os.path.join(bindir, bins[0]))
         placed = [bins[0]]
     # An asset that doesn't carry every binary the registry says it does -- a

--- a/homepkg_test
+++ b/homepkg_test
@@ -122,6 +122,77 @@ check("github_pick_asset matches single-binary amd64", _pick_jq is not None and 
 check("github_pick_asset returns None when nothing matches",
       hp.github_pick_asset([("tool-win.zip", "x")], _linux) is None)
 
+# cargo-dist publishes an updater binary next to the real archives, named
+# <tool>-<triple>-update. It has no extension, so it matches the platform
+# tokens just as well as the archive does and github_extract would then treat
+# it as the tool's own raw binary -- installing axoupdater as `atuin`, which
+# answers `atuin init zsh` with a clap usage error.
+_dist = [
+    ("atuin-x86_64-unknown-linux-musl-update", "bad"),
+    ("atuin-x86_64-unknown-linux-musl.tar.gz", "good"),
+    ("atuin-x86_64-unknown-linux-gnu-update", "bad2"),
+    ("atuin-x86_64-unknown-linux-gnu.tar.gz", "gnu"),
+    ("atuin-installer.sh", "sh"),
+    ("sha256.sum", "sum"),
+]
+check("github_pick_asset skips the cargo-dist updater",
+      hp.github_pick_asset(_dist, _linux)[1] == "good")
+check("github_pick_asset skips installers and unified checksums",
+      all(hp.github_pick_asset([a], _linux) is None
+          for a in (_dist[4], _dist[5])))
+
+# Same silent-install vector as the updater, via a different route, and the
+# reason the package formats are ranked instead of listed: goreleaser ships
+# .deb, .rpm and .apk beside the tarball, all matching every token, none of
+# them something homepkg can unpack. Ordering must not decide.
+_pkgs = [("carapace-bin_1.7.3_linux_amd64.apk", "apk"),
+         ("carapace-bin_1.7.3_linux_amd64.deb", "deb"),
+         ("carapace-bin_1.7.3_linux_amd64.rpm", "rpm"),
+         ("carapace-bin_1.7.3_linux_amd64.tar.gz", "tgz")]
+check("github_pick_asset prefers the tarball over distro packages",
+      hp.github_pick_asset(_pkgs, _linux)[1] == "tgz")
+check("github_pick_asset ranks packages the same either way round",
+      hp.github_pick_asset(list(reversed(_pkgs)), _linux)[1] == "tgz")
+# Installability outranks the musl/gnu preference: a musl package we can't
+# open is no use next to a gnu archive we can.
+check("github_pick_asset takes a gnu archive over a musl package",
+      hp.github_pick_asset([("t-x86_64-unknown-linux-musl.deb", "deb"),
+                            ("t-x86_64-unknown-linux-gnu.tar.gz", "tgz")],
+                           _linux)[1] == "tgz")
+# A bare binary is the middle rank -- above a package, below an archive --
+# so jq's asset still wins where it's the best on offer.
+check("github_pick_asset takes a bare binary over a package",
+      hp.github_pick_asset([("jq-linux-amd64.rpm", "rpm"),
+                            ("jq-linux-amd64", "raw")], _linux)[1] == "raw")
+
+# Ranking by extension would rate a source tarball as highly as a real one,
+# and an Arch package's .pkg.tar.zst higher than it deserves. Neither needs a
+# rule, because neither names a platform the way a binary archive does -- but
+# that's load-bearing now, so pin it. atuin ships source.tar.gz for real.
+for _name in ("source.tar.gz", "atuin-source.tar.gz",
+              "helix-25.01-source.tar.xz",
+              "carapace-1.7.3-1-x86_64.pkg.tar.zst",
+              "tool-25.01-x86_64.AppImage"):
+    check(f"github_pick_asset needs a platform in the name ({_name})",
+          hp.github_pick_asset([(_name, "x")], _linux) is None)
+
+# One repo can release several binaries. atuin ships atuin-<triple>.tar.gz
+# beside atuin-server-<triple>.tar.gz; both match every token, so the pick
+# must not come down to the order GitHub lists assets in.
+_siblings = [
+    ("atuin-x86_64-unknown-linux-musl.tar.gz", "atuin"),
+    ("atuin-server-x86_64-unknown-linux-musl.tar.gz", "server"),
+]
+check("github_pick_asset prefers the tool over a sibling binary",
+      hp.github_pick_asset(_siblings, _linux)[1] == "atuin")
+check("github_pick_asset picks the same sibling either way round",
+      hp.github_pick_asset(list(reversed(_siblings)), _linux)[1] == "atuin")
+# The tie-break must not outrank the musl/gnu preference it sits behind.
+check("github_pick_asset still prefers musl over a shorter gnu name",
+      hp.github_pick_asset([("a-x86_64-linux-gnu.tar.gz", "gnu"),
+                            ("atuin-x86_64-unknown-linux-musl.tar.gz", "musl")],
+                           _linux)[1] == "musl")
+
 # --- codeberg asset selection -------------------------------------------------
 
 _kw_assets = [
@@ -578,6 +649,33 @@ with tempfile.TemporaryDirectory() as td:
     placed = hp.github_extract(asset, os.path.basename(asset), prefix, ["jq"])
     jq = os.path.join(prefix, "bin", "jq")
     check("github_extract treats a raw asset as the binary", placed == ["jq"] and os.access(jq, os.X_OK))
+
+with tempfile.TemporaryDirectory() as td:
+    prefix = os.path.join(td, "prefix")
+    asset = os.path.join(td, "atuin-x86_64-unknown-linux-musl-update")
+    with open(asset, "wb") as f:
+        f.write(b"\x7fELF\x02\x01\x01\x00")
+    placed = hp.github_extract(asset, os.path.basename(asset), prefix, ["atuin"])
+    check("github_extract still installs a raw ELF asset",
+          placed == ["atuin"] and os.access(os.path.join(prefix, "bin", "atuin"), os.X_OK))
+
+# The raw-asset path can't tell what program it was handed, so a mis-picked
+# non-executable would otherwise be copied onto PATH under the tool's name and
+# only fail when run. Refuse it instead, and leave nothing behind.
+with tempfile.TemporaryDirectory() as td:
+    prefix = os.path.join(td, "prefix")
+    asset = os.path.join(td, "atuin-x86_64-unknown-linux-musl.deb")
+    with open(asset, "wb") as f:
+        f.write(b"!<arch>\ndebian-binary   ")
+    _err = None
+    try:
+        hp.github_extract(asset, os.path.basename(asset), prefix, ["atuin"])
+    except hp.HomepkgError as e:
+        _err = e
+    check("github_extract refuses a non-executable raw asset",
+          _err is not None and "atuin" in str(_err))
+    check("github_extract leaves no binary behind when it refuses one",
+          not os.path.exists(os.path.join(prefix, "bin", "atuin")))
 
 # An asset that's missing one of the binaries the registry names -- a release
 # that changed its layout, or the asset picker choosing the wrong archive --


### PR DESCRIPTION
## The bug

`homepkg --backend github install atuin carapace` could put a file on `PATH` under the tool's name that isn't the tool. **Both** of the shell tools were affected, by different routes.

atuin ended up as an executable that doesn't understand its own CLI:

```
$ ~/.local/bin/atuin --version
error: a value is required for '--version <VERSION>' but none was supplied
$ ~/.local/bin/atuin init zsh
error: unexpected argument 'init' found
```

**atuin** is built with cargo-dist, which publishes an *updater* binary beside the real archives, named `<tool>-<triple>-update`. With no extension it matched `github_pick_asset`'s platform tokens exactly as well as `atuin-x86_64-unknown-linux-musl.tar.gz` did — both scored 2 — and the tie was broken by whichever asset the GitHub API happened to list first. When the updater won, `github_extract` saw no archive suffix, took it for the tool's own raw single binary, and installed axoupdater under the name `atuin`. It runs, so nothing complains until it's used.

`setup` doesn't self-heal, either: `missing_shell_tools` tests `-x "$HOME/.local/bin/atuin"`, and the bad file is executable, so it reports the tool as already installed and never retries. The file has to be deleted first.

**carapace** is built with goreleaser, which ships `.deb`, `.rpm` *and* `.apk` beside the tarball. All four match `linux`/`amd64`, none carries a musl/gnu token, so it was a four-way tie decided purely by asset order — and three of the four are packages homepkg cannot unpack.

Neither was visible from the releases pages: atuin's shows 14 assets where `dist-manifest.json` lists 49.

## The fix

**Rank assets by what `github_extract` can actually open** — archive, then extensionless (possibly a bare binary, as `jq` ships), then anything else — rather than listing formats to exclude. Enumerating them is a losing game; `.apk` was already missing from a first attempt at exactly that list. Installability leads the score, ahead of the musl/gnu preference, since a musl package we can't open is no use next to a gnu archive we can.

The ranking reads the same suffix tuples `github_extract` opens, rather than keeping a list of its own, so teaching extraction a new format can't leave the two disagreeing about what counts as installable.

The cargo-dist updater is the one case ranking can't catch, because it *is* a bare binary and looks just like `jq`'s — just not the tool's. It's excluded by name, alongside the checksums, signatures, manifests and installer scripts.

**Make the remaining tie deterministic.** Where two archives still match equally, prefer the one with the least name in front of the platform triple, so `atuin-<triple>.tar.gz` beats `atuin-server-<triple>.tar.gz` regardless of ordering. This stays a tie-break *behind* the musl/gnu preference rather than a match against the tool name, because several tools ship under a longer name than their registry key (`carapace` → `carapace-bin_<ver>_linux_amd64`).

**Require a raw asset to look like an executable** (ELF, Mach-O either endianness, universal binary, or `#!`) before installing it. Nothing in an extensionless name proves it is one, and getting it wrong is silent in the worst way. This is the backstop that turns any future mis-pick into a loud failure; it raises before `_place_binary`, so the previous install is left untouched.

Both the install path and the bundle staging path go through `github_pick_asset`, so both are covered.

Source archives need no rule of their own — they carry no platform in the name, so the existing arch/os token tests already drop them. That's now pinned by tests, since the ranking makes it load-bearing.

## Verification

Against the real releases — atuin's 49 assets and carapace's 25 — on linux and macOS, x86_64 and aarch64, with the asset list forwards and reversed:

```
atuin v18.18.1 (49 assets)
  OK  ('linux', 'x86_64')    -> atuin-x86_64-unknown-linux-musl.tar.gz
  OK  ('linux', 'aarch64')   -> atuin-aarch64-unknown-linux-musl.tar.gz
  OK  ('macos', 'aarch64')   -> atuin-aarch64-apple-darwin.tar.gz
  OK  ('macos', 'x86_64')    -> atuin-x86_64-apple-darwin.tar.gz

carapace v1.7.3 (25 assets)
  OK  ('linux', 'x86_64')    -> carapace-bin_1.7.3_linux_amd64.tar.gz
  OK  ('linux', 'aarch64')   -> carapace-bin_1.7.3_linux_arm64.tar.gz
  OK  ('macos', 'aarch64')   -> carapace-bin_1.7.3_darwin_arm64.tar.gz
  OK  ('macos', 'x86_64')    -> carapace-bin_1.7.3_darwin_amd64.tar.gz
```

`uv` had the identical cargo-dist updater trap; `gh`, `ripgrep` and `zoxide` all publish a package that tied with their tarball. Realistic asset lists for every other registry tool (`ripgrep`, `jq`, `fzf`, `gh`, `helix`, `delta`, `zoxide`, `jj`, `uv`, `carapace`) still resolve to the right archive — including `jq`, which legitimately needs the raw-binary path.

15 new tests in `homepkg_test`. Against `origin/main` 7 of them fail; all pass after:

```
not ok 13 - github_pick_asset skips the cargo-dist updater
not ok 15 - github_pick_asset prefers the tarball over distro packages
not ok 17 - github_pick_asset takes a gnu archive over a musl package
not ok 18 - github_pick_asset takes a bare binary over a package
not ok 25 - github_pick_asset picks the same sibling either way round
not ok 67 - github_extract refuses a non-executable raw asset
not ok 68 - github_extract leaves no binary behind when it refuses one
217 tests, 210 passed, 7 failed     <- origin/main
217 tests, 217 passed, 0 failed     <- this branch
```

`make test` green across the whole suite.

No changes needed in the `conf` repo: `init_atuin`, `eval_tool_init` and `config/atuin/config.toml` all check out against real atuin 18.18.1, where `init zsh` exits 0 and both config keys are still current.

## Known gap

A source archive that *did* carry platform tokens (`tool-1.0-x86_64-unknown-linux-musl-source.tar.gz`) would rank as an archive and tie with the real one. It fails loudly at extract, so it can't install the wrong thing, but it could make a tool uninstallable. No release in the registry does this, so it's left unguarded rather than filtered speculatively.

## Repairing an affected machine

`setup` alone won't do it, per the `missing_shell_tools` note above:

```sh
rm -f ~/.local/bin/atuin ~/.local/bin/carapace
~/scripts/homepkg --backend github install atuin carapace
```