### PR TITLE
setup-kde: build Krohnkite in a private temporary directory

### DIFF
--- a/setup-kde
+++ b/setup-kde
@@ -64,7 +64,19 @@ KROHNKITE_REPO="${KROHNKITE_REPO:-$KROHNKITE_DEFAULT_REPO}"
 if test -z "${KROHNKITE_BRANCH:-}" && test "$KROHNKITE_REPO" = "$KROHNKITE_DEFAULT_REPO"; then
     KROHNKITE_BRANCH=mikel
 fi
-KROHNKITE_DIR="${TMPDIR:-/tmp}/krohnkite-$$"
+# Scratch checkout for the source-build fallback, created by
+# install_krohnkite_from_source when that path is actually reached. Empty until
+# then: a config-only run never builds anything, so it has no reason to leave a
+# directory behind.
+#
+# It's created with mktemp -d rather than named from the PID. This path gets a
+# git clone, a build, and then a kpackagetool6 install of whatever ends up in
+# it, so on a shared /tmp a guessable name is one a symlink can be planted at
+# ahead of time -- the build would then run in someone else's directory and the
+# installed KWin script would come from there, with the cleanup below removing
+# only the link. A stale directory left by a killed run with a recycled PID
+# would collide the same way.
+KROHNKITE_DIR=""
 
 # Directory containing this script, resolved up front while $0 still means
 # what the caller typed: install_krohnkite cds into the Krohnkite checkout,
@@ -204,9 +216,11 @@ if test "$LIVE_SHORTCUTS_MODE" = on; then
 fi
 
 cleanup() {
-    rm -rf "$KROHNKITE_DIR"
-    # An if, not a &&: a false test as the last command would make the EXIT
-    # trap return non-zero.
+    # Ifs, not &&: a false test as the trap's last command would make the EXIT
+    # trap return non-zero. Both paths are empty unless their step ran.
+    if test -n "$KROHNKITE_DIR"; then
+        rm -rf "$KROHNKITE_DIR"
+    fi
     if test -n "$LIVE_SHORTCUTS"; then
         rm -f "$LIVE_SHORTCUTS"
     fi
@@ -307,6 +321,14 @@ SHIM
 install_krohnkite_from_source() {
     command -v git >/dev/null 2>&1 \
         || error "git is required to build Krohnkite from source (the prebuilt release could not be fetched)"
+
+    # Fail rather than fall back to a predictable path: everything below runs
+    # in this directory and the result gets installed, so there's no safe
+    # substitute for one only this run can name. git clone is happy with the
+    # empty directory mktemp leaves.
+    KROHNKITE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/krohnkite-XXXXXX")" \
+        || error "could not create a temporary directory to build Krohnkite in"
+
     if test -n "${KROHNKITE_BRANCH:-}"; then
         info "Cloning Krohnkite from $KROHNKITE_REPO ($KROHNKITE_BRANCH)"
         git clone --depth 1 --branch "$KROHNKITE_BRANCH" "$KROHNKITE_REPO" "$KROHNKITE_DIR"

--- a/setup-kde_test
+++ b/setup-kde_test
@@ -544,6 +544,48 @@ test_source_build_uses_local_tsc_not_remote_npm() {
     assert_not_called "npm"
 }
 
+# The build directory is named by mktemp, not from the PID. Everything the
+# source build does happens in it and the result is installed from it, so a
+# guessable name on a shared /tmp is one a symlink can be planted at in advance
+# -- the build would run in someone else's directory, the installed KWin script
+# would come from there, and the cleanup would remove only the link. Observed
+# through the clone target the mock git records.
+test_source_build_dir_is_unpredictable() {
+    add_source_build_mocks
+    TMPDIR="$TEST_TMPDIR"; export TMPDIR
+    run_kde
+    unset TMPDIR
+    clone_dir="$(sed -n 's/^git clone .* \([^ ]*\)$/\1/p' "$CALLS" | head -1)"
+    assert_status 0 &&
+    case "$clone_dir" in
+        */krohnkite-$$) echo "  FAIL: build directory is named from the PID"
+            TEST_FAILED=1; return 1 ;;
+        */krohnkite-??????) ;;
+        *) echo "  FAIL: unexpected build directory '$clone_dir'"
+            TEST_FAILED=1; return 1 ;;
+    esac
+}
+
+# A config-only run builds nothing, so it has no reason to create a scratch
+# directory at all. Uses a logging passthrough for mktemp, since the absence of
+# a directory that would be cleaned up anyway isn't otherwise observable.
+test_config_only_run_creates_no_build_dir() {
+    cat > "$TEST_TMPDIR/bin/mktemp" <<MOCK
+#!/bin/sh
+printf "%s\\n" "mktemp \$*" >> "$CALLS"
+exec /usr/bin/mktemp "\$@"
+MOCK
+    chmod +x "$TEST_TMPDIR/bin/mktemp"
+    TMPDIR="$TEST_TMPDIR"; export TMPDIR
+    run_kde --no-install
+    unset TMPDIR
+    assert_status 0 &&
+    assert_output_contains "KDE configured successfully" &&
+    assert_not_called "mktemp" &&
+    # And nothing was left behind under TMPDIR either.
+    ! ls "$TEST_TMPDIR" | grep -q '^krohnkite-'
+}
+
 # Missing tsc is a prerequisite *warning*, not an error: a checkout that
 # ships a prebuilt .kwinscript installs without any compiler, so the
 # install must still succeed. Skipped when the host itself has tsc on the
@@ -1184,6 +1226,10 @@ run_test "prebuilt package installs without npm (fallback)" \
     test_prebuilt_package_installs_without_npm
 run_test "source build uses local tsc, never remote npm (fallback)" \
     test_source_build_uses_local_tsc_not_remote_npm
+run_test "the source-build directory name is unpredictable (fallback)" \
+    test_source_build_dir_is_unpredictable
+run_test "a config-only run creates no build directory" \
+    test_config_only_run_creates_no_build_dir
 run_test "missing tsc warns up front but prebuilt still installs (fallback)" \
     test_missing_tsc_warns_but_prebuilt_still_installs
 run_test "source build without tsc errors instead of remote npm (fallback)" \


### PR DESCRIPTION
The Krohnkite source-build fallback cloned into `${TMPDIR:-/tmp}/krohnkite-$$`, a name anyone on the machine can predict.

## Why it matters

Everything the build does happens in that directory, and `kpackagetool6` then installs whatever ends up there. On a shared `/tmp` that makes a guessable name one a symlink can be planted at ahead of time: the clone and build run in someone else's directory, the installed KWin script comes from it, and the cleanup removes only the link rather than the contents. A stale directory left by a run killed before its trap, with a recycled PID, collides the same way.

Same class as the shortcut-batch finding Codex raised on #168. That one was fixed there; this was pre-existing and I said so at the time rather than widening that PR.

## The change

`mktemp -d`, created in `install_krohnkite_from_source` rather than at startup — a config-only run builds nothing and has no reason to leave a directory behind. Failing to create it is an error rather than a fall back to a predictable path: there's no safe substitute for a name only this run knows. `git clone` is happy with the empty directory `mktemp` leaves.

The cleanup trap guards both scratch paths with an `if`, since either can be empty when its step didn't run, and a false `test` as the trap's last command would change the exit status.

## Testing

`make test` — all suites green. `setup-kde_test` 49 → 51.

Being precise about what the two tests are worth:

- **The clone target is `krohnkite-??????`, not PID-derived.** Observed through the target the mock `git` records. This fails against `main` and passes here — it's the regression test.
- **A config-only run calls `mktemp` not at all**, via a logging passthrough, and leaves nothing under `TMPDIR`. This passes on `main` too, since nothing created the directory there either. It's a guard against a future change making the allocation eager, not a regression test.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E589dPgYRz7UxHsuS3FWqb)_