### PR TITLE
setup-kde: don't apply shortcuts live by default; it crashed kwin

### DIFF
--- a/kdeshortcut.py
+++ b/kdeshortcut.py
@@ -13,6 +13,11 @@
 # reads the binding back out of the daemon so a shortcut that didn't take is
 # reported now instead of silently deferring to the next login.
 #
+# Only actions kglobalaccel reports it already has are ever set. In Plasma 6
+# the daemon runs inside kwin, so a call it mishandles doesn't just fail -- it
+# can take the compositor down, and every client with it. Enumerating first
+# (read-only) is what keeps a mutating call off an action that doesn't exist.
+#
 # Usage:
 #     kdeshortcut.py <component> <action> <keys> [label]
 #     kdeshortcut.py --batch [<file>]
@@ -35,10 +40,13 @@
 #        session bus, or kglobalaccel not running. The caller should fall back
 #        to telling the user to log out; nothing was changed.
 
+import contextlib
+import fcntl
 import os
 import re
 import subprocess
 import sys
+import tempfile
 
 HELP = """Usage: kdeshortcut.py [--check] [--quiet] <component> <action> <keys> [label]
        kdeshortcut.py [--check] [--quiet] --batch [<file>]
@@ -58,9 +66,18 @@ Options:
   --batch    read tab-separated component/action/keys/label lines from <file>
              (default stdin); blank lines and #-comments are skipped
   --check    report what the daemon currently holds, changing nothing
+  --who KEYS report which component and action hold KEYS, e.g. --who Meta+T.
+             Read-only; use it to find what is grabbing a key
   --quiet    only report failures
   --backend  force a D-Bus backend: gdbus or dbus-python (default: whichever
              works, gdbus first)
+  --journal  file naming the shortcut currently being applied, so a call that
+             takes kwin down can be identified afterwards. An entry left in it
+             is skipped on every later run until --forget retires it. Defaults
+             to $XDG_STATE_HOME/kdeshortcut.inflight; a mutating run always has
+             one, and refuses to run if it can't be created
+  --forget   retire the journal's entries so those shortcuts are attempted
+             again. Use it once the cause is fixed
   -h, --help show this help and exit
 
 Exit status:
@@ -133,6 +150,40 @@ class ShortcutError(Exception):
     """A shortcut string that can't be turned into Qt keycodes."""
 
 
+def default_journal_path():
+    """Where the crash journal lives when --journal isn't given.
+
+    A mutating run always has one: with no path, record() would be a no-op and
+    a call that took kwin down would leave nothing to identify it -- the hole
+    this whole mechanism exists to close.
+
+    setup-kde passes this same path explicitly. Every entry point shares one
+    journal on purpose: a marker names an action that kills the compositor,
+    which is true of the action however it came to be applied.
+    """
+    state = os.environ.get('XDG_STATE_HOME') or os.path.join(
+        os.path.expanduser('~'), '.local', 'state')
+    return os.path.join(state, 'kdeshortcut.inflight')
+
+
+class JournalError(Exception):
+    """The crash journal couldn't be read or written.
+
+    Fatal to the shortcut it was recording: the journal is what keeps a call
+    that killed the compositor from being made again, so a mutating call without
+    it is exactly what it exists to prevent.
+    """
+
+
+class DaemonGone(Exception):
+    """A call returned an error and left the daemon unreachable.
+
+    Raised so the batch stops there. Carrying on would call into a daemon
+    that's already down, and -- worse -- would overwrite the journal entry
+    naming the call that took it down, which is the one thing worth keeping.
+    """
+
+
 def keycode(token):
     """Map one key name ("T", "Return", "F3", "\\") to its Qt::Key value."""
     key = token.strip()
@@ -199,6 +250,31 @@ def parse_shortcut(text):
     return [modifiers | keycode(key)]
 
 
+# A QKeySequence is four key slots, and the daemon reports all four: a
+# one-key shortcut reads back as the key plus three empty slots. Empty is not
+# always zero -- Qt::Key_unknown shows up too -- so a slot counts as real only
+# if it's neither.
+KEY_UNKNOWN = 0x01FFFFFF
+
+
+def real_keys(keys):
+    """Drop the empty tail slots from a sequence the daemon reported."""
+    trimmed = list(keys)
+    while trimmed and trimmed[-1] in (0, KEY_UNKNOWN):
+        trimmed.pop()
+    return trimmed
+
+
+def holds_wanted(live, wanted):
+    """Whether the daemon's reported sequence is the one that was asked for.
+
+    Compared on the real slots only. The tail can hold padding this script
+    doesn't get to predict -- an exact list comparison reported every correctly
+    applied shortcut as a failure, which made the whole readback worthless.
+    """
+    return real_keys(live) == real_keys(wanted)
+
+
 def format_keys(keys):
     """Render keycodes back for reporting. Exact spelling doesn't matter --
     this is only ever shown to a human comparing what was asked vs. what the
@@ -208,8 +284,18 @@ def format_keys(keys):
     return '+'.join(str(key) for key in keys)
 
 
+# setForeignShortcut/shortcut rather than the current setForeignShortcutKeys/
+# shortcutKeys pair: the newer methods take a(ai), an array of QKeySequence
+# structs, and sending that from a generic D-Bus tool crashed kwin_wayland
+# outright ("dbus: type invalid 0 not a basic type" -- the daemon's
+# demarshaller reading past the end of the container). The older methods take a
+# flat ai, which is the same QList<int> the daemon converts to and from
+# internally (see intListFromShortcut/shortcutFromIntList in kglobalaccel), so
+# there is no struct to get wrong. They're deprecated but still exported, and a
+# deprecated call that can't take the compositor down beats a current one that
+# can.
 class DbusPythonBackend:
-    """dbus-python: preferred, since it marshals a(ai) natively."""
+    """dbus-python: no subprocess, and it marshals ai natively."""
 
     name = 'dbus-python'
 
@@ -220,22 +306,32 @@ class DbusPythonBackend:
         bus = dbus.SessionBus()
         proxy = bus.get_object(SERVICE, OBJECT)
         self._iface = dbus.Interface(proxy, INTERFACE)
-
-    def _sequences(self, keys):
-        dbus = self._dbus
-        # a(ai): array of QKeySequence, each a struct wrapping an int array.
-        return dbus.Array(
-            [dbus.Struct((dbus.Array([dbus.Int32(key) for key in keys], signature='i'),))],
-            signature='(ai)',
-        ) if keys else dbus.Array([], signature='(ai)')
+        self._peer = dbus.Interface(proxy, 'org.freedesktop.DBus.Peer')
 
     def set_keys(self, action_id, keys):
-        self._iface.setForeignShortcutKeys(
-            self._dbus.Array(action_id, signature='s'), self._sequences(keys))
+        self._iface.setForeignShortcut(
+            self._dbus.Array(action_id, signature='s'),
+            self._dbus.Array([self._dbus.Int32(key) for key in keys], signature='i'))
 
     def get_keys(self, action_id):
-        result = self._iface.shortcutKeys(self._dbus.Array(action_id, signature='s'))
-        return [int(key) for sequence in result for key in sequence]
+        result = self._iface.shortcut(self._dbus.Array(action_id, signature='s'))
+        return [int(key) for key in result]
+
+    def list_actions(self, component):
+        result = self._iface.allActionsForComponent(
+            self._dbus.Array(component_id(component), signature='s'))
+        return {str(entry[1]) for entry in result if len(entry) > 1}
+
+    def alive(self):
+        try:
+            self._peer.Ping()
+        except Exception:  # noqa: BLE001 - any failure means "can't tell, assume gone"
+            return False
+        return True
+
+    def holders(self, key):
+        result = self._iface.getGlobalShortcutsByKey(self._dbus.Int32(key))
+        return [(str(info[0]), str(info[2])) for info in result if len(info) > 2]
 
 
 class GdbusBackend:
@@ -265,24 +361,76 @@ class GdbusBackend:
         return '[%s]' % ', '.join(gvariant_string(field) for field in action_id)
 
     def set_keys(self, action_id, keys):
-        if keys:
-            # A one-element GVariant tuple needs the trailing comma.
-            sequences = '[([%s],)]' % ', '.join(str(key) for key in keys)
-        else:
-            # An empty list is ambiguous in GVariant text; annotate the type.
-            sequences = '@a(ai) []'
-        self._call('%s.setForeignShortcutKeys' % INTERFACE,
-                   [self._action_id(action_id), sequences])
+        # An empty list is ambiguous in GVariant text, so annotate the type.
+        flat = '[%s]' % ', '.join(str(key) for key in keys) if keys else '@ai []'
+        self._call('%s.setForeignShortcut' % INTERFACE,
+                   [self._action_id(action_id), flat])
 
     def get_keys(self, action_id):
-        output = self._call('%s.shortcutKeys' % INTERFACE,
+        output = self._call('%s.shortcut' % INTERFACE,
                             [self._action_id(action_id)])
         return [int(match) for match in re.findall(r'-?\d+', output)]
+
+    def list_actions(self, component):
+        output = self._call('%s.allActionsForComponent' % INTERFACE,
+                            [self._action_id(component_id(component))])
+        return {group[1] for group in parse_gvariant_string_lists(output)
+                if len(group) > 1}
+
+    def alive(self):
+        try:
+            self._call('org.freedesktop.DBus.Peer.Ping', [])
+        except RuntimeError:
+            return False
+        return True
+
+    def holders(self, key):
+        # The deprecated flat-int form again: its argument is a plain i, where
+        # globalShortcutsByKey takes a QKeySequence struct.
+        output = self._call('%s.getGlobalShortcutsByKey' % INTERFACE, [str(key)])
+        return parse_shortcut_infos(output)
 
 
 def gvariant_string(text):
     """Quote a string for GVariant text format."""
     return "'%s'" % text.replace('\\', '\\\\').replace("'", "\\'")
+
+
+def parse_gvariant_string_lists(text):
+    """Pull the inner string lists out of gdbus's aas output.
+
+    Matching the innermost brackets keeps each action's fields together, which
+    membership testing over every quoted token in the reply would not: an
+    action name can appear as some other action's friendly name.
+    """
+    groups = []
+    for match in re.finditer(r'\[([^][]*)\]', text):
+        items = re.findall(r"'((?:[^'\\]|\\.)*)'", match.group(1))
+        if items:
+            groups.append([item.replace("\\'", "'").replace('\\\\', '\\')
+                           for item in items])
+    return groups
+
+
+def parse_shortcut_infos(text):
+    """Pull (component, action) out of a KGlobalShortcutInfo reply.
+
+    Each entry is (ssssssaiai): unique and friendly names for the component,
+    the action and the context, then the keys. Only the first and third
+    matter here, so this reads the six leading strings of each struct and
+    ignores the int arrays -- enough for a diagnostic, and it can't be confused
+    by a name that happens to look like a keycode.
+    """
+    field = r"'((?:[^'\\]|\\.)*)'"
+    pattern = r'\(\s*' + r'\s*,\s*'.join([field] * 6)
+    return [(match.group(1), match.group(3))
+            for match in re.finditer(pattern, text)]
+
+
+def component_id(component):
+    """kglobalaccel only reads field 0 of an actionId when looking up a
+    component, but send all four so a stricter build can't index past the end."""
+    return [component, '', component, '']
 
 
 def which(program):
@@ -320,8 +468,220 @@ def open_backend(wanted=None):
     raise RuntimeError('; '.join(reasons))
 
 
-def apply_shortcut(backend, component, action, keys_text, label, check_only):
+class Journal:
+    """Records the shortcut about to be applied, on disk, before the call.
+
+    kglobalaccel is part of kwin in Plasma 6, so a call that kills the daemon
+    takes the compositor down and every client with it -- including whatever
+    terminal this was reporting to. A file is what survives to name the
+    shortcut that was in flight.
+
+    Every entry found at startup is therefore a shortcut some previous run did
+    not come back from. Those are skipped and named, so one crash doesn't
+    become a crash every run.
+
+    They also accumulate: a marker outlives the run that reads it, and only
+    --forget removes one. Clearing it once it had been read would mean the run
+    after that retried the crashing call -- a crash every other run rather than
+    every run. The in-flight entry is written alongside them, so a run that
+    skips a known-bad shortcut still journals the ones it does attempt.
+
+    A journal that can't be read or written fails closed. It isn't a diagnostic
+    aid: it's what stops a call that killed the compositor from being made
+    again, so mutating without it is the thing it exists to prevent. An
+    unreadable file may be preserving exactly the marker that matters, and an
+    unwritable one can't record the call about to be made.
+    """
+
+    def __init__(self, path):
+        self.path = path
+        self.poisoned = set()
+        self.sealed = False
+        # Set when the existing journal couldn't be read. Not raised here, so
+        # --forget can still retire an unreadable file; main() fails closed on
+        # it before anything mutating.
+        self.unreadable = None
+        self._load()
+
+    def _load(self):
+        """Read the markers. Called again inside transaction(), under the lock,
+        so a concurrent run's markers are seen rather than a stale snapshot."""
+        self.poisoned = set()
+        self.unreadable = None
+        if not self.path:
+            return
+        try:
+            with open(self.path) as stream:
+                lines = stream.read().splitlines()
+        except FileNotFoundError:
+            # No journal yet: no previous run left anything in flight.
+            return
+        except OSError as error:
+            self.unreadable = str(error)
+            return
+        for line in lines:
+            fields = line.rstrip('\n').split('\t')
+            if len(fields) >= 2 and fields[0] and fields[1]:
+                self.poisoned.add((fields[0], fields[1]))
+
+    @contextlib.contextmanager
+    def _locked(self):
+        """Hold the exclusive lock, nothing else.
+
+        Separate from transaction() because --forget has to take the same lock
+        while still working on a journal it can't read, which transaction()
+        refuses.
+        """
+        if not self.path:
+            yield
+            return
+        try:
+            handle = open(self.path + '.lock', 'w')
+        except OSError as error:
+            raise JournalError('cannot open the journal lock for %s: %s'
+                               % (self.path, error))
+        try:
+            fcntl.flock(handle, fcntl.LOCK_EX)
+            yield
+        finally:
+            # Closing releases the lock, including on the raising paths.
+            handle.close()
+
+    @contextlib.contextmanager
+    def transaction(self):
+        """Hold an exclusive lock across one record/call/clear cycle.
+
+        Replacing each write atomically isn't enough when two runs overlap: both
+        would snapshot the same markers, and the second record() would replace
+        the first's in-flight entry. If the first call then killed kwin, the
+        surviving journal would name the wrong action -- and the real one would
+        be retried. The lock makes the whole cycle exclusive, and the markers are
+        re-read inside it so this run sees what the other one wrote.
+
+        The wait is unbounded on purpose: a holder that dies -- which is what a
+        compositor crash does to it -- releases the lock through the kernel, so
+        there's nothing to time out for.
+        """
+        with self._locked():
+            self._load()
+            if self.unreadable:
+                raise JournalError('cannot read %s: %s'
+                                   % (self.path, self.unreadable))
+            yield
+
+    def seal(self):
+        """Keep the file as it stands: it names the call that killed the daemon,
+        so no later record() or clear() may rewrite it."""
+        self.sealed = True
+
+    def _write(self, entries):
+        """Replace the file with these entries, or remove it when there are
+        none. Raises JournalError so the caller can decide -- which for record()
+        means not making the call it was about to journal.
+
+        Written to a temporary file and renamed over the original, never
+        truncated in place: a write that fails partway -- out of space, a bad
+        fsync, or the compositor taking this process down mid-update -- would
+        otherwise erase the existing markers or leave a half-written line that
+        the next run parses as absent, and retry a shortcut already known to
+        kill kwin.
+        """
+        if not entries:
+            try:
+                os.remove(self.path)
+            except FileNotFoundError:
+                pass
+            except OSError as error:
+                raise JournalError('cannot remove %s: %s' % (self.path, error))
+            return
+
+        directory = os.path.dirname(self.path) or '.'
+        try:
+            handle, temporary = tempfile.mkstemp(
+                dir=directory, prefix=os.path.basename(self.path) + '.')
+        except OSError as error:
+            raise JournalError('cannot write %s: %s' % (self.path, error))
+        try:
+            with os.fdopen(handle, 'w') as stream:
+                for component, action in entries:
+                    stream.write('%s\t%s\n' % (component, action))
+                stream.flush()
+                os.fsync(stream.fileno())
+            # The rename is what makes the new contents visible, so until it
+            # succeeds the previous markers are still the journal.
+            os.replace(temporary, self.path)
+        except OSError as error:
+            try:
+                os.remove(temporary)
+            except OSError:
+                # Reported below either way; a leftover temp file is the lesser
+                # problem and naming both errors would obscure the real one.
+                pass
+            raise JournalError('cannot write %s: %s' % (self.path, error))
+
+    def record(self, component, action):
+        """Name the call about to be made, keeping every existing marker.
+
+        Propagates JournalError: without the marker written, a call that takes
+        kwin down leaves nothing to identify it and the next run retries it, so
+        the call must not be made.
+        """
+        if not self.path or self.sealed:
+            return
+        self._write(sorted(self.poisoned) + [(component, action)])
+
+    def clear(self):
+        """Called once a mutating call has returned: nothing is in flight. The
+        markers stay -- only --forget retires those.
+
+        Failure is reported but not raised: the call already returned, so
+        there's nothing left to prevent. The cost is a stale marker that skips a
+        good shortcut next run, which --forget retires.
+        """
+        if not self.path or self.sealed:
+            return
+        try:
+            self._write(sorted(self.poisoned))
+        except JournalError as error:
+            sys.stderr.write('kdeshortcut.py: %s\n' % error)
+
+    def forget(self):
+        """Retire the markers this journal was holding, so those shortcuts are
+        attempted again. Returns (retired, kept).
+
+        Under the same lock as a transaction: otherwise this could delete an
+        entry another process had just journaled and not yet returned from, and
+        if that call took kwin down there'd be nothing left to name it.
+
+        Only the markers read at startup are retired. Waiting for the lock can
+        take as long as someone else's D-Bus call, and if that call is the one
+        that kills kwin, its marker appears while this waits -- writing an empty
+        file on acquiring the lock would delete the very evidence the crash just
+        produced. Retiring is a decision about the markers the user was told
+        about, so anything newer is kept.
+        """
+        with self._locked():
+            retiring = set(self.poisoned)
+            self._load()
+            if self.unreadable:
+                # Nothing can be compared, so there's no way to tell a fresh
+                # marker from an old one. Removing it is the documented way out
+                # of an unreadable journal, and main() says the set is unknown.
+                self.poisoned = set()
+                self.sealed = False
+                self.unreadable = None
+                self._write([])
+                return sorted(retiring), []
+            kept = self.poisoned - retiring
+            self.sealed = False
+            self._write(sorted(kept))
+            self.poisoned = set(kept)
+            return sorted(retiring), sorted(kept)
+
+
+def apply_shortcut(backend, entry, check_only, registered, journal):
     """Set one shortcut and confirm the daemon holds it. Returns (ok, note)."""
+    component, action, keys_text, label = entry
     wanted = parse_shortcut(keys_text)
 
     # actionId is kglobalaccel's 4-field identity: unique and friendly names
@@ -332,20 +692,61 @@ def apply_shortcut(backend, component, action, keys_text, label, check_only):
     # know, and the label describes the action.
     action_id = [component, action, component, label or action]
 
+    # A marker blocks mutating, not reading. --check makes no call that could
+    # repeat the crash, and after one this is exactly the shortcut you want to
+    # ask the daemon about -- same reasoning as letting --check past an
+    # unreadable journal.
+    poisoned = (component, action) in journal.poisoned
+    if poisoned and not check_only:
+        return False, ('skipped: a previous run did not return from applying '
+                       'this one, which is what would take kwin down with it '
+                       '(--forget to retry it)')
+
+    # Never mutate an action the daemon doesn't already have. setShortcutKeys
+    # is only defined for a registered action, and since the daemon lives
+    # inside kwin, a call it mishandles costs the whole session -- so an
+    # unregistered action is reported, not attempted.
+    if action not in registered:
+        if not wanted:
+            # Nothing is bound, which is all an unbind was asking for.
+            return True, 'not registered, nothing to unbind'
+        return False, ('daemon has no such action, so it was not called; the '
+                       'shortcut applies at next login')
+
     if not check_only:
-        backend.set_keys(action_id, wanted)
+        # One transaction: nothing else may rewrite the journal between naming
+        # this call and the call returning.
+        with journal.transaction():
+            # Re-checked under the lock, against markers just re-read: a
+            # concurrent run may have journaled this very action as crashing
+            # since this one started.
+            if (component, action) in journal.poisoned:
+                return False, ('skipped: a concurrent run did not return from '
+                               'applying this one (--forget to retry it)')
+            journal.record(component, action)
+            try:
+                backend.set_keys(action_id, wanted)
+            except Exception as error:
+                # Control came back, so this call didn't take the process down.
+                # Keep the entry only when the daemon itself is gone -- that's
+                # the case it exists to catch. An ordinary transient error must
+                # not poison the shortcut, or one failed call would refuse to
+                # apply it ever again.
+                if backend.alive():
+                    journal.clear()
+                    raise
+                journal.seal()
+                raise DaemonGone('%s (the daemon stopped answering)' % error)
+            journal.clear()
 
     live = backend.get_keys(action_id)
-    if live == wanted:
-        return True, format_keys(wanted)
-
-    if not live:
-        # setForeignShortcutKeys only mutates actions already registered in
-        # the session. An action the daemon has never heard of stays absent,
-        # which is the common case for a component that hasn't started yet.
-        return False, ('daemon holds no binding -- action not registered in '
-                       'this session, so it applies at next login')
-    return False, ('daemon holds %s, wanted %s' % (format_keys(live), format_keys(wanted)))
+    # Under --check a marker is still worth saying: the daemon may well hold the
+    # shortcut, and the reason an apply would skip it isn't otherwise visible.
+    marked = ' (journaled as crashing; --forget to retry it)' if poisoned else ''
+    if holds_wanted(live, wanted):
+        return True, format_keys(real_keys(live)) + marked
+    return False, ('daemon holds %s, wanted %s%s'
+                   % (format_keys(live), format_keys(wanted), marked))
 
 
 def read_batch(stream):
@@ -379,6 +780,9 @@ def main(argv):
     batch = False
     quiet = False
     wanted_backend = None
+    journal_path = None
+    who = None
+    forget = False
     args = []
 
     index = 0
@@ -398,6 +802,24 @@ def main(argv):
                 wanted_backend = argv[index]
             else:
                 wanted_backend = argument.split('=', 1)[1]
+        elif argument == '--who' or argument.startswith('--who='):
+            if argument == '--who':
+                index += 1
+                if index >= len(argv):
+                    return usage('--who needs a shortcut')
+                who = argv[index]
+            else:
+                who = argument.split('=', 1)[1]
+        elif argument == '--forget':
+            forget = True
+        elif argument == '--journal' or argument.startswith('--journal='):
+            if argument == '--journal':
+                index += 1
+                if index >= len(argv):
+                    return usage('--journal needs an argument')
+                journal_path = argv[index]
+            else:
+                journal_path = argument.split('=', 1)[1]
         elif argument in ('-h', '--help'):
             sys.stdout.write(HELP)
             return 0
@@ -406,6 +828,69 @@ def main(argv):
         else:
             args.append(argument)
         index += 1
+
+    if who is not None:
+        try:
+            keys = parse_shortcut(who)
+        except ShortcutError as error:
+            sys.stderr.write('kdeshortcut.py: %s\n' % error)
+            return 2
+        if not keys:
+            return usage('--who needs a shortcut, not an unbind')
+        try:
+            backend = open_backend(wanted_backend)
+        except RuntimeError as error:
+            sys.stderr.write('kdeshortcut.py: cannot reach kglobalaccel (%s)\n'
+                             % error)
+            return 3
+        holders = backend.holders(keys[0])
+        if not holders:
+            sys.stdout.write('nothing holds %s\n' % who)
+        for component, action in holders:
+            sys.stdout.write('%s holds %s/%s\n' % (who, component, action))
+        return 0
+
+    # Retiring markers is a file operation, so it needs no daemon and happens
+    # before anything else -- including on a bare --forget with no shortcut to
+    # apply, which is how a user clears one after fixing the cause.
+    # A mutating run always gets a journal: without one, record() is a no-op and
+    # a call that takes kwin down leaves nothing to identify it. --check needs
+    # none, since it makes no such call.
+    if journal_path is None and (forget or not check_only):
+        journal_path = default_journal_path()
+        directory = os.path.dirname(journal_path)
+        try:
+            os.makedirs(directory, exist_ok=True)
+        except OSError as error:
+            sys.stderr.write('kdeshortcut.py: cannot create %s for the crash '
+                             'journal (%s)\n' % (directory, error))
+            sys.stderr.write('kdeshortcut.py: refusing to apply shortcuts '
+                             'without one -- pass --journal to put it '
+                             'elsewhere\n')
+            return 1
+
+    if forget:
+        retired = Journal(journal_path)
+        if retired.unreadable:
+            # Worth saying: the names being retired can't be listed, so this is
+            # retiring an unknown set rather than the ones printed below.
+            sys.stderr.write('kdeshortcut.py: cannot read %s (%s); retiring it '
+                             'anyway\n' % (journal_path, retired.unreadable))
+        try:
+            gone, kept = retired.forget()
+        except JournalError as error:
+            sys.stderr.write('kdeshortcut.py: %s\n' % error)
+            return 1
+        for component, action in gone:
+            sys.stdout.write('forgetting %s/%s; it will be retried\n'
+                             % (component, action))
+        # Anything journaled while this waited for the lock is somebody else's
+        # fresh crash, not part of what was being retired.
+        for component, action in kept:
+            sys.stdout.write('keeping %s/%s; it was journaled while this ran\n'
+                             % (component, action))
+        if not args and not batch:
+            return 0
 
     try:
         if batch:
@@ -433,11 +918,70 @@ def main(argv):
         sys.stderr.write('kdeshortcut.py: cannot reach kglobalaccel (%s)\n' % error)
         return 3
 
+    journal = Journal(journal_path)
+
+    # An unreadable journal may be preserving the marker for a call that took
+    # kwin down, so nothing mutating may run until it can be read or --forget
+    # retires it. --check is read-only, so it's allowed through.
+    if journal.unreadable and not check_only:
+        sys.stderr.write('kdeshortcut.py: cannot read the crash journal %s '
+                         '(%s)\n' % (journal_path, journal.unreadable))
+        sys.stderr.write('kdeshortcut.py: refusing to apply shortcuts without '
+                         'it -- it may name a call that took kwin down. Fix its '
+                         'permissions, or --forget to retire it.\n')
+        return 1
+
+    for component, action in sorted(journal.poisoned):
+        sys.stderr.write('kdeshortcut.py: skipping %s/%s this run: a previous '
+                         'run did not return from it (--forget to retry it)\n'
+                         % (component, action))
+
+    # Ask the daemon which actions it actually has, once per component, before
+    # changing anything. Enumeration is read-only, and it's what keeps a
+    # mutating call off an action the daemon never registered.
+    registered = {}
+
+    def actions_in(component):
+        if component not in registered:
+            registered[component] = backend.list_actions(component)
+        return registered[component]
+
     failures = 0
-    for component, action, keys_text, label in entries:
+    remaining = list(entries)
+    for position, entry in enumerate(entries):
+        component, action, keys_text = entry[0], entry[1], entry[2]
         try:
-            ok, note = apply_shortcut(backend, component, action, keys_text,
-                                      label, check_only)
+            ok, note = apply_shortcut(backend, entry, check_only,
+                                      actions_in(component), journal)
+        except DaemonGone as error:
+            # Don't touch the daemon again: it's down, and the journal now names
+            # the call that took it there.
+            failures += 1
+            sys.stderr.write('FAIL  %s/%s (%s): %s\n'
+                             % (component, action, keys_text, error))
+            skipped = remaining[position + 1:]
+            if skipped:
+                failures += len(skipped)
+                sys.stderr.write('kdeshortcut.py: stopping; %d shortcut(s) not '
+                                 'attempted\n' % len(skipped))
+            break
+        except JournalError as error:
+            # The marker couldn't be written, so this call wasn't made -- and it
+            # won't be for the rest either, since a full or unwritable state
+            # directory doesn't fix itself between entries. Stop once rather
+            # than repeat the same failure for every shortcut.
+            failures += 1
+            sys.stderr.write('FAIL  %s/%s (%s): %s\n'
+                             % (component, action, keys_text, error))
+            sys.stderr.write('kdeshortcut.py: not applying anything without a '
+                             'crash journal -- a call that takes kwin down could '
+                             'not be identified afterwards\n')
+            skipped = remaining[position + 1:]
+            if skipped:
+                failures += len(skipped)
+                sys.stderr.write('kdeshortcut.py: stopping; %d shortcut(s) not '
+                                 'attempted\n' % len(skipped))
+            break
         except ShortcutError as error:
             ok, note = False, str(error)
         except Exception as error:  # noqa: BLE001 - one bad shortcut isn't fatal

--- a/kdeshortcut_test
+++ b/kdeshortcut_test
@@ -10,6 +10,7 @@
 # on a running Plasma session -- kdeshortcut.py's own readback is what reports
 # that, and these tests cover the readback logic, not the daemon.
 
+import fcntl
 import importlib.util
 import os
 import shutil
@@ -157,11 +158,28 @@ for arg in "$@"; do
     case "$arg" in *Peer.Ping) exit 0;; esac
 done
 case "$*" in
-    *shortcutKeys*)
+    *allActionsForComponent*)
+        # $STUB_ACTIONS is a ;-separated list of action names the daemon claims
+        # to have -- ';' because action names contain spaces. The reply shape is
+        # aas, one 4-field list per action.
+        out=""
+        oldifs="$IFS"; IFS=';'
+        for action in $STUB_ACTIONS; do
+            IFS="$oldifs"
+            out="$out['comp', '$action', 'comp', '$action'], "
+            IFS=';'
+        done
+        IFS="$oldifs"
+        printf '([%s],)\\n' "$out"
+        ;;
+    *getGlobalShortcutsByKey*)
+        printf "([('kwin', 'KWin', 'Edit Tiles', 'Edit Tiles', '', '', [1], [1])],)\\n"
+        ;;
+    *KGlobalAccel.shortcut*)
         if test -n "$STUB_KEYS"; then
-            printf '([([%s],)],)\\n' "$STUB_KEYS"
+            printf '([%s],)\\n' "$STUB_KEYS"
         else
-            printf '(@a(ai) [],)\\n'
+            printf '(@ai [],)\\n'
         fi
         ;;
     *) echo '()';;
@@ -178,8 +196,10 @@ try:
         handle.write(STUB)
     os.chmod(stub, 0o755)
     log = os.path.join(workdir, 'gdbus.log')
+    statedir = os.path.join(workdir, 'state')
+    default_journal = os.path.join(statedir, 'kdeshortcut.inflight')
 
-    def run(args, keys='', path=None, stdin=None):
+    def run(args, keys='', path=None, stdin=None, actions=None, extra=None):
         """Run kdeshortcut.py with the stub gdbus, returning (status, out, err,
         gdbus calls)."""
         if os.path.exists(log):
@@ -187,9 +207,16 @@ try:
         env = dict(os.environ,
                    PATH=path if path is not None else bindir + os.pathsep + os.environ.get('PATH', ''),
                    GDBUS_LOG=log,
-                   STUB_KEYS=keys)
+                   STUB_KEYS=keys,
+                   # Pinned so a run without --journal writes its default
+                   # journal here rather than into the caller's real state dir.
+                   XDG_STATE_HOME=statedir,
+                   STUB_ACTIONS='Window Close;Other;Grid View'
+                   if actions is None else actions)
         # PYTHONDONTWRITEBYTECODE: no __pycache__ in the repo from a subprocess.
         env['PYTHONDONTWRITEBYTECODE'] = '1'
+        if extra:
+            env.update(extra)
         result = subprocess.run([sys.executable, _script] + args,
                                 capture_output=True, text=True, env=env,
                                 input=stdin)
@@ -204,20 +231,52 @@ try:
     status, out, err, calls = run(['kwin', 'Window Close', 'Meta+T', 'Close'],
                                   keys=META_T)
     check('a shortcut the daemon confirms exits 0', 0, status)
-    check('the daemon is asked to set the shortcut, the way System Settings does',
-          True, 'org.kde.KGlobalAccel.setForeignShortcutKeys' in calls)
+    check('the shortcut is set through the flat-int API, not the QKeySequence one',
+          True, 'org.kde.KGlobalAccel.setForeignShortcut ' in calls
+          and 'setForeignShortcutKeys' not in calls)
     check('actionId is the 4-field identity, component friendly name included',
           True, "['kwin', 'Window Close', 'kwin', 'Close']" in calls)
-    check('keys marshal as a(ai): an array of one-element key sequences',
-          True, '[([%s],)]' % META_T in calls)
+    check('keys marshal as a flat ai, with no QKeySequence struct to get wrong',
+          True, '[%s]' % META_T in calls and '([%s],)' % META_T not in calls)
     check('the binding is read back out of the daemon, not assumed',
-          True, 'org.kde.KGlobalAccel.shortcutKeys' in calls)
+          True, 'org.kde.KGlobalAccel.shortcut ' in calls)
     check('a confirmed shortcut is reported as live', True, 'live' in out)
+
+    # A real daemon reports all four slots of a QKeySequence, padding the unused
+    # ones with 0 or Qt::Key_unknown. Requiring exact equality reported every
+    # correctly applied shortcut as a failure, which made the readback useless.
+    status, out, err, calls = run(['kwin', 'Window Close', 'Meta+T'],
+                                  keys='%s, 33554431, 33554431, 0' % META_T)
+    check('a four-slot reply with an empty tail counts as live', 0, status)
+    check('the report shows the real key, not the padding', True,
+          META_T in out and '33554431' not in out)
+
+    # The tail is padding, but the head still has to match.
+    status, out, err, calls = run(['kwin', 'Window Close', 'Meta+T'],
+                                  keys='999, 0, 0, 0')
+    check('padding does not excuse a different key', 1, status)
+
+    status, out, err, calls = run(['kwin', 'Grid View', 'none'],
+                                  keys='0, 33554431, 33554431, 0')
+    check('an unbind is live when every slot is empty', 0, status)
+
+    # --who: which component holds a key. Read-only, and the argument is a plain
+    # int, so there is no struct to marshal.
+    status, out, err, calls = run(['--who', 'Meta+T'])
+    check('--who reports the holder of a key', 0, status)
+    check('--who names the component and action', True,
+          'kwin' in out and 'Edit Tiles' in out)
+    check('--who changes nothing', True, 'setForeignShortcut' not in calls)
+    check('--who asks the daemon by keycode', True,
+          'getGlobalShortcutsByKey' in calls and META_T in calls)
+
+    status, out, err, calls = run(['--who', 'none'])
+    check('--who with an unbind is a usage error', 2, status)
 
     status, out, err, calls = run(['kwin', 'Grid View', 'none'], keys='')
     check('an unbind exits 0 when the daemon holds no keys', 0, status)
     check('an empty key list is type-annotated, since GVariant [] is ambiguous',
-          True, '@a(ai) []' in calls)
+          True, '@ai []' in calls)
 
     status, out, err, calls = run(['kwin', 'Window Close', 'Meta+T'], keys='999')
     check('a daemon holding different keys is a failure', 1, status)
@@ -229,11 +288,445 @@ try:
     check('the unregistered case says it applies at next login',
           True, 'next login' in err)
 
+    # The safety property this whole guard exists for: kglobalaccel is part of
+    # kwin, so a mutating call it mishandles kills the compositor. An action the
+    # daemon doesn't list must be reported, never called.
+    status, out, err, calls = run(['kwin', 'Bogus Action', 'Meta+T'], keys='')
+    check('an unknown action is never handed to a mutating call', True,
+          'setForeignShortcut' not in calls)
+    check('the daemon is asked which actions it has, first', True,
+          'allActionsForComponent' in calls)
+    check('an unknown action still reports it applies at next login', True,
+          'next login' in err)
+
+    # Unbinding something the daemon doesn't have isn't a failure: there is no
+    # binding, which is what was wanted.
+    status, out, err, calls = run(['kwin', 'Bogus Action', 'none'])
+    check('an unbind of an unknown action is a success', 0, status)
+    check('an unbind of an unknown action calls nothing', True,
+          'setForeignShortcut' not in calls)
+
+    # One enumeration per component, not per shortcut.
+    status, out, err, calls = run(
+        ['--batch'], keys=META_T,
+        stdin='kwin\tWindow Close\tMeta+T\nkwin\tOther\tMeta+T\n')
+    check('the action list is fetched once per component', 1,
+          calls.count('allActionsForComponent'))
+
+    # --- The journal ---
+    #
+    # A call that kills kwin kills this process's terminal too, so the file is
+    # the only thing left to say which shortcut was in flight.
+    journal = os.path.join(workdir, 'inflight')
+    status, out, err, calls = run(['--journal', journal, 'kwin', 'Window Close',
+                                   'Meta+T'], keys=META_T)
+    check('a completed run leaves no journal entry behind', False,
+          os.path.exists(journal))
+
+    # A journal naming a shortcut means the previous run didn't return from it.
+    with open(journal, 'w') as handle:
+        handle.write('kwin\tWindow Close\n')
+    status, out, err, calls = run(['--journal', journal, 'kwin', 'Window Close',
+                                   'Meta+T'], keys=META_T)
+    check('a shortcut the previous run died on is skipped, not retried', True,
+          'setForeignShortcut' not in calls)
+    check('the skipped shortcut is named', True,
+          'Window Close' in err and 'previous run' in err)
+    check('skipping it counts as not live', 1, status)
+    def journal_text():
+        """The journal's contents, or '' when it's gone -- never a traceback,
+        so a regression shows up as a failed check rather than a dead run."""
+        try:
+            with open(journal) as handle:
+                return handle.read()
+        except FileNotFoundError:
+            return ''
+
+    check('reading a marker does not retire it -- the run after would retry it',
+          True, 'Window Close' in journal_text())
+
+    # A marker blocks mutating, not reading: --check makes no call that could
+    # repeat the crash, and it's the shortcut you most want to ask about after
+    # one. Journal still names 'kwin/Window Close' from just above.
+    status, out, err, calls = run(['--check', '--journal', journal, 'kwin',
+                                   'Window Close', 'Meta+T'], keys=META_T)
+    check('--check reads the daemon even for a journaled shortcut', True,
+          'KGlobalAccel.shortcut' in calls)
+    check('--check makes no mutating call for a journaled shortcut', True,
+          'setForeignShortcut' not in calls)
+    check('--check reports a journaled shortcut the daemon holds as live',
+          0, status)
+    check('--check still says the shortcut is journaled', True,
+          'journaled as crashing' in out)
+    # An apply, by contrast, still refuses it.
+    status, out, err, calls = run(['--journal', journal, 'kwin', 'Window Close',
+                                   'Meta+T'], keys=META_T)
+    check('an apply still skips a journaled shortcut', True,
+          'setForeignShortcut' not in calls and status == 1)
+
+    # The cross-run case: the marker has to survive a run that applies *other*
+    # shortcuts successfully. Every setup-kde batch has some, and clearing on
+    # one of those took the marker with it -- so the third run retried the call
+    # that killed kwin.
+    with open(journal, 'w') as handle:
+        handle.write('kwin\tWindow Close\n')
+    batch_text = ('kwin\tWindow Close\tMeta+T\n'
+                  'kwin\tOther\tMeta+T\n')
+    status, out, err, calls = run(['--journal', journal, '--batch'],
+                                  keys=META_T, actions='Window Close;Other',
+                                  stdin=batch_text)
+    check('a later successful shortcut does not retire the marker', True,
+          'Window Close' in journal_text())
+    check('the poisoned one is still the only one skipped', 1,
+          calls.count('setForeignShortcut'))
+
+    # The in-flight entry is written alongside the markers and removed when the
+    # call returns, so a completed run leaves the markers and nothing else.
+    check('a completed entry is not left in the journal beside the marker',
+          True, 'Other' not in journal_text())
+
+    # --forget is the deliberate retirement, and the only thing that retires.
+    status, out, err, calls = run(['--journal', journal, '--forget'])
+    check('--forget retires the marker', False, os.path.exists(journal))
+    check('--forget exits 0 with nothing else to do', 0, status)
+    check('--forget names what it retired', True, 'Window Close' in out)
+    # --forget with no --journal retires the default journal rather than erroring:
+    # it's the same file a journal-less mutating run would have used.
+    os.makedirs(statedir, exist_ok=True)
+    with open(default_journal, 'w') as handle:
+        handle.write('kwin\tWindow Close\n')
+    status, out, err, calls = run(['--forget'])
+    check('--forget with no --journal retires the default journal', 0, status)
+    check('the default journal is gone after --forget', False,
+          os.path.exists(default_journal))
+
+    # Once retired, the shortcut is attempted again.
+    status, out, err, calls = run(['--journal', journal, 'kwin', 'Window Close',
+                                   'Meta+T'], keys=META_T)
+    check('after --forget the shortcut is retried', True,
+          'setForeignShortcut' in calls)
+
+    # A journal that can't be read may be preserving the marker that matters, so
+    # nothing mutating may run. A directory at the path is an unreadable journal
+    # whatever the uid, where a chmod would not be for root.
+    unreadable = os.path.join(workdir, 'unreadable-journal')
+    os.mkdir(unreadable)
+    status, out, err, calls = run(['--journal', unreadable, 'kwin',
+                                   'Window Close', 'Meta+T'], keys=META_T)
+    check('an unreadable journal makes no mutating call', True,
+          'setForeignShortcut' not in calls)
+    check('an unreadable journal fails rather than proceeding blind', 1, status)
+    check('the unreadable journal says how to get out of it', True,
+          'refusing to apply' in err and '--forget' in err)
+    # Read-only work needs no marker, so it isn't blocked.
+    status, out, err, calls = run(['--check', '--journal', unreadable, 'kwin',
+                                   'Window Close', 'Meta+T'], keys=META_T)
+    check('--check is allowed through an unreadable journal', 0, status)
+    status, out, err, calls = run(['--journal', unreadable, '--forget'])
+    check('--forget on an unretireable journal reports it', 1, status)
+    check('--forget says it could not remove it', True, 'cannot remove' in err)
+
+    # A journal that can't be written: the marker for the call about to be made
+    # can't be recorded, so the call must not happen. A path under a directory
+    # that doesn't exist reads as "no journal yet" and fails on write.
+    unwritable = os.path.join(workdir, 'no-such-dir', 'inflight')
+    status, out, err, calls = run(['--journal', unwritable, 'kwin',
+                                   'Window Close', 'Meta+T'], keys=META_T)
+    check('a journal that cannot be written makes no mutating call', True,
+          'setForeignShortcut' not in calls)
+    check('a journal that cannot be written fails the shortcut', 1, status)
+    check('the reason names the missing crash journal', True,
+          'crash journal' in err)
+
+    # And it stops the batch rather than repeating the same failure per entry:
+    # a full state directory doesn't fix itself between shortcuts.
+    status, out, err, calls = run(['--journal', unwritable, '--batch'],
+                                  keys=META_T,
+                                  stdin='kwin\tWindow Close\tMeta+T\n'
+                                        'kwin\tOther\tMeta+T\n')
+    check('an unwritable journal stops the batch', True,
+          'not attempted' in err)
+    check('no shortcut in the batch was applied', True,
+          'setForeignShortcut' not in calls)
+
+    # A mutating run with no --journal must not run unjournaled: with no path,
+    # record() is a no-op and a call that kills kwin leaves nothing behind. The
+    # default journal is proved to be in use by seeding a marker in it and
+    # watching the run skip that shortcut.
+    os.makedirs(statedir, exist_ok=True)
+    with open(default_journal, 'w') as handle:
+        handle.write('kwin\tWindow Close\n')
+    status, out, err, calls = run(['kwin', 'Window Close', 'Meta+T'], keys=META_T)
+    check('a run with no --journal uses the default journal', True,
+          'setForeignShortcut' not in calls and status == 1)
+    check('the default journal marker is reported', True, 'previous run' in err)
+    os.remove(default_journal)
+
+    # A default journal that can't be created is the same fail-closed case as an
+    # unwritable one: a regular file where the state directory should be.
+    state_is_file = os.path.join(workdir, 'state-file')
+    with open(state_is_file, 'w') as handle:
+        handle.write('not a directory\n')
+    status, out, err, calls = run(['kwin', 'Window Close', 'Meta+T'],
+                                  keys=META_T,
+                                  extra={'XDG_STATE_HOME': state_is_file})
+    check('an uncreatable default journal makes no mutating call', True,
+          'setForeignShortcut' not in calls)
+    check('an uncreatable default journal fails the run', 1, status)
+    check('it points at --journal as the way out', True, '--journal' in err)
+    # --check needs no journal at all, so it is unaffected.
+    status, out, err, calls = run(['--check', 'kwin', 'Window Close', 'Meta+T'],
+                                  keys=META_T,
+                                  extra={'XDG_STATE_HOME': state_is_file})
+    check('--check needs no journal, so an uncreatable one is irrelevant',
+          0, status)
+
+    # Serializing the transaction. Replacing each write atomically isn't enough:
+    # two overlapping runs would snapshot the same markers and the second
+    # record() would replace the first's in-flight entry, so a crash would name
+    # the wrong action. The stub probes the lock during set_keys -- if the lock is
+    # held across the call, a non-blocking attempt from inside it fails.
+    lock_probe = os.path.join(workdir, 'lock-probe')
+    probe_journal = os.path.join(workdir, 'probe-journal')
+    probe_stub = """#!/bin/sh
+printf '%%s\\n' "$*" >> "$GDBUS_LOG"
+case "$*" in
+    *Peer.Ping) exit 0;;
+    *allActionsForComponent*) printf "([['c', 'Window Close', 'c', 'x']],)\\n";;
+    *setForeignShortcut*)
+        "%s" -c 'import fcntl, sys
+handle = open(sys.argv[1] + ".lock", "w")
+try:
+    fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    print("free")
+except OSError:
+    print("held")' "%s" >> "%s"
+        echo '()'
+        ;;
+    *) printf '(@ai [],)\\n';;
+esac
+exit 0
+""" % (sys.executable, probe_journal, lock_probe)
+    def install_stub(text):
+        with open(stub, 'w') as handle:
+            handle.write(text)
+        os.chmod(stub, 0o755)
+
+    install_stub(probe_stub)
+    status, out, err, calls = run(['--journal', probe_journal, 'kwin',
+                                   'Window Close', 'Meta+T'], keys=META_T)
+    check('the journal lock is held across the D-Bus call', 'held',
+          open(lock_probe).read().strip() if os.path.exists(lock_probe) else '')
+    install_stub(STUB)
+
+    # --forget takes the same lock. Without it, retiring markers could delete an
+    # entry another process had journaled and not yet returned from -- and if
+    # that call took kwin down, nothing would name it. Asserted by holding the
+    # lock here and watching --forget block until it's released.
+    contended = os.path.join(workdir, 'contended-journal')
+    with open(contended, 'w') as handle:
+        handle.write('kwin\tWindow Close\n')
+    lock_handle = open(contended + '.lock', 'w')
+    fcntl.flock(lock_handle, fcntl.LOCK_EX)
+    forget_command = [sys.executable, _script, '--journal', contended, '--forget']
+    forget_env = dict(os.environ, PYTHONDONTWRITEBYTECODE='1',
+                      XDG_STATE_HOME=statedir)
+    blocked = False
+    try:
+        subprocess.run(forget_command, capture_output=True, text=True,
+                       env=forget_env, timeout=2)
+    except subprocess.TimeoutExpired:
+        blocked = True
+    check('--forget waits for the journal lock rather than racing a call',
+          True, blocked)
+    def contended_text():
+        """Crash-safe read: a regression must fail a check, not kill the run."""
+        try:
+            with open(contended) as handle:
+                return handle.read()
+        except FileNotFoundError:
+            return ''
+
+    check('the markers survive while the lock is held',
+          'kwin\tWindow Close\n', contended_text())
+    # Released: the same command now completes and retires the marker.
+    lock_handle.close()
+    result = subprocess.run(forget_command, capture_output=True, text=True,
+                            env=forget_env, timeout=30)
+    check('--forget completes once the lock is released', 0, result.returncode)
+    check('the marker is retired after the lock is released', False,
+          os.path.exists(contended))
+
+    # A marker that appears while --forget waits for the lock is somebody else's
+    # fresh crash -- quite possibly the call that was in flight when it started
+    # waiting. Retiring is a decision about the markers the user was shown, so
+    # anything newer survives. Driven in-process: the wait is what creates the
+    # window, and reproducing that through subprocesses would be a race rather
+    # than a test.
+    waited = os.path.join(workdir, 'waited-journal')
+    with open(waited, 'w') as handle:
+        handle.write('kwin\tOld\n')
+    def forget_result(journal):
+        """(retired, kept) from forget(), or (None, None) if it returns neither.
+        A shape regression must fail a check, not kill the run with a
+        TypeError and take every later check with it."""
+        outcome = journal.forget()
+        if isinstance(outcome, tuple) and len(outcome) == 2:
+            return outcome
+        return None, None
+
+    retiring = kdeshortcut.Journal(waited)
+    check('the snapshot holds what was there at startup',
+          {('kwin', 'Old')}, retiring.poisoned)
+    # The crashing call's marker lands while this one waits for the lock.
+    with open(waited, 'w') as handle:
+        handle.write('kwin\tOld\nkwin\tCrashedWhileWaiting\n')
+    gone, kept = forget_result(retiring)
+    check('--forget retires what it was holding', [('kwin', 'Old')], gone)
+    check('a marker journaled while --forget waited is kept',
+          [('kwin', 'CrashedWhileWaiting')], kept)
+    check('the kept marker is still on disk, so the crash is not retried',
+          'kwin\tCrashedWhileWaiting\n',
+          open(waited).read() if os.path.exists(waited) else '')
+
+    # With nothing newer, the journal goes away entirely as before.
+    only_old = os.path.join(workdir, 'only-old-journal')
+    with open(only_old, 'w') as handle:
+        handle.write('kwin\tOld\n')
+    gone, kept = forget_result(kdeshortcut.Journal(only_old))
+    check('--forget with nothing newer removes the journal', ([('kwin', 'Old')], []),
+          (gone, kept))
+    check('no journal file is left behind', False, os.path.exists(only_old))
+
+    # And the markers are re-read inside the lock, so a run sees what a
+    # concurrent one wrote rather than its startup snapshot.
+    fresh = os.path.join(workdir, 'fresh-journal')
+    entry = kdeshortcut.Journal(fresh)
+    check('nothing is poisoned before the concurrent write', set(), entry.poisoned)
+    with open(fresh, 'w') as handle:
+        handle.write('kwin\tConcurrent\n')
+    with entry.transaction():
+        seen = set(entry.poisoned)
+    check('transaction() re-reads the markers under the lock',
+          {('kwin', 'Concurrent')}, seen)
+
+    # The journal is replaced by rename, never truncated in place. A write that
+    # fails partway would otherwise erase the markers or leave a half-written
+    # line that the next run reads as absent -- and retry a known killer. Tested
+    # in-process by making the rename fail, which no filesystem trick can do
+    # reliably as root.
+    atomic = os.path.join(workdir, 'atomic-journal')
+    with open(atomic, 'w') as handle:
+        handle.write('kwin\tWindow Close\n')
+    entry = kdeshortcut.Journal(atomic)
+    real_replace = os.replace
+    raised = False
+
+    def failing_replace(*args, **kwargs):
+        raise OSError(28, 'No space left on device')
+
+    os.replace = failing_replace
+    try:
+        entry.record('kwin', 'Other')
+    except kdeshortcut.JournalError:
+        raised = True
+    finally:
+        os.replace = real_replace
+
+    check('a journal replacement that fails raises rather than warns',
+          True, raised)
+    check('the previous markers survive a failed replacement',
+          'kwin\tWindow Close\n', open(atomic).read())
+    check('a failed replacement leaves no temporary file behind', ['atomic-journal'],
+          sorted(name for name in os.listdir(workdir)
+                 if name.startswith('atomic-journal')))
+
+    # And the successful path really does replace, rather than append.
+    entry.record('kwin', 'Other')
+    check('a successful record keeps the markers and adds the in-flight entry',
+          ['kwin\tOther', 'kwin\tWindow Close'],
+          sorted(open(atomic).read().splitlines()))
+
+    # A crash mid-call: the set fails and the daemon stops answering. The
+    # journal must keep the shortcut's name, since that call is the one that
+    # took kwin down. The first Ping still succeeds -- that's the backend
+    # opening -- and later ones don't.
+    crash_stub = """#!/bin/sh
+printf '%s\\n' "$*" >> "$GDBUS_LOG"
+case "$*" in
+    *Peer.Ping)
+        if test -f "$STUB_PINGED"; then exit 1; fi
+        : > "$STUB_PINGED"
+        exit 0
+        ;;
+    *allActionsForComponent*) printf "([['c', 'Window Close', 'c', 'x']],)\\n";;
+    *setForeignShortcut*) echo "Error: connection closed" >&2; exit 1;;
+    *) printf '(@ai [],)\\n';;
+esac
+"""
+    pinged = os.path.join(workdir, 'pinged')
+
+    def write_stub(text):
+        with open(stub, 'w') as handle:
+            handle.write(text)
+        os.chmod(stub, 0o755)
+
+    write_stub(crash_stub)
+    for stale in (journal, pinged):
+        if os.path.exists(stale):
+            os.remove(stale)
+    env_extra = {'STUB_PINGED': pinged}
+    status, out, err, calls = run(['--journal', journal, 'kwin', 'Window Close',
+                                   'Meta+T'], extra=env_extra)
+    check('a call that took the daemon down leaves its shortcut in the journal',
+          True, os.path.exists(journal)
+          and 'Window Close' in open(journal).read())
+
+    # A batch where the first entry kills the daemon: the journal must keep that
+    # first action, and the rest must not be attempted. Carrying on would call
+    # into a dead daemon and overwrite the one entry worth keeping.
+    for stale in (journal, pinged):
+        if os.path.exists(stale):
+            os.remove(stale)
+    status, out, err, calls = run(
+        ['--journal', journal, '--batch'], extra=env_extra,
+        stdin='kwin\tWindow Close\tMeta+T\nkwin\tWindow Close\tMeta+Y\n')
+    check('the journal keeps the entry that killed the daemon, not a later one',
+          True, os.path.exists(journal)
+          and open(journal).read().strip().endswith('Window Close'))
+    check('nothing is attempted after the daemon is found dead', 1,
+          calls.count('.setForeignShortcut '))
+    check('the unattempted shortcuts are reported, not silently dropped', True,
+          'not attempted' in err)
+    check('a dead daemon mid-batch is a failure', 1, status)
+
+    # An ordinary transient error, with the daemon still answering: the journal
+    # must be cleared, or one failed call would refuse that shortcut forever.
+    write_stub("""#!/bin/sh
+printf '%s\\n' "$*" >> "$GDBUS_LOG"
+case "$*" in
+    *Peer.Ping) exit 0;;
+    *allActionsForComponent*) printf "([['c', 'Window Close', 'c', 'x']],)\\n";;
+    *setForeignShortcut*) echo "Error: temporarily unavailable" >&2; exit 1;;
+    *) printf '(@ai [],)\\n';;
+esac
+""")
+    if os.path.exists(journal):
+        os.remove(journal)
+    status, out, err, calls = run(['--journal', journal, 'kwin', 'Window Close',
+                                   'Meta+T'])
+    check('a transient error with a live daemon does not poison the shortcut',
+          False, os.path.exists(journal))
+    check('the transient error is still reported as a failure', 1, status)
+
+    write_stub(STUB)
+    if os.path.exists(journal):
+        os.remove(journal)
+
     status, out, err, calls = run(['--check', 'kwin', 'Window Close', 'Meta+T'],
                                   keys=META_T)
     check('--check exits 0 when the daemon already agrees', 0, status)
-    check('--check changes nothing', True,
-          'setForeignShortcutKeys' not in calls)
+    check('--check changes nothing', True, 'setForeignShortcut' not in calls)
 
     status, out, err, calls = run(['--quiet', 'kwin', 'Window Close', 'Meta+T'],
                                   keys=META_T)
@@ -246,7 +739,7 @@ try:
     status, out, err, calls = run(['--batch'], keys=META_T, stdin=batch_text)
     check('--batch reads shortcuts from stdin', 0, status)
     check('--batch applies every entry in one process', 2,
-          calls.count('setForeignShortcutKeys'))
+          calls.count('.setForeignShortcut '))
 
     batch_file = os.path.join(workdir, 'batch')
     with open(batch_file, 'w') as handle:

--- a/setup
+++ b/setup
@@ -125,6 +125,12 @@ INSTALL=yes
 #   yes - keep going past failures (--ignore-errors)
 IGNORE_ERRORS=no
 
+# Whether to ask setup-kde to apply keyboard shortcuts to the running session
+# (--live-shortcuts). Off by default, matching setup-kde: the D-Bus call it
+# needs runs inside kwin and can take the compositor down, so opting in is a
+# deliberate, attended choice.
+LIVE_SHORTCUTS=no
+
 # Whether to generate an SSH key. One of:
 #   auto - skip when a key is already available -- loaded in the agent
 #          (ssh-add -l) or present on disk -- otherwise generate one (default)
@@ -180,6 +186,7 @@ usage() {
     cat <<'USAGE'
 Usage: setup [--gui | --no-gui] [--kde] [--minimal | --full]
              [--no-install] [--no-sudo] [--no-root] [--ignore-errors]
+             [--live-shortcuts]
              [--ssh | --no-ssh] [--no-npm] [--github PREFIX] [-h | --help]
 
 Bootstrap a new machine: install packages, fonts, tools, and dotfiles.
@@ -210,6 +217,12 @@ Options:
                    instead. For machines where you have no root at all
   --ignore-errors  Keep going past failures instead of aborting on the first
                    one. Forwarded to setup-kde/macos
+  --live-shortcuts Ask setup-kde to apply the keyboard shortcuts to the running
+                   session instead of leaving them for the next login. Off by
+                   default: the call runs inside kwin and can crash it, closing
+                   every window on Wayland. Forwarded to setup-kde
+  --no-live-shortcuts
+                   The default; state it explicitly. Forwarded to setup-kde
   --ssh            Generate an SSH key even if one is already available
   --no-ssh         Skip SSH key generation
   --no-npm         Skip installing Node.js (node/npm) and the TypeScript
@@ -438,6 +451,12 @@ while test $# -gt 0; do
         --ignore-errors)
             IGNORE_ERRORS=yes
             ;;
+        --live-shortcuts)
+            LIVE_SHORTCUTS=yes
+            ;;
+        --no-live-shortcuts)
+            LIVE_SHORTCUTS=no
+            ;;
         --ssh)
             SSH=yes
             ;;
@@ -526,6 +545,16 @@ if test "$SUDO" = no; then
 fi
 if test "$IGNORE_ERRORS" = yes; then
     DESKTOP_SETUP_FLAGS="$DESKTOP_SETUP_FLAGS --ignore-errors"
+fi
+# Flags for setup-kde only, kept out of DESKTOP_SETUP_FLAGS because
+# setup-macos shares that and rejects anything it doesn't know.
+#
+# Only forwarded when asked for: setup-kde's default is not to touch the running
+# session, and an unattended bootstrap must not opt into a D-Bus call that can
+# take the compositor down. See setup-kde's apply_shortcuts_live.
+KDE_SETUP_FLAGS=""
+if test "$LIVE_SHORTCUTS" = yes; then
+    KDE_SETUP_FLAGS="$KDE_SETUP_FLAGS --live-shortcuts"
 fi
 
 clone_or_pull() {
@@ -1832,8 +1861,8 @@ if test "$GUI_ENABLED" -eq 1; then
         "$SCRIPTS_DIR/setup-macos" $DESKTOP_SETUP_FLAGS
     else
         info "Configuring KDE desktop environment"
-        # shellcheck disable=SC2086  # $DESKTOP_SETUP_FLAGS expands to zero or more flags
-        "$SCRIPTS_DIR/setup-kde" $DESKTOP_SETUP_FLAGS
+        # shellcheck disable=SC2086  # both expand to zero or more flags
+        "$SCRIPTS_DIR/setup-kde" $DESKTOP_SETUP_FLAGS $KDE_SETUP_FLAGS
     fi
 else
     info "Skipping desktop environment configuration (no GUI)"

--- a/setup-kde
+++ b/setup-kde
@@ -8,18 +8,23 @@
 # - Application launch shortcuts (browser, terminal, music)
 # - The session keyboard layout (US Dvorak, Caps Lock as Compose)
 #
-# Every setting applies to the running session -- no logout. The KDE config
-# files this writes are only what the *next* login loads, so each step is
-# paired with the reload that makes the current session pick it up: kwinrc via
-# `kwin reconfigure`, Krohnkite by unloading and reloading the script, and
-# shortcuts via kdeshortcut.py, which hands them to kglobalaccel the way
-# System Settings does and reports any that didn't take. A shortcut that can't
-# be applied live is reported, never assumed -- see apply_shortcuts_live.
+# The KDE config files this writes are only what the *next* login loads, so
+# most steps are paired with the reload that makes the current session pick
+# them up: kwinrc via `kwin reconfigure`, Krohnkite by unloading and reloading
+# the script, the keyboard layout by kxkbrc's own watcher.
+#
+# Keyboard shortcuts are the exception, and deliberately so. kglobalaccel holds
+# the live shortcut registry in memory and only reads kglobalshortcutsrc at
+# startup, and in Plasma 6 it runs inside kwin -- so the D-Bus call that would
+# apply a shortcut now can, if the daemon mishandles it, kill the compositor
+# and every client with it. It's behind --live-shortcuts and off by default
+# until that path is confirmed on real hardware; see apply_shortcuts_live and
+# kdeshortcut.py.
 #
 # Requires: kpackagetool6, kwriteconfig6
-# Wants: python3 plus either gdbus or python3-dbus, for applying shortcuts to
-#        the running session (kdeshortcut.py). Without them the shortcuts are
-#        still written, and the script says a logout is needed.
+# Wants: python3 plus either gdbus or python3-dbus, for --live-shortcuts
+#        (kdeshortcut.py). Without them the shortcuts are still written, and
+#        the script says a logout is needed.
 # This helper does not use sudo: Krohnkite and every KDE setting are installed
 # for the current user, so setup-kde still works when system sudo is restricted.
 # Optional: homepkg (fetches Krohnkite's prebuilt .kwinscript release, the
@@ -79,6 +84,16 @@ IGNORE_ERRORS=no
 # a box where python3 isn't the name of a working Python 3.
 PYTHON="${PYTHON:-python3}"
 
+# Whether to push the shortcuts into the running session (--live-shortcuts).
+#
+# Off by default, and it has to stay off until the live path is confirmed on
+# real hardware: kglobalaccel runs inside kwin, so a call it mishandles doesn't
+# fail, it kills the compositor -- and on Wayland that takes every client with
+# it. The first version of this defaulted to on and did exactly that, losing a
+# session's worth of terminals. Writing the config and asking for a logout is
+# slower but can't cost you anything, so that's what an unattended run does.
+LIVE_SHORTCUTS_MODE=off
+
 info() {
     printf "%s\n" "$*"
 }
@@ -98,7 +113,8 @@ is_command() {
 
 usage() {
     cat <<'USAGE'
-Usage: setup-kde [--no-install] [--no-sudo] [--ignore-errors] [-h | --help]
+Usage: setup-kde [--no-install] [--no-sudo] [--ignore-errors]
+                 [--live-shortcuts] [-h | --help]
 
 Configure the KDE Plasma 6 desktop environment.
 
@@ -107,6 +123,14 @@ Options:
   --no-sudo        Accepted for consistency with setup; setup-kde uses no
                    sudo, so there's nothing to skip
   --ignore-errors  Keep going past failures instead of aborting on the first
+  --live-shortcuts Also apply the shortcuts to the running session, instead of
+                   leaving them for the next login. UNVERIFIED: kglobalaccel
+                   runs inside kwin, and a call it mishandles kills the
+                   compositor -- which on Wayland closes every window. Save
+                   your work first
+  --no-live-shortcuts
+                   The default: write the shortcuts and let the next login
+                   pick them up
   -h, --help       Show this help and exit
 USAGE
 }
@@ -127,6 +151,12 @@ while test $# -gt 0; do
             ;;
         --ignore-errors)
             IGNORE_ERRORS=yes
+            ;;
+        --live-shortcuts)
+            LIVE_SHORTCUTS_MODE=on
+            ;;
+        --no-live-shortcuts)
+            LIVE_SHORTCUTS_MODE=off
             ;;
         -h|--help)
             usage
@@ -160,10 +190,17 @@ fi
 # An unusable temp directory isn't fatal -- every config write still works, and
 # only the live apply is lost -- but it can't pass silently either, so the
 # empty value is what apply_shortcuts_live reports on.
+#
+# Only allocated when the live apply was actually asked for. On the default path
+# the batch is never read, so creating it would mean a temp file, a warning
+# about a feature the user didn't request, and -- worse -- an append that can
+# abort the whole run under set -e for a file nothing consumes.
 LIVE_SHORTCUTS=""
-if ! LIVE_SHORTCUTS="$(mktemp "${TMPDIR:-/tmp}/setup-kde-shortcuts-XXXXXX")"; then
-    LIVE_SHORTCUTS=""
-    warn "could not create a temporary file for the shortcut batch"
+if test "$LIVE_SHORTCUTS_MODE" = on; then
+    if ! LIVE_SHORTCUTS="$(mktemp "${TMPDIR:-/tmp}/setup-kde-shortcuts-XXXXXX")"; then
+        LIVE_SHORTCUTS=""
+        warn "could not create a temporary file for the shortcut batch"
+    fi
 fi
 
 cleanup() {
@@ -494,7 +531,8 @@ configure_keyboard_layout() {
 # a line here, and the whole batch is pushed into the running daemon at the
 # end of the run. Tab-separated because action IDs contain spaces.
 record_live_shortcut() {
-    # No batch file means mktemp failed above, which was already reported.
+    # No batch file means either the live apply wasn't asked for -- the default,
+    # where nothing would read it -- or mktemp failed, which was reported there.
     test -n "$LIVE_SHORTCUTS" || return 0
     printf '%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "${4:-$2}" >> "$LIVE_SHORTCUTS"
 }
@@ -841,6 +879,13 @@ reload_kglobalaccel() {
 # Both halves are kept: the file is what survives a reboot, the D-Bus call is
 # what makes this session agree with it.
 apply_shortcuts_live() {
+    if test "$LIVE_SHORTCUTS_MODE" != on; then
+        # Not a warning: this is the default, and the config is correct either
+        # way. Only the current session is behind.
+        info "Shortcuts written; they apply at next login (--live-shortcuts applies them now)"
+        return 0
+    fi
+
     # Without a batch file the shortcuts were written but can't be applied, so
     # the session still needs the old treatment.
     if test -z "$LIVE_SHORTCUTS"; then
@@ -867,9 +912,32 @@ apply_shortcuts_live() {
         return 0
     fi
 
+    # The journal survives the session: kglobalaccel runs inside kwin, so a
+    # call that takes the compositor down takes this script's terminal with it,
+    # and the file is then the only record of which shortcut was in flight.
+    # kdeshortcut.py skips whatever it names on the next run.
+    # The same file kdeshortcut.py defaults to, deliberately: a marker names an
+    # action that took the compositor down, which is a property of the action
+    # and not of whoever applied it. A private journal here would let a direct
+    # kdeshortcut.py run repeat the very call that crashed, and would leave its
+    # --forget clearing the wrong file.
+    journal_dir="${XDG_STATE_HOME:-$HOME/.local/state}"
+    journal="$journal_dir/kdeshortcut.inflight"
+    if ! mkdir -p "$journal_dir"; then
+        # Fail closed rather than run without the journal. Applying anyway is
+        # the case it exists to prevent: a call that takes the compositor down
+        # would leave nothing to identify it, so the next run would make it
+        # again. The config is written either way, so the only cost of waiting
+        # for the next login is the wait.
+        warn "could not create the state directory for the crash journal (\$XDG_STATE_HOME); not applying shortcuts to the running session"
+        reload_kglobalaccel
+        return 0
+    fi
+
     info "Applying shortcuts to the running session"
     status=0
-    "$PYTHON" "$helper" --quiet --batch "$LIVE_SHORTCUTS" || status=$?
+    "$PYTHON" "$helper" --quiet --journal "$journal" \
+        --batch "$LIVE_SHORTCUTS" || status=$?
     case "$status" in
         0)
             info "Shortcuts are live; no logout needed"

--- a/setup-kde_test
+++ b/setup-kde_test
@@ -855,15 +855,66 @@ assert_batch_contains() {
     fi
 }
 
+# The default must not touch the running session at all. kglobalaccel lives
+# inside kwin, so a mishandled call kills the compositor and every client with
+# it -- which is what happened when this defaulted to on. An unattended run
+# writes the config and says a logout is needed; nothing else.
+test_live_apply_is_off_by_default() {
+    mock_python3 0
+    run_kde --no-install
+    assert_status 0 &&
+    assert_not_called "kdeshortcut.py" &&
+    assert_output_contains "they apply at next login" &&
+    assert_output_contains "KDE configured successfully" &&
+    # The config is still written in full -- only the live push is skipped.
+    assert_called "kwriteconfig6 --file kglobalshortcutsrc --group kwin --key Window Close"
+}
+
+# The default path allocates no batch at all. It never reads one, so creating it
+# would put a temp file, a warning about a feature that wasn't requested, and an
+# append that can abort the run under set -e in the way of a plain config run.
+# An unusable TMPDIR is how that shows up: it must be a non-event here, while
+# --live-shortcuts still reports it (see the fallback test below).
+test_default_run_allocates_no_batch() {
+    mock_python3 0
+    set +e
+    output="$(HOME="$TEST_TMPDIR/home" \
+        XDG_CONFIG_HOME="$TEST_TMPDIR/home/.config" \
+        XDG_SESSION_TYPE=wayland \
+        PATH="$TEST_TMPDIR/bin:/usr/local/bin:/usr/bin:/bin" \
+        TMPDIR="$TEST_TMPDIR/no-such-dir" \
+        "$KDE_SCRIPT" --no-install 2>&1)"
+    status=$?
+    set -e
+    assert_status 0 &&
+    assert_output_lacks "could not create a temporary file" &&
+    assert_output_lacks "no shortcut batch was recorded" &&
+    assert_output_contains "they apply at next login" &&
+    assert_output_contains "KDE configured successfully" &&
+    assert_not_called "kdeshortcut.py" &&
+    # The config writes are unaffected by any of this.
+    assert_called "kwriteconfig6 --file kglobalshortcutsrc --group kwin --key Window Close"
+}
+
+# --no-live-shortcuts is accepted explicitly, for a caller that wants to state
+# the default rather than rely on it.
+test_no_live_shortcuts_flag_is_accepted() {
+    mock_python3 0
+    run_kde --no-install --no-live-shortcuts
+    assert_status 0 &&
+    assert_not_called "kdeshortcut.py" &&
+    assert_output_contains "KDE configured successfully"
+}
+
 # Every shortcut written to the config is also handed to kdeshortcut.py, with
 # the component, action, keys and label the config got -- tab-separated,
 # because action IDs contain spaces.
 test_shortcuts_pushed_to_running_session() {
     add_launcher browser1
     mock_python3 0
-    run_kde --no-install
+    run_kde --no-install --live-shortcuts
     assert_status 0 &&
-    assert_called "kdeshortcut.py --quiet --batch" &&
+    assert_called "kdeshortcut.py --quiet --journal" &&
     assert_batch_contains 'kwin\tWindow Close\tMeta+Backspace' &&
     assert_batch_contains 'kwin\tSwitch to Desktop 1\tMeta+1' &&
     assert_batch_contains 'kwin\tKrohnkiteSetMaster\tMeta+Return' &&
@@ -881,7 +932,7 @@ test_shortcuts_pushed_to_running_session() {
 # is handed, since that's the only place the name is observable.
 test_batch_file_name_is_unpredictable() {
     mock_python3 0
-    run_kde --no-install
+    run_kde --no-install --live-shortcuts
     batch_arg="$(sed -n 's/.*--batch //p' "$CALLS" | head -1)"
     assert_status 0 &&
     case "$batch_arg" in
@@ -903,7 +954,7 @@ test_unusable_tmpdir_falls_back_to_logout_advice() {
         XDG_SESSION_TYPE=wayland \
         PATH="$TEST_TMPDIR/bin:/usr/local/bin:/usr/bin:/bin" \
         TMPDIR="$TEST_TMPDIR/no-such-dir" \
-        "$KDE_SCRIPT" --no-install 2>&1)"
+        "$KDE_SCRIPT" --no-install --live-shortcuts 2>&1)"
     status=$?
     set -e
     assert_status 0 &&
@@ -914,11 +965,60 @@ test_unusable_tmpdir_falls_back_to_logout_advice() {
     assert_called "kwriteconfig6 --file kglobalshortcutsrc --group kwin --key Window Close"
 }
 
+# No crash journal means no live apply. Running without it is precisely the case
+# the journal exists to prevent: a call that takes the compositor down would
+# leave nothing to identify it, so the next run would make it again. A regular
+# file where the state directory should be is a state directory that can't be
+# created, for any uid.
+test_uncreatable_journal_dir_skips_live_apply() {
+    mock_python3 0
+    : > "$TEST_TMPDIR/state-is-a-file"
+    set +e
+    output="$(HOME="$TEST_TMPDIR/home" \
+        XDG_CONFIG_HOME="$TEST_TMPDIR/home/.config" \
+        XDG_SESSION_TYPE=wayland \
+        PATH="$TEST_TMPDIR/bin:/usr/local/bin:/usr/bin:/bin" \
+        XDG_STATE_HOME="$TEST_TMPDIR/state-is-a-file/state" \
+        "$KDE_SCRIPT" --no-install --live-shortcuts 2>&1)"
+    status=$?
+    set -e
+    assert_status 0 &&
+    assert_output_contains "could not create the state directory" &&
+    assert_output_contains "not applying shortcuts to the running session" &&
+    assert_output_contains "shortcuts take effect after logging out" &&
+    assert_output_contains "KDE configured successfully" &&
+    # Nothing may reach the daemon without the journal.
+    assert_not_called "kdeshortcut.py" &&
+    # The config writes still happen; only the live push is skipped.
+    assert_called "kwriteconfig6 --file kglobalshortcutsrc --group kwin --key Window Close"
+}
+
+# The helper is never invoked without --journal: that would leave Journal with
+# no path, where record() is a no-op and every mutating call runs unprotected.
+#
+# The path is also the one kdeshortcut.py defaults to. A marker names an action
+# that takes the compositor down, which is true of the action whoever applied
+# it -- so a private journal here would let a direct kdeshortcut.py run repeat
+# the call that crashed, and would leave its --forget clearing the wrong file.
+test_live_apply_always_passes_a_journal() {
+    mock_python3 0
+    run_kde --no-install --live-shortcuts
+    journal_arg="$(sed -n 's/.*--journal \([^ ]*\).*/\1/p' "$CALLS" | head -1)"
+    assert_status 0 &&
+    assert_called "kdeshortcut.py --quiet --journal" &&
+    ! grep -q 'kdeshortcut\.py --quiet --batch' "$CALLS" &&
+    case "$journal_arg" in
+        */kdeshortcut.inflight) ;;
+        *) echo "  FAIL: journal '$journal_arg' is not the helper's default path"
+            TEST_FAILED=1; return 1 ;;
+    esac
+}
+
 # The whole point is not having to log out, so a successful run must not tell
 # the user to.
 test_live_apply_does_not_advise_logout() {
     mock_python3 0
-    run_kde --no-install
+    run_kde --no-install --live-shortcuts
     assert_status 0 &&
     assert_output_lacks "logging out" &&
     assert_output_lacks "log out"
@@ -936,7 +1036,7 @@ test_missing_python3_falls_back_to_logout_advice() {
         XDG_SESSION_TYPE=wayland \
         PATH="$TEST_TMPDIR/bin:/usr/local/bin:/usr/bin:/bin" \
         PYTHON=no-such-python3 \
-        "$KDE_SCRIPT" --no-install 2>&1)"
+        "$KDE_SCRIPT" --no-install --live-shortcuts 2>&1)"
     status=$?
     set -e
     assert_status 0 &&
@@ -949,7 +1049,7 @@ test_missing_python3_falls_back_to_logout_advice() {
 # run still succeeds -- the config on disk is correct either way.
 test_failed_live_apply_warns_and_continues() {
     mock_python3 1
-    run_kde --no-install
+    run_kde --no-install --live-shortcuts
     assert_status 0 &&
     assert_output_contains "some shortcuts could not be applied" &&
     assert_output_contains "shortcuts take effect after logging out" &&
@@ -960,7 +1060,7 @@ test_failed_live_apply_warns_and_continues() {
 # changed in the session, rather than some shortcut being rejected.
 test_unreachable_daemon_warns_and_continues() {
     mock_python3 3
-    run_kde --no-install
+    run_kde --no-install --live-shortcuts
     assert_status 0 &&
     assert_output_contains "could not reach kglobalaccel" &&
     assert_output_contains "KDE configured successfully"
@@ -1111,12 +1211,22 @@ run_test "stale-group sweep rewrites through a symlink" \
     test_stale_group_sweep_follows_symlink
 run_test "stale-group sweep needs no python3" \
     test_stale_group_sweep_needs_no_python3
+run_test "the live apply is off by default" \
+    test_live_apply_is_off_by_default
+run_test "the default run allocates no shortcut batch" \
+    test_default_run_allocates_no_batch
+run_test "--no-live-shortcuts is accepted" \
+    test_no_live_shortcuts_flag_is_accepted
 run_test "shortcuts are pushed to the running session" \
     test_shortcuts_pushed_to_running_session
 run_test "the shortcut batch file name is unpredictable" \
     test_batch_file_name_is_unpredictable
 run_test "an unusable TMPDIR falls back to the logout advice" \
     test_unusable_tmpdir_falls_back_to_logout_advice
+run_test "an uncreatable journal directory skips the live apply" \
+    test_uncreatable_journal_dir_skips_live_apply
+run_test "the live apply always passes a journal" \
+    test_live_apply_always_passes_a_journal
 run_test "a successful live apply doesn't advise logging out" \
     test_live_apply_does_not_advise_logout
 run_test "missing python3 falls back to the logout advice" \

--- a/setup_test
+++ b/setup_test
@@ -1384,6 +1384,44 @@ test_unprefixed_caller_skips_the_mismatch_check() {
     assert_output_contains "BOOTSTRAP_CONTINUED"
 }
 
+# --- live-shortcuts mode ---
+
+# Both flags are known options, so a later --help is still reached.
+test_live_shortcuts_flags_accepted() {
+    run_setup --live-shortcuts --help
+    assert_status 0 &&
+    assert_output_contains "Usage: setup" || return 1
+    run_setup --no-live-shortcuts --help
+    assert_status 0 &&
+    assert_output_contains "Usage: setup"
+}
+
+# Documented in usage, along with the reason it's off by default.
+test_live_shortcuts_in_usage() {
+    run_setup --help
+    assert_status 0 &&
+    assert_output_contains "--live-shortcuts" &&
+    assert_output_contains "--no-live-shortcuts"
+}
+
+# --live-shortcuts is forwarded to setup-kde; the default is not. An unattended
+# bootstrap must not opt into a D-Bus call that can take the compositor down,
+# so the flag is only ever added when explicitly asked for.
+test_live_shortcuts_parsing_and_forwarding() {
+    assert_source_contains "LIVE_SHORTCUTS=no" &&
+    assert_source_contains '[-]-live-shortcuts)' &&
+    assert_source_contains '[-]-no-live-shortcuts)' &&
+    assert_source_contains "LIVE_SHORTCUTS=yes" &&
+    assert_source_contains 'KDE_SETUP_FLAGS --live-shortcuts' &&
+    # Never forwarded unconditionally: the guard is what keeps the default off.
+    assert_source_contains 'test "$LIVE_SHORTCUTS" = yes' &&
+    # KDE-only: setup-macos shares DESKTOP_SETUP_FLAGS and rejects options it
+    # doesn't know, so a KDE flag in there would abort the macOS run.
+    assert_source_contains 'setup-kde" $DESKTOP_SETUP_FLAGS $KDE_SETUP_FLAGS' &&
+    assert_source_not_contains 'DESKTOP_SETUP_FLAGS --live-shortcuts' &&
+    assert_source_not_contains 'setup-macos" .*KDE_SETUP_FLAGS'
+}
+
 # --- no-sudo mode ---
 
 # --no-sudo is a known option: it's accepted (not an "Unknown option" error),
@@ -1710,6 +1748,11 @@ run_test "the default prefix doesn't second-guess an existing remote" \
 run_test "a caller whose URL isn't from the prefix skips the check" \
     test_unprefixed_caller_skips_the_mismatch_check
 
+run_test "--live-shortcuts and --no-live-shortcuts are accepted" \
+    test_live_shortcuts_flags_accepted
+run_test "--live-shortcuts is documented in usage" test_live_shortcuts_in_usage
+run_test "--live-shortcuts forwards to setup-kde only when asked" \
+    test_live_shortcuts_parsing_and_forwarding
 run_test "--no-sudo is accepted as a known option" test_no_sudo_flag_accepted
 run_test "--no-sudo is documented in usage" test_no_sudo_in_usage
 run_test "--no-sudo parses and forwards to desktop helpers" \


### PR DESCRIPTION
Follow-up to #168, which shipped the live shortcut apply on by default. On real hardware it killed `kwin_wayland` — and on Wayland that takes every client with it, so a session's worth of terminals went with it. This makes the live path opt-in, fixes the call that crashed, and fixes the readback that would have hidden it.

## What happened

```
Krohnkite.WARNING: qt.createQmlObject(): Missing parent object
dbus: type invalid 0 not a basic type
unable to print a backtrace
kwin_wayland crashing... crashRecursionCounter = 2
```

`coredumpctl` recorded `/usr/bin/kwin_wayland SIGABRT` (core inaccessible, so no backtrace).

`SIGABRT` rather than `SIGSEGV` is the tell: something called `abort()` on a failed precondition, not memory corruption. A null action — the failure mode I'd have guessed — would have segfaulted. The message is libdbus's own assertion from `dbus-signature.c` (`dbus_type_is_basic()`), which fires while *demarshalling* a basic type from a container that has already run out, and libdbus aborts the process by design when it trips.

The implicated call is `setForeignShortcutKeys`, whose keys argument is `a(ai)`: an array of `QKeySequence` structs. I was building that struct with a single int.

**Since confirmed directly on the affected machine.** Reading a shortcut back out of the daemon returns *four* ints for one key — `268435540, 33554431, 33554431, 0`, where `33554431` is `0x01FFFFFF` = `Qt::Key_unknown`. A `QKeySequence` is four key slots and the daemon reports all four. One int was sent where four were expected; the demarshaller ran off the end. That's the underrun, observed rather than inferred.

## The fix

**Stop hand-marshalling `QKeySequence`.** `setForeignShortcut` and `shortcut` take a flat `ai`, which is the same `QList` the daemon converts to and from internally (`intListFromShortcut` / `shortcutFromIntList` in kglobalaccel), so there's no fixed-width struct to get wrong. Both are deprecated but still exported, and a deprecated call that can't take the compositor down beats a current one that can. Both backends used the same bad struct, so both changed.

**Default the live apply off**, behind `--live-shortcuts` (with `--no-live-shortcuts` to state the default). Plain `setup-kde` writes the config and asks for a logout, exactly as before #168, and makes no D-Bus calls at all. An unverified call that can end a session has no business running unattended.

Both flags are plumbed through `setup` too, since that's the dispatcher these helpers are normally reached through — in a KDE-only `KDE_SETUP_FLAGS`, because `setup-macos` shares `DESKTOP_SETUP_FLAGS` and exits on options it doesn't know.

**The readback was broken, which matters as much as the crash.** It compared the daemon's reply to the requested keys with `==`, so a correctly applied shortcut — four slots against one — reported `FAIL`. #168's central claim was that it verifies what it applied; it would have cried wolf on all 43. Comparison is now on the real slots, ignoring the empty tail (`0` or `Qt::Key_unknown`).

**Guards for when the live path is asked for:**

- Enumerate the daemon's actions first (read-only) and never hand a mutating call an action it doesn't list.
- Journal the shortcut being applied before the call, remove it after. A call that never returns leaves its name on disk — the only record that survives the terminal dying with the compositor — and it's skipped on later runs, so one crash doesn't become a crash every time.
- Markers accumulate and outlive the run that reads them; only `--forget` retires one. Clearing a marker once it had been read would mean the next run retried the crashing call — a crash every other run rather than every run. The in-flight entry is journaled alongside the markers, so a run that skips a known-bad shortcut still records what it does attempt.
- **Nothing mutating runs without a journal.** An unreadable file may be preserving exactly the marker that matters; an unwritable one can't record the call about to be made; a state directory that can't be created makes `setup-kde` skip the live apply entirely; and the helper's own CLI defaults `--journal` to `$XDG_STATE_HOME/kdeshortcut.inflight` rather than letting `record()` become a silent no-op. Each of those refuses rather than proceeds.
- **The record/call/clear cycle is one locked transaction**, with the markers re-read inside the lock. Atomic individual writes aren't enough when two runs overlap: both would snapshot the same markers and the second `record()` would replace the first's in-flight entry, so a crash would name the wrong action and the real one would be retried. The wait is unbounded on purpose — a holder killed by the compositor releases the lock through the kernel.
- **A marker gates mutating, not reading.** `--check` passes both a marker and an unreadable journal: it makes no call that could repeat the crash, and after one, the journaled shortcut is exactly the one you want to ask the daemon about. It still says the shortcut is journaled.
- The journal is replaced by rename, never truncated in place. A write that fails partway — out of space, a bad `fsync`, or the compositor taking the process down mid-update — would otherwise erase the markers or leave a half-written line that the next run reads as absent, and retry a shortcut already known to kill kwin.
- On an error that *does* return control, the entry is kept only if the daemon stopped answering (`Peer.Ping`). Clearing unconditionally loses the X11 case where kwin dies but this process lives; keeping unconditionally lets one transient error refuse a shortcut forever.
- A dead daemon raises `DaemonGone` and stops the batch, and the file is sealed, so nothing overwrites the name of the call that did the damage.
- The batch file is allocated only when the live apply is asked for. The default path never reads it, so creating it would mean a temp file, a warning about a feature that wasn't requested, and an append that can abort the whole run under `set -e` for a file nothing consumes.

**New: `--who` and `--forget`.** `kdeshortcut.py --who Meta+T` reports which component and action hold a key, via `getGlobalShortcutsByKey` — read-only, and its argument is a plain `i`. `--forget` retires the journal's markers once the cause is fixed; the skip message and the help both name it.

## Testing

`make test` — all suites green. `setup_test` 92 → 95, `setup-kde_test` 44 → 49, `kdeshortcut_test` 61 → 126.

Load-bearing tests: the default calls `kdeshortcut.py` not at all while still writing the full config, and allocates no batch even with an unusable `TMPDIR`; a four-slot reply with an empty tail counts as live, while a different head does not; an unknown action never reaches a mutating call; a batch whose first call kills the daemon keeps *that* journal entry, makes exactly one mutating call, and reports the rest as not attempted; a marker survives a later run that applies other shortcuts successfully, and only `--forget` retires it; an unreadable journal, an unwritable one, an uncreatable state directory, and an uncreatable default journal each make no mutating call at all; a failed journal replacement leaves the previous markers byte-for-byte and no temp file; the stub `gdbus` finds the journal lock **held** while it runs, which is a real assertion about mutual exclusion around the call rather than about my own bookkeeping; `--check` reads a journaled shortcut back while an apply of it still refuses; and `setup`'s forwarding is conditional and KDE-only.

Every round of review fixes was checked against the commit it fixed, so the new tests are known to fail there rather than merely pass here. The harness now also pins `XDG_STATE_HOME` into the sandbox, so the suite can't write a journal into the caller's real state directory.

## Still open

- **`Meta+T` and the other launch shortcuts don't work**, while `Meta+1` and friends do. Both of my hypotheses are now ruled out: the entries appear in System Settings, and the readback shows the daemon holding `Meta+T` for `shortcut-terminal.desktop/_launch` correctly. The launcher also runs fine under `env -i HOME=$HOME`, so it isn't the environment either. Remaining suspect is a grab conflict — what `--who Meta+T` was added to answer. Predates #168; not addressed here.
- **Upstream bug worth filing.** A client sending a signature-correct D-Bus message should not be able to abort the compositor, whatever the payload — any script poking that interface can end a Wayland session. No existing report surfaced, though bugs.kde.org blocks automated searches, so that's "not found" rather than "doesn't exist".

## Review

Thirteen Codex P2s across seven rounds, all real and all fixed: `setup` not learning the new flags; the journal not cleared on a transient error; the KDE-only flag reaching `setup-macos`, which exits on unknown options; a later journal write overwriting the preserved dead-daemon entry; the batch allocated on the default path that never reads it; a marker retired by the *next* run's first successful shortcut; an unreadable or unwritable journal warned about but proceeded past; `setup-kde` invoking the helper with no journal when the state directory couldn't be created; the journal truncated in place rather than replaced atomically; a marker blocking `--check`'s read-only readback; the helper's own CLI still mutating with no journal at all; and the record/call/clear cycle not being serialized between concurrent runs.

Worth noting the shape of that list. After the first two rounds every finding has been in the journal — the mechanism that only runs on the opt-in path, guarding a call that can end a session. Most were the same mistake in a new place: I'd close a hole in one caller and leave it open in another, or secure one property and mistake it for a stronger one, as with atomic writes versus an atomic transaction.