### PR TITLE
setup-macos: install Karabiner for the one binding the rotation inverts

### DIFF
--- a/docs/MACOS.md
+++ b/docs/MACOS.md
@@ -26,6 +26,7 @@ For why Amethyst rather than yabai or AeroSpace, skip to the
   - [And afterwards](#and-afterwards)
 - [Key mapping](#key-mapping)
   - [Modifier rotation](#modifier-rotation)
+  - [The one binding the rotation inverts](#the-one-binding-the-rotation-inverts)
 - [How desktop switching works](#how-desktop-switching-works)
   - [Reliability](#reliability)
 - [What doesn't carry over](#what-doesnt-carry-over)
@@ -75,8 +76,17 @@ this file.
 | `--no-root` | Unprivileged install; CLI tools come from conda-forge via `homepkg` instead |
 | `--no-npm` | Skip node and tsc |
 
-`--no-sudo` and `--no-root` are accepted but change little on macOS: nothing
-in the desktop configuration uses sudo, and Homebrew never wants it.
+`--no-sudo` and `--no-root` change little on macOS. Homebrew never wants sudo
+and installing Amethyst needs write access to an Applications directory rather
+than privilege. The one exception is Karabiner: its cask is backed by a `.pkg`,
+so Homebrew hands it to the system installer, which asks for an administrator
+password.
+
+The default is to try anyway. If you have admin rights you'll get the usual
+password prompt; if you don't, the install fails, the run warns and carries on,
+and everything except the Alt+Tab rule still applies. Pass `--no-sudo` only if
+you want to skip the attempt outright — `setup` promises that flag never
+prompts or stalls, so it has to skip rather than try.
 
 ### Desktop configuration on its own
 
@@ -94,7 +104,7 @@ missed step.
 | `--no-install` | Configure whatever Amethyst is already there; don't install |
 | `--ignore-errors` | Keep going past failures instead of aborting on the first |
 | `--yes` | Skip the preflight pause |
-| `--no-sudo` | Accepted for consistency with `setup`; nothing here uses sudo |
+| `--no-sudo` | Skip anything needing administrator rights — only Karabiner's installer does |
 | `--help` | Usage |
 
 `setup` forwards `--no-install`, `--no-sudo` and `--ignore-errors` when it
@@ -176,38 +186,50 @@ The run repeats the instruction when it gets there.
 
 ## Key mapping
 
-After the modifier rotation (see below), the physical Win/Super key sends
-Option, so a `Meta+X` binding on KDE is the same physical keypress as
-`Option+X` here.
+Both columns are the **physical keys you press** on a PC keyboard — not the
+modifier macOS receives. That distinction matters here, because the rotation
+below means the two are never the same thing: pressing `Win` sends Option,
+pressing `Ctrl` sends Command.
 
-| Action | KDE / Krohnkite | macOS | Provided by |
+Reading it this way is also the point of the whole arrangement. The columns
+match on all but two rows, which is the muscle memory being preserved.
+
+| Action | Linux (KDE) | macOS | Provided by |
 | --- | --- | --- | --- |
-| Switch to desktop 1–9 | `Meta+1`..`9` | `Option+1`..`9` | symbolichotkeys (IDs 118–126) |
-| Move window to desktop 1–9 | `Meta+Shift+1`..`9` | `Option+Control+1`..`9` | Amethyst `throw-space-N` |
-| Grow main pane | `Meta+\` | `Option+\` | Amethyst `expand-main` |
-| Shrink main pane | `Meta+/` | `Option+/` | Amethyst `shrink-main` |
-| Monocle / fullscreen layout | ``Meta+` `` | ``Option+` `` | Amethyst `select-fullscreen-layout` |
-| Previous layout | `Meta+,` | `Option+,` | Amethyst `cycle-layout-backward` |
-| Next layout | `Meta+.` | `Option+.` | Amethyst `cycle-layout` |
-| Set master window | `Meta+Return` | `Option+Return` | Amethyst `swap-main` |
-| Launcher / Spotlight | — | `Option+Space` | symbolichotkeys (ID 64) |
-| Browser 1 | `Meta+G` | `Option+G` | Automator Quick Action |
-| Browser 2 | `Meta+H` | `Option+H` | Automator Quick Action |
-| Terminal | `Meta+T` | `Option+T` | Automator Quick Action |
-| Terminal on workstation | `Meta+W` | `Option+W` | Automator Quick Action |
-| Music | `Meta+Y` | `Option+Y` | Automator Quick Action |
-| Close window | `Meta+Backspace` | `Cmd+W` (physical `Ctrl+W`) | macOS default, not configured |
+| Switch to desktop 1–9 | `Win+1`…`9` | `Win+1`…`9` | symbolichotkeys (IDs 118–126) |
+| Move window to desktop 1–9 | `Win+Shift+1`…`9` | **`Win+Alt+1`…`9`** | Amethyst `throw-space-N` |
+| Grow main pane | `Win+\` | `Win+\` | Amethyst `expand-main` |
+| Shrink main pane | `Win+/` | `Win+/` | Amethyst `shrink-main` |
+| Monocle / fullscreen layout | ``Win+` `` | ``Win+` `` | Amethyst `select-fullscreen-layout` |
+| Previous layout | `Win+,` | `Win+,` | Amethyst `cycle-layout-backward` |
+| Next layout | `Win+.` | `Win+.` | Amethyst `cycle-layout` |
+| Set master window | `Win+Return` | `Win+Return` | Amethyst `swap-main` |
+| Launcher / Spotlight | — | `Win+Space` | symbolichotkeys (ID 64) |
+| Browser 1 | `Win+G` | `Win+G` | Automator Quick Action |
+| Browser 2 | `Win+H` | `Win+H` | Automator Quick Action |
+| Terminal | `Win+T` | `Win+T` | Automator Quick Action |
+| Terminal on workstation | `Win+W` | `Win+W` | Automator Quick Action |
+| Music | `Win+Y` | `Win+Y` | Automator Quick Action |
+| Close window | `Win+Backspace` | **`Ctrl+W`** | macOS default, not configured |
+| Switch applications | `Alt+Tab` | `Alt+Tab` † | Karabiner rule |
+| Next tab in app | `Ctrl+Tab` | `Ctrl+Tab` † | Karabiner rule |
 
-Two deviations worth knowing:
+† Without Karabiner those last two swap round — `Ctrl+Tab` switches
+applications and `Alt+Tab` goes to the next tab. Its driver extension is the
+one part of this setup a managed Mac can refuse; see
+[the one binding the rotation inverts](#the-one-binding-the-rotation-inverts).
 
-**Move-to-desktop uses Option+Control, not Option+Shift.** Option is macOS's
-dead-key layer: `Option+Shift+1` emits `⁄` rather than registering as a
-modifier combination. Krohnkite's `Meta+Shift+N` has no clean equivalent, so
-`amethyst.yml` binds `mod2` (Option+Control) instead.
+Only two rows differ from the Linux keys:
 
-**Close window isn't rebound.** `Cmd+W` is the macOS convention and, after the
-rotation, sits under the physical Ctrl key where the Linux muscle memory
-expects it.
+**Move-to-desktop is `Win+Alt+N`, not `Win+Shift+N`.** With `Win` sending
+Option, macOS treats `Option+Shift+1` as its dead-key layer and emits `⁄`
+rather than registering a modifier combination. Krohnkite's `Meta+Shift+N` has
+no clean equivalent, so `amethyst.yml` uses `mod2` (Option+Control) — which is
+`Win+Alt` under the fingers.
+
+**Close window is `Ctrl+W`.** `Cmd+W` is the macOS convention and it isn't
+rebound; after the rotation it lands under the physical Ctrl key, which is
+where a Linux hand already reaches for close.
 
 ### Modifier rotation
 
@@ -222,6 +244,63 @@ expects it.
 This assumes a PC keyboard. `hidutil` applies it to every attached keyboard,
 including a laptop's built-in one whose keys are already in the Mac order this
 rotation is undoing.
+
+### The one binding the rotation inverts
+
+The rotation works because macOS uses Command wherever Linux uses Control, so
+`Ctrl+C`, `Ctrl+V`, `Ctrl+T` and `Ctrl+W` all stay under the same physical key.
+
+Tab is the exception. macOS switches applications with `Cmd+Tab`, which Linux
+does with `Alt+Tab` — the one common binding where macOS uses Command for
+something Linux does with Alt. Left alone, the rotation swaps the two round:
+
+| | Linux (PC keyboard) | After the rotation alone |
+| --- | --- | --- |
+| physical `Ctrl+Tab` | next tab in app | **switch applications** |
+| physical `Alt+Tab` | switch windows | **next tab in app** |
+
+`setup-macos` installs Karabiner-Elements and the conf repo ships a complex
+modification that swaps them back:
+
+| Physical keys | Rotation alone | With the Karabiner rule |
+| --- | --- | --- |
+| `Alt+Tab` | next tab in app | **switch applications** |
+| `Ctrl+Tab` | switch applications | **next tab in app** |
+
+Both directions are mapped, and that matters. Remapping only `Alt+Tab` would
+put application switching on the physical Alt key without taking it off the
+physical Ctrl key, leaving next-tab with no physical keys at all. Shift
+variants are mapped alongside each, so `Shift+Alt+Tab` cycles the switcher
+backwards and `Shift+Ctrl+Tab` goes to the previous tab.
+
+**This is the one part of the setup that a managed Mac can refuse.** Karabiner
+installs a driver extension, and an MDM profile can block system extensions
+outright — which is why the key mapping table qualifies both Tab rows. It's
+free and open source, so there's no cost beyond disk, but it is a heavier
+commitment than an ordinary app: a driver extension loading at boot plus a
+background service, and a macOS upgrade can require re-approving the
+extension. If it's blocked, fails, or is uninstalled, the keyboard keeps
+working — the `hidutil` rotation is independent of it — and the only effect is
+that the two Tab bindings revert to the "rotation alone" column above.
+
+The rule maps left Alt+Tab to **`left_control`**+Tab, which reads wrong until
+you follow the layering: Karabiner grabs the keyboard and sees the *physical*
+key, and its output then passes through the `hidutil` rotation. So it has to
+name the key the rotation turns into Command — left Control. Naming
+`left_command` would come out as Option.
+
+Karabiner needs three things done by hand, none of them scriptable: its driver
+extension approved, Input Monitoring granted, and the rule enabled under
+Complex Modifications > Add rule. Until then Alt+Tab keeps switching tabs. The
+full reasoning, and what to flip if the layering differs on your macOS
+version, is in the conf repo's `config/karabiner/README.md`.
+
+The reciprocal mapping works the same way in reverse: physical Ctrl emits
+`left_option`, which the rotation turns back into Control. Karabiner doesn't
+feed its own output through its manipulators, so the two directions don't
+chase each other.
+
+Only left Alt is mapped; right Alt stays a plain modifier.
 
 ## How desktop switching works
 

--- a/setup-macos
+++ b/setup-macos
@@ -9,6 +9,8 @@
 # - Amethyst tiling window manager: installs it (Homebrew, or a staged bundle
 #   offline), then sets focus follows mouse. Its layouts, modifiers and margins
 #   come from ~/.amethyst.yml, which confinst symlinks out of the conf repo.
+# - Karabiner-Elements, for the one binding the modifier rotation inverts:
+#   Alt+Tab. Its rule is symlinked out of the conf repo too.
 # - Application launch shortcuts via Automator Quick Actions (browser, terminal,
 #   music)
 # - Finder preferences (show hidden files, path bar, file extensions)
@@ -59,10 +61,12 @@
 #                 [-h | --help]
 #
 # setup forwards --no-install, --no-sudo, and --ignore-errors here.
-# --no-install skips installing Amethyst and configures whatever is already
-# there. macOS configuration uses no sudo, so --no-sudo is accepted but has
-# nothing to skip. --ignore-errors keeps going past failures instead of
-# aborting on the first one. --yes skips the preflight pause.
+# --no-install skips installing Amethyst and Karabiner-Elements and configures
+# whatever is already there. --no-sudo skips only Karabiner's install, the one
+# step here that needs administrator rights -- its cask is a .pkg and Homebrew
+# hands those to the system installer. --ignore-errors keeps going past
+# failures instead of aborting on the first one. --yes skips the preflight
+# pause.
 
 # Whether to keep going past failures. "no" aborts on the first error via
 # set -e; "yes" (via --ignore-errors) leaves it off and pushes through.
@@ -76,6 +80,11 @@ INSTALL=yes
 # Whether to skip the preflight pause (--yes). A stdin that isn't a terminal
 # skips it too; see preflight.
 ASSUME_YES=no
+
+# Whether privileged commands may run at all. Only Karabiner's install needs
+# this: its cask is a .pkg and Homebrew hands those to the system installer,
+# which prompts for an administrator password. --no-sudo skips it.
+SUDO=yes
 
 # Directory containing this script, resolved up front while $0 still means what
 # the caller typed. The launcher helpers the Quick Actions run live beside this
@@ -254,6 +263,22 @@ Then once this run has finished:
      This run installs Amethyst if it isn't already there, so the permission
      can only be granted afterwards -- the run says so again when it gets
      there.
+  4. Approve Karabiner-Elements' driver extension and Input Monitoring
+     permission when it first launches, then enable "Alt+Tab switches
+     applications" under Complex Modifications > Add rule. Without it Alt+Tab
+     switches tabs rather than applications, because the modifier rotation
+     puts Cmd+Tab on the physical Ctrl key.
+
+     Karabiner is free and open source, so no cost beyond the disk it takes.
+     It is a bigger commitment than an ordinary app, though: it installs a
+     driver extension that loads at boot and runs a background service, and a
+     managed Mac may refuse the extension outright. If it is blocked, fails,
+     or is removed, the keyboard keeps working -- the modifier rotation is
+     separate and does not depend on it -- and the only effect is that Alt+Tab
+     goes back to switching tabs. A macOS upgrade can also require approving
+     the extension again.
+
+
 
 Optional: macOS has no equivalent of KDE's dim-inactive effect. JankyBorders
 (`brew install borders`, free) outlines the focused window; HazeOver (around
@@ -294,10 +319,10 @@ Usage: setup-macos [--no-install] [--no-sudo] [--ignore-errors] [--yes]
 Configure the macOS desktop environment.
 
 Options:
-  --no-install     Don't install Amethyst; configure whatever is already
-                   there
-  --no-sudo        Accepted for consistency with setup; macOS configuration
-                   uses no sudo, so there's nothing to skip
+  --no-install     Don't install Amethyst or Karabiner-Elements; configure
+                   whatever is already there
+  --no-sudo        Don't run anything needing administrator rights. Only
+                   Karabiner-Elements' installer does, so only that is skipped
   --ignore-errors  Keep going past failures instead of aborting on the first
   --yes            Skip the preflight pause and start configuring right away
   -h, --help       Show this help and exit
@@ -314,12 +339,19 @@ while test $# -gt 0; do
         --no-install)
             INSTALL=no
             ;;
-        --sudo|--no-sudo)
-            # macOS configuration uses no sudo; accepted as a no-op so setup
-            # can forward these flags uniformly. Installing Amethyst needs
-            # write access to an Applications directory, not sudo: a staged
-            # bundle falls back to ~/Applications when /Applications isn't
-            # writable, and Homebrew never wants sudo.
+        --sudo)
+            SUDO=yes
+            ;;
+        --no-sudo)
+            # Almost nothing here needs sudo -- installing Amethyst needs write
+            # access to an Applications directory rather than privilege, and a
+            # staged bundle falls back to ~/Applications when /Applications
+            # isn't writable. Karabiner is the exception: its cask is backed by
+            # a .pkg, so Homebrew hands it to the system installer, which asks
+            # for an administrator password. setup promises --no-sudo never
+            # prompts or stalls, so that install has to be skipped rather than
+            # attempted. See install_karabiner.
+            SUDO=no
             ;;
         --ignore-errors)
             IGNORE_ERRORS=yes
@@ -852,6 +884,81 @@ configure_amethyst() {
     info "Grant Amethyst Accessibility access in System Settings > Privacy & Security"
 }
 
+# --- Configure Karabiner-Elements ---
+
+# Where Karabiner reads add-on rules from. confinst creates the directory for
+# real and symlinks the rule into it, so this is a symlink into the conf repo
+# rather than a file Karabiner owns -- Karabiner rewrites karabiner.json on
+# every UI change but never touches an asset.
+KARABINER_RULE="$HOME/.config/karabiner/assets/complex_modifications/pc-alt-tab.json"
+
+# Where Karabiner is, or empty if it isn't installed. Same is_usable_app test
+# as amethyst_path, and for the same reason: an interrupted install leaves a
+# directory with the right name and nothing in it, and treating that as
+# installed turns a failed install into a permanent one -- every later run
+# skips Homebrew and then tells the user to enable a rule in an application
+# that can't start.
+karabiner_path() {
+    for _dir in "$APPLICATIONS_DIR" "$USER_APPLICATIONS_DIR"; do
+        if is_usable_app "$_dir/Karabiner-Elements.app"; then
+            printf '%s' "$_dir/Karabiner-Elements.app"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# The modifier rotation makes the physical Ctrl key send Command, which is what
+# keeps Ctrl+C and friends where a Linux hand expects them. Tab is the one
+# binding that inverts under it -- macOS switches applications with Cmd+Tab
+# where Linux uses Alt+Tab -- so app switching lands on the physical Ctrl key
+# and next-tab on the physical Alt key. The rule in the conf repo swaps them
+# back; see config/karabiner/README.md there for why it emits left_control.
+#
+# Homebrew only. Unlike Amethyst there's no staged-bundle path: Karabiner
+# installs a driver extension that needs approving in the GUI anyway, so an
+# offline install would still leave the interactive half undone.
+install_karabiner() {
+    if _installed=$(karabiner_path); then
+        info "Karabiner-Elements is already installed at $_installed"
+        return 0
+    fi
+    if test "$INSTALL" = no; then
+        warn "Karabiner-Elements is not installed and --no-install was given; Alt+Tab will switch tabs rather than applications until it is"
+        return 0
+    fi
+    # Not attempted under --no-sudo: the cask is a .pkg, so Homebrew hands it
+    # to the system installer and an administrator prompt appears -- exactly
+    # what --no-sudo exists to avoid.
+    if test "$SUDO" = no; then
+        warn "Karabiner-Elements' installer needs administrator rights and --no-sudo was given; skipping it, so Alt+Tab will switch tabs rather than applications"
+        return 0
+    fi
+    if ! is_command brew; then
+        warn "Homebrew not found, so Karabiner-Elements can't be installed; Alt+Tab will switch tabs rather than applications until it is"
+        return 0
+    fi
+    info "Installing Karabiner-Elements"
+    brew install --cask karabiner-elements \
+        || warn "could not install Karabiner-Elements; Alt+Tab will switch tabs rather than applications until it is"
+}
+
+configure_karabiner() {
+    info "Configuring Karabiner-Elements"
+
+    install_karabiner
+
+    if ! test -f "$KARABINER_RULE"; then
+        warn "$KARABINER_RULE not found; run confinst after cloning the conf repo, or Alt+Tab keeps switching tabs"
+        return 0
+    fi
+
+    # Karabiner lists an asset under "Add rule" but doesn't enable it, and
+    # there's no supported way to enable one from a script: karabiner.json is
+    # rewritten by the app, so editing it here would be racing the GUI.
+    info "Enable \"Alt+Tab switches applications\" in Karabiner-Elements > Complex Modifications > Add rule"
+}
+
 # --- Configure application launch shortcuts ---
 
 # Print the path to a launcher helper, or fail if there isn't one. PATH first,
@@ -1121,6 +1228,7 @@ configure_modifier_keys
 configure_shortcuts
 configure_spaces
 configure_amethyst
+configure_karabiner
 configure_app_shortcuts
 configure_finder
 

--- a/setup-macos_test
+++ b/setup-macos_test
@@ -142,6 +142,16 @@ MOCK
     # machine, so the ordinary run has nothing to say about Option+1..9.
     stage_spaces 9
 
+    # Karabiner installed and its rule symlinked, i.e. the configured machine,
+    # so the ordinary run has nothing to warn about. Its tests remove one or
+    # the other.
+    # Contents/Info.plist plus Contents/MacOS, because that is what counts as
+    # installed -- a bare directory is what a half-finished install leaves.
+    mkdir -p "$APPLICATIONS_DIR/Karabiner-Elements.app/Contents/MacOS"
+    printf 'app\n' > "$APPLICATIONS_DIR/Karabiner-Elements.app/Contents/Info.plist"
+    mkdir -p "$TEST_TMPDIR/home/.config/karabiner/assets/complex_modifications"
+    touch "$TEST_TMPDIR/home/.config/karabiner/assets/complex_modifications/pc-alt-tab.json"
+
     # On PATH by default, so the ordinary run configures every shortcut. Tests
     # about missing launchers use isolate_script to get away from both these
     # and the real ones beside the script.
@@ -870,6 +880,132 @@ test_yes_skips_the_preflight_pause() {
     assert_output_lacks "stdin is not a terminal"
 }
 
+# --- Karabiner-Elements ---
+
+# Remove the pre-installed Karabiner, i.e. pretend a fresh machine.
+remove_karabiner() {
+    rm -rf "$APPLICATIONS_DIR/Karabiner-Elements.app" \
+        "$USER_APPLICATIONS_DIR/Karabiner-Elements.app"
+}
+
+# Regression: an interrupted install leaves a directory with the right name and
+# nothing usable in it. Treating that as installed skipped Homebrew on every
+# later run and then told the user to enable a rule in an application that
+# can't start -- a transient failure made permanent.
+test_partial_karabiner_bundle_is_reinstalled() {
+    remove_karabiner
+    mkdir -p "$APPLICATIONS_DIR/Karabiner-Elements.app"
+    run_macos
+    assert_status 0 &&
+    assert_called "brew install --cask karabiner-elements"
+}
+
+# The other half of the same check: Info.plist present but no executable
+# directory is equally unusable.
+test_karabiner_without_executable_dir_is_reinstalled() {
+    remove_karabiner
+    mkdir -p "$APPLICATIONS_DIR/Karabiner-Elements.app/Contents"
+    printf 'app\n' > "$APPLICATIONS_DIR/Karabiner-Elements.app/Contents/Info.plist"
+    run_macos
+    assert_status 0 &&
+    assert_called "brew install --cask karabiner-elements"
+}
+
+test_installs_karabiner_when_missing() {
+    remove_karabiner
+    run_macos
+    assert_status 0 &&
+    assert_called "brew install --cask karabiner-elements"
+}
+
+test_does_not_reinstall_karabiner() {
+    run_macos
+    assert_status 0 &&
+    assert_not_called "brew install --cask karabiner-elements"
+}
+
+# --no-install configures whatever is there; it must not reach for brew.
+test_no_install_skips_karabiner() {
+    remove_karabiner
+    run_macos --no-install --ignore-errors
+    assert_status 0 &&
+    assert_not_called "brew install --cask karabiner-elements" &&
+    assert_output_contains "Karabiner-Elements is not installed and --no-install was given"
+}
+
+# setup promises --no-sudo never prompts or escalates. Karabiner's cask is a
+# .pkg, so Homebrew hands it to the system installer and an administrator
+# prompt appears -- it has to be skipped rather than attempted.
+test_no_sudo_skips_karabiner_install() {
+    remove_karabiner
+    run_macos --no-sudo --ignore-errors
+    assert_status 0 &&
+    assert_not_called "brew install --cask karabiner-elements" &&
+    assert_output_contains "needs administrator rights and --no-sudo was given"
+}
+
+# --no-sudo must not touch Amethyst: its cask is a plain .app, so nothing
+# privileged is involved and skipping it would be a needless regression.
+test_no_sudo_still_installs_amethyst() {
+    remove_amethyst
+    run_macos --no-sudo --ignore-errors
+    assert_status 0 &&
+    assert_called "brew install --cask amethyst"
+}
+
+test_missing_brew_does_not_abort_karabiner() {
+    remove_karabiner
+    run_macos_without brew --ignore-errors
+    assert_status 0 &&
+    assert_output_contains "Homebrew not found, so Karabiner-Elements can't be installed"
+}
+
+# The rule is symlinked out of the conf repo, so a machine that hasn't run
+# confinst has Karabiner installed and no rule for it to load.
+test_missing_karabiner_rule_warns() {
+    rm -f "$TEST_TMPDIR/home/.config/karabiner/assets/complex_modifications/pc-alt-tab.json"
+    run_macos --ignore-errors
+    assert_status 0 &&
+    assert_output_contains "run confinst after cloning the conf repo"
+}
+
+# Karabiner lists an asset but doesn't enable it, and karabiner.json is
+# rewritten by the app -- so the enabling step is the user's, and saying so is
+# the only thing the script can do about it.
+test_says_how_to_enable_the_karabiner_rule() {
+    run_macos
+    assert_status 0 &&
+    assert_output_contains "Complex Modifications > Add rule"
+}
+
+# The preflight has to name the driver approval too: Karabiner is inert until
+# its system extension is allowed, which is a GUI-only step.
+test_preflight_names_karabiner_permissions() {
+    run_macos
+    assert_status 0 &&
+    assert_output_contains "driver extension and Input Monitoring"
+}
+
+# AGENTS.md wants cost and reliability stated before an external dependency is
+# recommended, and Karabiner is heavier than most: a driver extension at boot,
+# a background service, and an MDM that may refuse it outright.
+test_preflight_states_karabiner_cost_and_reliability() {
+    run_macos
+    assert_status 0 &&
+    assert_output_contains "free and open source" &&
+    assert_output_contains "driver extension that loads at boot" &&
+    assert_output_contains "managed Mac may refuse" &&
+    assert_output_contains "the keyboard keeps working"
+}
+
+# --no-install now skips two applications, so the help has to name both or it
+# is wrong precisely on the fresh machine where the flag matters.
+test_help_names_both_installs() {
+    run_macos --help
+    assert_status 0 &&
+    assert_output_contains "Amethyst or Karabiner-Elements"
+}
+
 # --- Amethyst ---
 
 test_enables_focus_follows_mouse() {
@@ -1163,6 +1299,9 @@ test_staged_bundle_clears_quarantine() {
 # assertion is worth.
 test_staged_bundle_falls_back_to_user_applications() {
     remove_amethyst
+    # Root can't be kept out by permissions, so this makes the directory
+    # genuinely absent instead -- which needs everything else out of it too.
+    remove_karabiner
     stage_amethyst_bundle "$TEST_TMPDIR/home/amethyst.zip"
     if test "$(id -u)" -eq 0; then
         rmdir "$APPLICATIONS_DIR"
@@ -1496,6 +1635,32 @@ run_test "no preflight pause without a terminal" \
     test_preflight_does_not_pause_without_a_terminal
 run_test "--yes skips the preflight pause" \
     test_yes_skips_the_preflight_pause
+run_test "installs Karabiner-Elements when missing" \
+    test_installs_karabiner_when_missing
+run_test "does not reinstall Karabiner-Elements" \
+    test_does_not_reinstall_karabiner
+run_test "a partial Karabiner bundle is reinstalled, not accepted" \
+    test_partial_karabiner_bundle_is_reinstalled
+run_test "a Karabiner bundle without an executable directory is reinstalled" \
+    test_karabiner_without_executable_dir_is_reinstalled
+run_test "--no-install skips installing Karabiner-Elements" \
+    test_no_install_skips_karabiner
+run_test "missing brew does not abort the Karabiner step" \
+    test_missing_brew_does_not_abort_karabiner
+run_test "--no-sudo skips the Karabiner install" \
+    test_no_sudo_skips_karabiner_install
+run_test "--no-sudo still installs Amethyst" \
+    test_no_sudo_still_installs_amethyst
+run_test "a missing Karabiner rule warns, not fatal" \
+    test_missing_karabiner_rule_warns
+run_test "says how to enable the Karabiner rule" \
+    test_says_how_to_enable_the_karabiner_rule
+run_test "the preflight names the Karabiner permissions" \
+    test_preflight_names_karabiner_permissions
+run_test "the preflight states Karabiner's cost and reliability" \
+    test_preflight_states_karabiner_cost_and_reliability
+run_test "--help names both applications --no-install skips" \
+    test_help_names_both_installs
 run_test "enables focus follows mouse" test_enables_focus_follows_mouse
 run_test "a missing amethyst config warns, not fatal" test_missing_amethyst_config
 run_test "says Amethyst needs Accessibility access" \


### PR DESCRIPTION
Installs Karabiner-Elements and surfaces its manual steps, so `Alt+Tab` switches applications rather than tabs. Pairs with mikelward/conf#236, which ships the rule itself.

Squashed to one commit — review fixes folded into the commit they belong to, per `AGENTS.md`.

## Why

The modifier rotation works because macOS uses Command wherever Linux uses Control — `Ctrl+C`, `Ctrl+V`, `Ctrl+T`, `Ctrl+W` all stay under the same physical key.

Tab is the exception. macOS switches applications with `Cmd+Tab` where Linux uses `Alt+Tab`, so the rotation puts app switching on the physical Ctrl key and next-tab on the physical Alt key — the two swap round. Both are bindings a hand reaches for without thinking.

## What this adds

`configure_karabiner`, following `configure_amethyst`'s shape:

- Installs Karabiner-Elements if it isn't there, via `karabiner_path` — the same `is_usable_app` check `amethyst_path` uses, so an interrupted install that left a bare directory gets replaced rather than treated as installed forever.
- Warns if the rule isn't symlinked (i.e. `confinst` hasn't run against the conf repo).
- Says how to enable the rule, which is a GUI step — Karabiner lists an asset under "Add rule" without enabling it, and `karabiner.json` is rewritten by the app, so editing it from here would be racing the GUI.

**Homebrew only, deliberately.** Unlike Amethyst there's no staged-bundle fallback: Karabiner installs a driver extension that has to be approved interactively regardless, so an offline install would still leave the interactive half undone.

Every failure path warns and carries on — missing `brew`, missing rule, `--no-install`, `--no-sudo`. Alt+Tab being wrong doesn't justify aborting the rest of the desktop setup.

## `--no-sudo` is now live

It used to be a documented no-op here, and that was accurate: Amethyst's cask is a plain `.app` and Homebrew wants no privilege for it. Karabiner's cask is backed by a `.pkg`, so Homebrew hands it to the system installer, which asks for an administrator password — and `setup`'s own help promises `--no-sudo` skips privileged commands *up front instead of attempting them, so setup never prompts or stalls*.

`setup-macos` now tracks `SUDO` and skips only that install when it's off. The default still attempts it and takes the password prompt, since admin rights are the common case; if the install fails for lack of them it warns and the run carries on.

## Cost and reliability

Karabiner is free and open source, so the figure is $0 beyond disk — but it's heavier than an ordinary app, and the preflight says so: a driver extension that loads at boot, a background service, an MDM that may refuse the extension outright, and a macOS upgrade that can require approving it again.

The blast radius is small, which is the part worth stating: the `hidutil` rotation is independent of Karabiner, so if the extension is blocked, fails, or is removed, the keyboard keeps working normally and the only casualty is Alt+Tab reverting to switching tabs.

## Docs

The key mapping table in `docs/MACOS.md` now reads in **physical keys** on both sides rather than mixing physical keys with the modifier macOS receives. That distinction matters here, because the rotation means the two are never the same thing — and read that way, the columns match on all but two rows, which is the muscle memory being preserved:

| Action | Linux (KDE) | macOS |
| --- | --- | --- |
| Switch to desktop 1–9 | `Win+1`…`9` | `Win+1`…`9` |
| Move window to desktop | `Win+Shift+1`…`9` | **`Win+Alt+1`…`9`** |
| Close window | `Win+Backspace` | **`Ctrl+W`** |
| Switch applications | `Alt+Tab` | `Alt+Tab` † |
| Next tab in app | `Ctrl+Tab` | `Ctrl+Tab` † |

† Without Karabiner those two swap round. TOC updated, anchors re-validated.

## Review findings

Five from Codex, all valid, all folded in:

- `--help` described `--no-install` as affecting Amethyst alone.
- Karabiner was installed with no cost/reliability disclosure, which `AGENTS.md` requires.
- The key mapping table gave the same physical keys to two different actions. Not just a bad row: the rule genuinely left next-tab unreachable, fixed in conf#236 by mapping the reciprocal.
- `test -d` accepted any directory named `Karabiner-Elements.app` as installed, so an interrupted install became permanent — reintroducing a bug the repo had already fixed for Amethyst via `is_usable_app`.
- `--no-sudo` wasn't honored, breaking a promise `setup`'s help makes.

## Testing

14 new tests: install when missing, don't reinstall, a partial bundle is reinstalled, a bundle without an executable directory is reinstalled, `--no-install` skips it, `--no-sudo` skips it, `--no-sudo` still installs Amethyst, missing brew doesn't abort, missing rule warns, the enable instruction is printed, the preflight names the permissions and the cost/reliability points, and `--help` names both applications. 917 tests, 0 failed. `shellcheck` clean.

One existing test needed a fix: `a staged bundle falls back to ~/Applications` empties the Applications directory with `rmdir` when running as root, which now fails with a second app in there. It removes Karabiner too.

## Caveat

I couldn't verify the Karabiner/`hidutil` layering from this sandbox — it's Linux and the interaction is macOS-specific. conf#236 documents the symptom if the ordering differs and how to correct it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0134VMrLZBcGLyb7KcBA5P7v