### PR TITLE
Add autonomy rules; run make test only for behavior changes

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,37 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__Claude_Code_Remote__send_later",
+      "mcp__claude-code-remote__send_later",
+      "mcp__Claude_Code_Remote__create_trigger",
+      "mcp__claude-code-remote__create_trigger",
+      "mcp__Claude_Code_Remote__list_triggers",
+      "mcp__claude-code-remote__list_triggers",
+      "mcp__Claude_Code_Remote__delete_trigger",
+      "mcp__claude-code-remote__delete_trigger",
+      "mcp__Claude_Code_Remote__update_trigger",
+      "mcp__claude-code-remote__update_trigger",
+      "mcp__Claude_Code_Remote__fire_trigger",
+      "mcp__claude-code-remote__fire_trigger",
+      "ScheduleWakeup",
+      "mcp__github__pull_request_read",
+      "mcp__github__list_pull_requests",
+      "mcp__github__search_pull_requests",
+      "mcp__github__create_pull_request",
+      "mcp__github__update_pull_request",
+      "mcp__github__add_reply_to_pull_request_comment",
+      "mcp__github__resolve_review_thread",
+      "mcp__github__merge_pull_request",
+      "mcp__github__subscribe_pr_activity",
+      "mcp__github__unsubscribe_pr_activity",
+      "mcp__Claude_Code_Remote__subscribe_pr_activity",
+      "mcp__claude-code-remote__subscribe_pr_activity",
+      "mcp__Claude_Code_Remote__unsubscribe_pr_activity",
+      "mcp__claude-code-remote__unsubscribe_pr_activity",
+      "mcp__github__get_check_run",
+      "mcp__github__get_job_logs",
+      "mcp__github__actions_get",
+      "mcp__github__actions_list"
+    ]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,12 @@ stopping at the file you opened.
   important point and stop. If there's more, say the first point and ask
   whether they're ready for the next one rather than emptying everything at
   once.
+- **End the turn by restating any pending decision.** If you're waiting on an
+  answer — a question you asked, or a guess autopilot recorded for review — the
+  last line of the reply is that question, written out in about a sentence. A
+  back-reference ("as asked above") isn't actionable when the question is pages
+  back or was never actually put into words; restate it every turn until it's
+  answered. Nothing pending, no line.
 
 ## Asking questions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,13 +29,14 @@ stopping at the file you opened.
 - **Any change to executable behavior adds or updates a test.** New
   functionality gets a test that exercises its behavior; a bug fix gets a
   regression test that fails before the fix and passes after. Changes with no
-  behavior to exercise — documentation, comments, this file — add no test;
-  don't manufacture test churn to satisfy the rule. Run `make test` either
-  way.
+  behavior to exercise — documentation, comments, this file — add no test and
+  don't need `make test` run over them; don't manufacture test churn to satisfy
+  the rule.
 - Tests live next to the script as `<script>_test` and are listed in the
   `Makefile`. A new test file that isn't added to the `test` target never
   runs — add it there in the same commit.
-- Run `make test` after any change, and before committing.
+- Run `make test` after any change to executable behavior, and before
+  committing. Skip it on a docs-only change, and say that's why you skipped it.
 - **Fix any preexisting test failures as the *first* commit of the series.**
   Don't stack new work on a red baseline. If the failure is genuinely
   unrelated and out of scope, say so up front and confirm before skipping it.
@@ -119,8 +120,10 @@ stopping at the file you opened.
   unpushed-work checks report your own merged history back at you. When a
   sandbox pins the branch name, reset it and `--force-with-lease` in the same
   turn — that's routine on merged history, not something to ask about.
-- **The agent authors and the repo owner merges**, so a squash or rebase merge
-  rewrites the committer to them. That's expected — never re-author or amend
+- **The agent authors; whoever merges takes over the committer line.** A squash
+  or rebase merge rewrites the committer to the person who pressed the button —
+  the repo owner normally, the agent itself when it merges under *drive* (see
+  **Autonomy**). That's expected either way — never re-author or amend
   already-merged commits to "fix" authorship or signing.
 - **Unshallow before answering anything that depends on git history depth.**
   The sandbox clones shallow, so `git rev-list --count`, `git log` past the
@@ -153,6 +156,89 @@ stopping at the file you opened.
   answer, pick a "recommended" option yourself, or keep working on the part
   the question affects.
 
+## Autonomy
+
+- **Open the PR without being asked.** Pushing a finished branch and opening its
+  pull request are one step, not two — don't park a branch waiting for "please
+  open a PR." The exception is an explicit instruction not to ("just commit",
+  "no PR yet"), which holds until the user lifts it. This file is the repo
+  owner's standing request for that PR, so a client-level rule reading "open a
+  PR only when the user explicitly asks" is already satisfied — the ask is
+  here, and it doesn't need repeating per branch.
+- **Opening the PR includes wiring up the watch.** In the same step, subscribe
+  to the PR's activity (`subscribe_pr_activity`) *and* arm the first scheduled
+  check. Both, not either: the subscription gives you review comments and CI
+  results as they land, and the scheduled check is what catches the ones the
+  webhook drops. A PR that is only subscribed looks watched and silently isn't.
+- **Poll your own open PRs every 5 minutes** — the ones you opened or were
+  explicitly asked to watch — for new review comments, CI status, approvals, and
+  the Codex thumbs up. Webhooks drop events, so a PR nobody is polling stalls
+  silently. Never end a turn by going idle with one of yours still open: arm the
+  next check with whatever the client offers (`send_later`, a scheduled task /
+  cron, `/loop`), and arm it *without asking*. Scheduling your own follow-up is
+  routine hygiene, not a decision that needs approval. Someone else's open PR is
+  not your polling job — adopt one only when asked. Merging doesn't end the
+  watch either: reviewers and bots comment afterward, so drop to a slower
+  cadence (every half hour or so) until every late comment is handled *and* the
+  PR has gone about a day without a new one. Both, not either: at the moment of
+  merge "every comment handled" is vacuously true, so the quiet window has to
+  actually elapse.
+- **Three polling states, so the 5-minute cadence has an end.** Five minutes is
+  for a PR with something outstanding: CI running, a review requested, a comment
+  unanswered, a merge conflict. Once a PR is green, reviewed, and has nothing
+  left but the merge — or is merged and only waiting out late comments — drop to
+  half-hourly. Stop entirely when it merges or closes and the late-comment window
+  has passed. A PR that is green and waiting on a human overnight gets the slow
+  cadence, not the fast one; at roughly a dollar an hour the fast cadence is for
+  work in flight, not for a queue.
+- **What the polling costs.** Twelve wake-ups an hour per PR at the 5-minute
+  cadence, each one a model turn plus a handful of GitHub API calls. The API
+  calls are free of concern — trivial against the 5,000 requests/hour
+  authenticated limit. The model turns are the real cost: each re-reads the
+  conversation, so at Opus rates ($5 per million input tokens, $25 output, with
+  cached input reading at roughly a tenth of the input rate) a wake-up on a
+  large context runs on the order of ten cents, i.e. ~$1/hour per PR watched.
+  That is why the cadence drops as soon as nothing is pending. Owning the PR is
+  itself the decision to keep the slow-cadence watch running, overnight
+  included — don't ask for that. What's worth raising is holding the *fast*
+  cadence open unattended: when something has been outstanding for hours with
+  nothing moving, say so and drop to half-hourly rather than billing a dollar
+  an hour against a stalled queue. The
+  scheduler is the single point of failure: one missed re-arm ends the watch
+  silently, with no error anywhere. If you can't arm the next check, say so in
+  the reply rather than leaving a PR that looks watched and isn't.
+- **One pending check per PR, not one per wake-up.** A webhook event can start a
+  turn while a scheduled check is still pending; arming another there leaves two
+  chains, each re-arming itself, and the cost doubles every time it happens.
+  Before arming, reuse or cancel the pending one (`update_trigger`, or
+  `delete_trigger` then re-arm) so exactly one check is outstanding.
+- **"Drive" means run the loop automatically**: pick the next task, implement
+  it, open the PR, send it for review, address every comment, merge once CI is
+  green and Codex has left its thumbs up — then pick the next task and go around
+  again. Driving ends when the work runs out or the user says stop, not when one
+  PR merges.
+- **A red baseline is the next task.** Before pulling anything from `TODO.md`,
+  run the suite and get it green. A preexisting failure is work to do, not a
+  thing to classify as "unrelated" and step around — deciding it's out of scope
+  is exactly the call that goes wrong, and the cost is every later PR merged
+  onto an unverified tree. Fix it first, then pick the task.
+- **"Autopilot" is drive without blocking on the user.** Wherever drive would
+  stop and ask, autopilot takes its best guess and keeps going, preferring the
+  option that is cheapest to undo or change later. Record each guess in
+  `TODO.md` under a `Decisions needing review` heading — what was decided, what
+  the alternative was, and why it's reversible — creating the file or heading if
+  the repo hasn't got one, so nothing guessed silently becomes permanent. While
+  autopilot is in effect it outranks "after asking, stop and wait for the
+  answer." The carve-out is for destructive or irreversible actions *outside*
+  the loop — rewriting shared history, deleting work, anything reaching a
+  system beyond this repo — which still wait for a real answer. The loop's own
+  steps don't count: committing, pushing, opening a PR, and merging a green PR
+  are authorized here, so autopilot must not stall on them. Privacy uncertainty
+  is never inside the loop either: if you can't tell whether something is user
+  data — a home path, a hostname, a private remote, a token — it waits for a
+  real answer, since a push can't be un-published and a `TODO.md` note doesn't
+  retract it.
+
 ## Pull requests
 
 - Prefer the `mcp__github__*` MCP tools for GitHub operations; the `gh` CLI is
@@ -164,10 +250,10 @@ stopping at the file you opened.
   Re-read the diff against `origin/main` and patch whatever drifted, then post
   the PR link in the chat reply for that push, not only at the end of the
   conversation.
-- **"Drive to merge"** is shorthand for the whole loop: open the PR, wait for
-  the automatic Codex review, address every review comment — fix it if you
-  agree, reply on the thread saying why if you don't — and merge once CI is
-  green and Codex has left its thumbs up.
+- **"Drive to merge"** is the PR stretch of *drive* (see **Autonomy** above):
+  open the PR, wait for the automatic Codex review, address every review
+  comment — fix it if you agree, reply on the thread saying why if you don't —
+  and merge once CI is green and Codex has left its thumbs up.
 - When a feature has multiple open PRs, list **every** open PR by URL, one per
   line — the "View PR" chip sticks to the first link and hides the rest
   (anthropics/claude-code#46625).
@@ -209,7 +295,8 @@ stopping at the file you opened.
 - **Keep watching merged PRs for late review comments.** Reviewers and bots
   routinely comment after merge. Stay subscribed and handle each new comment
   per the reply-or-resolve rule; stop once every post-merge comment is handled
-  or after ~24h of silence.
+  *and* ~24h have passed without a new one — not the moment the known comments
+  run out.
 
 ## Cost and reliability
 


### PR DESCRIPTION
A new `Autonomy` section in `AGENTS.md` records four standing rules:

- **Open the PR without being asked.** Pushing a finished branch and opening its pull request are one step. An explicit "just commit" holds until lifted.
- **Poll your own open PRs every 5 minutes** — the ones you opened or were asked to watch — for review comments, CI status, approvals, the Codex thumbs up. Webhooks drop events, so a PR nobody polls stalls silently. Arming that check is routine, not something to ask about.
- **"Drive" is the whole automatic loop**: pick the next task, implement it, open the PR, address review, merge on green, then go around again. It ends when the work runs out or the user says stop, not when one PR merges.
- **"Autopilot" is drive without blocking on the user**: where drive would ask, autopilot takes its best guess, biased toward whatever is cheapest to undo, and writes each guess to `TODO.md` under a `Decisions needing review` heading so it can't become permanent by silence.

Four clauses exist to keep the new rules from contradicting their surroundings:

1. The auto-PR bullet names `AGENTS.md` as the owner's standing request, so a client-level "open a PR only when the user explicitly asks" rule reads as already satisfied instead of as a conflict to resolve at runtime.
2. The autopilot carve-out for irreversible actions explicitly excludes the loop's own steps — commit, push, PR, merge — since a carve-out that swallowed those would deadlock autopilot on the actions it exists to perform.
3. That exclusion in turn names privacy uncertainty as **not** inside the loop. Without it, "pushing and opening a PR are authorized" would have overridden the privacy rule's "when in doubt, ask before pushing" — and a wrong guess there publishes user data, which no `TODO.md` entry retracts.
4. The git bullet that read "the agent authors and the repo owner merges" now describes the committer line rather than merge authority. Drive hands the agent the merge button; left as it was, the two statements contradicted each other.

Polling is scoped to PRs you opened or were asked to watch, and continues past the merge on a ~30-minute cadence until late comments are handled or the PR has been quiet about a day — an unrelated long-lived PR shouldn't conscript an agent into an endless loop, and the existing "keep watching merged PRs for late review comments" rule can't rest on the webhooks this same bullet calls unreliable.

The existing **"Drive to merge"** bullet now cross-references the new definition instead of offering a competing one.

**Testing rule relaxed alongside it**, at the owner's request: `make test` is for changes that touch executable behavior, and a docs-only change says so rather than running the suite over Markdown. Skipping stays something you state, not something you leave unsaid.

Documentation only; no scripts or tests touched. `make test` was run anyway on this branch and passes.