### PR TITLE
setup-macos: surface the manual steps, and document the macOS setup

### DIFF
--- a/MACOS.md
+++ b/MACOS.md
@@ -1,0 +1,404 @@
+# macOS desktop setup
+
+How the KDE/Krohnkite setup in `setup-kde` is reproduced on macOS by
+`setup-macos`, what carries over, what doesn't, and why Amethyst was chosen
+over the alternatives.
+
+The window manager config itself lives in the `conf` repo as `amethyst.yml`,
+which `confinst` symlinks to `~/.amethyst.yml`. This file covers the setup
+around it.
+
+For why Amethyst rather than yabai or AeroSpace, skip to the
+[window manager evaluation](#window-manager-evaluation) at the end.
+
+## Contents
+
+- [Running it](#running-it)
+  - [Full bootstrap](#full-bootstrap)
+  - [Desktop configuration on its own](#desktop-configuration-on-its-own)
+  - [What `setup-macos` requires](#what-setup-macos-requires)
+  - [Install backends for Amethyst](#install-backends-for-amethyst)
+- [Do these by hand first](#do-these-by-hand-first)
+- [Key mapping](#key-mapping)
+  - [Modifier rotation](#modifier-rotation)
+- [How desktop switching works](#how-desktop-switching-works)
+  - [Reliability](#reliability)
+- [What doesn't carry over](#what-doesnt-carry-over)
+- [Troubleshooting](#troubleshooting)
+- [Window manager evaluation](#window-manager-evaluation)
+  - [Amethyst](#amethyst)
+  - [yabai](#yabai)
+  - [AeroSpace](#aerospace)
+  - [Recommendation: Amethyst](#recommendation-amethyst)
+
+## Running it
+
+There are two entry points. `setup` is the full machine bootstrap and calls
+`setup-macos` at the end; `setup-macos` is the desktop configuration on its
+own and is safe to run directly.
+
+### Full bootstrap
+
+```sh
+setup
+```
+
+On macOS this installs Homebrew if it's missing, then, by category:
+
+| Category | Examples |
+| --- | --- |
+| Core CLI packages | git, python3, ripgrep, vim, zsh, shellcheck, unzip, p7zip |
+| Directory jumping | zoxide |
+| Node toolchain | node, typescript (skip with `--no-npm`) |
+| Android CLI tools | android-platform-tools (adb, fastboot) |
+| Graphical apps | kitty, iTerm2, Amethyst, Rectangle (skip with `--no-gui`) |
+| Heavyweight extras | helix, jj, nushell (`--minimal` skips, `--brew` / `--release` picks the source) |
+| Dotfiles | clones the `conf` repo and symlinks it via `confinst` |
+
+Then it hands off to `setup-macos` for the desktop configuration described in
+this file.
+
+`setup` flags that matter here:
+
+| Flag | Effect |
+| --- | --- |
+| `--no-gui` | Skip graphical packages *and* the whole desktop configuration |
+| `--no-install` | Configure only; install nothing. Forwarded to `setup-macos` |
+| `--ignore-errors` | Keep going past failures. Forwarded to `setup-macos` |
+| `--minimal` / `--full` | Skip or force the heavyweight extras |
+| `--brew` / `--release` | Take the extras from Homebrew bottles, or from GitHub releases into `~/.local` via `homepkg` |
+| `--no-root` | Unprivileged install; CLI tools come from conda-forge via `homepkg` instead |
+| `--no-npm` | Skip node and tsc |
+
+`--no-sudo` and `--no-root` are accepted but change little on macOS: nothing
+in the desktop configuration uses sudo, and Homebrew never wants it.
+
+### Desktop configuration on its own
+
+```sh
+setup-macos
+```
+
+The run opens with a preflight message listing what has to be done by hand,
+then waits for Enter. Do those steps first — two of them can't be done from a
+script at all, and skipping them looks like a broken keybinding rather than a
+missed step.
+
+| Flag | Effect |
+| --- | --- |
+| `--no-install` | Configure whatever Amethyst is already there; don't install |
+| `--ignore-errors` | Keep going past failures instead of aborting on the first |
+| `--yes` | Skip the preflight pause |
+| `--no-sudo` | Accepted for consistency with `setup`; nothing here uses sudo |
+| `--help` | Usage |
+
+`setup` forwards `--no-install`, `--no-sudo` and `--ignore-errors` when it
+dispatches here. The preflight pause is skipped automatically when stdin isn't
+a terminal, so an unattended bootstrap doesn't block on an Enter that can
+never arrive.
+
+### What `setup-macos` requires
+
+It's standalone: it doesn't need `setup` to have run, doesn't need root, and
+degrades with a warning rather than failing when an optional piece is absent.
+
+**Hard requirements**, checked up front so running it on the wrong OS says so
+instead of failing several steps in:
+
+- `defaults` and `hidutil` — i.e. macOS.
+
+**Optional, each with a stated fallback:**
+
+| Missing | Consequence |
+| --- | --- |
+| `brew` and no staged bundle | Amethyst isn't installed; the tiling settings have no effect until it is |
+| `activateSettings` | Shortcuts are written but need a logout to take effect |
+| `launchctl` | The modifier remap applies at next login rather than now |
+| `pbs` | Launch shortcuts need a logout to register |
+| `killall` / `pgrep` | Finder and the Dock need a manual restart or a logout |
+| Launcher helpers | Those launch shortcuts are skipped; the rest are configured |
+| `~/.amethyst.yml` | Warns; Amethyst runs with its own defaults instead of this setup's layouts and keybindings |
+
+The launcher helpers (`browser1`, `browser2`, `terminal`,
+`terminal_on_workstation`, `music`) are found on `PATH` or beside the script,
+so running out of a fresh clone works before anything is on `PATH`.
+
+`~/.amethyst.yml` is symlinked out of the `conf` repo by `confinst`. Without
+the `conf` repo cloned, everything else still applies — only the window
+manager's own layouts and keybindings are missing.
+
+### Install backends for Amethyst
+
+`setup-macos` tries these in order:
+
+1. **Homebrew** — `brew install --cask amethyst`. The normal path.
+2. **Staged bundle** — offline. Run `brew fetch --cask amethyst` on a
+   connected machine and drop the zip at `$AMETHYST_BUNDLE`, `./amethyst.zip`,
+   or `~/amethyst.zip`. It's unpacked to `/Applications`, falling back to
+   `~/Applications` when that isn't writable, with the quarantine attribute
+   cleared.
+
+There's no third backend. If Amethyst is already installed in either location,
+both are skipped.
+
+## Do these by hand first
+
+**Create nine Spaces** in Mission Control (Ctrl-Up, then `+` at the top
+right). There is no API that creates a Space — not for this script, not for
+any window manager. macOS accepts a "switch to desktop 7" binding whether or
+not desktop 7 exists, and the key simply does nothing when it doesn't. The
+script counts the Spaces afterwards and names which of `Option+1..9` are dead,
+but it can't fix it for you.
+
+**Quit System Settings.** It holds the keyboard shortcut registry in memory
+while open and can flush its cached copy back over the script's writes when it
+closes, silently reverting them. The script warns if it sees it running.
+
+**Grant Amethyst Accessibility access**, under System Settings > Privacy &
+Security > Accessibility. Amethyst moves and resizes windows through the
+Accessibility API and is completely inert without it — it will run, show its
+menu bar icon, and tile nothing.
+
+## Key mapping
+
+After the modifier rotation (see below), the physical Win/Super key sends
+Option, so a `Meta+X` binding on KDE is the same physical keypress as
+`Option+X` here.
+
+| Action | KDE / Krohnkite | macOS | Provided by |
+| --- | --- | --- | --- |
+| Switch to desktop 1–9 | `Meta+1`..`9` | `Option+1`..`9` | symbolichotkeys (IDs 118–126) |
+| Move window to desktop 1–9 | `Meta+Shift+1`..`9` | `Option+Control+1`..`9` | Amethyst `throw-space-N` |
+| Grow main pane | `Meta+\` | `Option+\` | Amethyst `expand-main` |
+| Shrink main pane | `Meta+/` | `Option+/` | Amethyst `shrink-main` |
+| Monocle / fullscreen layout | ``Meta+` `` | ``Option+` `` | Amethyst `select-fullscreen-layout` |
+| Previous layout | `Meta+,` | `Option+,` | Amethyst `cycle-layout-backward` |
+| Next layout | `Meta+.` | `Option+.` | Amethyst `cycle-layout` |
+| Set master window | `Meta+Return` | `Option+Return` | Amethyst `swap-main` |
+| Launcher / Spotlight | — | `Option+Space` | symbolichotkeys (ID 64) |
+| Browser 1 | `Meta+G` | `Option+G` | Automator Quick Action |
+| Browser 2 | `Meta+H` | `Option+H` | Automator Quick Action |
+| Terminal | `Meta+T` | `Option+T` | Automator Quick Action |
+| Terminal on workstation | `Meta+W` | `Option+W` | Automator Quick Action |
+| Music | `Meta+Y` | `Option+Y` | Automator Quick Action |
+| Close window | `Meta+Backspace` | `Cmd+W` (physical `Ctrl+W`) | macOS default, not configured |
+
+Two deviations worth knowing:
+
+**Move-to-desktop uses Option+Control, not Option+Shift.** Option is macOS's
+dead-key layer: `Option+Shift+1` emits `⁄` rather than registering as a
+modifier combination. Krohnkite's `Meta+Shift+N` has no clean equivalent, so
+`amethyst.yml` binds `mod2` (Option+Control) instead.
+
+**Close window isn't rebound.** `Cmd+W` is the macOS convention and, after the
+rotation, sits under the physical Ctrl key where the Linux muscle memory
+expects it.
+
+### Modifier rotation
+
+`hidutil` applies a three-key rotation, not a swap:
+
+| Physical key | Sends | Used for |
+| --- | --- | --- |
+| Ctrl (pinky) | Command | copy, paste, tabs, close |
+| Win / Super | Option | launcher, desktop switching, window management |
+| Alt (by space) | Control | free for per-app shortcuts |
+
+This assumes a PC keyboard. `hidutil` applies it to every attached keyboard,
+including a laptop's built-in one whose keys are already in the Mac order this
+rotation is undoing.
+
+## How desktop switching works
+
+macOS has no public API to switch Spaces — nothing can say "go to desktop 3".
+The only scriptable route is to hijack the system's own shortcut registry.
+
+`com.apple.symbolichotkeys` is the preference domain behind System Settings >
+Keyboard > Keyboard Shortcuts. Its `AppleSymbolicHotKeys` dictionary is keyed
+by integer IDs, one per built-in action:
+
+| ID | Action |
+| --- | --- |
+| 64 | Spotlight |
+| 65 | Finder search window (disabled here, to free Option+Space) |
+| 118–126 | Switch to Desktop 1–9 |
+
+Each entry carries `enabled` plus `parameters = [ASCII code, virtual keycode,
+modifier bitmask]`. The bitmask values are Shift 131072, Control 262144,
+Option 524288, Command 1048576 — so the `524288` throughout `setup-macos` is
+"Option, nothing else". The number-row virtual keycodes aren't sequential
+(`1=18 2=19 3=20 4=21 5=23 6=22 7=26 8=28 9=25`), which is why the script
+carries an explicit table.
+
+The Dock reads this domain, so it's restarted after the writes.
+
+### Reliability
+
+Once live, these bindings are solid. They aren't a third-party grab layered on
+top of macOS — they're the same registry the stock `Ctrl+1..9` uses, enforced
+by WindowServer, so they beat every application and need no daemon running.
+
+Getting them live is the fragile part:
+
+- **cfprefsd caching.** `defaults write` doesn't reach the running
+  WindowServer by itself. `activateSettings -u` is the nudge, but it's an
+  unsupported private-framework binary that Apple is free to move. The script
+  falls back to advising a logout, which always works.
+- **System Settings write-back.** See above — quit it before running.
+- **Spaces that don't exist.** The write succeeds and the key does nothing.
+  This is the most common apparent failure.
+- **Per-display numbering.** With "Displays have separate Spaces" enabled,
+  desktop numbers are per-display, so `Option+5` can land somewhere
+  unexpected on a multi-monitor setup.
+
+The script pins the Spaces order (`mru-spaces false`) because "Automatically
+rearrange Spaces based on most recent use" is on by default and reorders the
+desktops behind the numbered bindings.
+
+To check the current state:
+
+```sh
+defaults read com.apple.symbolichotkeys AppleSymbolicHotKeys   # bindings
+defaults read com.apple.spaces                                 # Spaces
+```
+
+## What doesn't carry over
+
+These are macOS platform limits. No window manager fixes them.
+
+**Window decorations.** There is no equivalent of KWin's "No titlebar and
+frame" rule. Every tile keeps its titlebar and rounded corners. Only per-app
+opt-outs exist — kitty, Alacritty and iTerm2 can hide their own.
+
+**Exact sizing.** Krohnkite sets geometry inside KWin. Amethyst goes through
+the Accessibility API, so applications can refuse or round a requested size:
+terminals that snap to a character grid, Electron and Java apps, and anything
+with a minimum size will leave gaps or overlap.
+
+**Relayout performance.** Accessibility calls are synchronous round-trips per
+window, so retiling is visibly slower than Krohnkite's, and one unresponsive
+application stalls the whole relayout.
+
+**Space-switch animation** can't be disabled. Turning on Reduce Motion makes
+it a crossfade rather than a slide, which is faster and less distracting.
+
+**Focus stealing prevention.** Amethyst has focus-follows-mouse (the script
+enables it), but there's no equivalent of KWin's `NextFocusPrefersMouse` or
+its focus-stealing prevention levels.
+
+**Dim inactive windows.** No macOS equivalent of KWin's `diminactive` effect.
+Two ways to get the cue back, neither installed or configured by the script:
+
+- **JankyBorders** — `brew install borders`. Free and open source. Draws a
+  colored border around the focused window instead of dimming the others.
+  Works with SIP fully enabled because it injects into nothing. This is the
+  practical choice.
+- **HazeOver** — paid (roughly $5–10 one-time, also on Setapp). Actually dims
+  the inactive windows, which is closer to the KDE behavior.
+
+Both run as a small always-on process. Neither touches shell startup, so
+there's no latency cost on a new prompt.
+
+
+## Troubleshooting
+
+**`Option+5..9` does nothing.** Fewer than nine Spaces exist. Create the rest
+in Mission Control; re-running `setup-macos` will confirm the count.
+
+**Shortcuts reverted after the run.** System Settings was open and wrote its
+cached copy back. Quit it and re-run.
+
+**Amethyst doesn't tile anything.** Accessibility access wasn't granted, or
+was reset by an update. Re-grant it under System Settings > Privacy &
+Security > Accessibility.
+
+**Keyboard layout or modifiers unchanged.** Those are read by the login
+session — log out and back in.
+
+**Numbered desktops switch to the wrong one.** The Spaces order drifted.
+`setup-macos` pins it, but verify "Automatically rearrange Spaces based on
+most recent use" is still off in Mission Control settings.
+
+## Window manager evaluation
+
+Three tiling window managers are realistic on macOS. The decisive question is
+how each one handles Spaces, because that determines whether a nine-desktop
+workflow survives at all.
+
+### Amethyst
+
+Uses native macOS Spaces and tiles within whichever is current. Space
+*switching* isn't its job — that's symbolichotkeys, above. It can throw a
+window to a Space, which is the part that matters.
+
+**Pros**
+- Throwing windows to a Space works with SIP fully enabled.
+- Layout model is a cycled list of named layouts — a direct match for
+  Krohnkite's Tile / ThreeColumn / Columns / Monocle.
+- Single app, no daemon, no separate hotkey program, YAML config.
+- No SIP or boot-security changes of any kind.
+
+**Cons**
+- Throw-to-space relies on private APIs and has been flaky across macOS
+  releases.
+- Fixed feature set — no scripting or query interface.
+- Weaker per-app rules than the alternatives.
+
+### yabai
+
+The most capable of the three, but its best features are behind a scripting
+addition that injects into the Dock, which needs SIP partially disabled *and*
+the boot security policy lowered to Reduced Security.
+
+**Pros**
+- With the scripting addition: real Space create/destroy/focus, window
+  opacity and shadows, sticky windows.
+- Excellent scripting surface — `yabai -m query`, event signals.
+- Fine-grained gaps, padding, and per-app rules.
+
+**Cons**
+- **With SIP enabled, it cannot move a window to another Space or focus one.**
+  That removes the whole move-to-desktop workflow with no keyboard
+  workaround.
+- SIP changes are commonly blocked on managed Macs: on Apple Silicon,
+  lowering the boot security policy requires a Volume Owner account, and
+  every MDM/EDR agent reports SIP state as a compliance attribute.
+- The scripting addition breaks on macOS major releases until updated, and
+  SIP must be re-disabled after some updates.
+- BSP tiling is a different mental model from Krohnkite's layout cycle.
+
+### AeroSpace
+
+Rejects native Spaces entirely, emulating workspaces by moving windows to
+far off-screen coordinates.
+
+**Pros**
+- Instant, animation-free workspace switching.
+- Workspace count is config, not something created by hand in Mission
+  Control.
+- No SIP changes, no symbolichotkeys, no Dock restarts.
+- i3-style tiling with a coherent config language.
+
+**Cons**
+- macOS still believes every window is on one Space, so **Cmd+Tab lists
+  windows from workspaces you aren't looking at** and Mission Control shows
+  all of them at once.
+- Native-fullscreen apps behave oddly.
+- Tools that query window position — screen recording, some accessibility
+  software — can get confused.
+
+### Recommendation: Amethyst
+
+For a nine-desktop workflow on a Mac where SIP can't be touched:
+
+- **yabai is out.** Without the scripting addition it can't move a window to a
+  Space at all, which is a hard regression against the Krohnkite setup, not a
+  trade-off.
+- **AeroSpace is out** on the Cmd+Tab behavior. Breaking the system app
+  switcher to gain faster workspace switching is a bad trade when the
+  switching already works.
+- **Amethyst keeps the workflow intact** and matches Krohnkite's layout model
+  one-for-one. It's also what `amethyst.yml` and `setup-macos` already target.
+
+If SIP restrictions ever lift, yabai plus skhd becomes the closest overall
+match to Krohnkite — but that's a boot-security change, not a preference.

--- a/setup-macos
+++ b/setup-macos
@@ -42,14 +42,25 @@
 #        restart Finder and the Dock. Without any of them the settings are
 #        still written and the script says what needs a logout.
 #
+# MACOS.md covers the whole setup: the key mapping against the KDE/Krohnkite
+# side, how the symbolic hotkeys work, what doesn't carry over from KWin, and
+# why Amethyst rather than yabai or AeroSpace.
+#
+# Three things here need a human first -- creating the Spaces, quitting System
+# Settings, and granting Amethyst Accessibility access -- and none of them can
+# be done from a script. The run opens by saying so and waiting for Enter; see
+# preflight. --yes skips the wait, and so does a non-terminal stdin, so an
+# unattended bootstrap doesn't block on an Enter that can never arrive.
+#
 # Usage:
-#     setup-macos [--no-install] [--no-sudo] [--ignore-errors] [-h | --help]
+#     setup-macos [--no-install] [--no-sudo] [--ignore-errors] [--yes]
+#                 [-h | --help]
 #
 # setup forwards --no-install, --no-sudo, and --ignore-errors here.
 # --no-install skips installing Amethyst and configures whatever is already
 # there. macOS configuration uses no sudo, so --no-sudo is accepted but has
 # nothing to skip. --ignore-errors keeps going past failures instead of
-# aborting on the first one.
+# aborting on the first one. --yes skips the preflight pause.
 
 # Whether to keep going past failures. "no" aborts on the first error via
 # set -e; "yes" (via --ignore-errors) leaves it off and pushes through.
@@ -59,6 +70,10 @@ IGNORE_ERRORS=no
 # already there, matching setup-kde, which installs its own tiling window
 # manager (Krohnkite) under the same flag.
 INSTALL=yes
+
+# Whether to skip the preflight pause (--yes). A stdin that isn't a terminal
+# skips it too; see preflight.
+ASSUME_YES=no
 
 # Directory containing this script, resolved up front while $0 still means what
 # the caller typed. The launcher helpers the Quick Actions run live beside this
@@ -169,6 +184,18 @@ write_file() {
     fi
 }
 
+# Whether APP is running, as pgrep's own exit status: 0 running, 1 not
+# running, anything else a pgrep failure.
+#
+# pgrep exits 1 for "no such process", but 2 and 3 for its own failures.
+# Reading every non-zero status as "not running" would skip a restart on a
+# broken probe and say nothing about why, so the failure statuses are passed
+# through rather than collapsed into "no" and each caller decides what an
+# unknown answer means.
+app_running() {
+    pgrep -x "$1" >/dev/null
+}
+
 # Restart APP so it re-reads the settings just written, where WHY names what
 # stays unapplied if it can't be. APP not running is the ordinary case on a
 # fresh machine and isn't a failure -- but it's not the only reason killall
@@ -181,11 +208,7 @@ restart_app() {
         warn "killall/pgrep not found; restart $_app (or log out) for $_why"
         return 0
     fi
-    # pgrep exits 1 for "no such process", but 2 and 3 for its own failures.
-    # Reading every non-zero status as "not running" would skip the restart on
-    # a broken probe and say nothing about why, which is the same mistake as
-    # reading killall's status that way.
-    if pgrep -x "$_app" >/dev/null; then
+    if app_running "$_app"; then
         _running=0
     else
         _running=$?
@@ -204,9 +227,60 @@ restart_app() {
     killall "$_app" || warn "could not restart $_app; log out for $_why"
 }
 
+# --- Preflight ---
+
+# What this script can't do for you, printed before anything is changed so the
+# manual steps happen first instead of being discovered later as a dead
+# keybinding. Each one is genuinely out of reach: there is no API to create a
+# Space, System Settings owns the shortcut registry while it's open, and
+# Accessibility access can only be granted by a human in the GUI.
+preflight_notes() {
+    cat <<'NOTES'
+
+Before continuing, do these by hand -- this script can't:
+
+  1. Create nine Spaces in Mission Control (Ctrl-Up, then + at the top right).
+     No API creates a Space, so Option+1..9 silently does nothing for every
+     Space that doesn't exist yet.
+  2. Quit System Settings. Left open, it can write its cached copy of the
+     keyboard shortcuts back over the ones written here.
+  3. Grant Amethyst Accessibility access, under System Settings > Privacy &
+     Security > Accessibility. It can't move or resize a window without it.
+
+Optional: macOS has no equivalent of KDE's dim-inactive effect. JankyBorders
+(`brew install borders`, free) outlines the focused window instead of dimming
+the others; HazeOver (paid) does the dimming itself. Neither is installed or
+configured here.
+
+The keyboard layout and modifier-key changes take effect at the next login.
+
+NOTES
+}
+
+preflight() {
+    preflight_notes
+    if test "$ASSUME_YES" = yes; then
+        return 0
+    fi
+    # Nothing to prompt on: setup runs this as part of an unattended bootstrap,
+    # which must not block on an Enter that can never arrive.
+    if ! test -t 0; then
+        info "stdin is not a terminal; continuing without pausing."
+        return 0
+    fi
+    printf "Press Enter to continue, or Ctrl-C to abort: "
+    # EOF rather than a line means stdin closed under us; treat it as consent
+    # for the same reason as the non-terminal case, and end the line the
+    # prompt left open so the first step doesn't print onto it.
+    if ! read -r _preflight_reply; then
+        info ""
+    fi
+}
+
 usage() {
     cat <<'USAGE'
-Usage: setup-macos [--no-install] [--no-sudo] [--ignore-errors] [-h | --help]
+Usage: setup-macos [--no-install] [--no-sudo] [--ignore-errors] [--yes]
+                   [-h | --help]
 
 Configure the macOS desktop environment.
 
@@ -216,6 +290,7 @@ Options:
   --no-sudo        Accepted for consistency with setup; macOS configuration
                    uses no sudo, so there's nothing to skip
   --ignore-errors  Keep going past failures instead of aborting on the first
+  --yes            Skip the preflight pause and start configuring right away
   -h, --help       Show this help and exit
 USAGE
 }
@@ -239,6 +314,9 @@ while test $# -gt 0; do
             ;;
         --ignore-errors)
             IGNORE_ERRORS=yes
+            ;;
+        -y|--yes)
+            ASSUME_YES=yes
             ;;
         -h|--help)
             usage
@@ -377,8 +455,39 @@ PLIST
 
 # --- Configure keyboard shortcuts ---
 
+# System Settings holds the shortcut registry in memory while it's open and can
+# flush its copy back over these writes when it closes, silently reverting
+# them. Worth a warning rather than a refusal: it only clobbers if the Keyboard
+# pane is actually visited, so a run with it open often still lands.
+warn_if_settings_app_running() {
+    if ! is_command pgrep; then
+        warn "pgrep not found; quit System Settings before this run, or it can overwrite the shortcuts written below"
+        return 0
+    fi
+    # Both names, because the app was renamed in macOS 13 and this script has
+    # to work on either side of that.
+    for _settings_app in "System Settings" "System Preferences"; do
+        if app_running "$_settings_app"; then
+            _settings_running=0
+        else
+            _settings_running=$?
+        fi
+        case "$_settings_running" in
+            0)
+                warn "$_settings_app is running and can overwrite these shortcuts when it closes; quit it and re-run if Option+1..9 doesn't work"
+                ;;
+            1) ;;
+            *)
+                warn "could not tell whether $_settings_app is running (pgrep exited $_settings_running); quit it before this run if it's open"
+                ;;
+        esac
+    done
+}
+
 configure_shortcuts() {
     info "Configuring keyboard shortcuts (Mission Control and Spotlight on Option)"
+
+    warn_if_settings_app_running
 
     # Remap Mission Control shortcuts from Control to Option
     # so the physical Win/Super key handles desktop switching
@@ -400,10 +509,24 @@ configure_shortcuts() {
             </dict>
         </dict>'
 
-    # Disable Finder search window (ID 65) to avoid conflict
+    # Disable Finder search window (ID 65) to avoid conflict.
+    #
+    # -dict-add replaces the whole entry, so writing a bare enabled=false would
+    # drop the parameters with it and leave the shortcut showing blank in
+    # System Settings, with nothing to restore it to. Its stock binding
+    # (Cmd+Option+Space: 1048576 + 524288) is written back alongside the flag,
+    # so turning it on again in the GUI gets the original key back.
     try defaults write com.apple.symbolichotkeys AppleSymbolicHotKeys -dict-add 65 '
         <dict>
             <key>enabled</key><false/>
+            <key>value</key><dict>
+                <key>parameters</key><array>
+                    <integer>32</integer>
+                    <integer>49</integer>
+                    <integer>1572864</integer>
+                </array>
+                <key>type</key><string>standard</string>
+            </dict>
         </dict>'
 
     # Switch to Desktop 1-9: Option+1..9 (IDs 118-126)
@@ -447,6 +570,40 @@ configure_shortcuts() {
 
 # --- Configure Spaces ---
 
+# How many Spaces exist, printed on stdout.
+#
+# There's no public API for this, so it comes out of the Dock's own plist:
+# every Space carries a ManagedSpaceID, so counting those counts Spaces. It's
+# a floor, not an audit -- the count spans all displays and includes the
+# Spaces macOS creates for fullscreen apps, so it can read high. High is the
+# safe direction: this exists only to catch the case where there are plainly
+# fewer than nine and the Option+5..9 bindings would do nothing at all.
+count_spaces() {
+    _spaces_plist=$(defaults read com.apple.spaces SpacesDisplayConfiguration) \
+        || return 1
+    # grep -c exits 1 when the count is zero, which is a real answer here
+    # rather than a failure, so take the count from its output either way.
+    if ! _spaces_count=$(printf '%s\n' "$_spaces_plist" | grep -c ManagedSpaceID); then
+        _spaces_count=0
+    fi
+    printf '%s\n' "$_spaces_count"
+}
+
+# The Option+1..9 bindings written above are positional slots: macOS accepts
+# the write for a Space that doesn't exist, and the key then does nothing.
+# That looks exactly like a broken keybinding, so say which ones are dead.
+check_spaces_count() {
+    if ! _spaces=$(count_spaces); then
+        warn "could not read the Spaces configuration; if Option+1..9 doesn't switch desktops, create nine Spaces in Mission Control (Ctrl-Up, then +)"
+        return 0
+    fi
+    if test "$_spaces" -lt 9; then
+        warn "only $_spaces Space(s) exist, so Option+$((_spaces + 1))..9 will do nothing until the rest are created in Mission Control (Ctrl-Up, then +)"
+        return 0
+    fi
+    info "$_spaces Spaces found; Option+1..9 has a desktop to switch to"
+}
+
 configure_spaces() {
     info "Pinning the Spaces order"
 
@@ -459,6 +616,10 @@ configure_spaces() {
 
     # The Dock owns Mission Control and reads this at launch.
     restart_app Dock "the Spaces order to be pinned"
+
+    # After the restart: the Dock rewrites com.apple.spaces as it goes, so
+    # counting before it has settled can read the pre-restart layout.
+    check_spaces_count
 }
 
 # --- Configure Amethyst tiling window manager ---
@@ -921,6 +1082,7 @@ configure_finder() {
 
 # --- Main ---
 
+preflight
 configure_keyboard
 configure_modifier_keys
 configure_shortcuts

--- a/setup-macos_test
+++ b/setup-macos_test
@@ -35,15 +35,18 @@ setup() {
     mkdir -p "$TEST_TMPDIR/bin" "$TEST_TMPDIR/home"
     MACOS_SCRIPT="$SCRIPT_DIR/setup-macos"
 
-    # `defaults read` answers from a file when a test has staged one, and
-    # otherwise fails the way the real one does for a key that was never
-    # written. Everything else just records argv.
+    # `defaults read` answers from a file when a test has staged one for that
+    # domain, and otherwise fails the way the real one does for a key that was
+    # never written. Staging is per-domain because the script reads two of them
+    # for unrelated reasons -- the input sources and the Spaces layout -- and a
+    # single shared answer would feed each one the other's fixture.
+    # Everything else just records argv.
     cat > "$TEST_TMPDIR/bin/defaults" <<MOCK
 #!/bin/sh
 printf "%s\\n" "defaults \$*" >> "$CALLS"
 if test "\$1" = read; then
-    if test -f "$TEST_TMPDIR/defaults_read"; then
-        cat "$TEST_TMPDIR/defaults_read"
+    if test -f "$TEST_TMPDIR/defaults_read.\$2"; then
+        cat "$TEST_TMPDIR/defaults_read.\$2"
         exit 0
     fi
     echo "Domain/default pair does not exist" >&2
@@ -58,13 +61,28 @@ MOCK
 
     # pgrep exits 0 by default, i.e. the app is running and restart_app should
     # go on to killall it.
-    for cmd in hidutil launchctl killall pgrep brew; do
+    for cmd in hidutil launchctl killall brew; do
         cat > "$TEST_TMPDIR/bin/$cmd" <<MOCK
 #!/bin/sh
 printf "%s\\n" "$cmd \$*" >> "$CALLS"
 exit 0
 MOCK
     done
+
+    # pgrep answers "running" for everything except the settings app, which
+    # would otherwise make every ordinary run warn about being clobbered. A
+    # test stages settings_app_running to say it is open.
+    cat > "$TEST_TMPDIR/bin/pgrep" <<MOCK
+#!/bin/sh
+printf "%s\\n" "pgrep \$*" >> "$CALLS"
+case "\$*" in
+    *"System Settings"*|*"System Preferences"*)
+        test -f "$TEST_TMPDIR/settings_app_running" && exit 0
+        exit 1
+        ;;
+esac
+exit 0
+MOCK
 
     # xattr is asked two different questions: -d removes the quarantine
     # attribute, -p reports whether anything still carries it. The default
@@ -120,6 +138,10 @@ MOCK
     # test_missing_amethyst_config removes it.
     touch "$TEST_TMPDIR/home/.amethyst.yml"
 
+    # Nine Spaces by default, for the same reason: that's the configured
+    # machine, so the ordinary run has nothing to say about Option+1..9.
+    stage_spaces 9
+
     # On PATH by default, so the ordinary run configures every shortcut. Tests
     # about missing launchers use isolate_script to get away from both these
     # and the real ones beside the script.
@@ -174,10 +196,28 @@ teardown() {
     rm -rf "$TEST_TMPDIR"
 }
 
-# Stage the output `defaults read` should print, i.e. pretend the key is
-# already set to this.
+# Stage the output `defaults read DOMAIN` should print, i.e. pretend that
+# domain is already set to this.
 stage_defaults_read() {
-    printf "%s\n" "$1" > "$TEST_TMPDIR/defaults_read"
+    printf "%s\n" "$2" > "$TEST_TMPDIR/defaults_read.$1"
+}
+
+# Pretend N Spaces exist. count_spaces counts ManagedSpaceID keys, so the
+# fixture only has to carry one per Space.
+stage_spaces() {
+    _staged_spaces=
+    _remaining="$1"
+    while test "$_remaining" -gt 0; do
+        _staged_spaces="$_staged_spaces        ManagedSpaceID = $_remaining;
+"
+        _remaining=$((_remaining - 1))
+    done
+    stage_defaults_read com.apple.spaces "$_staged_spaces"
+}
+
+# Pretend System Settings is open, so its clobber warning fires.
+stage_settings_app_running() {
+    touch "$TEST_TMPDIR/settings_app_running"
 }
 
 # Remove the pre-installed Amethyst, i.e. pretend a fresh machine.
@@ -205,6 +245,10 @@ fail_defaults_write() {
 
 # Run setup-macos in the sandbox: fresh HOME, and a PATH of just the mock bin
 # plus the symlinked system utilities -- nothing from the real /usr/bin.
+#
+# stdin comes from /dev/null so the preflight pause is never reached: it only
+# prompts on a terminal, and without this a developer running `make test` from
+# one would block on it while CI sailed past.
 run_macos() {
     set +e
     output="$(HOME="$TEST_TMPDIR/home" \
@@ -214,7 +258,7 @@ run_macos() {
         USER_APPLICATIONS_DIR="$USER_APPLICATIONS_DIR" \
         AMETHYST_BUNDLE="${AMETHYST_BUNDLE:-}" \
         PATH="$TEST_TMPDIR/bin:$TEST_TMPDIR/sysbin" \
-        "$MACOS_SCRIPT" "$@" 2>&1)"
+        "$MACOS_SCRIPT" "$@" </dev/null 2>&1)"
     status=$?
     set -e
 }
@@ -241,7 +285,7 @@ run_macos_without() {
         USER_APPLICATIONS_DIR="$USER_APPLICATIONS_DIR" \
         AMETHYST_BUNDLE="${AMETHYST_BUNDLE:-}" \
         PATH="$TEST_TMPDIR/reduced:$TEST_TMPDIR/sysbin" \
-        "$MACOS_SCRIPT" "$@" 2>&1)"
+        "$MACOS_SCRIPT" "$@" </dev/null 2>&1)"
     status=$?
     set -e
 }
@@ -417,7 +461,7 @@ test_enables_dvorak() {
 # stacked another Dvorak entry onto AppleEnabledInputSources on every run --
 # and setup is explicitly meant to be re-runnable.
 test_does_not_re_add_dvorak() {
-    stage_defaults_read '(
+    stage_defaults_read com.apple.HIToolbox '(
         {
         InputSourceKind = "Keyboard Layout";
         "KeyboardLayout ID" = 16300;
@@ -436,7 +480,7 @@ test_does_not_re_add_dvorak() {
 # machine as already configured -- then select a layout that isn't in the
 # enabled list. Matched on the layout ID instead.
 test_dvorak_variant_is_not_standard_dvorak() {
-    stage_defaults_read '(
+    stage_defaults_read com.apple.HIToolbox '(
         {
         InputSourceKind = "Keyboard Layout";
         "KeyboardLayout ID" = 16301;
@@ -618,6 +662,44 @@ test_disables_finder_search_hotkey() {
     assert_called "defaults write com.apple.symbolichotkeys AppleSymbolicHotKeys -dict-add 65"
 }
 
+# -dict-add replaces the whole entry, so a bare enabled=false would drop the
+# stock binding with it and leave nothing for System Settings to restore.
+# 1572864 is Cmd+Option, the modifier half of the original Cmd+Option+Space.
+test_disabled_finder_search_keeps_its_parameters() {
+    run_macos
+    assert_status 0 &&
+    assert_called "1572864"
+}
+
+# System Settings holds the shortcut registry while it's open and can write its
+# copy back over these, which looks exactly like the writes never happened.
+test_warns_when_settings_app_is_open() {
+    stage_settings_app_running
+    run_macos --ignore-errors
+    assert_status 0 &&
+    assert_output_contains "System Settings is running and can overwrite these shortcuts"
+}
+
+test_no_settings_app_warning_when_closed() {
+    run_macos
+    assert_status 0 &&
+    assert_output_lacks "can overwrite these shortcuts"
+}
+
+# A pgrep that failed says nothing about whether the app is open, so it must
+# not be reported as closed -- the same rule restart_app follows.
+test_unknown_settings_app_state_is_reported() {
+    cat > "$TEST_TMPDIR/bin/pgrep" <<MOCK
+#!/bin/sh
+printf "%s\\n" "pgrep \$*" >> "$CALLS"
+exit 2
+MOCK
+    chmod +x "$TEST_TMPDIR/bin/pgrep"
+    run_macos --ignore-errors
+    assert_status 0 &&
+    assert_output_contains "could not tell whether System Settings is running"
+}
+
 # Nine desktops, IDs 118-126, each on Option (modifier flag 524288).
 test_configures_nine_desktop_shortcuts() {
     run_macos
@@ -653,6 +735,78 @@ test_pins_the_spaces_order() {
     assert_status 0 &&
     assert_called "defaults write com.apple.dock mru-spaces -bool false" &&
     assert_called "killall Dock"
+}
+
+# macOS accepts a "switch to desktop N" binding for a Space that doesn't
+# exist, and the key then does nothing at all -- indistinguishable from a
+# binding that failed to write. Say which ones are dead instead.
+test_warns_when_too_few_spaces() {
+    stage_spaces 4
+    run_macos --ignore-errors
+    assert_status 0 &&
+    assert_output_contains "only 4 Space(s) exist, so Option+5..9 will do nothing"
+}
+
+test_no_spaces_warning_when_all_nine_exist() {
+    stage_spaces 9
+    run_macos
+    assert_status 0 &&
+    assert_output_contains "9 Spaces found" &&
+    assert_output_lacks "will do nothing"
+}
+
+# More Spaces than the bindings use is fine -- every Option+1..9 still lands
+# somewhere, so there is nothing to report.
+test_no_spaces_warning_when_more_than_nine() {
+    stage_spaces 12
+    run_macos
+    assert_status 0 &&
+    assert_output_lacks "will do nothing"
+}
+
+# An unreadable Spaces plist is not "zero Spaces": say the count is unknown
+# rather than reporting a number that was never read.
+test_unreadable_spaces_config_is_reported() {
+    rm -f "$TEST_TMPDIR/defaults_read.com.apple.spaces"
+    run_macos --ignore-errors
+    assert_status 0 &&
+    assert_output_contains "could not read the Spaces configuration" &&
+    assert_output_lacks "only 0 Space(s) exist"
+}
+
+# --- preflight ---
+
+test_preflight_names_the_manual_steps() {
+    run_macos
+    assert_status 0 &&
+    assert_output_contains "Create nine Spaces in Mission Control" &&
+    assert_output_contains "Quit System Settings" &&
+    assert_output_contains "Grant Amethyst Accessibility access"
+}
+
+# macOS has no dim-inactive equivalent, so the preflight names the two ways to
+# get a focus cue rather than leaving it as an unexplained gap.
+test_preflight_names_the_focus_cue_options() {
+    run_macos
+    assert_status 0 &&
+    assert_output_contains "JankyBorders" &&
+    assert_output_contains "HazeOver"
+}
+
+# The pause only happens on a terminal: setup runs this as part of an
+# unattended bootstrap, where a prompt would block forever.
+test_preflight_does_not_pause_without_a_terminal() {
+    run_macos
+    assert_status 0 &&
+    assert_output_contains "stdin is not a terminal" &&
+    assert_output_contains "macOS configured successfully"
+}
+
+test_yes_skips_the_preflight_pause() {
+    run_macos --yes
+    assert_status 0 &&
+    assert_output_contains "Create nine Spaces in Mission Control" &&
+    assert_output_lacks "stdin is not a terminal"
 }
 
 # --- Amethyst ---
@@ -1245,8 +1399,32 @@ run_test "applies the shortcut settings to this session" \
     test_applies_shortcut_settings
 run_test "missing activateSettings falls back to the logout advice" \
     test_missing_activate_settings_warns_about_logout
+run_test "a disabled Finder search keeps its stock binding" \
+    test_disabled_finder_search_keeps_its_parameters
+run_test "warns when System Settings is open to clobber the writes" \
+    test_warns_when_settings_app_is_open
+run_test "no clobber warning when System Settings is closed" \
+    test_no_settings_app_warning_when_closed
+run_test "an unknown System Settings state is reported, not read as closed" \
+    test_unknown_settings_app_state_is_reported
 run_test "pins the Spaces order so the numbered shortcuts hold" \
     test_pins_the_spaces_order
+run_test "warns which Option+N bindings have no Space to switch to" \
+    test_warns_when_too_few_spaces
+run_test "no Spaces warning when all nine exist" \
+    test_no_spaces_warning_when_all_nine_exist
+run_test "no Spaces warning when more than nine exist" \
+    test_no_spaces_warning_when_more_than_nine
+run_test "an unreadable Spaces config is reported, not counted as zero" \
+    test_unreadable_spaces_config_is_reported
+run_test "the preflight names the manual steps" \
+    test_preflight_names_the_manual_steps
+run_test "the preflight names the focus-cue options" \
+    test_preflight_names_the_focus_cue_options
+run_test "no preflight pause without a terminal" \
+    test_preflight_does_not_pause_without_a_terminal
+run_test "--yes skips the preflight pause" \
+    test_yes_skips_the_preflight_pause
 run_test "enables focus follows mouse" test_enables_focus_follows_mouse
 run_test "a missing amethyst config warns, not fatal" test_missing_amethyst_config
 run_test "says Amethyst needs Accessibility access" \


### PR DESCRIPTION
Three of the desktop shortcuts `setup-macos` configures can fail without anything looking wrong, and the reasoning behind the whole macOS arrangement wasn't written down anywhere. Two commits.

## `setup-macos`: say what needs doing by hand, and catch what silently undoes it

Three failure modes all present as a dead keybinding rather than as a missed step:

- **Spaces can't be created from a script at all.** macOS accepts a "switch to desktop 7" binding whether or not desktop 7 exists; the key then does nothing.
- **System Settings can flush its cached shortcut registry** back over the writes when it closes.
- **Amethyst tiles nothing** until it's granted Accessibility access.

The run now opens by naming those three and waits for Enter so they can be done first. The pause is skipped by `--yes` and by a stdin that isn't a terminal, so `setup`'s unattended bootstrap doesn't block on an Enter that can never arrive. The notes also name JankyBorders and HazeOver, since macOS has no equivalent of KWin's dim-inactive effect and the gap was otherwise unexplained.

After the Dock restart it counts the Spaces out of the Dock's own plist and names which of `Option+1..9` have nothing to switch to. The count is deliberately a floor — it spans displays and includes Spaces macOS made for fullscreen apps — which is the safe direction for a check that exists only to catch "plainly fewer than nine". An unreadable plist says so rather than being counted as zero.

Two smaller fixes in the same pass:

- **The Finder search hotkey lost its binding when disabled.** `-dict-add` replaces the whole entry, so writing a bare `enabled=false` discarded the stock `Cmd+Option+Space` with it and left nothing for System Settings to restore. The parameters are now written back alongside the flag.
- **`pgrep`'s three-way answer is shared with `restart_app`** rather than reimplemented, so an unknown status stays distinct from "not running" in both.

## `MACOS.md`

New reference covering both entry points (the full bootstrap and the desktop configuration on its own, including what the latter requires and how it degrades without each optional piece), the key mapping against the Krohnkite side, how the symbolic hotkeys work and where they're fragile, and the platform limits no window manager fixes.

The evaluation of Amethyst against yabai and AeroSpace sits at the end, out of the way of the reference material, linked from the top. The contents list is hand-written rather than a renderer directive: GitHub generates those anchors on its own file view and kramdown generates the same slugs under GitHub Pages, so one list works in both.

## Testing

- 11 new tests, each verified to fail against the unmodified script.
- Full suite: 899 tests, 0 failed.
- `shellcheck` clean.

The test harness needed three changes to support this: `defaults read` staging is now per-domain (the script reads two domains for unrelated reasons, and a shared fixture fed each the other's data), `pgrep` reports the settings app as closed by default, and both runners take stdin from `/dev/null` so the preflight pause is never reached from an interactive `make test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0134VMrLZBcGLyb7KcBA5P7v

---
_Generated by [Claude Code](https://claude.ai/code/session_0134VMrLZBcGLyb7KcBA5P7v)_