### PR TITLE
setup-macos: fix the shortcuts, make it re-runnable, and test it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,5 +17,6 @@ test:
 	./runenv_test
 	./setup_test
 	./setup-kde_test
+	./setup-macos_test
 	./kdeshortcut_test
 	./dvorak_test

--- a/setup-macos
+++ b/setup-macos
@@ -25,7 +25,9 @@
 #           steps in with "defaults: not found".
 # Wants: activateSettings, to apply the shortcut changes without a logout;
 #        launchctl, to load the key-remapping agent now rather than at the
-#        next login.
+#        next login; pbs, to register the Quick Actions; killall, to restart
+#        Finder and the Dock. Without any of them the settings are still
+#        written and the script says what needs a logout.
 #
 # Usage:
 #     setup-macos [--no-install] [--no-sudo] [--ignore-errors] [-h | --help]
@@ -40,13 +42,21 @@
 # set -e; "yes" (via --ignore-errors) leaves it off and pushes through.
 IGNORE_ERRORS=no
 
+# Directory containing this script, resolved up front while $0 still means what
+# the caller typed. The launcher helpers the Quick Actions run live beside this
+# script, and during a fresh bootstrap `setup` runs it straight out of the
+# just-cloned repo, before any login shell has put it on PATH.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 # macOS helpers that live at an absolute path rather than on PATH, so PATH
 # can't shadow them. Overridable so the tests can point them at mocks, in the
 # same spirit as setup-kde's $PYTHON.
 #
 # activateSettings makes the symbolic hotkey writes take effect without a
-# logout.
+# logout; pbs re-reads the Services registry so the Quick Actions and their key
+# equivalents are picked up.
 ACTIVATE_SETTINGS="${ACTIVATE_SETTINGS:-/System/Library/PrivateFrameworks/SystemAdministration.framework/Resources/activateSettings}"
+PBS="${PBS:-/System/Library/CoreServices/pbs}"
 
 # Dvorak as an input source entry, used both to enable the layout and to
 # select it. The layout ID is the part that identifies it: macOS ships several
@@ -305,6 +315,28 @@ configure_shortcuts() {
     fi
 }
 
+# --- Configure Spaces ---
+
+configure_spaces() {
+    info "Pinning the Spaces order"
+
+    # "Automatically rearrange Spaces based on most recent use" is on by
+    # default, and it reorders the Spaces behind the Option+1..9 bindings
+    # above -- so the shortcut that switched to a given desktop a moment ago
+    # switches somewhere else now. Numbered shortcuts only mean anything with
+    # a fixed order.
+    defaults write com.apple.dock mru-spaces -bool false
+
+    # The Dock owns Mission Control and reads this at launch.
+    if is_command killall; then
+        # A non-zero status means no Dock was running, which is not a failure
+        # to report: it will read the new value when it starts.
+        killall Dock || info "the Dock was not running; it will pick this up when it starts"
+    else
+        warn "killall not found; restart the Dock (or log out) for the Spaces order to be pinned"
+    fi
+}
+
 # --- Configure Amethyst tiling window manager ---
 
 configure_amethyst() {
@@ -323,27 +355,51 @@ configure_amethyst() {
 
 # --- Configure application launch shortcuts ---
 
-configure_app_shortcuts() {
-    info "Configuring application launch shortcuts (Automator Quick Actions)"
+# Print the path to a launcher helper, or fail if there isn't one. PATH first,
+# then beside this script: during a fresh bootstrap `setup` runs setup-macos
+# out of the just-cloned scripts repo, before any login shell has put it on
+# PATH. Baking $HOME/scripts into the workflow instead -- which is what this
+# used to do -- writes a Quick Action pointing at nothing on a checkout kept
+# anywhere else.
+resolve_launcher() {
+    _launcher=$(command -v "$1") || _launcher=""
+    if test -z "$_launcher" && test -x "$SCRIPT_DIR/$1"; then
+        _launcher="$SCRIPT_DIR/$1"
+    fi
+    test -n "$_launcher" || return 1
+    printf '%s' "$_launcher"
+}
 
-    services_dir="$HOME/Library/Services"
-    mkdir -p "$services_dir"
+# Print PATH as a single-quoted /bin/sh word, then escaped for XML, ready to
+# drop into the workflow's COMMAND_STRING. Two separate hazards: the string is
+# run as a shell command, so a checkout under a path with a space would be
+# split into two words (and one with a `$` or a `;` would be worse); and it's
+# embedded in a plist, so an `&` or a `<` in the path makes the XML invalid.
+# Quote for the shell first, then escape the result for XML -- the other order
+# would escape the quotes we just added.
+shell_quote_xml() {
+    printf '%s' "$1" \
+        | sed -e "s/'/'\\\\''/g" -e "s/^/'/" -e "s/\$/'/" \
+        | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g'
+}
 
-    scripts="$HOME/scripts"
+# Create an Automator Quick Action (.workflow) that runs a shell script.
+# These appear in System Settings > Keyboard > Shortcuts > Services, with the
+# Option+key shortcuts assigned below (physical Win key sends Option).
+create_launcher_workflow() {
+    name="$1"
+    script=$(shell_quote_xml "$2")
+    workflow_dir="$SERVICES_DIR/$name.workflow"
+    mkdir -p "$workflow_dir/Contents"
 
-    # Create an Automator Quick Action (.workflow) that runs a shell script.
-    # These appear in System Settings > Keyboard > Shortcuts > Services,
-    # where we assign Option+key shortcuts (physical Win key sends Option).
-    create_launcher_workflow() {
-        name="$1"
-        script="$2"
-        workflow_dir="$services_dir/$name.workflow"
-        mkdir -p "$workflow_dir/Contents"
-
-        # An unquoted heredoc, so $name expands. This used to be a fixed
-        # placeholder patched by `sed -i ''`, whose empty-suffix argument is
-        # BSD-only -- and unnecessary, since the value is known right here.
-        cat > "$workflow_dir/Contents/Info.plist" <<PLIST
+    # An unquoted heredoc, so $name expands. This used to be a fixed
+    # placeholder patched by `sed -i ''`, whose empty-suffix argument is
+    # BSD-only -- and unnecessary, since the value is known right here.
+    #
+    # NSSendTypes is present and empty on purpose: that's how a service
+    # declares it takes no input, which is what makes these appear whether or
+    # not anything is selected.
+    cat > "$workflow_dir/Contents/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -358,13 +414,15 @@ configure_app_shortcuts() {
             </dict>
             <key>NSMessage</key>
             <string>runWorkflowAsService</string>
+            <key>NSSendTypes</key>
+            <array/>
         </dict>
     </array>
 </dict>
 </plist>
 PLIST
 
-        cat > "$workflow_dir/Contents/document.wflow" <<WFLOW
+    cat > "$workflow_dir/Contents/document.wflow" <<WFLOW
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -467,36 +525,80 @@ PLIST
 </dict>
 </plist>
 WFLOW
-    }
+}
 
-    # Create Quick Action workflows for each launcher
-    create_launcher_workflow "Launch Browser1" "$scripts/browser1"
-    create_launcher_workflow "Launch Browser2" "$scripts/browser2"
-    create_launcher_workflow "Launch Terminal" "$scripts/terminal"
-    create_launcher_workflow "Launch Terminal on Workstation" "$scripts/terminal_on_workstation"
-    create_launcher_workflow "Launch Music" "$scripts/music"
+configure_app_shortcuts() {
+    info "Configuring application launch shortcuts (Automator Quick Actions)"
 
-    # Assign Option+key shortcuts to each Quick Action
-    # Option modifier = 524288, Option+Shift would be 655360
-    # These use logical key names, so Dvorak layout is handled by the OS
+    SERVICES_DIR="$HOME/Library/Services"
+    mkdir -p "$SERVICES_DIR"
+
+    # Quick Action name, launcher helper, and shortcut key. The Option modifier
+    # is "~" in a key equivalent (Option+Shift would be "~$"). These are logical
+    # key names, so the OS handles the Dvorak layout.
     #
-    # Shortcut keys (physical Win sends Option after hidutil remap):
+    # Shortcut keys (physical Win sends Option after the hidutil remap):
     #   Win+G → Option+G → browser1
     #   Win+H → Option+H → browser2
     #   Win+T → Option+T → terminal
     #   Win+W → Option+W → terminal_on_workstation
     #   Win+Y → Option+Y → music
-    defaults write pbs NSServicesStatus -dict-add \
-        '"(null) - Launch Browser1 - runWorkflowAsService"' \
-        '{ "enabled_context_menu" = 1; "enabled_services_menu" = 1; "key_equivalent" = "~g"; }' \
-        '"(null) - Launch Browser2 - runWorkflowAsService"' \
-        '{ "enabled_context_menu" = 1; "enabled_services_menu" = 1; "key_equivalent" = "~h"; }' \
-        '"(null) - Launch Terminal - runWorkflowAsService"' \
-        '{ "enabled_context_menu" = 1; "enabled_services_menu" = 1; "key_equivalent" = "~t"; }' \
-        '"(null) - Launch Terminal on Workstation - runWorkflowAsService"' \
-        '{ "enabled_context_menu" = 1; "enabled_services_menu" = 1; "key_equivalent" = "~w"; }' \
-        '"(null) - Launch Music - runWorkflowAsService"' \
-        '{ "enabled_context_menu" = 1; "enabled_services_menu" = 1; "key_equivalent" = "~y"; }'
+    #
+    # $@ accumulates the key/value pairs for one `defaults write`, so a
+    # launcher that isn't installed drops out of the registry entry too rather
+    # than leaving a shortcut bound to a workflow that runs nothing.
+    set --
+    for entry in \
+        "Launch Browser1:browser1:g" \
+        "Launch Browser2:browser2:h" \
+        "Launch Terminal:terminal:t" \
+        "Launch Terminal on Workstation:terminal_on_workstation:w" \
+        "Launch Music:music:y"; do
+        workflow_name=${entry%%:*}
+        entry_rest=${entry#*:}
+        launcher_name=${entry_rest%%:*}
+        shortcut_key=${entry_rest##*:}
+
+        if ! launcher_path=$(resolve_launcher "$launcher_name"); then
+            warn "$launcher_name not found on PATH or beside this script; skipping its launch shortcut"
+            # An earlier run may have installed a workflow for it. Leaving that
+            # behind would keep the shortcut working and running the path the
+            # launcher used to have, which is the opposite of skipping it. The
+            # NSServicesStatus entry naming it is left alone -- `defaults` has
+            # no way to delete one key from a nested dict, and rewriting the
+            # whole dict would drop other applications' services -- but with
+            # the workflow gone it names a service that no longer exists, so
+            # the key equivalent binds nothing.
+            stale_workflow="$SERVICES_DIR/$workflow_name.workflow"
+            if test -d "$stale_workflow"; then
+                info "Removing the stale Quick Action for $launcher_name"
+                rm -rf "$stale_workflow"
+            fi
+            continue
+        fi
+        create_launcher_workflow "$workflow_name" "$launcher_path"
+        # The key is quoted inside the value too: `defaults` parses it as an
+        # old-style plist, where spaces and parentheses need the quotes.
+        set -- "$@" \
+            "\"(null) - $workflow_name - runWorkflowAsService\"" \
+            "{ \"enabled_context_menu\" = 1; \"enabled_services_menu\" = 1; \"key_equivalent\" = \"~$shortcut_key\"; }"
+    done
+
+    if test $# -eq 0; then
+        warn "no launcher helpers found; no launch shortcuts were configured"
+        return 0
+    fi
+    defaults write pbs NSServicesStatus -dict-add "$@"
+
+    # Writing the workflows and the key equivalents isn't enough: the Services
+    # registry is a cache, and until pbs re-reads it the new Quick Actions
+    # aren't registered and their shortcuts silently do nothing.
+    if test -x "$PBS"; then
+        "$PBS" -flush \
+            || warn "could not refresh the Services registry; log out and back in for the launch shortcuts to work"
+    else
+        warn "$PBS not found; log out and back in for the launch shortcuts to work"
+    fi
 }
 
 # --- Configure Finder ---
@@ -514,6 +616,7 @@ configure_finder() {
 configure_keyboard
 configure_modifier_keys
 configure_shortcuts
+configure_spaces
 configure_amethyst
 configure_app_shortcuts
 configure_finder

--- a/setup-macos
+++ b/setup-macos
@@ -15,7 +15,10 @@
 #   Physical Win/Super       → Option   → launcher, desktop switching
 #   Physical Alt (by space)  → Control  → available for per-app custom shortcuts
 #
-# Requires: defaults, hidutil
+# Requires: defaults, hidutil (i.e. macOS). Both are checked up front, so
+#           running this anywhere else says so instead of failing several
+#           steps in with "defaults: not found".
+# Wants: activateSettings, to apply the shortcut changes without a logout.
 #
 # Usage:
 #     setup-macos [--no-install] [--no-sudo] [--ignore-errors] [-h | --help]
@@ -30,12 +33,29 @@
 # set -e; "yes" (via --ignore-errors) leaves it off and pushes through.
 IGNORE_ERRORS=no
 
+# macOS helpers that live at an absolute path rather than on PATH, so PATH
+# can't shadow them. Overridable so the tests can point them at mocks, in the
+# same spirit as setup-kde's $PYTHON.
+#
+# activateSettings makes the symbolic hotkey writes take effect without a
+# logout.
+ACTIVATE_SETTINGS="${ACTIVATE_SETTINGS:-/System/Library/PrivateFrameworks/SystemAdministration.framework/Resources/activateSettings}"
+
 info() {
     printf "%s\n" "$*"
 }
 
 warn() {
     printf "Warning: %s\n" "$*" >&2
+}
+
+error() {
+    printf "Error: %s\n" "$*" >&2
+    exit 1
+}
+
+is_command() {
+    command -v "$1" >/dev/null 2>&1
 }
 
 usage() {
@@ -83,6 +103,16 @@ done
 if test "$IGNORE_ERRORS" = no; then
     set -e
 fi
+
+# --- Check prerequisites ---
+
+# Every step below is a `defaults` write or a hidutil remap, so without those
+# two there is nothing this script can do. Checked up front, and by name, so
+# running it on the wrong OS says so rather than failing several steps in.
+# The rest of the macOS helpers are checked where they're used: each has a
+# documented fallback (a logout, mostly).
+is_command defaults || error "defaults is required (this script configures macOS)"
+is_command hidutil || error "hidutil is required (this script configures macOS)"
 
 # --- Configure keyboard ---
 
@@ -211,7 +241,12 @@ configure_shortcuts() {
     done
 
     # Apply changes
-    /System/Library/PrivateFrameworks/SystemAdministration.framework/Resources/activateSettings -u
+    if test -x "$ACTIVATE_SETTINGS"; then
+        "$ACTIVATE_SETTINGS" -u \
+            || warn "could not apply the shortcut settings to this session; log out and back in for the shortcut changes to take effect"
+    else
+        warn "$ACTIVATE_SETTINGS not found; log out and back in for the shortcut changes to take effect"
+    fi
 }
 
 # --- Configure Amethyst tiling window manager ---
@@ -249,7 +284,10 @@ configure_app_shortcuts() {
         workflow_dir="$services_dir/$name.workflow"
         mkdir -p "$workflow_dir/Contents"
 
-        cat > "$workflow_dir/Contents/Info.plist" <<'PLIST'
+        # An unquoted heredoc, so $name expands. This used to be a fixed
+        # placeholder patched by `sed -i ''`, whose empty-suffix argument is
+        # BSD-only -- and unnecessary, since the value is known right here.
+        cat > "$workflow_dir/Contents/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -260,7 +298,7 @@ configure_app_shortcuts() {
             <key>NSMenuItem</key>
             <dict>
                 <key>default</key>
-                <string>WORKFLOWNAME</string>
+                <string>$name</string>
             </dict>
             <key>NSMessage</key>
             <string>runWorkflowAsService</string>
@@ -269,8 +307,6 @@ configure_app_shortcuts() {
 </dict>
 </plist>
 PLIST
-        # Replace placeholder with actual name
-        sed -i '' "s/WORKFLOWNAME/$name/" "$workflow_dir/Contents/Info.plist"
 
         cat > "$workflow_dir/Contents/document.wflow" <<WFLOW
 <?xml version="1.0" encoding="UTF-8"?>

--- a/setup-macos
+++ b/setup-macos
@@ -3,11 +3,13 @@
 #
 # Sets up:
 # - Dvorak keyboard layout
-# - Swap Control and Command keys (for Linux-like Ctrl shortcuts)
+# - Rotate Control, Command and Option (for Linux-like Ctrl shortcuts)
 # - Spotlight and Switch to Desktop 1-9 on Option key (physical Win/Super)
 # - Disables auto-correct, auto-capitalize, smart quotes/dashes
-# - Amethyst tiling window manager (layouts, modifiers, margins, focus follows mouse)
-# - Application launch shortcuts via Automator Quick Actions (browser, terminal, music)
+# - Focus follows mouse for Amethyst (its layouts, modifiers and margins come
+#   from ~/.amethyst.yml, which confinst symlinks out of the conf repo)
+# - Application launch shortcuts via Automator Quick Actions (browser, terminal,
+#   music)
 # - Finder preferences (show hidden files, path bar, file extensions)
 #
 # Modifier key philosophy (matches Linux muscle memory):
@@ -20,14 +22,21 @@
 # keys are already in the Mac order this rotation is undoing. It assumes a PC
 # keyboard.
 #
+# Not everything here reaches the running session. The `defaults` writes go to
+# preference domains their owners read at launch (Finder and the Dock are
+# restarted below; other apps pick the text-substitution settings up as they
+# start), and the input source is read by the login session, so the layout
+# change needs a logout. Each step says which of those applies, and the run
+# ends by saying whether anything didn't work.
+#
 # Requires: defaults, hidutil (i.e. macOS). Both are checked up front, so
 #           running this anywhere else says so instead of failing several
 #           steps in with "defaults: not found".
 # Wants: activateSettings, to apply the shortcut changes without a logout;
 #        launchctl, to load the key-remapping agent now rather than at the
-#        next login; pbs, to register the Quick Actions; killall, to restart
-#        Finder and the Dock. Without any of them the settings are still
-#        written and the script says what needs a logout.
+#        next login; pbs, to register the Quick Actions; killall and pgrep, to
+#        restart Finder and the Dock. Without any of them the settings are
+#        still written and the script says what needs a logout.
 #
 # Usage:
 #     setup-macos [--no-install] [--no-sudo] [--ignore-errors] [-h | --help]
@@ -58,6 +67,12 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ACTIVATE_SETTINGS="${ACTIVATE_SETTINGS:-/System/Library/PrivateFrameworks/SystemAdministration.framework/Resources/activateSettings}"
 PBS="${PBS:-/System/Library/CoreServices/pbs}"
 
+# Count of steps that warned, so the closing message can say the run was
+# incomplete instead of claiming success over a screenful of warnings. Only
+# reachable with --ignore-errors: without it set -e aborts on the first
+# failure.
+WARNINGS=0
+
 # Dvorak as an input source entry, used both to enable the layout and to
 # select it. The layout ID is the part that identifies it: macOS ships several
 # variants whose names all contain "Dvorak" (Dvorak - Qwerty <Cmd>, Dvorak
@@ -72,6 +87,7 @@ info() {
 
 warn() {
     printf "Warning: %s\n" "$*" >&2
+    WARNINGS=$((WARNINGS + 1))
 }
 
 error() {
@@ -81,6 +97,97 @@ error() {
 
 is_command() {
     command -v "$1" >/dev/null 2>&1
+}
+
+# Run a configuration step, and make a failure visible either way.
+#
+# Without --ignore-errors, set -e would abort on a bare failing command, and
+# this aborts with the command named instead of silently. With it, set -e is
+# off -- so a bare failing command's status went nowhere at all: the run
+# carried on, WARNINGS stayed at zero, and the closing summary reported
+# success over a step that hadn't happened. That's the whole point of the
+# summary, so every state-changing step goes through here.
+try() {
+    "$@" && return 0
+    report_failure $? "$@"
+}
+
+# What a failed step does, split out of try so a step that can't be run
+# through try -- sourcing the local hook -- reports identically rather than
+# growing its own wording.
+report_failure() {
+    _status="$1"
+    shift
+    if test "$IGNORE_ERRORS" = yes; then
+        warn "failed (exit $_status): $*"
+        return 0
+    fi
+    error "failed (exit $_status): $*"
+}
+
+# Write stdin to FILE, as a command whose failure `try` can actually see.
+#
+# `try cat > "$file"` doesn't do that: the shell opens the target before it
+# invokes try, so a target that can't be opened -- a read-only file, a missing
+# directory -- skips try altogether and the failure goes unrecorded. Doing the
+# redirection in here puts it inside the command whose status try checks.
+#
+# Written to a temporary file and moved into place, so a failure part-way
+# through leaves the previous file rather than a truncated plist for launchd
+# or Automator to choke on.
+write_file() {
+    _dest="$1"
+    _tmp="$_dest.tmp.$$"
+    # `mv file dir` moves the file *into* dir rather than failing, so without
+    # this the plist would be quietly filed somewhere else and reported
+    # written.
+    if test -d "$_dest"; then
+        printf "%s is a directory, not a file\n" "$_dest" >&2
+        return 1
+    fi
+    if ! cat > "$_tmp"; then
+        rm -f "$_tmp"
+        return 1
+    fi
+    if ! mv "$_tmp" "$_dest"; then
+        rm -f "$_tmp"
+        return 1
+    fi
+}
+
+# Restart APP so it re-reads the settings just written, where WHY names what
+# stays unapplied if it can't be. APP not running is the ordinary case on a
+# fresh machine and isn't a failure -- but it's not the only reason killall
+# exits non-zero, so ask pgrep first rather than reading every non-zero status
+# as "it wasn't running" and reporting a refused kill as success.
+restart_app() {
+    _app="$1"
+    _why="$2"
+    if ! is_command killall || ! is_command pgrep; then
+        warn "killall/pgrep not found; restart $_app (or log out) for $_why"
+        return 0
+    fi
+    # pgrep exits 1 for "no such process", but 2 and 3 for its own failures.
+    # Reading every non-zero status as "not running" would skip the restart on
+    # a broken probe and say nothing about why, which is the same mistake as
+    # reading killall's status that way.
+    if pgrep -x "$_app" >/dev/null; then
+        _running=0
+    else
+        _running=$?
+    fi
+    case "$_running" in
+        0) ;;
+        1)
+            info "$_app was not running; it will pick up the new settings when it starts"
+            return 0
+            ;;
+        *)
+            warn "could not tell whether $_app is running (pgrep exited $_running); log out for $_why"
+            return 0
+            ;;
+    esac
+    killall "$_app" || warn "could not restart $_app; log out for $_why"
 }
 
 usage() {
@@ -162,14 +269,14 @@ configure_keyboard() {
             | grep -qE "\"?KeyboardLayout ID\"? *= *$DVORAK_LAYOUT_ID *;"; then
         info "Dvorak is already an enabled input source"
     else
-        defaults write com.apple.HIToolbox AppleEnabledInputSources -array-add \
+        try defaults write com.apple.HIToolbox AppleEnabledInputSources -array-add \
             "$DVORAK_INPUT_SOURCE"
     fi
     # -array, not -array-add: this is the single selected source, so replacing
     # the value outright is both correct and idempotent.
-    defaults write com.apple.HIToolbox AppleSelectedInputSources -array \
+    try defaults write com.apple.HIToolbox AppleSelectedInputSources -array \
         "$DVORAK_INPUT_SOURCE"
-    defaults write com.apple.HIToolbox AppleCurrentKeyboardLayoutInputSourceID \
+    try defaults write com.apple.HIToolbox AppleCurrentKeyboardLayoutInputSourceID \
         "com.apple.keylayout.Dvorak"
     # The login session reads the input source at startup and holds it in
     # memory, so unlike the hidutil remap below this one isn't live yet.
@@ -178,11 +285,11 @@ configure_keyboard() {
 
     # Disable auto-correct, auto-capitalize, smart quotes/dashes. Read by each
     # app as it launches, so already-running apps keep the old behavior.
-    defaults write NSGlobalDomain NSAutomaticSpellingCorrectionEnabled -bool false
-    defaults write NSGlobalDomain NSAutomaticCapitalizationEnabled -bool false
-    defaults write NSGlobalDomain NSAutomaticQuoteSubstitutionEnabled -bool false
-    defaults write NSGlobalDomain NSAutomaticDashSubstitutionEnabled -bool false
-    defaults write NSGlobalDomain NSAutomaticPeriodSubstitutionEnabled -bool false
+    try defaults write NSGlobalDomain NSAutomaticSpellingCorrectionEnabled -bool false
+    try defaults write NSGlobalDomain NSAutomaticCapitalizationEnabled -bool false
+    try defaults write NSGlobalDomain NSAutomaticQuoteSubstitutionEnabled -bool false
+    try defaults write NSGlobalDomain NSAutomaticDashSubstitutionEnabled -bool false
+    try defaults write NSGlobalDomain NSAutomaticPeriodSubstitutionEnabled -bool false
 
 }
 
@@ -203,14 +310,14 @@ configure_modifier_keys() {
 
     # Applies to the running session immediately; hidutil mappings are lost on
     # reboot, which is what the LaunchAgent below is for.
-    hidutil property --set "$KEY_REMAPPING" >/dev/null
+    try hidutil property --set "$KEY_REMAPPING" >/dev/null
 
     # Persist across reboots with a LaunchAgent
     launch_agent_dir="$HOME/Library/LaunchAgents"
     launch_agent="$launch_agent_dir/com.local.KeyRemapping.plist"
-    mkdir -p "$launch_agent_dir"
+    try mkdir -p "$launch_agent_dir"
 
-    cat > "$launch_agent" <<PLIST
+    try write_file "$launch_agent" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -257,7 +364,7 @@ configure_shortcuts() {
     # Modifier flags: Option = 524288
 
     # Spotlight: Option+Space (ID 64)
-    defaults write com.apple.symbolichotkeys AppleSymbolicHotKeys -dict-add 64 '
+    try defaults write com.apple.symbolichotkeys AppleSymbolicHotKeys -dict-add 64 '
         <dict>
             <key>enabled</key><true/>
             <key>value</key><dict>
@@ -271,7 +378,7 @@ configure_shortcuts() {
         </dict>'
 
     # Disable Finder search window (ID 65) to avoid conflict
-    defaults write com.apple.symbolichotkeys AppleSymbolicHotKeys -dict-add 65 '
+    try defaults write com.apple.symbolichotkeys AppleSymbolicHotKeys -dict-add 65 '
         <dict>
             <key>enabled</key><false/>
         </dict>'
@@ -292,7 +399,7 @@ configure_shortcuts() {
     while test $# -ge 3; do
         hotkey_id=$1 ascii=$2 keycode=$3
         shift 3
-        defaults write com.apple.symbolichotkeys AppleSymbolicHotKeys -dict-add "$hotkey_id" '
+        try defaults write com.apple.symbolichotkeys AppleSymbolicHotKeys -dict-add "$hotkey_id" '
             <dict>
                 <key>enabled</key><true/>
                 <key>value</key><dict>
@@ -325,16 +432,10 @@ configure_spaces() {
     # above -- so the shortcut that switched to a given desktop a moment ago
     # switches somewhere else now. Numbered shortcuts only mean anything with
     # a fixed order.
-    defaults write com.apple.dock mru-spaces -bool false
+    try defaults write com.apple.dock mru-spaces -bool false
 
     # The Dock owns Mission Control and reads this at launch.
-    if is_command killall; then
-        # A non-zero status means no Dock was running, which is not a failure
-        # to report: it will read the new value when it starts.
-        killall Dock || info "the Dock was not running; it will pick this up when it starts"
-    else
-        warn "killall not found; restart the Dock (or log out) for the Spaces order to be pinned"
-    fi
+    restart_app Dock "the Spaces order to be pinned"
 }
 
 # --- Configure Amethyst tiling window manager ---
@@ -350,7 +451,12 @@ configure_amethyst() {
 
     # Enable focus follows mouse
     info "Enabling focus follows mouse"
-    defaults write com.amethyst.Amethyst focus-follows-mouse -bool true
+    try defaults write com.amethyst.Amethyst focus-follows-mouse -bool true
+
+    # Amethyst can't move a window without Accessibility access, and macOS only
+    # grants that through an interactive prompt -- there's no defaults key for
+    # it, so say so rather than leave it looking configured but inert.
+    info "Grant Amethyst Accessibility access in System Settings > Privacy & Security"
 }
 
 # --- Configure application launch shortcuts ---
@@ -390,7 +496,7 @@ create_launcher_workflow() {
     name="$1"
     script=$(shell_quote_xml "$2")
     workflow_dir="$SERVICES_DIR/$name.workflow"
-    mkdir -p "$workflow_dir/Contents"
+    try mkdir -p "$workflow_dir/Contents"
 
     # An unquoted heredoc, so $name expands. This used to be a fixed
     # placeholder patched by `sed -i ''`, whose empty-suffix argument is
@@ -399,7 +505,7 @@ create_launcher_workflow() {
     # NSSendTypes is present and empty on purpose: that's how a service
     # declares it takes no input, which is what makes these appear whether or
     # not anything is selected.
-    cat > "$workflow_dir/Contents/Info.plist" <<PLIST
+    try write_file "$workflow_dir/Contents/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -422,7 +528,7 @@ create_launcher_workflow() {
 </plist>
 PLIST
 
-    cat > "$workflow_dir/Contents/document.wflow" <<WFLOW
+    try write_file "$workflow_dir/Contents/document.wflow" <<WFLOW
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -531,7 +637,7 @@ configure_app_shortcuts() {
     info "Configuring application launch shortcuts (Automator Quick Actions)"
 
     SERVICES_DIR="$HOME/Library/Services"
-    mkdir -p "$SERVICES_DIR"
+    try mkdir -p "$SERVICES_DIR"
 
     # Quick Action name, launcher helper, and shortcut key. The Option modifier
     # is "~" in a key equivalent (Option+Shift would be "~$"). These are logical
@@ -572,7 +678,7 @@ configure_app_shortcuts() {
             stale_workflow="$SERVICES_DIR/$workflow_name.workflow"
             if test -d "$stale_workflow"; then
                 info "Removing the stale Quick Action for $launcher_name"
-                rm -rf "$stale_workflow"
+                try rm -rf "$stale_workflow"
             fi
             continue
         fi
@@ -588,7 +694,7 @@ configure_app_shortcuts() {
         warn "no launcher helpers found; no launch shortcuts were configured"
         return 0
     fi
-    defaults write pbs NSServicesStatus -dict-add "$@"
+    try defaults write pbs NSServicesStatus -dict-add "$@"
 
     # Writing the workflows and the key equivalents isn't enough: the Services
     # registry is a cache, and until pbs re-reads it the new Quick Actions
@@ -605,10 +711,13 @@ configure_app_shortcuts() {
 
 configure_finder() {
     info "Configuring Finder"
-    defaults write com.apple.finder AppleShowAllFiles -bool true
-    defaults write com.apple.finder ShowPathbar -bool true
-    defaults write NSGlobalDomain AppleShowAllExtensions -bool true
-    killall Finder 2>/dev/null || true
+    try defaults write com.apple.finder AppleShowAllFiles -bool true
+    try defaults write com.apple.finder ShowPathbar -bool true
+    try defaults write NSGlobalDomain AppleShowAllExtensions -bool true
+
+    # This used to be `killall Finder 2>/dev/null || true`, which hid every
+    # failure to tolerate the one expected one. See restart_app.
+    restart_app Finder "its settings to take effect"
 }
 
 # --- Main ---
@@ -621,4 +730,34 @@ configure_amethyst
 configure_app_shortcuts
 configure_finder
 
-info "macOS configured successfully"
+# Machine-specific extras, matching setup-kde's setup-kde.local hook.
+if is_command setup-macos.local; then
+    info "Sourcing setup-macos.local"
+    # Not `try . setup-macos.local`: sourcing inside a function would run the
+    # hook with try's positional parameters ($1 = ".") instead of this
+    # script's, so its status is captured here and reported the same way.
+    #
+    # `. hook || status=$?` doesn't capture it portably: `.` is a special
+    # builtin, and under set -e dash exits at a hook that returns non-zero
+    # even inside a `||` list, so the failure would abort unnamed and with the
+    # hook's own status. bash carries on. Turning set -e off around the source
+    # gets the same behavior from both.
+    set +e
+    # shellcheck source=/dev/null
+    . setup-macos.local
+    hook_status=$?
+    if test "$IGNORE_ERRORS" = no; then
+        set -e
+    fi
+    test "$hook_status" -eq 0 || report_failure "$hook_status" "setup-macos.local"
+fi
+
+if test "$WARNINGS" -eq 0; then
+    info "macOS configured successfully"
+else
+    # Not via warn(): this is the tally, not another problem to count. Only
+    # reachable under --ignore-errors, which is the whole point of that flag --
+    # so the exit status stays 0 and the caller keeps going.
+    printf "macOS configured with %s problem(s); see the warnings above\n" \
+        "$WARNINGS" >&2
+fi

--- a/setup-macos
+++ b/setup-macos
@@ -15,10 +15,17 @@
 #   Physical Win/Super       → Option   → launcher, desktop switching
 #   Physical Alt (by space)  → Control  → available for per-app custom shortcuts
 #
+# The modifier remap is a three-key rotation, not a swap, and hidutil applies
+# it to every attached keyboard -- including a laptop's built-in one, whose
+# keys are already in the Mac order this rotation is undoing. It assumes a PC
+# keyboard.
+#
 # Requires: defaults, hidutil (i.e. macOS). Both are checked up front, so
 #           running this anywhere else says so instead of failing several
 #           steps in with "defaults: not found".
-# Wants: activateSettings, to apply the shortcut changes without a logout.
+# Wants: activateSettings, to apply the shortcut changes without a logout;
+#        launchctl, to load the key-remapping agent now rather than at the
+#        next login.
 #
 # Usage:
 #     setup-macos [--no-install] [--no-sudo] [--ignore-errors] [-h | --help]
@@ -40,6 +47,14 @@ IGNORE_ERRORS=no
 # activateSettings makes the symbolic hotkey writes take effect without a
 # logout.
 ACTIVATE_SETTINGS="${ACTIVATE_SETTINGS:-/System/Library/PrivateFrameworks/SystemAdministration.framework/Resources/activateSettings}"
+
+# Dvorak as an input source entry, used both to enable the layout and to
+# select it. The layout ID is the part that identifies it: macOS ships several
+# variants whose names all contain "Dvorak" (Dvorak - Qwerty <Cmd>, Dvorak
+# Left, Dvorak Right), so matching the name would confuse standard Dvorak with
+# any of them.
+DVORAK_LAYOUT_ID=16300
+DVORAK_INPUT_SOURCE="<dict><key>InputSourceKind</key><string>Keyboard Layout</string><key>KeyboardLayout ID</key><integer>$DVORAK_LAYOUT_ID</integer><key>KeyboardLayout Name</key><string>Dvorak</string></dict>"
 
 info() {
     printf "%s\n" "$*"
@@ -119,14 +134,40 @@ is_command hidutil || error "hidutil is required (this script configures macOS)"
 configure_keyboard() {
     info "Configuring keyboard"
 
-    # Set Dvorak as the input source
-    # This adds Dvorak; the user may still need to remove other layouts in System Settings
+    # Set Dvorak as the input source. AppleEnabledInputSources is the list of
+    # available layouts and AppleSelectedInputSources the active one, so both
+    # are needed for Dvorak to be picked rather than merely offered.
+    #
+    # -array-add appends unconditionally, so re-running setup used to stack a
+    # second, third, fourth Dvorak entry in the list. Add it only when it isn't
+    # there already. A `defaults read` of a key that was never written prints a
+    # "does not exist" diagnostic and exits non-zero; here that is the answer
+    # "no layouts enabled yet", not a failure to report.
+    #
+    # Matched on the layout ID, not the name: "Dvorak - Qwerty <Cmd>" contains
+    # "Dvorak" too, so a machine with only that variant enabled would look
+    # like it already had standard Dvorak -- and the select below would then
+    # point at a source missing from the enabled list.
+    if defaults read com.apple.HIToolbox AppleEnabledInputSources 2>/dev/null \
+            | grep -qE "\"?KeyboardLayout ID\"? *= *$DVORAK_LAYOUT_ID *;"; then
+        info "Dvorak is already an enabled input source"
+    else
+        defaults write com.apple.HIToolbox AppleEnabledInputSources -array-add \
+            "$DVORAK_INPUT_SOURCE"
+    fi
+    # -array, not -array-add: this is the single selected source, so replacing
+    # the value outright is both correct and idempotent.
+    defaults write com.apple.HIToolbox AppleSelectedInputSources -array \
+        "$DVORAK_INPUT_SOURCE"
     defaults write com.apple.HIToolbox AppleCurrentKeyboardLayoutInputSourceID \
         "com.apple.keylayout.Dvorak"
-    defaults write com.apple.HIToolbox AppleEnabledInputSources -array-add \
-        '<dict><key>InputSourceKind</key><string>Keyboard Layout</string><key>KeyboardLayout ID</key><integer>16300</integer><key>KeyboardLayout Name</key><string>Dvorak</string></dict>'
+    # The login session reads the input source at startup and holds it in
+    # memory, so unlike the hidutil remap below this one isn't live yet.
+    info "Log out and back in for the Dvorak layout to take effect"
+    info "(other layouts, if you want them gone, are removed in System Settings)"
 
-    # Disable auto-correct, auto-capitalize, smart quotes/dashes
+    # Disable auto-correct, auto-capitalize, smart quotes/dashes. Read by each
+    # app as it launches, so already-running apps keep the old behavior.
     defaults write NSGlobalDomain NSAutomaticSpellingCorrectionEnabled -bool false
     defaults write NSGlobalDomain NSAutomaticCapitalizationEnabled -bool false
     defaults write NSGlobalDomain NSAutomaticQuoteSubstitutionEnabled -bool false
@@ -137,28 +178,29 @@ configure_keyboard() {
 
 # --- Remap modifier keys ---
 
+# The remap, as one line, so the live hidutil call and the LaunchAgent that
+# reapplies it at login can't drift apart. They used to be two hand-maintained
+# copies of the same JSON.
+#
+# Remap modifier keys to match Linux muscle memory:
+#   Physical Ctrl (E0/E4) → Command (E3/E7)
+#   Physical Win  (E3/E7) → Option  (E2/E6)
+#   Physical Alt  (E2/E6) → Control (E0/E4)
+KEY_REMAPPING='{"UserKeyMapping":[{"HIDKeyboardModifierMappingSrc":0x7000000E0,"HIDKeyboardModifierMappingDst":0x7000000E3},{"HIDKeyboardModifierMappingSrc":0x7000000E3,"HIDKeyboardModifierMappingDst":0x7000000E2},{"HIDKeyboardModifierMappingSrc":0x7000000E2,"HIDKeyboardModifierMappingDst":0x7000000E0},{"HIDKeyboardModifierMappingSrc":0x7000000E4,"HIDKeyboardModifierMappingDst":0x7000000E7},{"HIDKeyboardModifierMappingSrc":0x7000000E7,"HIDKeyboardModifierMappingDst":0x7000000E6},{"HIDKeyboardModifierMappingSrc":0x7000000E6,"HIDKeyboardModifierMappingDst":0x7000000E4}]}'
+
 configure_modifier_keys() {
     info "Remapping modifier keys (Ctrl→Cmd, Win→Option, Alt→Control)"
 
-    # Remap modifier keys to match Linux muscle memory:
-    #   Physical Ctrl (E0/E4) → Command (E3/E7)
-    #   Physical Win  (E3/E7) → Option  (E2/E6)
-    #   Physical Alt  (E2/E6) → Control (E0/E4)
-    hidutil property --set '{"UserKeyMapping":[
-        {"HIDKeyboardModifierMappingSrc":0x7000000E0,"HIDKeyboardModifierMappingDst":0x7000000E3},
-        {"HIDKeyboardModifierMappingSrc":0x7000000E3,"HIDKeyboardModifierMappingDst":0x7000000E2},
-        {"HIDKeyboardModifierMappingSrc":0x7000000E2,"HIDKeyboardModifierMappingDst":0x7000000E0},
-        {"HIDKeyboardModifierMappingSrc":0x7000000E4,"HIDKeyboardModifierMappingDst":0x7000000E7},
-        {"HIDKeyboardModifierMappingSrc":0x7000000E7,"HIDKeyboardModifierMappingDst":0x7000000E6},
-        {"HIDKeyboardModifierMappingSrc":0x7000000E6,"HIDKeyboardModifierMappingDst":0x7000000E4}
-    ]}' >/dev/null
+    # Applies to the running session immediately; hidutil mappings are lost on
+    # reboot, which is what the LaunchAgent below is for.
+    hidutil property --set "$KEY_REMAPPING" >/dev/null
 
     # Persist across reboots with a LaunchAgent
     launch_agent_dir="$HOME/Library/LaunchAgents"
     launch_agent="$launch_agent_dir/com.local.KeyRemapping.plist"
     mkdir -p "$launch_agent_dir"
 
-    cat > "$launch_agent" <<'PLIST'
+    cat > "$launch_agent" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -170,13 +212,27 @@ configure_modifier_keys() {
         <string>/usr/bin/hidutil</string>
         <string>property</string>
         <string>--set</string>
-        <string>{"UserKeyMapping":[{"HIDKeyboardModifierMappingSrc":0x7000000E0,"HIDKeyboardModifierMappingDst":0x7000000E3},{"HIDKeyboardModifierMappingSrc":0x7000000E3,"HIDKeyboardModifierMappingDst":0x7000000E2},{"HIDKeyboardModifierMappingSrc":0x7000000E2,"HIDKeyboardModifierMappingDst":0x7000000E0},{"HIDKeyboardModifierMappingSrc":0x7000000E4,"HIDKeyboardModifierMappingDst":0x7000000E7},{"HIDKeyboardModifierMappingSrc":0x7000000E7,"HIDKeyboardModifierMappingDst":0x7000000E6},{"HIDKeyboardModifierMappingSrc":0x7000000E6,"HIDKeyboardModifierMappingDst":0x7000000E4}]}</string>
+        <string>$KEY_REMAPPING</string>
     </array>
     <key>RunAtLoad</key>
     <true/>
 </dict>
 </plist>
 PLIST
+
+    # Load it now rather than leaving it for the next login: a malformed plist
+    # is worth hearing about while the script that wrote it is still running,
+    # not the next time the machine boots without a working Ctrl key.
+    if ! is_command launchctl; then
+        warn "launchctl not found; the key remapping is live now but was not verified for the next login"
+        return 0
+    fi
+    # A previous run's copy has to go first -- bootstrap refuses a label that's
+    # already loaded -- and on the first run there is nothing to unload, which
+    # is why this one failure is discarded rather than reported.
+    launchctl bootout "gui/$(id -u)/com.local.KeyRemapping" 2>/dev/null || true
+    launchctl bootstrap "gui/$(id -u)" "$launch_agent" \
+        || warn "could not load $launch_agent; the remapping is live now but won't survive a reboot"
 }
 
 # --- Configure keyboard shortcuts ---

--- a/setup-macos_test
+++ b/setup-macos_test
@@ -8,7 +8,7 @@
 # same way setup-kde_test mocks kwriteconfig6.
 #
 # The absolute-path helpers can't be shadowed by PATH, so setup-macos takes
-# them from the environment ($ACTIVATE_SETTINGS) and the mocks go there.
+# them from the environment ($ACTIVATE_SETTINGS, $PBS) and the mocks go there.
 
 set -e
 
@@ -49,13 +49,16 @@ exit 0
 MOCK
     done
 
-    # The absolute-path helper.
-    cat > "$TEST_TMPDIR/bin/activateSettings" <<MOCK
+    # The absolute-path helpers.
+    for cmd in activateSettings pbs; do
+        cat > "$TEST_TMPDIR/bin/$cmd" <<MOCK
 #!/bin/sh
-printf "%s\\n" "activateSettings \$*" >> "$CALLS"
+printf "%s\\n" "$cmd \$*" >> "$CALLS"
 exit 0
 MOCK
+    done
     ACTIVATE_SETTINGS="$TEST_TMPDIR/bin/activateSettings"
+    PBS="$TEST_TMPDIR/bin/pbs"
 
     chmod +x "$TEST_TMPDIR"/bin/*
 
@@ -67,7 +70,7 @@ MOCK
     # reached the real hidutil and launchctl would remap the developer's
     # keyboard and load a LaunchAgent while they ran `make test`.
     mkdir -p "$TEST_TMPDIR/sysbin"
-    for cmd in cat dirname grep id mkdir rm; do
+    for cmd in cat dirname grep id mkdir rm sed; do
         ln -sf "$(command -v "$cmd")" "$TEST_TMPDIR/sysbin/$cmd"
     done
 
@@ -75,6 +78,55 @@ MOCK
     # so the ordinary run has nothing to warn about;
     # test_missing_amethyst_config removes it.
     touch "$TEST_TMPDIR/home/.amethyst.yml"
+
+    # On PATH by default, so the ordinary run configures every shortcut. Tests
+    # about missing launchers use isolate_script to get away from both these
+    # and the real ones beside the script.
+    add_all_launchers
+}
+
+# Add a fake launcher helper (e.g. browser1) to the mock bin, i.e. on PATH.
+add_launcher() {
+    cat > "$TEST_TMPDIR/bin/$1" <<'MOCK'
+#!/bin/sh
+exit 0
+MOCK
+    chmod +x "$TEST_TMPDIR/bin/$1"
+}
+
+# Underscore-prefixed, and not "name": run_test holds the test's name in a
+# plain global, and a loop variable that collides with it renames every test
+# that calls this.
+add_all_launchers() {
+    for _each_launcher in browser1 browser2 terminal terminal_on_workstation music; do
+        add_launcher "$_each_launcher"
+    done
+}
+
+# Run a copy of setup-macos from a directory with no launcher siblings. In the
+# real repo the launchers live beside setup-macos and the sibling fallback
+# finds them, so tests about genuinely-missing launchers need it isolated --
+# and the mock bin copies removed from PATH.
+isolate_script() {
+    # An optional directory name, so a test can isolate into a path with a
+    # space or an XML metacharacter in it.
+    ISOLATED_DIR="$TEST_TMPDIR/${1:-isolated}"
+    mkdir -p "$ISOLATED_DIR"
+    cp "$SCRIPT_DIR/setup-macos" "$ISOLATED_DIR/setup-macos"
+    MACOS_SCRIPT="$ISOLATED_DIR/setup-macos"
+    for _each_launcher in browser1 browser2 terminal terminal_on_workstation music; do
+        rm -f "$TEST_TMPDIR/bin/$_each_launcher"
+    done
+}
+
+# Put a launcher beside the isolated script but NOT on PATH, to exercise the
+# sibling fallback on its own.
+add_sibling_launcher() {
+    cat > "$ISOLATED_DIR/$1" <<'MOCK'
+#!/bin/sh
+exit 0
+MOCK
+    chmod +x "$ISOLATED_DIR/$1"
 }
 
 teardown() {
@@ -93,6 +145,7 @@ run_macos() {
     set +e
     output="$(HOME="$TEST_TMPDIR/home" \
         ACTIVATE_SETTINGS="$ACTIVATE_SETTINGS" \
+        PBS="$PBS" \
         PATH="$TEST_TMPDIR/bin:$TEST_TMPDIR/sysbin" \
         "$MACOS_SCRIPT" "$@" 2>&1)"
     status=$?
@@ -116,6 +169,7 @@ run_macos_without() {
     set +e
     output="$(HOME="$TEST_TMPDIR/home" \
         ACTIVATE_SETTINGS="$ACTIVATE_SETTINGS" \
+        PBS="$PBS" \
         PATH="$TEST_TMPDIR/reduced:$TEST_TMPDIR/sysbin" \
         "$MACOS_SCRIPT" "$@" 2>&1)"
     status=$?
@@ -164,6 +218,14 @@ assert_not_called() {
 assert_file_exists() {
     if ! test -f "$1"; then
         echo "  FAIL: expected file '$1' to exist"
+        TEST_FAILED=1
+        return 1
+    fi
+}
+
+assert_file_not_exists() {
+    if test -f "$1"; then
+        echo "  FAIL: unexpected file '$1' exists"
         TEST_FAILED=1
         return 1
     fi
@@ -416,6 +478,18 @@ test_missing_activate_settings_warns_about_logout() {
     assert_output_contains "log out and back in for the shortcut changes"
 }
 
+# --- Spaces ---
+
+# Regression: with the Dock's "automatically rearrange Spaces" left on (the
+# default), the Option+1..9 bindings above point at whichever desktop was used
+# most recently rather than at desktop N.
+test_pins_the_spaces_order() {
+    run_macos
+    assert_status 0 &&
+    assert_called "defaults write com.apple.dock mru-spaces -bool false" &&
+    assert_called "killall Dock"
+}
+
 # --- Amethyst ---
 
 test_enables_focus_follows_mouse() {
@@ -454,6 +528,82 @@ test_workflow_name_is_substituted() {
     assert_file_lacks "$plist" "WORKFLOWNAME"
 }
 
+# Regression: the command baked into the workflow used to be a hard-coded
+# "$HOME/scripts/<launcher>" regardless of where the launcher actually is, so
+# a checkout kept anywhere else got Quick Actions pointing at nothing.
+test_workflow_runs_the_resolved_launcher() {
+    run_macos
+    wflow="$TEST_TMPDIR/home/Library/Services/Launch Browser1.workflow/Contents/document.wflow"
+    assert_status 0 &&
+    assert_file_contains "$wflow" "$TEST_TMPDIR/bin/browser1" &&
+    assert_file_lacks "$wflow" "$TEST_TMPDIR/home/scripts/browser1"
+}
+
+# During a fresh bootstrap setup runs setup-macos out of the just-cloned repo,
+# before any login shell has put it on PATH -- so the launchers have to be
+# found beside the script too.
+test_sibling_launcher_fallback() {
+    isolate_script
+    add_sibling_launcher browser1
+    run_macos --ignore-errors
+    wflow="$TEST_TMPDIR/home/Library/Services/Launch Browser1.workflow/Contents/document.wflow"
+    assert_status 0 &&
+    assert_file_contains "$wflow" "$ISOLATED_DIR/browser1"
+}
+
+# A launcher that isn't installed must not be fatal, and must not leave a
+# shortcut bound to a workflow that runs nothing.
+test_missing_launcher_skipped_not_fatal() {
+    isolate_script
+    add_sibling_launcher browser1
+    run_macos --ignore-errors
+    services="$TEST_TMPDIR/home/Library/Services"
+    assert_status 0 &&
+    assert_output_contains "music not found on PATH or beside this script" &&
+    assert_file_exists "$services/Launch Browser1.workflow/Contents/document.wflow" &&
+    assert_file_not_exists "$services/Launch Music.workflow/Contents/document.wflow" &&
+    assert_not_called "Launch Music - runWorkflowAsService"
+}
+
+# The COMMAND_STRING is run as a /bin/sh command and lives inside a plist, so
+# a checkout under a path with a space would be split into two words, and one
+# with an `&` would make the XML invalid.
+test_launcher_path_is_quoted_and_escaped() {
+    isolate_script "odd & dir"
+    add_sibling_launcher browser1
+    run_macos --ignore-errors
+    wflow="$TEST_TMPDIR/home/Library/Services/Launch Browser1.workflow/Contents/document.wflow"
+    assert_status 0 &&
+    assert_file_contains "$wflow" "<string>'$TEST_TMPDIR/odd &amp; dir/browser1'</string>" &&
+    assert_file_lacks "$wflow" "<string>$TEST_TMPDIR/odd & dir/browser1</string>"
+}
+
+# A launcher that existed on an earlier run leaves a workflow behind. Skipping
+# it now has to take that with it, or the shortcut keeps working and runs the
+# path the launcher used to have.
+test_stale_workflow_removed_when_launcher_disappears() {
+    run_macos
+    services="$TEST_TMPDIR/home/Library/Services"
+    assert_status 0 &&
+    assert_file_exists "$services/Launch Music.workflow/Contents/document.wflow" || return 1
+
+    isolate_script
+    add_sibling_launcher browser1
+    run_macos --ignore-errors
+    assert_status 0 &&
+    assert_output_contains "Removing the stale Quick Action for music" &&
+    assert_file_not_exists "$services/Launch Music.workflow/Contents/document.wflow" &&
+    assert_file_exists "$services/Launch Browser1.workflow/Contents/document.wflow"
+}
+
+test_no_launchers_at_all_warns_without_writing_the_registry() {
+    isolate_script
+    run_macos --ignore-errors
+    assert_status 0 &&
+    assert_output_contains "no launcher helpers found" &&
+    assert_not_called "defaults write pbs NSServicesStatus"
+}
+
 test_assigns_option_key_equivalents() {
     run_macos
     assert_status 0 &&
@@ -463,6 +613,22 @@ test_assigns_option_key_equivalents() {
     assert_called '"key_equivalent" = "~t"' &&
     assert_called '"key_equivalent" = "~w"' &&
     assert_called '"key_equivalent" = "~y"'
+}
+
+# Regression: writing the workflows and the key equivalents isn't enough. The
+# Services registry is a cache, and until pbs re-reads it the Quick Actions
+# aren't registered and the shortcuts silently do nothing.
+test_flushes_the_services_registry() {
+    run_macos
+    assert_status 0 &&
+    assert_called "pbs -flush"
+}
+
+test_missing_pbs_warns_about_logout() {
+    PBS="$TEST_TMPDIR/bin/no-such-pbs"
+    run_macos --ignore-errors
+    assert_status 0 &&
+    assert_output_contains "log out and back in for the launch shortcuts to work"
 }
 
 # --- Finder ---
@@ -512,12 +678,30 @@ run_test "applies the shortcut settings to this session" \
     test_applies_shortcut_settings
 run_test "missing activateSettings falls back to the logout advice" \
     test_missing_activate_settings_warns_about_logout
+run_test "pins the Spaces order so the numbered shortcuts hold" \
+    test_pins_the_spaces_order
 run_test "enables focus follows mouse" test_enables_focus_follows_mouse
 run_test "a missing amethyst config warns, not fatal" test_missing_amethyst_config
 run_test "creates a Quick Action per launcher" test_creates_launcher_workflows
 run_test "substitutes the workflow name without sed" \
     test_workflow_name_is_substituted
+run_test "the workflow runs the resolved launcher path" \
+    test_workflow_runs_the_resolved_launcher
+run_test "finds a launcher beside the script without PATH" \
+    test_sibling_launcher_fallback
+run_test "a missing launcher is skipped, not fatal" \
+    test_missing_launcher_skipped_not_fatal
+run_test "quotes and XML-escapes the launcher path" \
+    test_launcher_path_is_quoted_and_escaped
+run_test "removes a stale Quick Action when its launcher goes away" \
+    test_stale_workflow_removed_when_launcher_disappears
+run_test "no launchers at all leaves the registry alone" \
+    test_no_launchers_at_all_warns_without_writing_the_registry
 run_test "assigns the Option+key equivalents" test_assigns_option_key_equivalents
+run_test "flushes the Services registry so the shortcuts work" \
+    test_flushes_the_services_registry
+run_test "missing pbs falls back to the logout advice" \
+    test_missing_pbs_warns_about_logout
 run_test "configures Finder and restarts it" test_configures_finder
 
 echo

--- a/setup-macos_test
+++ b/setup-macos_test
@@ -1,0 +1,410 @@
+#!/bin/sh
+# Tests for setup-macos
+#
+# setup-macos is pure configuration -- every step is a `defaults` write, a
+# hidutil remap, or a file dropped in ~/Library -- so it runs against a
+# throwaway HOME with the macOS CLI tools mocked, and the assertions look at
+# what it asked those tools to do. That means these run on Linux CI too, the
+# same way setup-kde_test mocks kwriteconfig6.
+#
+# The absolute-path helpers can't be shadowed by PATH, so setup-macos takes
+# them from the environment ($ACTIVATE_SETTINGS) and the mocks go there.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+setup() {
+    TEST_TMPDIR="$(mktemp -d)"
+    CALLS="$TEST_TMPDIR/calls"
+    rm -f "$CALLS"
+    mkdir -p "$TEST_TMPDIR/bin" "$TEST_TMPDIR/home"
+    MACOS_SCRIPT="$SCRIPT_DIR/setup-macos"
+
+    # `defaults read` fails the way the real one does for a key that was never
+    # written. Everything else just records argv.
+    cat > "$TEST_TMPDIR/bin/defaults" <<MOCK
+#!/bin/sh
+printf "%s\\n" "defaults \$*" >> "$CALLS"
+if test "\$1" = read; then
+    echo "Domain/default pair does not exist" >&2
+    exit 1
+fi
+exit 0
+MOCK
+
+    for cmd in hidutil killall; do
+        cat > "$TEST_TMPDIR/bin/$cmd" <<MOCK
+#!/bin/sh
+printf "%s\\n" "$cmd \$*" >> "$CALLS"
+exit 0
+MOCK
+    done
+
+    # The absolute-path helper.
+    cat > "$TEST_TMPDIR/bin/activateSettings" <<MOCK
+#!/bin/sh
+printf "%s\\n" "activateSettings \$*" >> "$CALLS"
+exit 0
+MOCK
+    ACTIVATE_SETTINGS="$TEST_TMPDIR/bin/activateSettings"
+
+    chmod +x "$TEST_TMPDIR"/bin/*
+
+    # The ordinary system utilities setup-macos shells out to, symlinked into
+    # a directory of their own. The sandbox PATH is built from just these two
+    # directories -- never /usr/bin -- because on a real Mac the system copies
+    # of defaults, hidutil and launchctl would otherwise still be on PATH:
+    # run_macos_without could not simulate a missing command, and a run that
+    # reached the real hidutil and launchctl would remap the developer's
+    # keyboard and load a LaunchAgent while they ran `make test`.
+    mkdir -p "$TEST_TMPDIR/sysbin"
+    for cmd in cat dirname grep id mkdir rm; do
+        ln -sf "$(command -v "$cmd")" "$TEST_TMPDIR/sysbin/$cmd"
+    done
+
+    # confinst normally symlinks this out of the conf repo. Present by default
+    # so the ordinary run has nothing to warn about;
+    # test_missing_amethyst_config removes it.
+    touch "$TEST_TMPDIR/home/.amethyst.yml"
+}
+
+teardown() {
+    rm -rf "$TEST_TMPDIR"
+}
+
+# Run setup-macos in the sandbox: fresh HOME, and a PATH of just the mock bin
+# plus the symlinked system utilities -- nothing from the real /usr/bin.
+run_macos() {
+    set +e
+    output="$(HOME="$TEST_TMPDIR/home" \
+        ACTIVATE_SETTINGS="$ACTIVATE_SETTINGS" \
+        PATH="$TEST_TMPDIR/bin:$TEST_TMPDIR/sysbin" \
+        "$MACOS_SCRIPT" "$@" 2>&1)"
+    status=$?
+    set -e
+}
+
+# Like run_macos, but with the named commands removed from PATH. The reduced
+# directory replaces the mock bin entirely, so a removed command is genuinely
+# absent rather than falling through to a system copy.
+run_macos_without() {
+    missing="$1"
+    shift
+    mkdir -p "$TEST_TMPDIR/reduced"
+    for f in "$TEST_TMPDIR"/bin/*; do
+        base="${f##*/}"
+        case " $missing " in
+            *" $base "*) continue ;;
+        esac
+        cp "$f" "$TEST_TMPDIR/reduced/$base"
+    done
+    set +e
+    output="$(HOME="$TEST_TMPDIR/home" \
+        ACTIVATE_SETTINGS="$ACTIVATE_SETTINGS" \
+        PATH="$TEST_TMPDIR/reduced:$TEST_TMPDIR/sysbin" \
+        "$MACOS_SCRIPT" "$@" 2>&1)"
+    status=$?
+    set -e
+}
+
+assert_status() {
+    if test "$status" -ne "$1"; then
+        echo "  FAIL: expected exit status $1, got $status"
+        echo "  output: $output"
+        TEST_FAILED=1
+        return 1
+    fi
+}
+
+assert_output_contains() {
+    case "$output" in
+        *"$1"*) ;;
+        *)
+            printf "%s\n" "  FAIL: output does not contain '$1'"
+            echo "  output: $output"
+            TEST_FAILED=1
+            return 1
+            ;;
+    esac
+}
+
+assert_called() {
+    if ! grep -qF -- "$1" "$CALLS" 2>/dev/null; then
+        printf "%s\n" "  FAIL: expected call '$1' not found"
+        printf "%s\n" "  calls: $(cat "$CALLS" 2>/dev/null)"
+        TEST_FAILED=1
+        return 1
+    fi
+}
+
+assert_file_exists() {
+    if ! test -f "$1"; then
+        echo "  FAIL: expected file '$1' to exist"
+        TEST_FAILED=1
+        return 1
+    fi
+}
+
+assert_file_contains() {
+    if ! test -f "$1"; then
+        echo "  FAIL: expected file '$1' to exist"
+        TEST_FAILED=1
+        return 1
+    fi
+    if ! grep -qF -- "$2" "$1"; then
+        printf "%s\n" "  FAIL: '$1' does not contain '$2'"
+        TEST_FAILED=1
+        return 1
+    fi
+}
+
+assert_file_lacks() {
+    if grep -qF -- "$2" "$1" 2>/dev/null; then
+        printf "%s\n" "  FAIL: '$1' unexpectedly contains '$2'"
+        TEST_FAILED=1
+        return 1
+    fi
+}
+
+run_test() {
+    name="$1"
+    func="$2"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    setup
+    TEST_FAILED=
+    if "$func" && test -z "$TEST_FAILED"; then
+        echo "ok $TESTS_RUN $name"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        echo "not ok $TESTS_RUN $name"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+    teardown
+}
+
+# --- usage and help ---
+
+test_help_flag() {
+    run_macos --help
+    assert_status 0 &&
+    assert_output_contains "Usage: setup-macos"
+}
+
+test_unknown_option() {
+    run_macos --bogus
+    assert_status 1 &&
+    assert_output_contains "Unknown option"
+}
+
+# setup forwards these three to every desktop helper. --no-install and
+# --no-sudo have nothing to skip here, but they must still be accepted.
+test_forwarded_flags_accepted() {
+    run_macos --no-install --no-sudo --ignore-errors
+    assert_status 0 &&
+    assert_called "defaults write com.apple.finder AppleShowAllFiles -bool true"
+}
+
+# --- prerequisites ---
+
+# Without `defaults` nothing this script does is possible. Say so by name
+# rather than failing several steps in with "defaults: not found" -- which is
+# what running it on the wrong OS used to look like.
+test_missing_defaults_errors() {
+    run_macos_without defaults
+    assert_status 1 &&
+    assert_output_contains "defaults is required"
+}
+
+test_missing_hidutil_errors() {
+    run_macos_without hidutil
+    assert_status 1 &&
+    assert_output_contains "hidutil is required"
+}
+
+# The prerequisite check must not pre-empt --help: asking for usage on a
+# machine that can't run the script is still a reasonable thing to do.
+test_help_works_without_macos_tools() {
+    run_macos_without "defaults hidutil" --help
+    assert_status 0 &&
+    assert_output_contains "Usage: setup-macos"
+}
+
+# --- keyboard layout ---
+
+test_enables_dvorak() {
+    run_macos
+    assert_status 0 &&
+    assert_called "defaults write com.apple.HIToolbox AppleEnabledInputSources -array-add" &&
+    assert_called "defaults write com.apple.HIToolbox AppleCurrentKeyboardLayoutInputSourceID com.apple.keylayout.Dvorak"
+}
+
+test_disables_text_substitutions() {
+    run_macos
+    assert_status 0 &&
+    assert_called "NSAutomaticSpellingCorrectionEnabled -bool false" &&
+    assert_called "NSAutomaticCapitalizationEnabled -bool false" &&
+    assert_called "NSAutomaticQuoteSubstitutionEnabled -bool false" &&
+    assert_called "NSAutomaticDashSubstitutionEnabled -bool false" &&
+    assert_called "NSAutomaticPeriodSubstitutionEnabled -bool false"
+}
+
+# --- modifier keys ---
+
+# The three-key rotation: Ctrl→Cmd, Win→Option, Alt→Control, on both sides of
+# the keyboard. E0/E4 are the Controls, E2/E6 the Options, E3/E7 the Commands.
+test_remaps_modifier_keys() {
+    run_macos
+    assert_status 0 &&
+    assert_called '"HIDKeyboardModifierMappingSrc":0x7000000E0,"HIDKeyboardModifierMappingDst":0x7000000E3' &&
+    assert_called '"HIDKeyboardModifierMappingSrc":0x7000000E3,"HIDKeyboardModifierMappingDst":0x7000000E2' &&
+    assert_called '"HIDKeyboardModifierMappingSrc":0x7000000E2,"HIDKeyboardModifierMappingDst":0x7000000E0' &&
+    assert_called '"HIDKeyboardModifierMappingSrc":0x7000000E4,"HIDKeyboardModifierMappingDst":0x7000000E7' &&
+    assert_called '"HIDKeyboardModifierMappingSrc":0x7000000E7,"HIDKeyboardModifierMappingDst":0x7000000E6' &&
+    assert_called '"HIDKeyboardModifierMappingSrc":0x7000000E6,"HIDKeyboardModifierMappingDst":0x7000000E4'
+}
+
+test_writes_launch_agent() {
+    run_macos
+    agent="$TEST_TMPDIR/home/Library/LaunchAgents/com.local.KeyRemapping.plist"
+    assert_status 0 &&
+    assert_file_exists "$agent" &&
+    assert_file_contains "$agent" "<string>/usr/bin/hidutil</string>" &&
+    assert_file_contains "$agent" "com.local.KeyRemapping"
+}
+
+# --- keyboard shortcuts ---
+
+test_configures_spotlight_on_option_space() {
+    run_macos
+    assert_status 0 &&
+    assert_called "defaults write com.apple.symbolichotkeys AppleSymbolicHotKeys -dict-add 64"
+}
+
+test_disables_finder_search_hotkey() {
+    run_macos
+    assert_status 0 &&
+    assert_called "defaults write com.apple.symbolichotkeys AppleSymbolicHotKeys -dict-add 65"
+}
+
+# Nine desktops, IDs 118-126, each on Option (modifier flag 524288).
+test_configures_nine_desktop_shortcuts() {
+    run_macos
+    assert_status 0 || return 1
+    for _hotkey_id in 118 119 120 121 122 123 124 125 126; do
+        assert_called "AppleSymbolicHotKeys -dict-add $_hotkey_id" || return 1
+    done
+    assert_called "524288"
+}
+
+test_applies_shortcut_settings() {
+    run_macos
+    assert_status 0 &&
+    assert_called "activateSettings -u"
+}
+
+# The path used to be hard-coded, so a run anywhere it doesn't exist died with
+# status 127 partway through instead of finishing and saying what was left.
+test_missing_activate_settings_warns_about_logout() {
+    ACTIVATE_SETTINGS="$TEST_TMPDIR/bin/no-such-activateSettings"
+    run_macos --ignore-errors
+    assert_status 0 &&
+    assert_output_contains "log out and back in for the shortcut changes"
+}
+
+# --- Amethyst ---
+
+test_enables_focus_follows_mouse() {
+    run_macos
+    assert_status 0 &&
+    assert_called "defaults write com.amethyst.Amethyst focus-follows-mouse -bool true"
+}
+
+test_missing_amethyst_config() {
+    rm -f "$TEST_TMPDIR/home/.amethyst.yml"
+    run_macos --ignore-errors
+    assert_status 0 &&
+    assert_output_contains "run confinst after cloning the conf repo"
+}
+
+# --- application launch shortcuts ---
+
+test_creates_launcher_workflows() {
+    run_macos
+    services="$TEST_TMPDIR/home/Library/Services"
+    assert_status 0 &&
+    assert_file_exists "$services/Launch Browser1.workflow/Contents/Info.plist" &&
+    assert_file_exists "$services/Launch Browser1.workflow/Contents/document.wflow" &&
+    assert_file_exists "$services/Launch Terminal on Workstation.workflow/Contents/document.wflow" &&
+    assert_file_exists "$services/Launch Music.workflow/Contents/document.wflow"
+}
+
+# Regression: the workflow name used to be substituted with `sed -i ''`, whose
+# empty-suffix argument is BSD-only -- so this step aborted the run under any
+# GNU sed, and the name never made it into the plist.
+test_workflow_name_is_substituted() {
+    run_macos
+    plist="$TEST_TMPDIR/home/Library/Services/Launch Browser1.workflow/Contents/Info.plist"
+    assert_status 0 &&
+    assert_file_contains "$plist" "<string>Launch Browser1</string>" &&
+    assert_file_lacks "$plist" "WORKFLOWNAME"
+}
+
+test_assigns_option_key_equivalents() {
+    run_macos
+    assert_status 0 &&
+    assert_called "defaults write pbs NSServicesStatus -dict-add" &&
+    assert_called '"key_equivalent" = "~g"' &&
+    assert_called '"key_equivalent" = "~h"' &&
+    assert_called '"key_equivalent" = "~t"' &&
+    assert_called '"key_equivalent" = "~w"' &&
+    assert_called '"key_equivalent" = "~y"'
+}
+
+# --- Finder ---
+
+test_configures_finder() {
+    run_macos
+    assert_status 0 &&
+    assert_called "defaults write com.apple.finder AppleShowAllFiles -bool true" &&
+    assert_called "defaults write com.apple.finder ShowPathbar -bool true" &&
+    assert_called "defaults write NSGlobalDomain AppleShowAllExtensions -bool true" &&
+    assert_called "killall Finder"
+}
+
+# --- Test runner ---
+
+run_test "--help exits 0 and prints usage" test_help_flag
+run_test "an unknown option is a usage error" test_unknown_option
+run_test "the flags setup forwards are all accepted" test_forwarded_flags_accepted
+run_test "missing defaults is reported by name" test_missing_defaults_errors
+run_test "missing hidutil is reported by name" test_missing_hidutil_errors
+run_test "--help works without the macOS tools" test_help_works_without_macos_tools
+run_test "enables the Dvorak layout" test_enables_dvorak
+run_test "disables the text substitutions" test_disables_text_substitutions
+run_test "rotates Ctrl, Command and Option on both sides" \
+    test_remaps_modifier_keys
+run_test "writes the key-remapping LaunchAgent" test_writes_launch_agent
+run_test "puts Spotlight on Option+Space" test_configures_spotlight_on_option_space
+run_test "disables the conflicting Finder search hotkey" \
+    test_disables_finder_search_hotkey
+run_test "binds Option+1..9 to the nine desktops" \
+    test_configures_nine_desktop_shortcuts
+run_test "applies the shortcut settings to this session" \
+    test_applies_shortcut_settings
+run_test "missing activateSettings falls back to the logout advice" \
+    test_missing_activate_settings_warns_about_logout
+run_test "enables focus follows mouse" test_enables_focus_follows_mouse
+run_test "a missing amethyst config warns, not fatal" test_missing_amethyst_config
+run_test "creates a Quick Action per launcher" test_creates_launcher_workflows
+run_test "substitutes the workflow name without sed" \
+    test_workflow_name_is_substituted
+run_test "assigns the Option+key equivalents" test_assigns_option_key_equivalents
+run_test "configures Finder and restarts it" test_configures_finder
+
+echo
+echo "$TESTS_RUN tests, $TESTS_PASSED passed, $TESTS_FAILED failed"
+test "$TESTS_FAILED" -eq 0

--- a/setup-macos_test
+++ b/setup-macos_test
@@ -24,19 +24,24 @@ setup() {
     mkdir -p "$TEST_TMPDIR/bin" "$TEST_TMPDIR/home"
     MACOS_SCRIPT="$SCRIPT_DIR/setup-macos"
 
-    # `defaults read` fails the way the real one does for a key that was never
+    # `defaults read` answers from a file when a test has staged one, and
+    # otherwise fails the way the real one does for a key that was never
     # written. Everything else just records argv.
     cat > "$TEST_TMPDIR/bin/defaults" <<MOCK
 #!/bin/sh
 printf "%s\\n" "defaults \$*" >> "$CALLS"
 if test "\$1" = read; then
+    if test -f "$TEST_TMPDIR/defaults_read"; then
+        cat "$TEST_TMPDIR/defaults_read"
+        exit 0
+    fi
     echo "Domain/default pair does not exist" >&2
     exit 1
 fi
 exit 0
 MOCK
 
-    for cmd in hidutil killall; do
+    for cmd in hidutil launchctl killall; do
         cat > "$TEST_TMPDIR/bin/$cmd" <<MOCK
 #!/bin/sh
 printf "%s\\n" "$cmd \$*" >> "$CALLS"
@@ -74,6 +79,12 @@ MOCK
 
 teardown() {
     rm -rf "$TEST_TMPDIR"
+}
+
+# Stage the output `defaults read` should print, i.e. pretend the key is
+# already set to this.
+stage_defaults_read() {
+    printf "%s\n" "$1" > "$TEST_TMPDIR/defaults_read"
 }
 
 # Run setup-macos in the sandbox: fresh HOME, and a PATH of just the mock bin
@@ -135,6 +146,15 @@ assert_output_contains() {
 assert_called() {
     if ! grep -qF -- "$1" "$CALLS" 2>/dev/null; then
         printf "%s\n" "  FAIL: expected call '$1' not found"
+        printf "%s\n" "  calls: $(cat "$CALLS" 2>/dev/null)"
+        TEST_FAILED=1
+        return 1
+    fi
+}
+
+assert_not_called() {
+    if grep -qF -- "$1" "$CALLS" 2>/dev/null; then
+        printf "%s\n" "  FAIL: unexpected call '$1' found"
         printf "%s\n" "  calls: $(cat "$CALLS" 2>/dev/null)"
         TEST_FAILED=1
         return 1
@@ -242,6 +262,55 @@ test_enables_dvorak() {
     assert_called "defaults write com.apple.HIToolbox AppleCurrentKeyboardLayoutInputSourceID com.apple.keylayout.Dvorak"
 }
 
+# Regression: -array-add appends unconditionally, so the original version
+# stacked another Dvorak entry onto AppleEnabledInputSources on every run --
+# and setup is explicitly meant to be re-runnable.
+test_does_not_re_add_dvorak() {
+    stage_defaults_read '(
+        {
+        InputSourceKind = "Keyboard Layout";
+        "KeyboardLayout ID" = 16300;
+        "KeyboardLayout Name" = Dvorak;
+    }
+)'
+    run_macos
+    assert_status 0 &&
+    assert_not_called "AppleEnabledInputSources -array-add" &&
+    assert_output_contains "already an enabled input source"
+}
+
+# Enabling a layout only offers it; selecting it is a separate key. Written
+# with -array (replace) rather than -array-add, so it stays idempotent.
+# The variants all have "Dvorak" in the name, so a name match would see this
+# machine as already configured -- then select a layout that isn't in the
+# enabled list. Matched on the layout ID instead.
+test_dvorak_variant_is_not_standard_dvorak() {
+    stage_defaults_read '(
+        {
+        InputSourceKind = "Keyboard Layout";
+        "KeyboardLayout ID" = 16301;
+        "KeyboardLayout Name" = "Dvorak - Qwerty \U2318";
+    }
+)'
+    run_macos
+    assert_status 0 &&
+    assert_called "AppleEnabledInputSources -array-add"
+}
+
+test_selects_dvorak_input_source() {
+    run_macos
+    assert_status 0 &&
+    assert_called "defaults write com.apple.HIToolbox AppleSelectedInputSources -array"
+}
+
+# The login session caches the input source, so this one genuinely does need a
+# logout -- and saying nothing left the user thinking it had applied.
+test_says_layout_needs_logout() {
+    run_macos
+    assert_status 0 &&
+    assert_output_contains "Log out and back in for the Dvorak layout"
+}
+
 test_disables_text_substitutions() {
     run_macos
     assert_status 0 &&
@@ -274,6 +343,38 @@ test_writes_launch_agent() {
     assert_file_exists "$agent" &&
     assert_file_contains "$agent" "<string>/usr/bin/hidutil</string>" &&
     assert_file_contains "$agent" "com.local.KeyRemapping"
+}
+
+# The live remap and the one the LaunchAgent reapplies at login have to be the
+# same mapping. They used to be two hand-maintained copies of the same JSON.
+test_launch_agent_matches_live_remap() {
+    run_macos
+    agent="$TEST_TMPDIR/home/Library/LaunchAgents/com.local.KeyRemapping.plist"
+    assert_status 0 &&
+    assert_file_contains "$agent" '{"HIDKeyboardModifierMappingSrc":0x7000000E0,"HIDKeyboardModifierMappingDst":0x7000000E3}' &&
+    assert_file_contains "$agent" '{"HIDKeyboardModifierMappingSrc":0x7000000E6,"HIDKeyboardModifierMappingDst":0x7000000E4}'
+}
+
+# Loading it now is what turns a malformed plist into an error the user sees
+# while setup is running, rather than a machine that boots without a Ctrl key.
+test_loads_launch_agent() {
+    run_macos
+    assert_status 0 &&
+    assert_called "launchctl bootstrap gui/"
+}
+
+# bootstrap refuses a label that's already loaded, so a re-run has to unload
+# the previous copy first.
+test_unloads_previous_launch_agent() {
+    run_macos
+    assert_status 0 &&
+    assert_called "launchctl bootout gui/"
+}
+
+test_missing_launchctl_is_not_fatal() {
+    run_macos_without launchctl
+    assert_status 0 &&
+    assert_output_contains "launchctl not found"
 }
 
 # --- keyboard shortcuts ---
@@ -384,10 +485,24 @@ run_test "missing defaults is reported by name" test_missing_defaults_errors
 run_test "missing hidutil is reported by name" test_missing_hidutil_errors
 run_test "--help works without the macOS tools" test_help_works_without_macos_tools
 run_test "enables the Dvorak layout" test_enables_dvorak
+run_test "doesn't stack a second Dvorak entry on a re-run" \
+    test_does_not_re_add_dvorak
+run_test "a Dvorak variant is not mistaken for standard Dvorak" \
+    test_dvorak_variant_is_not_standard_dvorak
+run_test "selects Dvorak, not just enables it" test_selects_dvorak_input_source
+run_test "says the layout needs a logout" test_says_layout_needs_logout
 run_test "disables the text substitutions" test_disables_text_substitutions
 run_test "rotates Ctrl, Command and Option on both sides" \
     test_remaps_modifier_keys
 run_test "writes the key-remapping LaunchAgent" test_writes_launch_agent
+run_test "the LaunchAgent reapplies the same mapping" \
+    test_launch_agent_matches_live_remap
+run_test "loads the LaunchAgent instead of waiting for a login" \
+    test_loads_launch_agent
+run_test "unloads a previous LaunchAgent before loading" \
+    test_unloads_previous_launch_agent
+run_test "missing launchctl warns and the run continues" \
+    test_missing_launchctl_is_not_fatal
 run_test "puts Spotlight on Option+Space" test_configures_spotlight_on_option_space
 run_test "disables the conflicting Finder search hotkey" \
     test_disables_finder_search_hotkey

--- a/setup-macos_test
+++ b/setup-macos_test
@@ -38,10 +38,16 @@ if test "\$1" = read; then
     echo "Domain/default pair does not exist" >&2
     exit 1
 fi
+if test "\$1" = write && test -f "$TEST_TMPDIR/defaults_write_fails"; then
+    echo "defaults: could not write domain" >&2
+    exit 1
+fi
 exit 0
 MOCK
 
-    for cmd in hidutil launchctl killall; do
+    # pgrep exits 0 by default, i.e. the app is running and restart_app should
+    # go on to killall it.
+    for cmd in hidutil launchctl killall pgrep; do
         cat > "$TEST_TMPDIR/bin/$cmd" <<MOCK
 #!/bin/sh
 printf "%s\\n" "$cmd \$*" >> "$CALLS"
@@ -70,7 +76,7 @@ MOCK
     # reached the real hidutil and launchctl would remap the developer's
     # keyboard and load a LaunchAgent while they ran `make test`.
     mkdir -p "$TEST_TMPDIR/sysbin"
-    for cmd in cat dirname grep id mkdir rm sed; do
+    for cmd in cat dirname grep id mkdir mv rm sed; do
         ln -sf "$(command -v "$cmd")" "$TEST_TMPDIR/sysbin/$cmd"
     done
 
@@ -139,6 +145,12 @@ stage_defaults_read() {
     printf "%s\n" "$1" > "$TEST_TMPDIR/defaults_read"
 }
 
+# Make every `defaults write` fail, to exercise what the run reports when a
+# configuration step doesn't take.
+fail_defaults_write() {
+    touch "$TEST_TMPDIR/defaults_write_fails"
+}
+
 # Run setup-macos in the sandbox: fresh HOME, and a PATH of just the mock bin
 # plus the symlinked system utilities -- nothing from the real /usr/bin.
 run_macos() {
@@ -190,6 +202,17 @@ assert_output_contains() {
         *"$1"*) ;;
         *)
             printf "%s\n" "  FAIL: output does not contain '$1'"
+            echo "  output: $output"
+            TEST_FAILED=1
+            return 1
+            ;;
+    esac
+}
+
+assert_output_lacks() {
+    case "$output" in
+        *"$1"*)
+            printf "%s\n" "  FAIL: output unexpectedly contains '$1'"
             echo "  output: $output"
             TEST_FAILED=1
             return 1
@@ -359,6 +382,82 @@ test_dvorak_variant_is_not_standard_dvorak() {
     assert_called "AppleEnabledInputSources -array-add"
 }
 
+# pgrep exits 1 for "no such process" but 2 and 3 for its own failures, so a
+# broken probe must not be read as "the app wasn't running".
+test_pgrep_failure_is_not_read_as_not_running() {
+    cat > "$TEST_TMPDIR/bin/pgrep" <<MOCK
+#!/bin/sh
+printf "%s\\n" "pgrep \$*" >> "$CALLS"
+exit 2
+MOCK
+    chmod +x "$TEST_TMPDIR/bin/pgrep"
+    run_macos --ignore-errors
+    assert_status 0 &&
+    assert_output_contains "could not tell whether Finder is running" &&
+    assert_output_lacks "Finder was not running" &&
+    assert_output_lacks "macOS configured successfully"
+}
+
+# Under --ignore-errors set -e is off, so a failed write's status went nowhere:
+# the run carried on and still claimed success. Every state-changing step now
+# goes through try, which counts the failure.
+# `try cat > "$file"` never worked: the shell opens the target before invoking
+# try, so an unopenable target skipped try entirely and the failure went
+# unrecorded -- the run carried on and still claimed success. Making the target
+# a directory is the one open failure that holds even when the tests run as
+# root.
+test_unwritable_file_is_reported() {
+    mkdir -p "$TEST_TMPDIR/home/Library/LaunchAgents/com.local.KeyRemapping.plist"
+    run_macos --ignore-errors
+    assert_status 0 &&
+    assert_output_contains "failed (exit 1): write_file" &&
+    assert_output_lacks "macOS configured successfully"
+}
+
+# The cleanup path itself: a write that gets as far as the temporary file and
+# then fails to move it into place must leave neither a truncated plist for
+# launchd to parse nor a stray temporary file. Failing `mv` is the only way to
+# reach that branch without depending on file permissions, which say nothing
+# when the tests run as root.
+test_failed_move_cleans_up_its_temporary_file() {
+    cat > "$TEST_TMPDIR/bin/mv" <<MOCK
+#!/bin/sh
+printf "%s\\n" "mv \$*" >> "$CALLS"
+echo "mv: refusing" >&2
+exit 1
+MOCK
+    chmod +x "$TEST_TMPDIR/bin/mv"
+    agents="$TEST_TMPDIR/home/Library/LaunchAgents"
+    run_macos --ignore-errors
+    assert_status 0 &&
+    assert_output_contains "failed (exit 1): write_file" &&
+    assert_file_not_exists "$agents/com.local.KeyRemapping.plist" &&
+    if ls "$agents"/*.tmp.* >/dev/null 2>&1; then
+        echo "  FAIL: a temporary file was left behind"
+        printf "%s\n" "  found: $(ls "$agents")"
+        TEST_FAILED=1
+        return 1
+    fi
+}
+
+test_failed_write_counts_under_ignore_errors() {
+    fail_defaults_write
+    run_macos --ignore-errors
+    assert_status 0 &&
+    assert_output_contains "failed (exit 1): defaults write" &&
+    assert_output_contains "problem(s)" &&
+    assert_output_lacks "macOS configured successfully"
+}
+
+# Without --ignore-errors the same failure aborts -- but named, rather than as
+# a bare set -e death with no output.
+test_failed_write_aborts_without_ignore_errors() {
+    fail_defaults_write
+    run_macos
+    assert_status 1 &&
+    assert_output_contains "failed (exit 1): defaults write"
+}
+
 test_selects_dvorak_input_source() {
     run_macos
     assert_status 0 &&
@@ -505,6 +604,14 @@ test_missing_amethyst_config() {
     assert_output_contains "run confinst after cloning the conf repo"
 }
 
+# Amethyst is inert without Accessibility access and there's no defaults key
+# for it, so the run has to say so.
+test_mentions_accessibility_permission() {
+    run_macos
+    assert_status 0 &&
+    assert_output_contains "Accessibility"
+}
+
 # --- application launch shortcuts ---
 
 test_creates_launcher_workflows() {
@@ -642,6 +749,139 @@ test_configures_finder() {
     assert_called "killall Finder"
 }
 
+# Regression: this used to be `killall Finder 2>/dev/null || true`, which hid
+# every failure. An app that isn't running is the expected case, so it's
+# reported as information and doesn't count against the run -- and it's
+# established by asking pgrep, not by reading killall's exit status.
+test_app_not_running_is_not_a_warning() {
+    cat > "$TEST_TMPDIR/bin/pgrep" <<MOCK
+#!/bin/sh
+printf "%s\\n" "pgrep \$*" >> "$CALLS"
+exit 1
+MOCK
+    chmod +x "$TEST_TMPDIR/bin/pgrep"
+    run_macos
+    assert_status 0 &&
+    assert_output_contains "Finder was not running" &&
+    assert_not_called "killall Finder" &&
+    assert_output_contains "macOS configured successfully"
+}
+
+# The other half of the same point: a killall that fails for any reason other
+# than the app being absent must be reported, not relabeled "wasn't running".
+test_failed_restart_is_reported() {
+    cat > "$TEST_TMPDIR/bin/killall" <<MOCK
+#!/bin/sh
+printf "%s\\n" "killall \$*" >> "$CALLS"
+echo "killall: warning: kill -TERM 1 : Operation not permitted" >&2
+exit 1
+MOCK
+    chmod +x "$TEST_TMPDIR/bin/killall"
+    run_macos --ignore-errors
+    assert_status 0 &&
+    assert_output_contains "could not restart Finder" &&
+    assert_output_contains "could not restart Dock" &&
+    assert_output_lacks "Finder was not running" &&
+    assert_output_lacks "macOS configured successfully"
+}
+
+test_missing_pgrep_warns_about_restarting() {
+    run_macos_without pgrep --ignore-errors
+    assert_status 0 &&
+    assert_output_contains "killall/pgrep not found"
+}
+
+# --- the local hook and the closing summary ---
+
+test_sources_local_hook() {
+    cat > "$TEST_TMPDIR/bin/setup-macos.local" <<'MOCK'
+#!/bin/sh
+echo "local hook ran"
+MOCK
+    chmod +x "$TEST_TMPDIR/bin/setup-macos.local"
+    run_macos
+    assert_status 0 &&
+    assert_output_contains "Sourcing setup-macos.local" &&
+    assert_output_contains "local hook ran"
+}
+
+# The hook is machine-specific configuration like any other step, so its
+# failure has to count. It can't go through try -- sourcing inside a function
+# would hand the hook try's positional parameters -- so this checks the
+# separate path reports identically.
+test_failing_local_hook_is_counted() {
+    cat > "$TEST_TMPDIR/bin/setup-macos.local" <<'MOCK'
+#!/bin/sh
+echo "local hook ran"
+return 3
+MOCK
+    chmod +x "$TEST_TMPDIR/bin/setup-macos.local"
+    run_macos --ignore-errors
+    assert_status 0 &&
+    assert_output_contains "failed (exit 3): setup-macos.local" &&
+    assert_output_lacks "macOS configured successfully"
+}
+
+test_failing_local_hook_aborts_without_ignore_errors() {
+    cat > "$TEST_TMPDIR/bin/setup-macos.local" <<'MOCK'
+#!/bin/sh
+return 3
+MOCK
+    chmod +x "$TEST_TMPDIR/bin/setup-macos.local"
+    run_macos
+    assert_status 1 &&
+    assert_output_contains "failed (exit 3): setup-macos.local"
+}
+
+# The hook must still see the script's own (empty) positional parameters, not
+# the arguments of whatever helper sourced it.
+test_local_hook_sees_no_positional_parameters() {
+    cat > "$TEST_TMPDIR/bin/setup-macos.local" <<'MOCK'
+#!/bin/sh
+echo "hook argc=$#"
+MOCK
+    chmod +x "$TEST_TMPDIR/bin/setup-macos.local"
+    run_macos
+    assert_status 0 &&
+    assert_output_contains "hook argc=0"
+}
+
+# Announcing the removal and then not checking it left the obsolete Quick
+# Action in place while the run reported success.
+test_failed_stale_workflow_removal_is_reported() {
+    run_macos
+    assert_status 0 || return 1
+    isolate_script
+    add_sibling_launcher browser1
+    cat > "$TEST_TMPDIR/bin/rm" <<MOCK
+#!/bin/sh
+printf "%s\\n" "rm \$*" >> "$CALLS"
+echo "rm: cannot remove" >&2
+exit 1
+MOCK
+    chmod +x "$TEST_TMPDIR/bin/rm"
+    run_macos --ignore-errors
+    assert_status 0 &&
+    assert_output_contains "failed (exit 1): rm -rf" &&
+    assert_output_lacks "macOS configured successfully"
+}
+
+test_reports_success_when_nothing_warned() {
+    run_macos
+    assert_status 0 &&
+    assert_output_contains "macOS configured successfully"
+}
+
+# Regression: with --ignore-errors the run used to print "configured
+# successfully" over a screenful of warnings.
+test_reports_problems_instead_of_success() {
+    isolate_script
+    run_macos --ignore-errors
+    assert_status 0 &&
+    assert_output_lacks "macOS configured successfully" &&
+    assert_output_contains "problem(s); see the warnings above"
+}
+
 # --- Test runner ---
 
 run_test "--help exits 0 and prints usage" test_help_flag
@@ -653,8 +893,6 @@ run_test "--help works without the macOS tools" test_help_works_without_macos_to
 run_test "enables the Dvorak layout" test_enables_dvorak
 run_test "doesn't stack a second Dvorak entry on a re-run" \
     test_does_not_re_add_dvorak
-run_test "a Dvorak variant is not mistaken for standard Dvorak" \
-    test_dvorak_variant_is_not_standard_dvorak
 run_test "selects Dvorak, not just enables it" test_selects_dvorak_input_source
 run_test "says the layout needs a logout" test_says_layout_needs_logout
 run_test "disables the text substitutions" test_disables_text_substitutions
@@ -682,6 +920,8 @@ run_test "pins the Spaces order so the numbered shortcuts hold" \
     test_pins_the_spaces_order
 run_test "enables focus follows mouse" test_enables_focus_follows_mouse
 run_test "a missing amethyst config warns, not fatal" test_missing_amethyst_config
+run_test "says Amethyst needs Accessibility access" \
+    test_mentions_accessibility_permission
 run_test "creates a Quick Action per launcher" test_creates_launcher_workflows
 run_test "substitutes the workflow name without sed" \
     test_workflow_name_is_substituted
@@ -703,6 +943,37 @@ run_test "flushes the Services registry so the shortcuts work" \
 run_test "missing pbs falls back to the logout advice" \
     test_missing_pbs_warns_about_logout
 run_test "configures Finder and restarts it" test_configures_finder
+run_test "an app that isn't running is reported, not swallowed" \
+    test_app_not_running_is_not_a_warning
+run_test "a failed restart is reported, not relabeled" \
+    test_failed_restart_is_reported
+run_test "missing pgrep warns about restarting by hand" \
+    test_missing_pgrep_warns_about_restarting
+run_test "a pgrep failure is not read as 'not running'" \
+    test_pgrep_failure_is_not_read_as_not_running
+run_test "a Dvorak variant is not mistaken for standard Dvorak" \
+    test_dvorak_variant_is_not_standard_dvorak
+run_test "an unwritable file is reported, not skipped" \
+    test_unwritable_file_is_reported
+run_test "a failed move cleans up its temporary file" \
+    test_failed_move_cleans_up_its_temporary_file
+run_test "a failed write is counted under --ignore-errors" \
+    test_failed_write_counts_under_ignore_errors
+run_test "a failed write aborts without --ignore-errors" \
+    test_failed_write_aborts_without_ignore_errors
+run_test "sources setup-macos.local when present" test_sources_local_hook
+run_test "a failing local hook is counted" \
+    test_failing_local_hook_is_counted
+run_test "a failing local hook aborts without --ignore-errors" \
+    test_failing_local_hook_aborts_without_ignore_errors
+run_test "the local hook sees no positional parameters" \
+    test_local_hook_sees_no_positional_parameters
+run_test "a failed stale-workflow removal is reported" \
+    test_failed_stale_workflow_removal_is_reported
+run_test "reports success when nothing warned" \
+    test_reports_success_when_nothing_warned
+run_test "reports the problem count instead of success" \
+    test_reports_problems_instead_of_success
 
 echo
 echo "$TESTS_RUN tests, $TESTS_PASSED passed, $TESTS_FAILED failed"


### PR DESCRIPTION
A review of `setup-macos` for correctness and coverage, and the fixes it
turned up. It was the only script in the repo with no test file — and it
could not have had one, so that's where this starts.

Four commits, each with its tests, each individually green (21 / 29 / 38 / 54)
so the series bisects. `make test` passes; the new suite is 54 tests, runs on
Linux CI the way `setup-kde_test` does (mocked `defaults`, `hidutil`,
`launchctl`, `killall`, `pgrep`, `pbs`, `activateSettings`), and passes under
both dash and bash.

### What was wrong

**The launch shortcuts never worked.** Writing the `.workflow` bundles and
the `pbs NSServicesStatus` key equivalents isn't enough — the Services
registry is a cache, and until `pbs` re-reads it the Quick Actions aren't
registered, so Option+G and friends fell through to the focused window. The
symbolic hotkeys already had their equivalent step (`activateSettings`); the
services had none.

**The workflows pointed at a guessed path.** The command was hard-coded to
`$HOME/scripts/NAME`, so a checkout kept anywhere else produced Quick
Actions running nothing, and no launcher's existence was checked. Each is
now resolved on PATH and then beside the script — the same two-step
`setup-kde`'s `add_app_shortcut` does, for the same reason — and a missing
one is skipped rather than getting a key bound to it.

**The numbered desktop shortcuts fought the Dock.** "Automatically rearrange
Spaces based on most recent use" is on by default, so the Spaces behind
Option+1..9 reorder as you use them. Pinned now.

**Re-running stacked up input sources.** `AppleEnabledInputSources` was
written with `-array-add`, which appends unconditionally, so every re-run
added another identical Dvorak entry. `AppleSelectedInputSources` — the key
that actually picks the layout — wasn't written at all, so a machine with
another layout enabled came up on that one.

**Two copies of the hidutil mapping**, one live and one in the LaunchAgent
plist, with nothing keeping them in step. The agent was also written but
never loaded, so a plist this script got wrong would surface at the next
boot rather than while it was still running.

**`sed -i ''`** is BSD-only; under any GNU sed the workflow-name
substitution aborted the run and left the placeholder in the plist. The
value is known where the heredoc is written, so it's expanded there.

**A hard-coded `activateSettings` path** meant a run without it died with
status 127 partway through instead of finishing and reporting what was left.

**`killall Finder 2>/dev/null || true`** discarded every failure to tolerate
the one expected non-zero status. And the run ended with "macOS configured
successfully" unconditionally — including, under `--ignore-errors`, over a
screenful of warnings.

### From Codex review

Ten comments over four rounds, all valid, all fixed and folded into the
commits they belong to rather than tacked on. Rounds two through four were
each reviewing the previous round's fixes, and each found a real defect in
them.

**Round one, on the original work:**

- **The test harness could have damaged the developer's Mac.** The sandbox
  PATH still included `/usr/bin`, so `run_macos_without` didn't actually
  remove a command — and `make test` on macOS would have reached the real
  `hidutil` and `launchctl` and remapped the keyboard. PATH is now built
  only from the mock bin plus a `sysbin` of symlinks to the handful of
  ordinary utilities the script uses.
- **Launcher paths are shell-quoted and XML-escaped** before being embedded
  as the workflow's `COMMAND_STRING` — a checkout under a path with a space
  was split into two words, and an `&` made the plist invalid.
- **A skipped launcher's stale `.workflow` is removed.** Left behind, it
  kept the shortcut working and running the launcher's old path. (Its
  `NSServicesStatus` key is deliberately left: there's no way to delete one
  key from a nested dict, and replacing the dict would drop other apps'
  services — with the bundle gone the entry names a service that no longer
  exists, so it binds nothing.)
- **`killall` failures are no longer relabeled "wasn't running."**

**Round two:**

- **Failed writes are counted under `--ignore-errors`.** That flag turns
  `set -e` off, which is precisely when a bare `defaults write` failure went
  nowhere — so the summary commit was blind in the only mode it was
  reachable from. State-changing steps go through a `try` helper that warns
  and counts under `--ignore-errors`, and aborts *by name* rather than as a
  silent `set -e` death without it.
- **The Dvorak check matches the layout ID, not the name.** All four
  built-in variants contain "Dvorak", so a machine with only
  `Dvorak - Qwerty ⌘` looked already-configured — and the run then selected
  a source it had left out of the enabled list.
- **`pgrep`'s exit status is taken apart.** Round one replaced a careless
  read of `killall`'s status with a `pgrep` probe, then read *that* status
  just as carelessly: 2 (syntax error) and 3 (fatal) were treated as 1 (no
  match), so a broken probe silently skipped the restart.

**Round three:**

- **Three of the `try` call sites couldn't report anything.** `try cat >
  "$file"` doesn't work — the shell opens the target *before* invoking
  `try`, so an unopenable target skips the helper entirely. Verified in both
  dash and bash. The write now happens inside a `write_file` helper, via a
  temporary file moved into place so a part-way failure leaves the previous
  plist rather than a truncated one. That turned up a further problem: `mv
  file dir` moves the file *into* the directory instead of failing, so a
  destination that was somehow a directory would have had the plist quietly
  filed one level down and reported as written — checked explicitly now.

**Round four:**

- **The `setup-macos.local` hook and the stale-workflow `rm` were outside
  the contract**, so a failing hook or a failed removal left the run
  claiming success. The removal matters most: the line above it announces
  the Quick Action is gone, so an unchecked failure meant saying so while it
  was still on disk. The hook can't go through `try` — sourcing inside a
  function hands it that function's positional parameters (`$1 = "."`) — so
  the reporting is split into a `report_failure` helper both paths call.
  Capturing the hook's status portably needed care too: `.` is a special
  builtin, so under `set -e` dash exits at a hook returning non-zero even
  inside a `||` list, where bash carries on.

### Verified correct, left alone

The modifier rotation's usage codes (E0/E2/E3 and E4/E6/E7), the symbolic
hotkey IDs (64, 65, 118–126), the Option modifier flag 524288, and the
non-sequential number-row virtual keycodes (`1=18 … 5=23 6=22 … 9=25`) all
check out. There are now tests pinning each.

### One thing deliberately not changed

`hidutil property --set` with no `--matching` applies to every attached
keyboard, including a laptop's built-in one, whose keys are already in the
Mac order this rotation undoes. Restricting it needs a specific keyboard's
vendor/product ID, which this script can't know, so it's documented in the
header rather than guessed at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QgM8WUGJS4GKY6orK5DsvP