### PR TITLE
setup: stop Homebrew asking to confirm what setup already decided

### DIFF
--- a/setup
+++ b/setup
@@ -99,6 +99,18 @@ CONF_DIR="$HOME/conf"
 SRC_DIR="$HOME/src"
 ROOT_DIR="$SRC_DIR/root"
 
+# Homebrew's ask mode is on by default, so `brew install` prints its plan and
+# waits for a yes whenever the plan pulls in dependencies -- which every
+# formula and cask list here does. Running setup is the yes; re-asking per
+# package is a question the user already answered. Exported rather than passed
+# per call so it covers setup-macos too, and so it survives an older brew that
+# predates the --no-ask flag (an unknown HOMEBREW_ variable is ignored, an
+# unknown flag is a hard error).
+#
+# This deliberately stops at confirmations. The administrator password a .pkg
+# cask asks for is the user's to give, and nothing here suppresses it.
+export HOMEBREW_NO_ASK=1
+
 # Whether to install/configure graphical components. One of:
 #   auto - decide based on a detected display server (the default)
 #   yes  - forced on via --gui
@@ -752,6 +764,13 @@ install_homebrew() {
         return 0
     fi
     info "Installing Homebrew"
+    # Deliberately not NONINTERACTIVE=1, tempting as it looks: that suppresses
+    # more than the installer's opening RETURN. It switches the installer's
+    # sudo calls to `sudo -n` and skips the `sudo -v` that would cache
+    # credentials, so on a fresh Mac with no warm sudo timestamp the installer
+    # aborts with "Need sudo access on macOS" instead of asking for the
+    # password. The administrator password is the user's to give -- one RETURN
+    # on the one run that installs Homebrew is the better trade.
     if ! /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"; then
         warn "Homebrew installation failed"
         return 1

--- a/setup-macos
+++ b/setup-macos
@@ -86,6 +86,13 @@ ASSUME_YES=no
 # which prompts for an administrator password. --no-sudo skips it.
 SUDO=yes
 
+# Homebrew's ask mode is on by default, so the cask installs below stop to
+# confirm a plan the caller already asked for. setup exports this too; set it
+# here as well because setup-macos is also run on its own. It stops at
+# confirmations -- the administrator password Karabiner's .pkg needs is the
+# user's to give, and nothing here suppresses it.
+export HOMEBREW_NO_ASK=1
+
 # Directory containing this script, resolved up front while $0 still means what
 # the caller typed. The launcher helpers the Quick Actions run live beside this
 # script, and during a fresh bootstrap `setup` runs it straight out of the

--- a/setup-macos_test
+++ b/setup-macos_test
@@ -61,13 +61,21 @@ MOCK
 
     # pgrep exits 0 by default, i.e. the app is running and restart_app should
     # go on to killall it.
-    for cmd in hidutil launchctl killall brew; do
+    for cmd in hidutil launchctl killall; do
         cat > "$TEST_TMPDIR/bin/$cmd" <<MOCK
 #!/bin/sh
 printf "%s\\n" "$cmd \$*" >> "$CALLS"
 exit 0
 MOCK
     done
+
+    # brew records its environment as well as its arguments: ask mode is
+    # Homebrew's default, and the only evidence it's off is what brew inherits.
+    cat > "$TEST_TMPDIR/bin/brew" <<MOCK
+#!/bin/sh
+printf "%s\\n" "brew \$* [HOMEBREW_NO_ASK=\${HOMEBREW_NO_ASK:-unset}]" >> "$CALLS"
+exit 0
+MOCK
 
     # pgrep answers "running" for everything except the settings app, which
     # would otherwise make every ordinary run warn about being clobbered. A
@@ -953,6 +961,18 @@ test_no_sudo_still_installs_amethyst() {
     assert_called "brew install --cask amethyst"
 }
 
+# Homebrew's ask mode is the default, so the cask installs stopped to confirm
+# a plan the caller had already asked for by running setup-macos. This is not
+# behind --yes: that flag skips the preflight pause, a separate question.
+test_cask_installs_do_not_ask_for_confirmation() {
+    remove_amethyst
+    remove_karabiner
+    run_macos --ignore-errors
+    assert_status 0 &&
+    assert_called "brew install --cask amethyst [HOMEBREW_NO_ASK=1]" &&
+    assert_called "brew install --cask karabiner-elements [HOMEBREW_NO_ASK=1]"
+}
+
 test_missing_brew_does_not_abort_karabiner() {
     remove_karabiner
     run_macos_without brew --ignore-errors
@@ -1645,6 +1665,8 @@ run_test "a Karabiner bundle without an executable directory is reinstalled" \
     test_karabiner_without_executable_dir_is_reinstalled
 run_test "--no-install skips installing Karabiner-Elements" \
     test_no_install_skips_karabiner
+run_test "cask installs don't stop for confirmation" \
+    test_cask_installs_do_not_ask_for_confirmation
 run_test "missing brew does not abort the Karabiner step" \
     test_missing_brew_does_not_abort_karabiner
 run_test "--no-sudo skips the Karabiner install" \

--- a/setup_test
+++ b/setup_test
@@ -125,6 +125,46 @@ extract_functions() {
     ' "$SETUP"
 }
 
+# The Homebrew environment lives at setup's top level rather than inside a
+# function, so extract_functions can't reach it. Pull the export lines out of
+# the source the same way, so a harness that replays them fails if setup stops
+# setting them -- a hand-written copy here would pass either way.
+extract_homebrew_env() {
+    grep '^export HOMEBREW_' "$SETUP"
+}
+
+# Run install_homebrew against a stub curl. The installer is fetched and run as
+# `/bin/bash -c "$(curl ...)"`, so having curl print a one-line script is
+# enough to see the environment the installer is actually handed -- bash runs
+# it for real, no stubbing of bash needed. PATH holds only the stub, so the
+# real brew (present on the GitHub Actions runners) can't short-circuit the
+# function before it gets there.
+run_homebrew_installer() {
+    brew_tmpdir="$(mktemp -d)"
+    brew_calls="$brew_tmpdir/calls"
+    cat > "$brew_tmpdir/curl" <<MOCK
+#!/bin/sh
+cat <<'INSTALLER'
+printf '%s\n' "installer ran [NONINTERACTIVE=\${NONINTERACTIVE:-unset}]" >> "$brew_calls"
+INSTALLER
+MOCK
+    chmod +x "$brew_tmpdir/curl"
+    # The only real tools the stub PATH needs: sh to run the extracted
+    # functions, cat for the stub curl itself.
+    for tool in sh cat; do
+        ln -s "$(command -v "$tool")" "$brew_tmpdir/$tool"
+    done
+
+    set +e
+    output="$(PATH="$brew_tmpdir" \
+        sh -c "$(extract_functions "info warn install_homebrew")
+install_homebrew" 2>&1)"
+    status=$?
+    set -e
+    calls="$(cat "$brew_calls" 2>/dev/null)"
+    rm -rf "$brew_tmpdir"
+}
+
 # Run set_default_terminal for one OS against mocked KDE/xdg tools.
 # terminal_mode=fail makes kwriteconfig6 and xdg-mime exit non-zero, so the
 # tests can check that a failure is reported rather than swallowed -- and that
@@ -177,7 +217,7 @@ run_macos_packages() {
     macos_calls="$macos_tmpdir/calls"
     cat > "$macos_tmpdir/brew" <<MOCK
 #!/bin/sh
-printf '%s\n' "brew \$*" >> "$macos_calls"
+printf '%s\n' "brew \$* [HOMEBREW_NO_ASK=\${HOMEBREW_NO_ASK:-unset}]" >> "$macos_calls"
 exit 1
 MOCK
     chmod +x "$macos_tmpdir/brew"
@@ -185,6 +225,7 @@ MOCK
     set +e
     output="$(PATH="$macos_tmpdir:$PATH" \
         sh -c "set -e
+$(extract_homebrew_env)
 OS=macos
 NPM=yes
 ROOT=yes
@@ -1017,6 +1058,28 @@ test_macos_brew_failure_still_attempts_later_steps() {
     assert_calls_contain "brew install zoxide" &&
     assert_calls_contain "brew install --cask android-platform-tools" &&
     assert_calls_contain "brew install kitty"
+}
+
+# Homebrew's ask mode is on by default, so each install below printed its plan
+# and waited for a yes whenever it pulled in a dependency -- which the core
+# formula list always does. Running setup is the yes. The mock reports what
+# brew inherited, and the harness replays setup's own export rather than a copy
+# of it, so dropping the export from the script fails this.
+test_brew_installs_do_not_ask_for_confirmation() {
+    run_macos_packages 0
+    assert_status 0 &&
+    assert_calls_contain "brew install zoxide [HOMEBREW_NO_ASK=1]" &&
+    assert_calls_contain "brew install --cask android-platform-tools [HOMEBREW_NO_ASK=1]"
+}
+
+# NONINTERACTIVE must not reach the Homebrew installer. It does more than skip
+# the opening RETURN: the installer switches its sudo calls to `sudo -n` and
+# skips the `sudo -v` that caches credentials, so a fresh Mac with no warm sudo
+# timestamp aborts with "Need sudo access on macOS" rather than asking for the
+# password -- and setup then skips every macOS package it exists to install.
+test_installer_can_still_ask_for_the_admin_password() {
+    run_homebrew_installer
+    assert_calls_contain "installer ran [NONINTERACTIVE=unset]"
 }
 
 # When Homebrew itself can't be made available there is nothing to install
@@ -1880,6 +1943,10 @@ run_test "macOS brew failures warn instead of aborting the bootstrap" \
     test_macos_brew_failures_are_not_fatal
 run_test "a failing brew still attempts the later macOS steps" \
     test_macos_brew_failure_still_attempts_later_steps
+run_test "brew installs don't stop for confirmation" \
+    test_brew_installs_do_not_ask_for_confirmation
+run_test "the Homebrew installer can still ask for the admin password" \
+    test_installer_can_still_ask_for_the_admin_password
 run_test "macOS without Homebrew skips the arm and continues" \
     test_macos_without_homebrew_skips_the_arm
 run_test "no unguarded brew install remains" \


### PR DESCRIPTION
Running `setup` on macOS stopped for a confirmation at every Homebrew step.

## Cause

Homebrew's **ask mode is on by default**. From `Library/Homebrew/env_config.rb`:

> Ask mode is the default for `brew install`, `brew upgrade` and `brew reinstall` commands. Ask mode prints the plan before proceeding and prompts only if the plan includes dependencies, dependants or packages other than named arguments. […] The confirmation prompt is skipped without a TTY.

Every formula and cask list in `setup` pulls in dependencies, so every step qualified. The "skipped without a TTY" clause is why CI never saw this and an interactive run always did.

## Fix

Export `HOMEBREW_NO_ASK=1` from `setup`, and from `setup-macos` as well since it is also run standalone.

The environment variable rather than `--no-ask` on each call site, for two reasons: it covers every brew invocation including ones added later, and an older brew that predates the flag ignores an unknown `HOMEBREW_` variable where an unknown command-line flag is a hard error.

## What is deliberately left alone

**The Homebrew installer's opening RETURN.** `NONINTERACTIVE=1` would skip it, and an earlier revision of this branch did that — Codex caught it, correctly. In `install.sh`'s `have_sudo_access`, that variable also appends `-n` to every sudo invocation and skips the `sudo -v` that caches credentials, so on a fresh Mac with a cold sudo timestamp the installer aborts with `Need sudo access on macOS` and `setup` then skips every package it exists to install.

There is no clean way to suppress only the pause: `NONINTERACTIVE` is the one knob for it, and it is the same knob that sets `-n`. Warming the timestamp with `sudo -v` first would trade this for a worse failure — a fresh install fetches the Command Line Tools, which routinely outruns sudo's 5-minute `timestamp_timeout`, so an expiry would abort partway through instead of at the start. One RETURN on the single run that installs Homebrew is the better trade.

**The administrator password** a `.pkg` cask hands to the system installer. That is the user's to give, and nothing here suppresses it. That's the line this PR draws: don't re-ask for decisions the caller already made by running `setup`, do still ask for what only the user can supply.

Independent of `setup-macos --yes`, which skips the preflight pause and is a separate question.

## Tests

Four new behavioral tests, each failing before the corresponding fix:

- `setup_test`: brew installs don't stop for confirmation
- `setup_test`: the Homebrew installer can still ask for the admin password
- `setup-macos_test`: cask installs don't stop for confirmation

The brew mocks in both suites now record `HOMEBREW_NO_ASK` from the environment alongside the arguments, so the assertion is on what brew actually inherited rather than on what the script appears to say. `setup_test`'s macOS harness replays the `export` line pulled out of `setup` itself (`extract_homebrew_env`, alongside the existing `extract_functions`) rather than a hand-written copy — removing the export from the script fails the test.

The installer test is behavioral rather than a source grep: `run_homebrew_installer` stubs `curl` to print a one-line script that records its own environment, and since `install_homebrew` runs it via `/bin/bash -c "$(curl ...)"`, bash executes it for real. Re-adding `NONINTERACTIVE=1` to that line fails the test.

`make test` is green across the whole suite.