### PR TITLE
Don't reuse a merged branch name; don't re-author merged commits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,15 @@ stopping at the file you opened.
 - **Merge cue (`merged` / `I merged` / `landed` / merge webhook) runs hygiene
   *before* engaging with the rest of the message:** `git fetch origin`, cut a
   fresh `<agent>/<short-topic>` branch off `origin/main`, announce the switch.
+- **After a merge, take a fresh `<agent>/<short-topic>`** — don't reset the
+  merged name onto the new base. Its remote ref still points at the pre-merge
+  tip, so `origin/<branch>..HEAD` keeps spanning the merged commits and
+  unpushed-work checks report your own merged history back at you. When a
+  sandbox pins the branch name, reset it and `--force-with-lease` in the same
+  turn — that's routine on merged history, not something to ask about.
+- **The agent authors and the repo owner merges**, so a squash or rebase merge
+  rewrites the committer to them. That's expected — never re-author or amend
+  already-merged commits to "fix" authorship or signing.
 - **Unshallow before answering anything that depends on git history depth.**
   The sandbox clones shallow, so `git rev-list --count`, `git log` past the
   shallow boundary, and blame return wrong answers without warning. If


### PR DESCRIPTION
Cross-pollinates two rules from the global agent rules in `conf`
(mikelward/conf#234), so all five repos carry them.

## Where they came from

A real bite earlier today. After the five AGENTS.md PRs merged, I reset each
feature branch onto the refreshed default branch while keeping the branch name.
The old remote ref still pointed at the pre-merge tip, so `origin/<branch>..HEAD`
spanned the merged commits and the stop hook reported them as unpushed and
unverified — the repo owner's own merged history, handed back with a suggestion
to amend and re-author it.

## The rules

- **After a merge, take a fresh `<agent>/<short-topic>`** — don't reset the merged
  name onto the new base. Where a sandbox pins the branch name, reset and
  `--force-with-lease` in the same turn; that's the routine case here, not an
  exception worth a round trip.
- **The agent authors and the repo owner merges**, so a squash or rebase merge
  rewrites the committer. Expected, not a defect to repair — never re-author or
  amend already-merged commits to "fix" authorship or signing.

Nine lines. An earlier draft in `conf` grew to ~23 encoding fast-forward vs
non-fast-forward, lease semantics, and a pre-flight check; that was cut back
deliberately, and the rare hazards are left unenumerated by choice.

## Sibling PRs

- https://github.com/mikelward/vcs/pull/57
- https://github.com/mikelward/mesh/pull/305
- https://github.com/mikelward/root/pull/31

## Testing

Documentation only, so no test added, per the rule about not manufacturing test
churn. `make test` passes, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UqKFQQtAQE92fdLbW2ds9i

---
_Generated by [Claude Code](https://claude.ai/code/session_01UqKFQQtAQE92fdLbW2ds9i)_