### PR TITLE
setup-macos: install Amethyst, online or from a staged bundle

### DIFF
--- a/setup-macos
+++ b/setup-macos
@@ -6,8 +6,9 @@
 # - Rotate Control, Command and Option (for Linux-like Ctrl shortcuts)
 # - Spotlight and Switch to Desktop 1-9 on Option key (physical Win/Super)
 # - Disables auto-correct, auto-capitalize, smart quotes/dashes
-# - Focus follows mouse for Amethyst (its layouts, modifiers and margins come
-#   from ~/.amethyst.yml, which confinst symlinks out of the conf repo)
+# - Amethyst tiling window manager: installs it (Homebrew, or a staged bundle
+#   offline), then sets focus follows mouse. Its layouts, modifiers and margins
+#   come from ~/.amethyst.yml, which confinst symlinks out of the conf repo.
 # - Application launch shortcuts via Automator Quick Actions (browser, terminal,
 #   music)
 # - Finder preferences (show hidden files, path bar, file extensions)
@@ -32,7 +33,10 @@
 # Requires: defaults, hidutil (i.e. macOS). Both are checked up front, so
 #           running this anywhere else says so instead of failing several
 #           steps in with "defaults: not found".
-# Wants: activateSettings, to apply the shortcut changes without a logout;
+# Wants: brew, to install Amethyst (a bundle staged at $AMETHYST_BUNDLE,
+#        ./amethyst.zip or ~/amethyst.zip is the offline path, and unzip and
+#        xattr unpack it); activateSettings, to apply the shortcut changes
+#        without a logout;
 #        launchctl, to load the key-remapping agent now rather than at the
 #        next login; pbs, to register the Quick Actions; killall and pgrep, to
 #        restart Finder and the Dock. Without any of them the settings are
@@ -41,15 +45,20 @@
 # Usage:
 #     setup-macos [--no-install] [--no-sudo] [--ignore-errors] [-h | --help]
 #
-# setup forwards --no-install, --no-sudo, and --ignore-errors here. macOS
-# configuration installs no separate software (everything is
-# `defaults`/Automator config) and uses no sudo, so --no-install and --no-sudo
-# are accepted but have nothing to skip. --ignore-errors keeps going past
-# failures instead of aborting on the first one.
+# setup forwards --no-install, --no-sudo, and --ignore-errors here.
+# --no-install skips installing Amethyst and configures whatever is already
+# there. macOS configuration uses no sudo, so --no-sudo is accepted but has
+# nothing to skip. --ignore-errors keeps going past failures instead of
+# aborting on the first one.
 
 # Whether to keep going past failures. "no" aborts on the first error via
 # set -e; "yes" (via --ignore-errors) leaves it off and pushes through.
 IGNORE_ERRORS=no
+
+# Whether to install Amethyst. --no-install skips it and configures whatever is
+# already there, matching setup-kde, which installs its own tiling window
+# manager (Krohnkite) under the same flag.
+INSTALL=yes
 
 # Directory containing this script, resolved up front while $0 still means what
 # the caller typed. The launcher helpers the Quick Actions run live beside this
@@ -66,6 +75,11 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # equivalents are picked up.
 ACTIVATE_SETTINGS="${ACTIVATE_SETTINGS:-/System/Library/PrivateFrameworks/SystemAdministration.framework/Resources/activateSettings}"
 PBS="${PBS:-/System/Library/CoreServices/pbs}"
+
+# Where applications live. Overridable for the same reason as the helpers
+# above: the tests can't write to the real /Applications.
+APPLICATIONS_DIR="${APPLICATIONS_DIR:-/Applications}"
+USER_APPLICATIONS_DIR="${USER_APPLICATIONS_DIR:-$HOME/Applications}"
 
 # Count of steps that warned, so the closing message can say the run was
 # incomplete instead of claiming success over a screenful of warnings. Only
@@ -197,8 +211,8 @@ Usage: setup-macos [--no-install] [--no-sudo] [--ignore-errors] [-h | --help]
 Configure the macOS desktop environment.
 
 Options:
-  --no-install     Accepted for consistency with setup; macOS configuration
-                   installs no separate software, so there's nothing to skip
+  --no-install     Don't install Amethyst; configure whatever is already
+                   there
   --no-sudo        Accepted for consistency with setup; macOS configuration
                    uses no sudo, so there's nothing to skip
   --ignore-errors  Keep going past failures instead of aborting on the first
@@ -210,9 +224,18 @@ USAGE
 
 while test $# -gt 0; do
     case "$1" in
-        --install|--no-install|--sudo|--no-sudo)
-            # No separate install step and no sudo on macOS; accepted as a
-            # no-op so setup can forward these flags uniformly.
+        --install)
+            INSTALL=yes
+            ;;
+        --no-install)
+            INSTALL=no
+            ;;
+        --sudo|--no-sudo)
+            # macOS configuration uses no sudo; accepted as a no-op so setup
+            # can forward these flags uniformly. Installing Amethyst needs
+            # write access to an Applications directory, not sudo: a staged
+            # bundle falls back to ~/Applications when /Applications isn't
+            # writable, and Homebrew never wants sudo.
             ;;
         --ignore-errors)
             IGNORE_ERRORS=yes
@@ -440,8 +463,184 @@ configure_spaces() {
 
 # --- Configure Amethyst tiling window manager ---
 
+# Where Amethyst is, or empty if it isn't installed. Both locations count:
+# Homebrew casks land in /Applications, and a staged bundle falls back to
+# ~/Applications when /Applications isn't writable.
+# Whether DIR is a usable .app rather than a directory with the right name: a
+# half-extracted or half-copied bundle has neither its Info.plist nor the
+# Contents/MacOS the executable lives in, and calling that "installed" is how a
+# failed install becomes a permanent one.
+#
+# One function because there are two callers -- what counts as installed, and
+# what is allowed to be published -- and they have already drifted apart once,
+# which let a bundle be published that the next run then treated as missing.
+#
+# Contents/MacOS as a directory, not Contents/MacOS/Amethyst: the executable's
+# name comes from CFBundleExecutable and isn't ours to assume. Guessing it
+# wrong would make a perfectly good install look unusable, and the publish path
+# deletes what it judges unusable.
+is_usable_app() {
+    test -f "$1/Contents/Info.plist" && test -d "$1/Contents/MacOS"
+}
+
+amethyst_path() {
+    for _dir in "$APPLICATIONS_DIR" "$USER_APPLICATIONS_DIR"; do
+        if is_usable_app "$_dir/Amethyst.app"; then
+            printf '%s' "$_dir/Amethyst.app"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Unpack a staged Amethyst zip, the offline path. Mirrors setup-kde's staged
+# Krohnkite bundle: same three places, same reason -- a machine with no network
+# still has to come up configured.
+#
+# `brew fetch --cask amethyst` produces exactly this file on a connected
+# machine, so staging one is a copy rather than a build.
+install_amethyst_from_bundle() {
+    _bundle=""
+    for _cand in "${AMETHYST_BUNDLE:-}" \
+            "$SCRIPT_DIR/amethyst.zip" \
+            "$HOME/amethyst.zip"; do
+        if test -n "$_cand" && test -f "$_cand"; then
+            _bundle="$_cand"
+            break
+        fi
+    done
+    if test -z "$_bundle"; then
+        warn "no Amethyst bundle staged (fetch one on a connected machine with 'brew fetch --cask amethyst' and copy it to $SCRIPT_DIR/amethyst.zip); the tiling settings below will have no effect until Amethyst is installed"
+        return 0
+    fi
+    if ! is_command unzip; then
+        warn "unzip not found; cannot unpack $_bundle"
+        return 0
+    fi
+
+    # /Applications needs admin rights this script doesn't ask for, so fall
+    # back to ~/Applications, which Amethyst runs from just as well.
+    _dest="$APPLICATIONS_DIR"
+    if ! test -w "$_dest"; then
+        _dest="$USER_APPLICATIONS_DIR"
+        info "$APPLICATIONS_DIR is not writable; installing Amethyst to $_dest"
+        try mkdir -p "$_dest"
+    fi
+
+    info "Installing Amethyst from bundle: $_bundle"
+
+    # Extracted beside the destination and moved into place only once it's
+    # whole. unzip writes as it goes, so extracting straight into $_dest would
+    # leave a partial Amethyst.app behind on a truncated archive or a full
+    # disk -- and amethyst_path would then read that as installed and skip
+    # both install paths on every later run, so a transient failure would
+    # stick permanently. Same reason write_file stages its plists.
+    #
+    # Staging inside $_dest keeps the move a rename within one filesystem
+    # rather than a second copy that can fail halfway itself.
+    _staging="$_dest/.amethyst-install.$$"
+    # Checked, unlike the cleanups below: those run after a failure that's
+    # already being reported, but this one guards what gets published. A
+    # leftover staging directory from a crashed run with this PID would be
+    # extracted over rather than replaced, and the stale files would ship.
+    if ! rm -rf "$_staging"; then
+        warn "could not clear $_staging"
+        return 0
+    fi
+    if ! mkdir -p "$_staging"; then
+        warn "could not create $_staging"
+        return 0
+    fi
+    if ! unzip -oq "$_bundle" -d "$_staging"; then
+        # The cleanup's own status is deliberately not reported here or in the
+        # paths below: the failure being cleaned up after is already going to
+        # warn, and a second warning about the tidy-up would bury it.
+        rm -rf "$_staging"
+        warn "could not unpack $_bundle"
+        return 0
+    fi
+    # The same invariant amethyst_path applies, via the same function, so the
+    # two can't disagree about what counts as an app.
+    if ! is_usable_app "$_staging/Amethyst.app"; then
+        rm -rf "$_staging"
+        warn "$_bundle did not contain a usable Amethyst.app"
+        return 0
+    fi
+
+    # Gatekeeper refuses to launch anything carrying com.apple.quarantine, and
+    # a hand-unpacked zip always does. Clearing it here means this path does
+    # NOT get the signature check `brew install --cask` performs -- it trusts
+    # the bundle because a person deliberately staged it. Prefer the brew path
+    # where there's a network.
+    #
+    # Done in staging, so what lands in $_dest is already launchable.
+    if is_command xattr; then
+        xattr -d -r com.apple.quarantine "$_staging/Amethyst.app" 2>/dev/null
+        # xattr exits non-zero both when the attribute was already absent and
+        # when it couldn't be removed, so its status can't tell those apart --
+        # the same trap as reading killall's. Ask what is actually true
+        # instead, and don't publish an app Gatekeeper will refuse.
+        if xattr -r -p com.apple.quarantine "$_staging/Amethyst.app" >/dev/null 2>&1; then
+            rm -rf "$_staging"
+            warn "could not clear the quarantine attribute on $_bundle; macOS would refuse to launch it, so it was not installed"
+            return 0
+        fi
+    else
+        warn "xattr not found; if macOS refuses to open Amethyst, clear its quarantine attribute by hand"
+    fi
+
+    # An unusable Amethyst.app can be sitting in the destination: amethyst_path
+    # treats one with no Info.plist as not installed, which is how this got
+    # here. `mv src dir` moves the source *inside* an existing directory and
+    # returns 0 -- the trap write_file already guards against -- which would
+    # bury the staged copy at Amethyst.app/Amethyst.app, leave the broken outer
+    # bundle in place, and report success.
+    if test -e "$_dest/Amethyst.app"; then
+        info "Replacing the unusable $_dest/Amethyst.app"
+        if ! rm -rf "$_dest/Amethyst.app"; then
+            rm -rf "$_staging"
+            warn "could not remove the unusable $_dest/Amethyst.app"
+            return 0
+        fi
+    fi
+
+    if ! mv "$_staging/Amethyst.app" "$_dest/Amethyst.app"; then
+        rm -rf "$_staging"
+        warn "could not move Amethyst.app into $_dest"
+        return 0
+    fi
+    rm -rf "$_staging"
+}
+
+install_amethyst() {
+    if _installed=$(amethyst_path); then
+        info "Amethyst is already installed at $_installed"
+        return 0
+    fi
+    if test "$INSTALL" = no; then
+        warn "Amethyst is not installed and --no-install was given; the tiling settings below will have no effect until it is"
+        return 0
+    fi
+
+    if is_command brew; then
+        info "Installing Amethyst"
+        if brew install --cask amethyst; then
+            return 0
+        fi
+        warn "could not install Amethyst via Homebrew; trying a staged bundle"
+    else
+        info "Homebrew not found; looking for a staged Amethyst bundle"
+    fi
+    install_amethyst_from_bundle
+}
+
 configure_amethyst() {
     info "Configuring Amethyst"
+
+    # Configuring an application that isn't there writes preferences nothing
+    # will ever read: `defaults` creates the domain regardless, so without this
+    # the run reported success over a machine with no tiling at all.
+    install_amethyst
 
     # Amethyst config lives in ~/conf/amethyst.yml and is symlinked
     # to ~/.amethyst.yml by confinst. Nothing to do here.

--- a/setup-macos_test
+++ b/setup-macos_test
@@ -13,6 +13,17 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# The harness builds a real zip to exercise the offline install path. Say so
+# plainly if the tools aren't there -- otherwise the bundle tests fail looking
+# like a fault in setup-macos.
+for _tool in zip unzip; do
+    command -v "$_tool" >/dev/null 2>&1 || {
+        echo "setup-macos_test needs $_tool to build a staged bundle fixture" >&2
+        exit 1
+    }
+done
+
 TESTS_RUN=0
 TESTS_PASSED=0
 TESTS_FAILED=0
@@ -47,13 +58,26 @@ MOCK
 
     # pgrep exits 0 by default, i.e. the app is running and restart_app should
     # go on to killall it.
-    for cmd in hidutil launchctl killall pgrep; do
+    for cmd in hidutil launchctl killall pgrep brew; do
         cat > "$TEST_TMPDIR/bin/$cmd" <<MOCK
 #!/bin/sh
 printf "%s\\n" "$cmd \$*" >> "$CALLS"
 exit 0
 MOCK
     done
+
+    # xattr is asked two different questions: -d removes the quarantine
+    # attribute, -p reports whether anything still carries it. The default
+    # models a clean removal -- -d succeeds, and the follow-up -p finds
+    # nothing, which is a non-zero status from the real xattr.
+    cat > "$TEST_TMPDIR/bin/xattr" <<MOCK
+#!/bin/sh
+printf "%s\\n" "xattr \$*" >> "$CALLS"
+case "\$*" in
+    *-p*) exit 1 ;;
+esac
+exit 0
+MOCK
 
     # The absolute-path helpers.
     for cmd in activateSettings pbs; do
@@ -76,9 +100,20 @@ MOCK
     # reached the real hidutil and launchctl would remap the developer's
     # keyboard and load a LaunchAgent while they ran `make test`.
     mkdir -p "$TEST_TMPDIR/sysbin"
-    for cmd in cat dirname grep id mkdir mv rm sed; do
+    for cmd in cat dirname grep id mkdir mv rm sed unzip; do
         ln -sf "$(command -v "$cmd")" "$TEST_TMPDIR/sysbin/$cmd"
     done
+
+    # Amethyst lives in a sandboxed Applications directory; the real
+    # /Applications isn't writable by the tests and mustn't be touched.
+    APPLICATIONS_DIR="$TEST_TMPDIR/Applications"
+    USER_APPLICATIONS_DIR="$TEST_TMPDIR/home/Applications"
+    mkdir -p "$APPLICATIONS_DIR"
+    # Installed by default, so the ordinary run has nothing to install.
+    # Contents/Info.plist because that is what counts as installed: a bare
+    # directory is what a half-finished extraction leaves behind.
+    mkdir -p "$APPLICATIONS_DIR/Amethyst.app/Contents/MacOS"
+    printf 'app\n' > "$APPLICATIONS_DIR/Amethyst.app/Contents/Info.plist"
 
     # confinst normally symlinks this out of the conf repo. Present by default
     # so the ordinary run has nothing to warn about;
@@ -145,6 +180,23 @@ stage_defaults_read() {
     printf "%s\n" "$1" > "$TEST_TMPDIR/defaults_read"
 }
 
+# Remove the pre-installed Amethyst, i.e. pretend a fresh machine.
+remove_amethyst() {
+    rm -rf "$APPLICATIONS_DIR/Amethyst.app" "$USER_APPLICATIONS_DIR/Amethyst.app"
+}
+
+# Stage an Amethyst bundle at PATH containing a real Amethyst.app, so the
+# offline path has something to unpack.
+stage_amethyst_bundle() {
+    _staging="$TEST_TMPDIR/staging"
+    rm -rf "$_staging"
+    mkdir -p "$_staging/Amethyst.app/Contents/MacOS"
+    printf 'app\n' > "$_staging/Amethyst.app/Contents/Info.plist"
+    printf 'bin\n' > "$_staging/Amethyst.app/Contents/MacOS/Amethyst"
+    (cd "$_staging" && zip -qr "$1" Amethyst.app)
+    rm -rf "$_staging"
+}
+
 # Make every `defaults write` fail, to exercise what the run reports when a
 # configuration step doesn't take.
 fail_defaults_write() {
@@ -158,6 +210,9 @@ run_macos() {
     output="$(HOME="$TEST_TMPDIR/home" \
         ACTIVATE_SETTINGS="$ACTIVATE_SETTINGS" \
         PBS="$PBS" \
+        APPLICATIONS_DIR="$APPLICATIONS_DIR" \
+        USER_APPLICATIONS_DIR="$USER_APPLICATIONS_DIR" \
+        AMETHYST_BUNDLE="${AMETHYST_BUNDLE:-}" \
         PATH="$TEST_TMPDIR/bin:$TEST_TMPDIR/sysbin" \
         "$MACOS_SCRIPT" "$@" 2>&1)"
     status=$?
@@ -182,6 +237,9 @@ run_macos_without() {
     output="$(HOME="$TEST_TMPDIR/home" \
         ACTIVATE_SETTINGS="$ACTIVATE_SETTINGS" \
         PBS="$PBS" \
+        APPLICATIONS_DIR="$APPLICATIONS_DIR" \
+        USER_APPLICATIONS_DIR="$USER_APPLICATIONS_DIR" \
+        AMETHYST_BUNDLE="${AMETHYST_BUNDLE:-}" \
         PATH="$TEST_TMPDIR/reduced:$TEST_TMPDIR/sysbin" \
         "$MACOS_SCRIPT" "$@" 2>&1)"
     status=$?
@@ -241,6 +299,14 @@ assert_not_called() {
 assert_file_exists() {
     if ! test -f "$1"; then
         echo "  FAIL: expected file '$1' to exist"
+        TEST_FAILED=1
+        return 1
+    fi
+}
+
+assert_dir_not_exists() {
+    if test -d "$1"; then
+        echo "  FAIL: unexpected directory '$1' exists"
         TEST_FAILED=1
         return 1
     fi
@@ -791,6 +857,269 @@ test_missing_pgrep_warns_about_restarting() {
     assert_output_contains "killall/pgrep not found"
 }
 
+# Configuring an app that isn't installed writes preferences nothing reads:
+# `defaults` creates the domain regardless, so the run used to report success
+# over a machine with no tiling at all.
+test_installs_amethyst_when_missing() {
+    remove_amethyst
+    run_macos
+    assert_status 0 &&
+    assert_called "brew install --cask amethyst"
+}
+
+test_does_not_reinstall_amethyst_when_present() {
+    run_macos
+    assert_status 0 &&
+    assert_output_contains "Amethyst is already installed" &&
+    assert_not_called "brew install"
+}
+
+# --no-install used to be an accepted no-op. It now means what it says, and
+# says what the run won't do as a result.
+test_no_install_skips_amethyst() {
+    remove_amethyst
+    run_macos --no-install --ignore-errors
+    assert_status 0 &&
+    assert_not_called "brew install" &&
+    assert_output_contains "the tiling settings below will have no effect" &&
+    assert_output_lacks "macOS configured successfully"
+}
+
+# The offline path, mirroring setup-kde's staged Krohnkite bundle.
+test_installs_amethyst_from_staged_bundle_when_brew_fails() {
+    remove_amethyst
+    stage_amethyst_bundle "$TEST_TMPDIR/home/amethyst.zip"
+    cat > "$TEST_TMPDIR/bin/brew" <<MOCK
+#!/bin/sh
+printf "%s\\n" "brew \$*" >> "$CALLS"
+exit 1
+MOCK
+    chmod +x "$TEST_TMPDIR/bin/brew"
+    run_macos --ignore-errors
+    assert_status 0 &&
+    assert_output_contains "trying a staged bundle" &&
+    assert_output_contains "Installing Amethyst from bundle" &&
+    assert_file_exists "$APPLICATIONS_DIR/Amethyst.app/Contents/Info.plist"
+}
+
+# A staged bundle is the whole offline story, so it has to work with no brew
+# at all -- not just when brew is present and failing.
+test_installs_amethyst_from_bundle_without_brew() {
+    remove_amethyst
+    stage_amethyst_bundle "$TEST_TMPDIR/home/amethyst.zip"
+    run_macos_without brew --ignore-errors
+    assert_status 0 &&
+    assert_output_contains "Homebrew not found" &&
+    assert_file_exists "$APPLICATIONS_DIR/Amethyst.app/Contents/Info.plist"
+}
+
+# $AMETHYST_BUNDLE wins over the two default locations, matching
+# $HOMEPKG_KROHNKITE_BUNDLE.
+test_amethyst_bundle_env_var_is_honored() {
+    remove_amethyst
+    stage_amethyst_bundle "$TEST_TMPDIR/elsewhere.zip"
+    AMETHYST_BUNDLE="$TEST_TMPDIR/elsewhere.zip"
+    run_macos_without brew --ignore-errors
+    AMETHYST_BUNDLE=
+    assert_status 0 &&
+    assert_output_contains "elsewhere.zip" &&
+    assert_file_exists "$APPLICATIONS_DIR/Amethyst.app/Contents/Info.plist"
+}
+
+# Gatekeeper refuses to launch a hand-unpacked app, so the quarantine
+# attribute has to be cleared or the offline path installs something inert.
+test_staged_bundle_clears_quarantine() {
+    remove_amethyst
+    stage_amethyst_bundle "$TEST_TMPDIR/home/amethyst.zip"
+    run_macos_without brew --ignore-errors
+    assert_status 0 &&
+    assert_called "xattr -d -r com.apple.quarantine"
+}
+
+# Installing without write access to /Applications is the ordinary
+# unprivileged case; Amethyst runs from ~/Applications just as well.
+#
+# chmod is the real thing and is what runs on CI and on a developer's Mac,
+# both unprivileged. Running as root, permissions don't apply -- `test -w`
+# stays true on a mode-000 directory -- so the directory is removed instead,
+# which fails `test -w` for everyone and takes the same branch. Dropping
+# privileges to keep chmod meaningful under root needs the whole temp-dir path
+# traversable by the unprivileged user, which is more fragility than one
+# assertion is worth.
+test_staged_bundle_falls_back_to_user_applications() {
+    remove_amethyst
+    stage_amethyst_bundle "$TEST_TMPDIR/home/amethyst.zip"
+    if test "$(id -u)" -eq 0; then
+        rmdir "$APPLICATIONS_DIR"
+    else
+        chmod a-w "$APPLICATIONS_DIR"
+    fi
+    run_macos_without brew --ignore-errors
+    assert_status 0 &&
+    assert_output_contains "is not writable" &&
+    assert_file_exists "$USER_APPLICATIONS_DIR/Amethyst.app/Contents/Info.plist"
+}
+
+# Regression: unzip writes as it goes, so extracting straight into
+# /Applications left a partial Amethyst.app behind when the archive was
+# truncated or the disk filled -- and amethyst_path then read that directory as
+# installed, so every later run skipped both install paths. A transient failure
+# became a permanent one.
+test_failed_extraction_leaves_nothing_behind() {
+    remove_amethyst
+    stage_amethyst_bundle "$TEST_TMPDIR/home/amethyst.zip"
+    # Extract something and then fail, the way a truncated archive does.
+    cat > "$TEST_TMPDIR/bin/unzip" <<MOCK
+#!/bin/sh
+printf "%s\\n" "unzip \$*" >> "$CALLS"
+_prev=""
+_out=""
+for _arg in "\$@"; do
+    if test "\$_prev" = "-d"; then _out="\$_arg"; fi
+    _prev="\$_arg"
+done
+mkdir -p "\$_out/Amethyst.app/Contents"
+exit 2
+MOCK
+    chmod +x "$TEST_TMPDIR/bin/unzip"
+    run_macos_without brew --ignore-errors
+    assert_status 0 &&
+    assert_output_contains "could not unpack" &&
+    assert_dir_not_exists "$APPLICATIONS_DIR/Amethyst.app" &&
+    assert_output_lacks "macOS configured successfully" &&
+    if ls -d "$APPLICATIONS_DIR"/.amethyst-install.* >/dev/null 2>&1; then
+        echo "  FAIL: a staging directory was left behind"
+        TEST_FAILED=1
+        return 1
+    fi
+}
+
+# The other half of the same point: a directory named Amethyst.app with no app
+# in it must not count as installed, whatever left it there.
+test_partial_app_bundle_does_not_count_as_installed() {
+    remove_amethyst
+    mkdir -p "$APPLICATIONS_DIR/Amethyst.app/Contents"
+    run_macos
+    assert_status 0 &&
+    assert_called "brew install --cask amethyst" &&
+    assert_output_lacks "Amethyst is already installed"
+}
+
+# A staging directory left by a crashed run with this PID must not be
+# extracted over: unzip -o would merge the new bundle into the stale files and
+# publish the mixture. Unlike the cleanups after a failure, this one is checked.
+test_unclearable_staging_directory_aborts_the_install() {
+    remove_amethyst
+    stage_amethyst_bundle "$TEST_TMPDIR/home/amethyst.zip"
+    cat > "$TEST_TMPDIR/bin/rm" <<MOCK
+#!/bin/sh
+printf "%s\\n" "rm \$*" >> "$CALLS"
+case "\$*" in
+    *.amethyst-install.*) echo "rm: cannot remove" >&2; exit 1 ;;
+esac
+exec /bin/rm "\$@"
+MOCK
+    chmod +x "$TEST_TMPDIR/bin/rm"
+    run_macos_without brew --ignore-errors
+    assert_status 0 &&
+    assert_output_contains "could not clear" &&
+    assert_dir_not_exists "$APPLICATIONS_DIR/Amethyst.app" &&
+    assert_output_lacks "macOS configured successfully"
+}
+
+# A zip can contain a directory named Amethyst.app with nothing runnable in
+# it. Publishing that reported success over an install the next run would then
+# treat as missing -- amethyst_path applies this invariant, so the publish
+# check has to apply the same one.
+test_bundle_without_info_plist_is_rejected() {
+    remove_amethyst
+    _staging="$TEST_TMPDIR/badstaging"
+    rm -rf "$_staging"
+    mkdir -p "$_staging/Amethyst.app/Contents"
+    (cd "$_staging" && zip -qr "$TEST_TMPDIR/home/amethyst.zip" Amethyst.app)
+    rm -rf "$_staging"
+    run_macos_without brew --ignore-errors
+    assert_status 0 &&
+    assert_output_contains "did not contain a usable Amethyst.app" &&
+    assert_dir_not_exists "$APPLICATIONS_DIR/Amethyst.app" &&
+    assert_output_lacks "macOS configured successfully"
+}
+
+# `mv src dir` moves the source *into* an existing directory and returns 0, so
+# publishing over an unusable Amethyst.app used to bury the staged copy at
+# Amethyst.app/Amethyst.app and report success.
+test_unusable_destination_is_replaced_not_nested() {
+    remove_amethyst
+    mkdir -p "$APPLICATIONS_DIR/Amethyst.app/Contents"
+    stage_amethyst_bundle "$TEST_TMPDIR/home/amethyst.zip"
+    run_macos_without brew --ignore-errors
+    assert_status 0 &&
+    assert_output_contains "Replacing the unusable" &&
+    assert_file_exists "$APPLICATIONS_DIR/Amethyst.app/Contents/Info.plist" &&
+    assert_dir_not_exists "$APPLICATIONS_DIR/Amethyst.app/Amethyst.app"
+}
+
+# xattr exits non-zero both when the attribute was already absent and when it
+# couldn't be removed, so reading its status treated a real failure as the
+# benign case and published an app macOS would refuse to launch.
+test_unclearable_quarantine_is_not_published() {
+    remove_amethyst
+    stage_amethyst_bundle "$TEST_TMPDIR/home/amethyst.zip"
+    # -d fails, and -p still reports the attribute present.
+    cat > "$TEST_TMPDIR/bin/xattr" <<MOCK
+#!/bin/sh
+printf "%s\\n" "xattr \$*" >> "$CALLS"
+case "\$*" in
+    *-p*) echo "com.apple.quarantine: 0081;" ; exit 0 ;;
+esac
+echo "xattr: [Errno 1] Operation not permitted" >&2
+exit 1
+MOCK
+    chmod +x "$TEST_TMPDIR/bin/xattr"
+    run_macos_without brew --ignore-errors
+    assert_status 0 &&
+    assert_output_contains "could not clear the quarantine attribute" &&
+    assert_dir_not_exists "$APPLICATIONS_DIR/Amethyst.app" &&
+    assert_output_lacks "macOS configured successfully"
+}
+
+# An interrupted copy can leave an Info.plist with no executable directory. It
+# can't launch, so it mustn't count as installed -- otherwise every later run
+# skips both install paths.
+test_bundle_without_executable_dir_is_rejected() {
+    remove_amethyst
+    _bad="$TEST_TMPDIR/badexec"
+    rm -rf "$_bad"
+    mkdir -p "$_bad/Amethyst.app/Contents"
+    printf 'app\n' > "$_bad/Amethyst.app/Contents/Info.plist"
+    (cd "$_bad" && zip -qr "$TEST_TMPDIR/home/amethyst.zip" Amethyst.app)
+    rm -rf "$_bad"
+    run_macos_without brew --ignore-errors
+    assert_status 0 &&
+    assert_output_contains "did not contain a usable Amethyst.app" &&
+    assert_dir_not_exists "$APPLICATIONS_DIR/Amethyst.app"
+}
+
+test_installed_app_without_executable_dir_is_reinstalled() {
+    remove_amethyst
+    mkdir -p "$APPLICATIONS_DIR/Amethyst.app/Contents"
+    printf 'app\n' > "$APPLICATIONS_DIR/Amethyst.app/Contents/Info.plist"
+    run_macos
+    assert_status 0 &&
+    assert_called "brew install --cask amethyst" &&
+    assert_output_lacks "Amethyst is already installed"
+}
+
+# No network and nothing staged: say how to stage one rather than leaving the
+# user to work out why tiling never happens.
+test_no_brew_and_no_bundle_says_how_to_stage_one() {
+    remove_amethyst
+    run_macos_without brew --ignore-errors
+    assert_status 0 &&
+    assert_output_contains "brew fetch --cask amethyst" &&
+    assert_output_lacks "macOS configured successfully"
+}
+
 # --- the local hook and the closing summary ---
 
 test_sources_local_hook() {
@@ -961,6 +1290,40 @@ run_test "a failed write is counted under --ignore-errors" \
     test_failed_write_counts_under_ignore_errors
 run_test "a failed write aborts without --ignore-errors" \
     test_failed_write_aborts_without_ignore_errors
+run_test "installs Amethyst when it is missing" \
+    test_installs_amethyst_when_missing
+run_test "does not reinstall Amethyst when present" \
+    test_does_not_reinstall_amethyst_when_present
+run_test "--no-install skips installing Amethyst" \
+    test_no_install_skips_amethyst
+run_test "falls back to a staged bundle when brew fails" \
+    test_installs_amethyst_from_staged_bundle_when_brew_fails
+run_test "installs from a staged bundle with no brew at all" \
+    test_installs_amethyst_from_bundle_without_brew
+run_test "\$AMETHYST_BUNDLE overrides the default locations" \
+    test_amethyst_bundle_env_var_is_honored
+run_test "a staged bundle has its quarantine cleared" \
+    test_staged_bundle_clears_quarantine
+run_test "a staged bundle falls back to ~/Applications" \
+    test_staged_bundle_falls_back_to_user_applications
+run_test "a bundle without an executable directory is rejected" \
+    test_bundle_without_executable_dir_is_rejected
+run_test "an installed app without an executable directory is reinstalled" \
+    test_installed_app_without_executable_dir_is_reinstalled
+run_test "a bundle without Info.plist is rejected" \
+    test_bundle_without_info_plist_is_rejected
+run_test "an unusable destination is replaced, not nested" \
+    test_unusable_destination_is_replaced_not_nested
+run_test "an unclearable quarantine attribute is not published" \
+    test_unclearable_quarantine_is_not_published
+run_test "an unclearable staging directory aborts the install" \
+    test_unclearable_staging_directory_aborts_the_install
+run_test "a failed extraction leaves nothing behind" \
+    test_failed_extraction_leaves_nothing_behind
+run_test "a partial app bundle does not count as installed" \
+    test_partial_app_bundle_does_not_count_as_installed
+run_test "says how to stage a bundle when there is none" \
+    test_no_brew_and_no_bundle_says_how_to_stage_one
 run_test "sources setup-macos.local when present" test_sources_local_hook
 run_test "a failing local hook is counted" \
     test_failing_local_hook_is_counted


### PR DESCRIPTION
`configure_amethyst` wrote `com.amethyst.Amethyst` preferences without ever
checking Amethyst was installed. `defaults` creates the preference domain
either way, so on a machine without it every write succeeded, the run printed
"macOS configured successfully", and you got no tiling and no hint why.

`setup-kde` installs its own tiling window manager, so `setup-macos` now
installs its own.

### Install path

`brew install --cask amethyst`, falling back to a staged bundle, falling back
to a warning that says how to stage one. That mirrors `install_krohnkite`'s
online → bundle → fallback shape and uses the same three-place search
(`$AMETHYST_BUNDLE`, beside the script, `$HOME`), so the convention is one
thing to learn rather than two.

`brew fetch --cask amethyst` produces exactly the file to stage, so preparing
an offline install is a copy rather than a build.

Extraction is staged and published atomically: the bundle unpacks into
`$_dest/.amethyst-install.$$` and `Amethyst.app` is moved into place only once
unzip has succeeded and the archive is confirmed to contain it. `unzip` writes
as it goes, so extracting straight into `/Applications` would leave a partial
`Amethyst.app` behind on a truncated archive — and since that directory reads
as "installed", one transient failure would skip both install paths on every
later run, permanently. Staging inside the destination keeps the publish a
rename within one filesystem rather than a second copy that can fail halfway
itself.

For the same reason, "installed" means `Amethyst.app/Contents/Info.plist`
exists, not just the directory — a bundle with nothing runnable in it
shouldn't count, however it got there.

### The bundle path is less verified than the brew path

Unpacking a staged zip means clearing `com.apple.quarantine`, which Gatekeeper
would otherwise refuse to launch past. That skips the signature check
`brew install --cask` performs — it trusts the bundle only because someone
deliberately staged it. The code says so at the point it happens and points
back at the brew path where there's a network.

Worth stating plainly since it's a security-relevant trade, not an
implementation detail. `brew bundle` (Brewfile) is a manifest, not a payload,
and wouldn't have avoided this — it still downloads at install time.

Installing needs a writable Applications directory rather than sudo, so the
bundle path falls back to `~/Applications` when `/Applications` isn't
writable. Amethyst runs from there just as well.

### Flags

`--no-install` stops being an accepted no-op and now means what it says: skip
the install, configure whatever is already there, and say what won't take
effect as a result. `--no-sudo` stays a no-op, and the header now explains
why.

The Applications directories are overridable so the tests can point them
somewhere writable, in the same spirit as `$ACTIVATE_SETTINGS` and `$PBS`.

### Tests

Eleven new tests: install when missing, skip when present, `--no-install`,
bundle fallback when brew fails, bundle with no brew at all,
`$AMETHYST_BUNDLE` precedence, quarantine clearing, `~/Applications` fallback,
the how-to-stage-one message, and — from Codex review — a failed extraction
leaving nothing behind and a partial bundle not counting as installed. All
verified failing against the commit each was written for.

One needed care worth recording. The `~/Applications` fallback test first used
`chmod a-w`, which proves nothing under root — `test -w` stays true — and I
wrongly assumed CI ran as root and replaced it with a remove-the-directory
proxy. It now uses real `chmod` when unprivileged (CI and a developer's Mac)
and the proxy only under root. Verified by running the whole suite as
`nobody`, and by breaking the writability check in `setup-macos` and
confirming exactly that test fails.

Dropping privileges under root was considered and rejected: `su` consumes the
script's own flags, and an unprivileged user can't traverse the temp-dir path
without opening up the whole chain — more fragility than one assertion is
worth.

`make test` passes; the suite is 65 tests and passes under dash, bash, and as
an unprivileged user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QgM8WUGJS4GKY6orK5DsvP