### PR TITLE
Run the launching shell in new shpool sessions

### DIFF
--- a/autoshpool
+++ b/autoshpool
@@ -33,6 +33,12 @@
 # terminal's switch nor have its own session-creation derailed by it. A request
 # made outside any session has no owning loop, so it stays unkeyed and is
 # serviced by the next loop that wakes (or starts).
+#
+# When SESSION_SHELL is set (the launching shell's own command line, e.g.
+# "/path/to/nu -l"), sessions this loop creates run it via `shpool attach
+# --cmd`, so starting nu gets a nu session instead of the daemon's default
+# shell. Only creation honors it: a session's shell is fixed when it is
+# spawned, so reattaching keeps whatever shell the session already runs.
 
 switch_session_file="$HOME/.autoshpool_switch"
 switch_pwd_file="$HOME/.autoshpool_switch_pwd"
@@ -165,6 +171,10 @@ first_disconnected_session() {
 create_and_attach_next() {
   declare -A sessions
   local session
+  # Run the launching shell in the session we create (see the SESSION_SHELL
+  # note in the header); without it the daemon's default shell applies.
+  local -a cmd_args=()
+  test -n "${SESSION_SHELL:-}" && cmd_args=(--cmd "$SESSION_SHELL")
   # Read line by line so existing names are matched whole: the prefix comes from
   # the project basename, which can contain glob metacharacters (e.g. "a*b"),
   # and an unquoted $() would glob-expand or IFS-split such a name.
@@ -179,7 +189,7 @@ create_and_attach_next() {
     echo "Creating shpool session $session"
     # -d . opens the new session in the directory this loop runs from (where the
     # user started the shell), instead of shpool's daemon dir.
-    shpool attach -d . "$session"
+    shpool attach -d . "${cmd_args[@]}" "$session"
     rc=$?
     # A clean exit alone is not proof that we actually owned the session: see
     # wait_attach_settled for the busy race it re-checks the listing for. If we
@@ -524,10 +534,19 @@ autoshpool_loop() {
       # case as a silent no-op (exit 0 without attaching) -- the loop would
       # return 0 and the caller's `&& exit` would close this terminal with
       # nothing attached.
+      # A target that doesn't exist yet is being created by this attach, so it
+      # gets the launching shell like create_and_attach_next's sessions do (see
+      # SESSION_SHELL in the header); an existing target keeps its own shell.
+      # session_exists is best-effort: when shpool is hung it reports "no" and
+      # the extra --cmd is ignored by an attach that spawns nothing.
+      local -a cmd_args=()
+      if test -n "${SESSION_SHELL:-}" && ! session_exists "$switch_session"; then
+        cmd_args=(--cmd "$SESSION_SHELL")
+      fi
       if test -n "$switch_pwd"; then
-        shpool attach -f -d "$switch_pwd" "$switch_session"
+        shpool attach -f -d "$switch_pwd" "${cmd_args[@]}" "$switch_session"
       else
-        shpool attach -f "$switch_session"
+        shpool attach -f "${cmd_args[@]}" "$switch_session"
       fi
       rc=$?
       current_session="$switch_session"

--- a/autoshpool_test
+++ b/autoshpool_test
@@ -89,6 +89,7 @@ TIMEOUT
   unset SHPOOL_SESSION_NAME
   unset SHPOOL_PREFIX
   unset SHPOOL_ATTACH_EXIT
+  unset SESSION_SHELL
   rm -f "$TEST_TMPDIR"/.autoshpool_switch*
   rm -f "$TEST_TMPDIR/.shpool_calls"
   rm -f "$TEST_TMPDIR/.shpool_sessions"
@@ -361,6 +362,62 @@ test_creates_session_1() {
   assert_status 0
   assert_called "shpool attach -d . 1"
   assert_output_contains "Creating shpool session 1"
+}
+
+test_switch_created_target_gets_session_shell() {
+  # A switch whose target doesn't exist yet creates it, so the launching shell
+  # is forwarded there too -- the prefix-mismatch switch and makeshpool both
+  # create through this path.
+  export SESSION_SHELL="/opt/shells/nu -l"
+  echo "myproject:1" > "$HOME/.autoshpool_switch"
+  echo "/home/u/proj" > "$HOME/.autoshpool_switch_pwd"
+  run_autoshpool
+  assert_status 0
+  assert_called "shpool attach -f -d /home/u/proj --cmd /opt/shells/nu -l myproject:1"
+}
+
+test_switch_existing_target_ignores_session_shell() {
+  # An existing switch target keeps the shell it was created with.
+  export SESSION_SHELL="/opt/shells/nu -l"
+  cat > "$HOME/.shpool_sessions" <<EOF
+myproject:1   2025-01-01T00:00:00Z   disconnected
+EOF
+  echo "myproject:1" > "$HOME/.autoshpool_switch"
+  run_autoshpool
+  assert_status 0
+  assert_called "shpool attach -f myproject:1"
+  if grep -q -- "--cmd" "$HOME/.shpool_calls" 2>/dev/null; then
+    echo "  FAIL: switch to an existing session passed --cmd"
+    echo "  calls: $(cat "$HOME/.shpool_calls" 2>/dev/null)"
+    return 1
+  fi
+}
+
+test_creates_session_with_session_shell() {
+  # SESSION_SHELL carries the launching shell's command line into the created
+  # session via --cmd, flags included.
+  export SESSION_SHELL="/opt/shells/nu -l"
+  run_autoshpool
+  assert_status 0
+  assert_called "shpool attach -d . --cmd /opt/shells/nu -l 1"
+  assert_output_contains "Creating shpool session 1"
+}
+
+test_reattach_ignores_session_shell() {
+  # A session's shell is fixed when it is spawned: reattaching a disconnected
+  # session must not pass --cmd.
+  export SESSION_SHELL="/opt/shells/nu -l"
+  cat > "$HOME/.shpool_sessions" <<EOF
+3      2025-01-01T00:00:00Z   disconnected
+EOF
+  run_autoshpool
+  assert_status 0
+  assert_called "shpool attach 3"
+  if grep -q -- "--cmd" "$HOME/.shpool_calls" 2>/dev/null; then
+    echo "  FAIL: reattach passed --cmd"
+    echo "  calls: $(cat "$HOME/.shpool_calls" 2>/dev/null)"
+    return 1
+  fi
 }
 
 test_attaches_disconnected_first() {
@@ -996,6 +1053,10 @@ run_test "records the current directory for a prefix-mismatch switch" test_attac
 run_test "records no directory for a plain switch" test_plain_switch_records_no_pwd
 run_test "loop passes the recorded directory to shpool attach -d" test_loop_switch_passes_recorded_pwd_as_dir
 run_test "creates session 1 when no sessions exist" test_creates_session_1
+run_test "SESSION_SHELL runs the launching shell in a created session" test_creates_session_with_session_shell
+run_test "reattach keeps the session's shell despite SESSION_SHELL" test_reattach_ignores_session_shell
+run_test "a switch that creates its target forwards SESSION_SHELL" test_switch_created_target_gets_session_shell
+run_test "a switch to an existing target ignores SESSION_SHELL" test_switch_existing_target_ignores_session_shell
 run_test "attaches to disconnected session before creating new one" test_attaches_disconnected_first
 run_test "reuses a disconnected separatorless session on startup" test_reuses_separatorless_session
 run_test "reuses a separatorless session on a prefix-mismatch switch" test_mismatch_switch_reuses_separatorless_session


### PR DESCRIPTION
When `SESSION_SHELL` is set (the launching shell's own command line, e.g. `/home/user/.local/bin/nu -l`), `autoshpool` passes it to `shpool attach --cmd` wherever an attach **creates** a session: `create_and_attach_next`'s numbered sessions, and a switch whose target doesn't exist yet (the prefix-mismatch switch and `makeshpool` both create through that path — added after Codex review).

A session's shell is fixed when it is spawned, so attaches to existing sessions — reattach, and switches to live targets — pass no `--cmd` and keep whatever shell the session already runs. Reattaching to a disconnected session therefore still gets that session's original shell — accepted behavior, per discussion.

The shell configs that provide `SESSION_SHELL` (scoped to the handoff of an explicitly started shell) are in the companion conf PR; mesh's side of the SHLVL gate is in the companion mesh PR:

- https://github.com/mikelward/conf/pull/244
- https://github.com/mikelward/mesh/pull/387

Testing: four new cases in `autoshpool_test` (creation passes `--cmd`, reattach does not, a switch that creates its target forwards it, a switch to an existing target does not); full `make test` green.