### PR TITLE
setup-kde: apply keyboard shortcuts to the session by default

### DIFF
--- a/setup
+++ b/setup
@@ -138,10 +138,10 @@ INSTALL=yes
 IGNORE_ERRORS=no
 
 # Whether to ask setup-kde to apply keyboard shortcuts to the running session
-# (--live-shortcuts). Off by default, matching setup-kde: the D-Bus call it
-# needs runs inside kwin and can take the compositor down, so opting in is a
-# deliberate, attended choice.
-LIVE_SHORTCUTS=no
+# (--live-shortcuts). On by default, matching setup-kde: kglobalaccel never
+# re-reads its config, so without the live apply the shortcuts do nothing until
+# the next login. --no-live-shortcuts opts out.
+LIVE_SHORTCUTS=yes
 
 # Whether to generate an SSH key. One of:
 #   auto - skip when a key is already available -- loaded in the agent
@@ -198,7 +198,7 @@ usage() {
     cat <<'USAGE'
 Usage: setup [--gui | --no-gui] [--kde] [--minimal | --full]
              [--no-install] [--no-sudo] [--no-root] [--ignore-errors]
-             [--live-shortcuts]
+             [--no-live-shortcuts]
              [--ssh | --no-ssh] [--no-npm] [--github PREFIX] [-h | --help]
 
 Bootstrap a new machine: install packages, fonts, tools, and dotfiles.
@@ -229,12 +229,14 @@ Options:
                    instead. For machines where you have no root at all
   --ignore-errors  Keep going past failures instead of aborting on the first
                    one. Forwarded to setup-kde/macos
-  --live-shortcuts Ask setup-kde to apply the keyboard shortcuts to the running
-                   session instead of leaving them for the next login. Off by
-                   default: the call runs inside kwin and can crash it, closing
-                   every window on Wayland. Forwarded to setup-kde
+  --live-shortcuts The default; state it explicitly. setup-kde applies the
+                   keyboard shortcuts to the running session, so they work
+                   without logging out. Forwarded to setup-kde
   --no-live-shortcuts
-                   The default; state it explicitly. Forwarded to setup-kde
+                   Leave the keyboard shortcuts for the next login. The live
+                   apply calls kglobalaccel, which runs inside kwin, so a call
+                   it mishandles closes every window on Wayland. Forwarded to
+                   setup-kde
   --ssh            Generate an SSH key even if one is already available
   --no-ssh         Skip SSH key generation
   --no-npm         Skip installing Node.js (node/npm) and the TypeScript
@@ -561,12 +563,14 @@ fi
 # Flags for setup-kde only, kept out of DESKTOP_SETUP_FLAGS because
 # setup-macos shares that and rejects anything it doesn't know.
 #
-# Only forwarded when asked for: setup-kde's default is not to touch the running
-# session, and an unattended bootstrap must not opt into a D-Bus call that can
-# take the compositor down. See setup-kde's apply_shortcuts_live.
+# Forwarded either way rather than letting setup-kde's default decide, so what
+# this run does to the session is stated outright and doesn't change under it
+# if that default moves again. See setup-kde's apply_shortcuts_live.
 KDE_SETUP_FLAGS=""
 if test "$LIVE_SHORTCUTS" = yes; then
     KDE_SETUP_FLAGS="$KDE_SETUP_FLAGS --live-shortcuts"
+else
+    KDE_SETUP_FLAGS="$KDE_SETUP_FLAGS --no-live-shortcuts"
 fi
 
 clone_or_pull() {

--- a/setup-kde
+++ b/setup-kde
@@ -13,16 +13,21 @@
 # them up: kwinrc via `kwin reconfigure`, Krohnkite by unloading and reloading
 # the script, the keyboard layout by kxkbrc's own watcher.
 #
-# Keyboard shortcuts are the exception, and deliberately so. kglobalaccel holds
-# the live shortcut registry in memory and only reads kglobalshortcutsrc at
-# startup, and in Plasma 6 it runs inside kwin -- so the D-Bus call that would
-# apply a shortcut now can, if the daemon mishandles it, kill the compositor
-# and every client with it. It's behind --live-shortcuts and off by default
-# until that path is confirmed on real hardware; see apply_shortcuts_live and
-# kdeshortcut.py.
+# Keyboard shortcuts need more than a file write: kglobalaccel holds the live
+# shortcut registry in memory and only reads kglobalshortcutsrc at startup, so
+# a written shortcut does nothing at all until the next login. The run
+# therefore pushes the whole batch into the running daemon as well; see
+# apply_shortcuts_live and kdeshortcut.py.
+#
+# That push isn't free of risk. In Plasma 6 kglobalaccel runs inside kwin, so a
+# call the daemon mishandles doesn't fail, it kills the compositor -- and on
+# Wayland that takes every client with it. kdeshortcut.py names each shortcut
+# in a crash journal before applying it, so a shortcut that does that is
+# skipped by every later run instead of crashing again. --no-live-shortcuts
+# skips the push entirely and leaves the shortcuts for the next login.
 #
 # Requires: kpackagetool6, kwriteconfig6
-# Wants: python3 plus either gdbus or python3-dbus, for --live-shortcuts
+# Wants: python3 plus either gdbus or python3-dbus, for the live apply
 #        (kdeshortcut.py). Without them the shortcuts are still written, and
 #        the script says a logout is needed.
 # This helper does not use sudo: Krohnkite and every KDE setting are installed
@@ -32,7 +37,8 @@
 #           (build-from-source fallback when the release can't be fetched)
 #
 # Usage:
-#     setup-kde [--no-install] [--no-sudo] [--ignore-errors] [-h | --help]
+#     setup-kde [--no-install] [--no-sudo] [--ignore-errors]
+#               [--no-live-shortcuts] [-h | --help]
 #
 # --no-install skips building/installing Krohnkite and only (re)applies the
 # KDE configuration. --ignore-errors keeps going past failures instead of
@@ -98,13 +104,19 @@ PYTHON="${PYTHON:-python3}"
 
 # Whether to push the shortcuts into the running session (--live-shortcuts).
 #
-# Off by default, and it has to stay off until the live path is confirmed on
-# real hardware: kglobalaccel runs inside kwin, so a call it mishandles doesn't
-# fail, it kills the compositor -- and on Wayland that takes every client with
-# it. The first version of this defaulted to on and did exactly that, losing a
-# session's worth of terminals. Writing the config and asking for a logout is
-# slower but can't cost you anything, so that's what an unattended run does.
-LIVE_SHORTCUTS_MODE=off
+# On by default, because writing the config alone doesn't configure anything a
+# user can press: kglobalaccel never re-reads kglobalshortcutsrc, so without
+# the push nothing works until the next login. That was the whole complaint
+# about the old default.
+#
+# The risk it trades against is real -- kglobalaccel runs inside kwin, so a
+# call it mishandles kills the compositor, and an early version of this did
+# exactly that. What makes on the right default now is kdeshortcut.py's crash
+# journal: the action being applied is named on disk before the call, so a
+# shortcut that takes the session down is skipped from then on rather than
+# crashing every run. --no-live-shortcuts still writes the config and asks for
+# a logout, for a session with too much open to risk.
+LIVE_SHORTCUTS_MODE=on
 
 info() {
     printf "%s\n" "$*"
@@ -126,7 +138,7 @@ is_command() {
 usage() {
     cat <<'USAGE'
 Usage: setup-kde [--no-install] [--no-sudo] [--ignore-errors]
-                 [--live-shortcuts] [-h | --help]
+                 [--no-live-shortcuts] [-h | --help]
 
 Configure the KDE Plasma 6 desktop environment.
 
@@ -135,14 +147,14 @@ Options:
   --no-sudo        Accepted for consistency with setup; setup-kde uses no
                    sudo, so there's nothing to skip
   --ignore-errors  Keep going past failures instead of aborting on the first
-  --live-shortcuts Also apply the shortcuts to the running session, instead of
-                   leaving them for the next login. UNVERIFIED: kglobalaccel
-                   runs inside kwin, and a call it mishandles kills the
-                   compositor -- which on Wayland closes every window. Save
-                   your work first
+  --live-shortcuts The default: also apply the shortcuts to the running
+                   session, so they work without logging out
   --no-live-shortcuts
-                   The default: write the shortcuts and let the next login
-                   pick them up
+                   Only write the shortcuts and let the next login pick them
+                   up. The live apply calls kglobalaccel, which runs inside
+                   kwin, so a call it mishandles closes every window on
+                   Wayland; use this when the session has too much open to
+                   risk that
   -h, --help       Show this help and exit
 USAGE
 }
@@ -203,10 +215,10 @@ fi
 # only the live apply is lost -- but it can't pass silently either, so the
 # empty value is what apply_shortcuts_live reports on.
 #
-# Only allocated when the live apply was actually asked for. On the default path
-# the batch is never read, so creating it would mean a temp file, a warning
-# about a feature the user didn't request, and -- worse -- an append that can
-# abort the whole run under set -e for a file nothing consumes.
+# Not allocated under --no-live-shortcuts. The batch is never read on that
+# path, so creating it would mean a temp file, a warning about a feature the
+# user turned off, and -- worse -- an append that can abort the whole run under
+# set -e for a file nothing consumes.
 LIVE_SHORTCUTS=""
 if test "$LIVE_SHORTCUTS_MODE" = on; then
     if ! LIVE_SHORTCUTS="$(mktemp "${TMPDIR:-/tmp}/setup-kde-shortcuts-XXXXXX")"; then
@@ -553,8 +565,8 @@ configure_keyboard_layout() {
 # a line here, and the whole batch is pushed into the running daemon at the
 # end of the run. Tab-separated because action IDs contain spaces.
 record_live_shortcut() {
-    # No batch file means either the live apply wasn't asked for -- the default,
-    # where nothing would read it -- or mktemp failed, which was reported there.
+    # No batch file means either the live apply was declined -- where nothing
+    # would read it -- or mktemp failed, which was reported there.
     test -n "$LIVE_SHORTCUTS" || return 0
     printf '%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "${4:-$2}" >> "$LIVE_SHORTCUTS"
 }
@@ -902,9 +914,9 @@ reload_kglobalaccel() {
 # what makes this session agree with it.
 apply_shortcuts_live() {
     if test "$LIVE_SHORTCUTS_MODE" != on; then
-        # Not a warning: this is the default, and the config is correct either
-        # way. Only the current session is behind.
-        info "Shortcuts written; they apply at next login (--live-shortcuts applies them now)"
+        # Not a warning: --no-live-shortcuts asked for exactly this, and the
+        # config is correct either way. Only the current session is behind.
+        info "Shortcuts written; they apply at next login (--no-live-shortcuts was given)"
         return 0
     fi
 

--- a/setup-kde_test
+++ b/setup-kde_test
@@ -31,6 +31,12 @@ MOCK
     done
 
     chmod +x "$TEST_TMPDIR"/bin/*
+
+    # The live apply is on by default, so every run reaches for python3 to run
+    # kdeshortcut.py. Mock it from the start or the tests would push shortcuts
+    # into the session bus of whoever is running them. Tests that care about
+    # what it returns re-mock it with mock_python3.
+    mock_python3 0
 }
 
 teardown() {
@@ -165,11 +171,14 @@ MOCK
 # kglobalshortcutsrc as ${XDG_CONFIG_HOME:-$HOME/.config}, so on a machine
 # that exports it, overriding HOME alone leaves the script reading -- and
 # remove_stale_app_shortcut_groups rewriting -- the caller's real KDE config
-# while the assertions look at the sandbox.
+# while the assertions look at the sandbox. XDG_STATE_HOME is pinned for the
+# same reason: it's where the live apply puts kdeshortcut.py's crash journal,
+# and a test run must not touch the caller's real one.
 run_kde() {
     set +e
     output="$(HOME="$TEST_TMPDIR/home" \
         XDG_CONFIG_HOME="$TEST_TMPDIR/home/.config" \
+        XDG_STATE_HOME="$TEST_TMPDIR/home/.local/state" \
         XDG_SESSION_TYPE=wayland \
         PATH="$TEST_TMPDIR/bin:/usr/local/bin:/usr/bin:/bin" \
         "$KDE_SCRIPT" "$@" 2>&1)"
@@ -183,6 +192,7 @@ run_kde_relative() {
     set +e
     output="$(cd "$(dirname "$KDE_SCRIPT")" && HOME="$TEST_TMPDIR/home" \
         XDG_CONFIG_HOME="$TEST_TMPDIR/home/.config" \
+        XDG_STATE_HOME="$TEST_TMPDIR/home/.local/state" \
         XDG_SESSION_TYPE=wayland \
         PATH="$TEST_TMPDIR/bin:/usr/local/bin:/usr/bin:/bin" \
         ./setup-kde "$@" 2>&1)"
@@ -569,6 +579,10 @@ test_source_build_dir_is_unpredictable() {
 # A config-only run builds nothing, so it has no reason to create a scratch
 # directory at all. Uses a logging passthrough for mktemp, since the absence of
 # a directory that would be cleaned up anyway isn't otherwise observable.
+#
+# "mktemp -d" rather than mktemp: the run does take a temp *file* for the
+# shortcut batch, and that's the point of it -- only the -d form is the build
+# directory this is about.
 test_config_only_run_creates_no_build_dir() {
     cat > "$TEST_TMPDIR/bin/mktemp" <<MOCK
 #!/bin/sh
@@ -581,7 +595,7 @@ MOCK
     unset TMPDIR
     assert_status 0 &&
     assert_output_contains "KDE configured successfully" &&
-    assert_not_called "mktemp" &&
+    assert_not_called "mktemp -d" &&
     # And nothing was left behind under TMPDIR either.
     ! ls "$TEST_TMPDIR" | grep -q '^krohnkite-'
 }
@@ -897,13 +911,36 @@ assert_batch_contains() {
     fi
 }
 
-# The default must not touch the running session at all. kglobalaccel lives
-# inside kwin, so a mishandled call kills the compositor and every client with
-# it -- which is what happened when this defaulted to on. An unattended run
-# writes the config and says a logout is needed; nothing else.
-test_live_apply_is_off_by_default() {
+# Writing kglobalshortcutsrc configures nothing a user can press: kglobalaccel
+# reads that file once at startup and never again. A plain run must therefore
+# push the shortcuts into the running daemon, which is what the flag used to be
+# needed for -- and what made setup-kde look like it did nothing.
+test_live_apply_is_on_by_default() {
     mock_python3 0
     run_kde --no-install
+    assert_status 0 &&
+    assert_called "kdeshortcut.py --quiet --journal" &&
+    assert_output_contains "Shortcuts are live; no logout needed" &&
+    assert_output_contains "KDE configured successfully" &&
+    assert_called "kwriteconfig6 --file kglobalshortcutsrc --group kwin --key Window Close"
+}
+
+# --live-shortcuts is still accepted, for a caller that wants to state the
+# default rather than rely on it.
+test_live_shortcuts_flag_is_accepted() {
+    mock_python3 0
+    run_kde --no-install --live-shortcuts
+    assert_status 0 &&
+    assert_called "kdeshortcut.py --quiet --journal" &&
+    assert_output_contains "KDE configured successfully"
+}
+
+# --no-live-shortcuts writes the config and stops there: nothing reaches the
+# running session, and the run says so rather than implying the shortcuts work
+# now.
+test_no_live_shortcuts_skips_the_running_session() {
+    mock_python3 0
+    run_kde --no-install --no-live-shortcuts
     assert_status 0 &&
     assert_not_called "kdeshortcut.py" &&
     assert_output_contains "they apply at next login" &&
@@ -912,20 +949,31 @@ test_live_apply_is_off_by_default() {
     assert_called "kwriteconfig6 --file kglobalshortcutsrc --group kwin --key Window Close"
 }
 
-# The default path allocates no batch at all. It never reads one, so creating it
-# would put a temp file, a warning about a feature that wasn't requested, and an
-# append that can abort the run under set -e in the way of a plain config run.
-# An unusable TMPDIR is how that shows up: it must be a non-event here, while
-# --live-shortcuts still reports it (see the fallback test below).
-test_default_run_allocates_no_batch() {
+# Both flags stay in the help. --no-live-shortcuts is the one that now needs
+# finding: it's the escape hatch for a session with too much open to risk the
+# D-Bus call, and nobody reaches for a flag the help doesn't mention.
+test_live_shortcut_flags_in_usage() {
+    run_kde --help
+    assert_status 0 &&
+    assert_output_contains "--live-shortcuts" &&
+    assert_output_contains "--no-live-shortcuts"
+}
+
+# --no-live-shortcuts allocates no batch at all. It never reads one, so creating
+# it would put a temp file, a warning about a feature that was turned off, and
+# an append that can abort the run under set -e in the way of a plain config
+# run. An unusable TMPDIR is how that shows up: it must be a non-event here,
+# while the default still reports it (see the fallback test below).
+test_declined_live_apply_allocates_no_batch() {
     mock_python3 0
     set +e
     output="$(HOME="$TEST_TMPDIR/home" \
         XDG_CONFIG_HOME="$TEST_TMPDIR/home/.config" \
+        XDG_STATE_HOME="$TEST_TMPDIR/home/.local/state" \
         XDG_SESSION_TYPE=wayland \
         PATH="$TEST_TMPDIR/bin:/usr/local/bin:/usr/bin:/bin" \
         TMPDIR="$TEST_TMPDIR/no-such-dir" \
-        "$KDE_SCRIPT" --no-install 2>&1)"
+        "$KDE_SCRIPT" --no-install --no-live-shortcuts 2>&1)"
     status=$?
     set -e
     assert_status 0 &&
@@ -936,16 +984,6 @@ test_default_run_allocates_no_batch() {
     assert_not_called "kdeshortcut.py" &&
     # The config writes are unaffected by any of this.
     assert_called "kwriteconfig6 --file kglobalshortcutsrc --group kwin --key Window Close"
-}
-
-# --no-live-shortcuts is accepted explicitly, for a caller that wants to state
-# the default rather than rely on it.
-test_no_live_shortcuts_flag_is_accepted() {
-    mock_python3 0
-    run_kde --no-install --no-live-shortcuts
-    assert_status 0 &&
-    assert_not_called "kdeshortcut.py" &&
-    assert_output_contains "KDE configured successfully"
 }
 
 # Every shortcut written to the config is also handed to kdeshortcut.py, with
@@ -993,6 +1031,7 @@ test_unusable_tmpdir_falls_back_to_logout_advice() {
     set +e
     output="$(HOME="$TEST_TMPDIR/home" \
         XDG_CONFIG_HOME="$TEST_TMPDIR/home/.config" \
+        XDG_STATE_HOME="$TEST_TMPDIR/home/.local/state" \
         XDG_SESSION_TYPE=wayland \
         PATH="$TEST_TMPDIR/bin:/usr/local/bin:/usr/bin:/bin" \
         TMPDIR="$TEST_TMPDIR/no-such-dir" \
@@ -1075,6 +1114,7 @@ test_missing_python3_falls_back_to_logout_advice() {
     set +e
     output="$(HOME="$TEST_TMPDIR/home" \
         XDG_CONFIG_HOME="$TEST_TMPDIR/home/.config" \
+        XDG_STATE_HOME="$TEST_TMPDIR/home/.local/state" \
         XDG_SESSION_TYPE=wayland \
         PATH="$TEST_TMPDIR/bin:/usr/local/bin:/usr/bin:/bin" \
         PYTHON=no-such-python3 \
@@ -1257,12 +1297,16 @@ run_test "stale-group sweep rewrites through a symlink" \
     test_stale_group_sweep_follows_symlink
 run_test "stale-group sweep needs no python3" \
     test_stale_group_sweep_needs_no_python3
-run_test "the live apply is off by default" \
-    test_live_apply_is_off_by_default
-run_test "the default run allocates no shortcut batch" \
-    test_default_run_allocates_no_batch
-run_test "--no-live-shortcuts is accepted" \
-    test_no_live_shortcuts_flag_is_accepted
+run_test "the live apply is on by default" \
+    test_live_apply_is_on_by_default
+run_test "--live-shortcuts is accepted" \
+    test_live_shortcuts_flag_is_accepted
+run_test "--no-live-shortcuts skips the running session" \
+    test_no_live_shortcuts_skips_the_running_session
+run_test "--no-live-shortcuts allocates no shortcut batch" \
+    test_declined_live_apply_allocates_no_batch
+run_test "both live-shortcut flags are documented in usage" \
+    test_live_shortcut_flags_in_usage
 run_test "shortcuts are pushed to the running session" \
     test_shortcuts_pushed_to_running_session
 run_test "the shortcut batch file name is unpredictable" \

--- a/setup_test
+++ b/setup_test
@@ -1467,16 +1467,17 @@ test_live_shortcuts_in_usage() {
     assert_output_contains "--no-live-shortcuts"
 }
 
-# --live-shortcuts is forwarded to setup-kde; the default is not. An unattended
-# bootstrap must not opt into a D-Bus call that can take the compositor down,
-# so the flag is only ever added when explicitly asked for.
+# The live apply is on by default -- without it the shortcuts do nothing until
+# the next login -- and whichever way it's set, the matching flag is forwarded
+# to setup-kde. Stating it outright is what keeps this run's effect on the
+# session from changing under it if setup-kde's own default moves again.
 test_live_shortcuts_parsing_and_forwarding() {
-    assert_source_contains "LIVE_SHORTCUTS=no" &&
+    assert_source_contains '^LIVE_SHORTCUTS=yes' &&
     assert_source_contains '[-]-live-shortcuts)' &&
     assert_source_contains '[-]-no-live-shortcuts)' &&
-    assert_source_contains "LIVE_SHORTCUTS=yes" &&
+    assert_source_contains "LIVE_SHORTCUTS=no" &&
     assert_source_contains 'KDE_SETUP_FLAGS --live-shortcuts' &&
-    # Never forwarded unconditionally: the guard is what keeps the default off.
+    assert_source_contains 'KDE_SETUP_FLAGS --no-live-shortcuts' &&
     assert_source_contains 'test "$LIVE_SHORTCUTS" = yes' &&
     # KDE-only: setup-macos shares DESKTOP_SETUP_FLAGS and rejects options it
     # doesn't know, so a KDE flag in there would abort the macOS run.
@@ -1814,7 +1815,7 @@ run_test "a caller whose URL isn't from the prefix skips the check" \
 run_test "--live-shortcuts and --no-live-shortcuts are accepted" \
     test_live_shortcuts_flags_accepted
 run_test "--live-shortcuts is documented in usage" test_live_shortcuts_in_usage
-run_test "--live-shortcuts forwards to setup-kde only when asked" \
+run_test "the live apply is on by default and forwarded either way" \
     test_live_shortcuts_parsing_and_forwarding
 run_test "--no-sudo is accepted as a known option" test_no_sudo_flag_accepted
 run_test "--no-sudo is documented in usage" test_no_sudo_in_usage


### PR DESCRIPTION
Writing `kglobalshortcutsrc` configures nothing anyone can press: kglobalaccel reads that file once at startup and never again, so without the live apply every shortcut `setup-kde` sets is inert until the next login. A plain run looked like it had done nothing — which is the reported problem.

The live apply was behind `--live-shortcuts` because the D-Bus call reaches kglobalaccel, which in Plasma 6 runs inside kwin: a call it mishandles takes the compositor down, and on Wayland every client with it. What has changed since that default was chosen is `kdeshortcut.py`'s crash journal — the action is named on disk before the call, so a shortcut that crashes the session is skipped by every later run rather than crashing again. That turns the risk from "loses your session, every time" into "loses it once", which is worth trading for shortcuts that actually work.

`--no-live-shortcuts` still writes the config and asks for a logout, for a session with too much open to risk it.

## Changes

- `setup-kde`: `LIVE_SHORTCUTS_MODE` defaults to `on`; help text, header comment, and the "written, applies at next login" message now describe `--no-live-shortcuts` as the opt-out.
- `setup`: `LIVE_SHORTCUTS` defaults to `yes`, and the matching flag is forwarded to `setup-kde` either way rather than only when opting in — so what a bootstrap does to the running session is stated outright instead of inherited from `setup-kde`'s default.

## Tests

- `setup-kde_test`: the default-path tests flip (the live apply is on by default; `--no-live-shortcuts` skips the running session and allocates no batch), plus a check that both flags stay in the help.
- `setup()` now installs a `python3` mock for every test. Without it, a default-on live apply would have each test run `kdeshortcut.py` against the session bus of whoever ran the suite. `XDG_STATE_HOME` is pinned for the same reason, so the crash journal stays in the sandbox.
- The config-only run still creates no build directory; that test now pins `mktemp -d` specifically, since a default run legitimately takes a temp *file* for the shortcut batch.
- `setup_test`: forwarding assertions updated for the new default and the both-ways forwarding.

`make test`: 136 + all other suites green.

---
_Generated by [Claude Code](https://claude.ai/code/session_0192MMij1CmPZ3BXiYcQNc2w)_