### PR TITLE
Address the Codex findings on #175, and publish the docs with GitHub Pages

### DIFF
--- a/docs/MACOS.md
+++ b/docs/MACOS.md
@@ -1,3 +1,7 @@
+---
+title: macOS desktop setup
+---
+
 # macOS desktop setup
 
 How the KDE/Krohnkite setup in `setup-kde` is reproduced on macOS by
@@ -19,6 +23,7 @@ For why Amethyst rather than yabai or AeroSpace, skip to the
   - [What `setup-macos` requires](#what-setup-macos-requires)
   - [Install backends for Amethyst](#install-backends-for-amethyst)
 - [Do these by hand first](#do-these-by-hand-first)
+  - [And afterwards](#and-afterwards)
 - [Key mapping](#key-mapping)
   - [Modifier rotation](#modifier-rotation)
 - [How desktop switching works](#how-desktop-switching-works)
@@ -150,14 +155,24 @@ not desktop 7 exists, and the key simply does nothing when it doesn't. The
 script counts the Spaces afterwards and names which of `Option+1..9` are dead,
 but it can't fix it for you.
 
+With "Displays have separate Spaces" enabled, each display needs its own nine
+— the numbering is per display, so five Spaces on each of two displays leaves
+`Option+6..9` dead on both. The count is reported per display for that reason.
+
 **Quit System Settings.** It holds the keyboard shortcut registry in memory
 while open and can flush its cached copy back over the script's writes when it
 closes, silently reverting them. The script warns if it sees it running.
+
+### And afterwards
 
 **Grant Amethyst Accessibility access**, under System Settings > Privacy &
 Security > Accessibility. Amethyst moves and resizes windows through the
 Accessibility API and is completely inert without it — it will run, show its
 menu bar icon, and tile nothing.
+
+This one can only be done *after* the run, not before it: on a first run
+Amethyst isn't installed yet, so there's nothing to grant the permission to.
+The run repeats the instruction when it gets there.
 
 ## Key mapping
 
@@ -293,7 +308,7 @@ Two ways to get the cue back, neither installed or configured by the script:
   colored border around the focused window instead of dimming the others.
   Works with SIP fully enabled because it injects into nothing. This is the
   practical choice.
-- **HazeOver** — paid (roughly $5–10 one-time, also on Setapp). Actually dims
+- **HazeOver** — paid (around $10 one-time, also on Setapp). Actually dims
   the inactive windows, which is closer to the KDE behavior.
 
 Both run as a small always-on process. Neither touches shell startup, so
@@ -302,8 +317,9 @@ there's no latency cost on a new prompt.
 
 ## Troubleshooting
 
-**`Option+5..9` does nothing.** Fewer than nine Spaces exist. Create the rest
-in Mission Control; re-running `setup-macos` will confirm the count.
+**`Option+5..9` does nothing.** Fewer than nine Spaces exist on that display.
+Create the rest in Mission Control; re-running `setup-macos` reports the count
+per display.
 
 **Shortcuts reverted after the run.** System Settings was open and wrote its
 cached copy back. Quit it and re-run.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,22 @@
+# GitHub Pages configuration.
+#
+# Pages serves this directory (Settings > Pages > Deploy from a branch, main,
+# /docs), so the published site is exactly what's in here. That's why there's
+# no exclude list: serving the repository root would copy all ~150 scripts
+# into the site, and keeping the docs in their own directory avoids the
+# problem rather than enumerating it away.
+
+title: scripts
+description: Shell utilities, and the macOS desktop setup they configure.
+theme: jekyll-theme-cayman
+
+# Only a file with YAML front matter is rendered as a page; everything else is
+# copied verbatim. Setting the layout here rather than in each file keeps a
+# page's front matter down to a title, which matters because GitHub renders
+# front matter as a table above the document on its own file view.
+defaults:
+  - scope:
+      path: ""
+      type: pages
+    values:
+      layout: default

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,22 @@
+---
+title: scripts
+---
+
+Shell utilities for setting up and driving a Linux or macOS workstation.
+
+## Documentation
+
+- [macOS desktop setup](MACOS.html) — reproducing the KDE/Krohnkite tiling
+  setup on macOS with Amethyst: the key mapping, the steps that can't be
+  scripted, what doesn't carry over from KWin, and why Amethyst rather than
+  yabai or AeroSpace.
+
+The [repository README](https://github.com/mikelward/scripts#readme) covers
+the scripts themselves.
+
+<!--
+This page exists for GitHub Pages, which needs an index for the site root --
+the repository's own README.md is its landing page and is left alone. Links
+here point at the built .html rather than the source .md, since Jekyll renders
+each page to .html and doesn't rewrite Markdown links.
+-->

--- a/setup-macos
+++ b/setup-macos
@@ -570,38 +570,62 @@ configure_shortcuts() {
 
 # --- Configure Spaces ---
 
-# How many Spaces exist, printed on stdout.
+# Spaces per display, printed on stdout as counts separated by spaces -- one
+# per display, in the order the Dock lists them.
 #
 # There's no public API for this, so it comes out of the Dock's own plist:
-# every Space carries a ManagedSpaceID, so counting those counts Spaces. It's
-# a floor, not an audit -- the count spans all displays and includes the
-# Spaces macOS creates for fullscreen apps, so it can read high. High is the
-# safe direction: this exists only to catch the case where there are plainly
-# fewer than nine and the Option+5..9 bindings would do nothing at all.
-count_spaces() {
+# every Space carries a ManagedSpaceID, so counting those counts Spaces. The
+# count has to be per display rather than a total, because with "Displays have
+# separate Spaces" enabled the desktop numbering is per display too: two
+# displays with five Spaces each total ten, and Option+6..9 is dead on both.
+#
+# Each count can read one high, since the monitor's current-Space marker
+# carries a ManagedSpaceID of its own, and can read high again for Spaces
+# macOS created for fullscreen apps. So this catches "plainly too few" rather
+# than auditing the exact number -- which is its whole remit. It deliberately
+# makes no "all nine are fine" claim, because that's the direction an
+# over-count would get wrong.
+count_spaces_per_display() {
     _spaces_plist=$(defaults read com.apple.spaces SpacesDisplayConfiguration) \
         || return 1
-    # grep -c exits 1 when the count is zero, which is a real answer here
-    # rather than a failure, so take the count from its output either way.
-    if ! _spaces_count=$(printf '%s\n' "$_spaces_plist" | grep -c ManagedSpaceID); then
-        _spaces_count=0
-    fi
-    printf '%s\n' "$_spaces_count"
+    printf '%s\n' "$_spaces_plist" | awk '
+        # Each monitor block is introduced by its display identifier, so that
+        # line closes the previous block and opens the next.
+        /Display Identifier/ {
+            if (seen) { counts = counts " " n }
+            seen = 1; n = 0; next
+        }
+        /ManagedSpaceID/ { if (seen) n++ }
+        END {
+            if (!seen) { exit }
+            counts = counts " " n
+            sub(/^ /, "", counts)
+            print counts
+        }'
 }
 
 # The Option+1..9 bindings written above are positional slots: macOS accepts
 # the write for a Space that doesn't exist, and the key then does nothing.
 # That looks exactly like a broken keybinding, so say which ones are dead.
 check_spaces_count() {
-    if ! _spaces=$(count_spaces); then
+    if ! _per_display=$(count_spaces_per_display); then
         warn "could not read the Spaces configuration; if Option+1..9 doesn't switch desktops, create nine Spaces in Mission Control (Ctrl-Up, then +)"
         return 0
     fi
-    if test "$_spaces" -lt 9; then
-        warn "only $_spaces Space(s) exist, so Option+$((_spaces + 1))..9 will do nothing until the rest are created in Mission Control (Ctrl-Up, then +)"
+    # No display in the plist is not "no Spaces": say the count is unknown
+    # rather than reporting a number that was never read.
+    if test -z "$_per_display"; then
+        warn "the Spaces configuration named no displays, so the Space count is unknown; if Option+1..9 doesn't switch desktops, create nine Spaces in Mission Control (Ctrl-Up, then +)"
         return 0
     fi
-    info "$_spaces Spaces found; Option+1..9 has a desktop to switch to"
+    info "Spaces per display: $_per_display"
+    _display_number=0
+    for _count in $_per_display; do
+        _display_number=$((_display_number + 1))
+        if test "$_count" -lt 9; then
+            warn "display $_display_number has $_count Space(s), so Option+$((_count + 1))..9 will do nothing there until the rest are created in Mission Control (Ctrl-Up, then +)"
+        fi
+    done
 }
 
 configure_spaces() {

--- a/setup-macos
+++ b/setup-macos
@@ -42,13 +42,15 @@
 #        restart Finder and the Dock. Without any of them the settings are
 #        still written and the script says what needs a logout.
 #
-# MACOS.md covers the whole setup: the key mapping against the KDE/Krohnkite
+# docs/MACOS.md covers the whole setup: the key mapping against the KDE/Krohnkite
 # side, how the symbolic hotkeys work, what doesn't carry over from KWin, and
 # why Amethyst rather than yabai or AeroSpace.
 #
-# Three things here need a human first -- creating the Spaces, quitting System
-# Settings, and granting Amethyst Accessibility access -- and none of them can
-# be done from a script. The run opens by saying so and waiting for Enter; see
+# Two things here need a human first -- creating the Spaces and quitting System
+# Settings -- and a third, granting Amethyst Accessibility access, needs one
+# afterwards, since a first run installs Amethyst partway through and there is
+# nothing to grant the permission to until it has. None of the three can be
+# done from a script. The run opens by saying so and waiting for Enter; see
 # preflight. --yes skips the wait, and so does a non-terminal stdin, so an
 # unattended bootstrap doesn't block on an Enter that can never arrive.
 #
@@ -244,13 +246,20 @@ Before continuing, do these by hand -- this script can't:
      Space that doesn't exist yet.
   2. Quit System Settings. Left open, it can write its cached copy of the
      keyboard shortcuts back over the ones written here.
+
+Then once this run has finished:
+
   3. Grant Amethyst Accessibility access, under System Settings > Privacy &
      Security > Accessibility. It can't move or resize a window without it.
+     This run installs Amethyst if it isn't already there, so the permission
+     can only be granted afterwards -- the run says so again when it gets
+     there.
 
 Optional: macOS has no equivalent of KDE's dim-inactive effect. JankyBorders
-(`brew install borders`, free) outlines the focused window instead of dimming
-the others; HazeOver (paid) does the dimming itself. Neither is installed or
-configured here.
+(`brew install borders`, free) outlines the focused window; HazeOver (around
+$10 one-time) dims the others instead. Each runs as an always-on process,
+and neither is installed or configured here. If one is missing or stops
+running, the only consequence is losing the focus cue.
 
 The keyboard layout and modifier-key changes take effect at the next login.
 

--- a/setup-macos_test
+++ b/setup-macos_test
@@ -118,7 +118,7 @@ MOCK
     # reached the real hidutil and launchctl would remap the developer's
     # keyboard and load a LaunchAgent while they ran `make test`.
     mkdir -p "$TEST_TMPDIR/sysbin"
-    for cmd in cat dirname grep id mkdir mv rm sed unzip; do
+    for cmd in awk cat dirname grep id mkdir mv rm sed unzip; do
         ln -sf "$(command -v "$cmd")" "$TEST_TMPDIR/sysbin/$cmd"
     done
 
@@ -202,17 +202,28 @@ stage_defaults_read() {
     printf "%s\n" "$2" > "$TEST_TMPDIR/defaults_read.$1"
 }
 
-# Pretend N Spaces exist. count_spaces counts ManagedSpaceID keys, so the
-# fixture only has to carry one per Space.
+# Pretend each argument is a display with that many Spaces, e.g.
+# `stage_spaces 9` for one display with nine, `stage_spaces 9 5` for a second
+# display with five. count_spaces_per_display splits on the display identifier
+# and counts ManagedSpaceID keys, so the fixture only needs those two.
 stage_spaces() {
     _staged_spaces=
-    _remaining="$1"
-    while test "$_remaining" -gt 0; do
-        _staged_spaces="$_staged_spaces        ManagedSpaceID = $_remaining;
+    for _display_spaces in "$@"; do
+        _staged_spaces="$_staged_spaces        \"Display Identifier\" = Main;
 "
-        _remaining=$((_remaining - 1))
+        _remaining="$_display_spaces"
+        while test "$_remaining" -gt 0; do
+            _staged_spaces="$_staged_spaces            ManagedSpaceID = $_remaining;
+"
+            _remaining=$((_remaining - 1))
+        done
     done
     stage_defaults_read com.apple.spaces "$_staged_spaces"
+}
+
+# A Spaces plist that parses but names no display, i.e. the count is unknown.
+stage_spaces_without_display() {
+    stage_defaults_read com.apple.spaces '    "Management Data" = { };'
 }
 
 # Pretend System Settings is open, so its clobber warning fires.
@@ -744,14 +755,14 @@ test_warns_when_too_few_spaces() {
     stage_spaces 4
     run_macos --ignore-errors
     assert_status 0 &&
-    assert_output_contains "only 4 Space(s) exist, so Option+5..9 will do nothing"
+    assert_output_contains "display 1 has 4 Space(s), so Option+5..9 will do nothing there"
 }
 
 test_no_spaces_warning_when_all_nine_exist() {
     stage_spaces 9
     run_macos
     assert_status 0 &&
-    assert_output_contains "9 Spaces found" &&
+    assert_output_contains "Spaces per display: 9" &&
     assert_output_lacks "will do nothing"
 }
 
@@ -764,6 +775,26 @@ test_no_spaces_warning_when_more_than_nine() {
     assert_output_lacks "will do nothing"
 }
 
+# Regression: the count used to span every display, so two displays with five
+# Spaces each totalled ten and the check called Option+1..9 fine while 6..9
+# were dead on both. Desktop numbering is per display, so the count must be.
+test_counts_spaces_per_display_not_in_total() {
+    stage_spaces 5 5
+    run_macos --ignore-errors
+    assert_status 0 &&
+    assert_output_contains "display 1 has 5 Space(s)" &&
+    assert_output_contains "display 2 has 5 Space(s)"
+}
+
+# Only the short display is named; the one with enough Spaces isn't.
+test_only_the_short_display_is_named() {
+    stage_spaces 9 3
+    run_macos --ignore-errors
+    assert_status 0 &&
+    assert_output_contains "display 2 has 3 Space(s)" &&
+    assert_output_lacks "display 1 has"
+}
+
 # An unreadable Spaces plist is not "zero Spaces": say the count is unknown
 # rather than reporting a number that was never read.
 test_unreadable_spaces_config_is_reported() {
@@ -771,7 +802,17 @@ test_unreadable_spaces_config_is_reported() {
     run_macos --ignore-errors
     assert_status 0 &&
     assert_output_contains "could not read the Spaces configuration" &&
-    assert_output_lacks "only 0 Space(s) exist"
+    assert_output_lacks "has 0 Space(s)"
+}
+
+# A plist that parses but names no display is the same kind of unknown, and
+# must not be reported as a display with zero Spaces.
+test_spaces_config_without_a_display_is_reported() {
+    stage_spaces_without_display
+    run_macos --ignore-errors
+    assert_status 0 &&
+    assert_output_contains "named no displays" &&
+    assert_output_lacks "has 0 Space(s)"
 }
 
 # --- preflight ---
@@ -1415,8 +1456,14 @@ run_test "no Spaces warning when all nine exist" \
     test_no_spaces_warning_when_all_nine_exist
 run_test "no Spaces warning when more than nine exist" \
     test_no_spaces_warning_when_more_than_nine
+run_test "counts Spaces per display, not as a total" \
+    test_counts_spaces_per_display_not_in_total
+run_test "only the display short of Spaces is named" \
+    test_only_the_short_display_is_named
 run_test "an unreadable Spaces config is reported, not counted as zero" \
     test_unreadable_spaces_config_is_reported
+run_test "a Spaces config naming no display is reported as unknown" \
+    test_spaces_config_without_a_display_is_reported
 run_test "the preflight names the manual steps" \
     test_preflight_names_the_manual_steps
 run_test "the preflight names the focus-cue options" \

--- a/setup-macos_test
+++ b/setup-macos_test
@@ -825,6 +825,26 @@ test_preflight_names_the_manual_steps() {
     assert_output_contains "Grant Amethyst Accessibility access"
 }
 
+# A first run installs Amethyst partway through, so asking for the permission
+# before that asks the user to grant it to an application that isn't there.
+test_preflight_defers_accessibility_until_after_the_run() {
+    run_macos
+    assert_status 0 &&
+    assert_output_contains "Then once this run has finished" &&
+    assert_output_contains "can only be granted afterwards"
+}
+
+# AGENTS.md wants a recommended external dependency to come with its cost and
+# what happens when it isn't there.
+test_preflight_states_focus_cue_cost_and_failure() {
+    run_macos
+    assert_status 0 &&
+    assert_output_contains "free" &&
+    assert_output_contains "one-time" &&
+    assert_output_contains "always-on process" &&
+    assert_output_contains "losing the focus cue"
+}
+
 # macOS has no dim-inactive equivalent, so the preflight names the two ways to
 # get a focus cue rather than leaving it as an unexplained gap.
 test_preflight_names_the_focus_cue_options() {
@@ -1468,6 +1488,10 @@ run_test "the preflight names the manual steps" \
     test_preflight_names_the_manual_steps
 run_test "the preflight names the focus-cue options" \
     test_preflight_names_the_focus_cue_options
+run_test "the preflight defers Accessibility until after the install" \
+    test_preflight_defers_accessibility_until_after_the_run
+run_test "the preflight states focus-cue cost and failure behavior" \
+    test_preflight_states_focus_cue_cost_and_failure
 run_test "no preflight pause without a terminal" \
     test_preflight_does_not_pause_without_a_terminal
 run_test "--yes skips the preflight pause" \


### PR DESCRIPTION
Follow-up to #175, which merged before its review comments could be acted on. All three Codex findings held up on inspection; each is fixed here. Also moves the documentation into `docs/` so GitHub Pages can serve it.

## `setup-macos`: count Spaces per display, not as a total

Codex was right, and this defeated the diagnostic in exactly the configuration it exists for. With "Displays have separate Spaces" enabled the desktop numbering is per display, but the count spanned all of them — two displays with five Spaces each totalled ten, so the check reported `Option+1..9` as fine while `6..9` were dead on both.

Now splits the plist on the display identifier and counts each monitor separately, naming only the displays that are short.

The success message is gone entirely. A count can read one high (a monitor's current-Space marker carries a `ManagedSpaceID` of its own) and higher again for Spaces macOS created for fullscreen apps, and an over-count turning into an all-clear is precisely the failure being fixed — so the check only ever reports a shortfall now, never an all-clear.

A plist that parses but names no display is reported as unknown rather than as a display with zero Spaces, matching how an unreadable one was already handled.

## `setup-macos`: ask for Accessibility access after the install, not before

Also correct. The preflight asked users to grant Amethyst Accessibility access before continuing, but a first run doesn't install Amethyst until `configure_amethyst`, several steps later — so there was nothing to grant the permission to, and following the preflight as written couldn't leave tiling working.

It's now in a separate "then once this run has finished" group that says why. The end of `configure_amethyst` already repeats the instruction at the point it can be acted on.

## `setup-macos`: state the focus-cue apps' cost and failure behavior

Third finding, also fair — `AGENTS.md` asks for a dollar figure and the failure implications whenever an external dependency is recommended, and the prompt gave HazeOver only as "paid". It now carries the approximate price, notes each runs as an always-on process, and says that a missing or stopped one costs nothing but the focus cue.

## `docs/`: move the documentation and publish it

`MACOS.md` moves to `docs/MACOS.md`, with `docs/_config.yml` and `docs/index.md` alongside. Pages serves a single directory, and pointing it at the repository root would copy all ~150 scripts into the published site; a docs directory avoids that by construction rather than through an exclude list every new script could fall through.

`_config.yml` sets the layout via `defaults` so each page's front matter stays down to a title — GitHub renders front matter as a table above the document, and one key is the least intrusive version of that. The contents list works unchanged in both renderers, since GitHub and kramdown generate the same anchors for these headings.

To enable: **Settings → Pages → Deploy from a branch → `main`, `/docs`**.

## Testing

- 5 new tests (per-display counting, the multi-display regression, a display-less plist, and the two preflight changes); 904 tests, 0 failed.
- `shellcheck` clean.
- `awk` added to the test sandbox's PATH allowlist, since the per-display parse needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0134VMrLZBcGLyb7KcBA5P7v

---
_Generated by [Claude Code](https://claude.ai/code/session_0134VMrLZBcGLyb7KcBA5P7v)_