### PR TITLE
Keep the KDE application launcher open under focus follows mouse

### DIFF
--- a/setup-kde
+++ b/setup-kde
@@ -3,7 +3,8 @@
 #
 # Sets up:
 # - Krohnkite tiling window manager
-# - Focus follows mouse (mouse precedence)
+# - Focus follows mouse (mouse precedence), with the application launcher
+#   pinned so mousing out doesn't close it
 # - Window management and desktop switching keybindings
 # - Application launch shortcuts (browser, terminal, music)
 # - The session keyboard layout (US Dvorak, Caps Lock as Compose)
@@ -11,7 +12,9 @@
 # The KDE config files this writes are only what the *next* login loads, so
 # most steps are paired with the reload that makes the current session pick
 # them up: kwinrc via `kwin reconfigure`, Krohnkite by unloading and reloading
-# the script, the keyboard layout by kxkbrc's own watcher.
+# the script, the keyboard layout by kxkbrc's own watcher. The launcher pin
+# skips the file entirely when it can and goes through plasmashell's own
+# scripting API, which applies now and persists itself.
 #
 # Keyboard shortcuts need more than a file write: kglobalaccel holds the live
 # shortcut registry in memory and only reads kglobalshortcutsrc at startup, so
@@ -30,6 +33,9 @@
 # Wants: python3 plus either gdbus or python3-dbus, for the live apply
 #        (kdeshortcut.py). Without them the shortcuts are still written, and
 #        the script says a logout is needed.
+#        qdbus6, to pin the application launcher in the running session.
+#        Without it the applet config is written instead, and plasmashell
+#        picks it up when it next starts.
 # This helper does not use sudo: Krohnkite and every KDE setting are installed
 # for the current user, so setup-kde still works when system sudo is restricted.
 # Optional: homepkg (fetches Krohnkite's prebuilt .kwinscript release, the
@@ -490,6 +496,163 @@ configure_focus_follows_mouse() {
     kwriteconfig6 --file kwinrc --group Windows --key FocusPolicy FocusFollowsMouse
     kwriteconfig6 --file kwinrc --group Windows --key NextFocusPrefersMouse true
     kwriteconfig6 --file kwinrc --group Windows --key FocusStealingPreventionLevel 2
+}
+
+# --- Keep the application launcher open when the pointer leaves it ---
+
+# Plasma popups hide themselves the moment they lose keyboard focus
+# (PopupPlasmaWindowPrivate::handleFocusChanged), so under focus follows mouse
+# the launcher disappears as soon as the pointer crosses onto a window behind
+# it -- upstream bug 431585.
+#
+# A KWin window rule for plasmashell can't fix that, however it's phrased. The
+# focus-follows-mouse path is Window::pointerEnterEvent ->
+# Workspace::requestDelayFocus -> Workspace::requestFocus, and none of those
+# consult the rules that focus stealing prevention (fsplevel) and focus
+# protection (fpplevel) hang off: checkFSP/checkFPP are only reached from
+# activation *requests* -- xdg-activation, _NET_ACTIVE_WINDOW, X11 focus-in.
+# Rules would matter if FocusStealingPreventionLevel above were raised to
+# High or Extreme, which stops the launcher from taking focus at all (bug
+# 377914); at Medium it opens and takes focus as it should.
+#
+# What Plasma does expose is the launcher's own "Keep Open" pin -- the
+# window-pin button in Kickoff's header, which binds hideOnWindowDeactivate to
+# !configuration.pin. A pinned launcher ignores focus loss entirely, so mousing
+# out leaves it up.
+#
+# The cost is bigger than it looks. Kickoff gates every close-on-activation
+# path on the same flag -- launching an entry (AbstractKickoffItemDelegate),
+# the Leave buttons, context menu actions -- so a pinned launcher stays up
+# after launching something too, not just after a click elsewhere. What's left
+# is the launcher button and Escape (CompactApplet.qml's Keys.onEscapePressed,
+# the one unconditional path), and Escape only reaches the launcher while it
+# holds keyboard focus, which under focus follows mouse means the pointer is
+# over it, the panel, or the desktop. The pin button unsets all this again from
+# the launcher itself.
+LAUNCHER_APPLET=org.kde.plasma.kickoff
+LAUNCHER_APPLETS_FILE=plasma-org.kde.plasma.desktop-appletsrc
+
+# Pin through plasmashell's scripting API. Preferred over writing the config
+# file: it reaches the running launcher, and plasmashell persists the change
+# itself. Returns non-zero when the launcher couldn't be pinned this way, so
+# the caller can fall back to the file.
+pin_launcher_live() {
+    if ! is_command qdbus6; then
+        warn "qdbus6 not found; writing the launcher config file instead"
+        return 1
+    fi
+
+    plasma_script=$(cat <<SCRIPT
+var pinned = 0;
+panels().concat(desktops()).forEach(function (container) {
+    container.widgets("$LAUNCHER_APPLET").forEach(function (widget) {
+        widget.currentConfigGroup = ["General"];
+        widget.writeConfig("pin", true);
+        widget.reloadConfig();
+        pinned += 1;
+    });
+});
+print(pinned);
+SCRIPT
+)
+
+    # qdbus6's own error is left on stderr: the ordinary cause is plasmashell
+    # not running (bootstrapping before the first KDE login), and anything else
+    # is worth seeing.
+    # The service is org.kde.plasmashell (KDBusService names it after the
+    # KAboutData component), even though the object and interface below are
+    # spelled PlasmaShell.
+    if ! pinned=$(qdbus6 org.kde.plasmashell /PlasmaShell \
+            org.kde.PlasmaShell.evaluateScript "$plasma_script"); then
+        warn "could not reach plasmashell; writing the launcher config file instead"
+        return 1
+    fi
+
+    pinned=$(printf '%s' "$pinned" | tr -d '[:space:]')
+    case "$pinned" in
+        "0")
+            # Pinning wrote nothing because there's nothing to pin -- a panel
+            # without a launcher widget, or one of the other launchers
+            # (Application Menu, Application Dashboard), which have no pin.
+            warn "no $LAUNCHER_APPLET widget found on any panel or desktop; nothing to keep open"
+            return 0
+            ;;
+        ""|*[!0-9]*)
+            warn "plasmashell did not report how many launchers were pinned (got '$pinned'); writing the config file instead"
+            return 1
+            ;;
+        *)
+            info "Pinned $pinned application launcher(s) open"
+            return 0
+            ;;
+    esac
+}
+
+# Fallback for when plasmashell isn't reachable: write pin=true straight into
+# the launcher's applet config.
+#
+# The applet's group path isn't fixed -- it's [Containments][<containment>]
+# [Applets][<applet>], with ids assigned when the widget was added -- so the
+# file has to be searched for the group whose plugin is the launcher.
+pin_launcher_config() {
+    config_file="${XDG_CONFIG_HOME:-$HOME/.config}/$LAUNCHER_APPLETS_FILE"
+    if ! test -f "$config_file"; then
+        warn "$config_file not found; the launcher keeps closing on focus loss until setup-kde runs against a configured Plasma session"
+        return 1
+    fi
+
+    # Collect the group paths first, then write -- same reasoning as
+    # unbind_all_krohnkite_shortcuts: kwriteconfig6 rewrites this very file,
+    # so writing from inside the read loop races KConfig's replacement of it.
+    launcher_groups=$(awk -v plugin="plugin=$LAUNCHER_APPLET" '
+        /^\[/     { group = $0; next }
+        $0 == plugin { print group }
+    ' "$config_file") || {
+        warn "could not read $config_file; the launcher will keep closing on focus loss"
+        return 1
+    }
+
+    if test -z "$launcher_groups"; then
+        warn "no $LAUNCHER_APPLET widget found in $config_file; nothing to keep open"
+        return 1
+    fi
+
+    # Each write is checked: this function is called on the left of a ||, so
+    # set -e doesn't apply to anything in it, and a read-only config directory
+    # or a full disk would otherwise reach the success message below with
+    # nothing written.
+    write_failures=0
+    while IFS= read -r group; do
+        test -n "$group" || continue
+        # "[Containments][2][Applets][7]" -> --group Containments --group 2 ...
+        group_args=()
+        for part in $(printf '%s' "$group" | tr -d '[' | tr ']' ' '); do
+            group_args+=(--group "$part")
+        done
+        kwriteconfig6 --file "$LAUNCHER_APPLETS_FILE" "${group_args[@]}" \
+            --group Configuration --group General --key pin true || {
+            warn "could not write the pin for the launcher at $group in $config_file"
+            write_failures=$((write_failures + 1))
+        }
+    done <<EOF
+$launcher_groups
+EOF
+
+    if test "$write_failures" -gt 0; then
+        return 1
+    fi
+
+    info "Launcher pinned in $LAUNCHER_APPLETS_FILE; plasmashell picks it up when it next starts"
+}
+
+configure_launcher_keep_open() {
+    info "Keeping the application launcher open when the pointer leaves it"
+    # Both helpers warn for themselves on the way out, and a launcher that
+    # couldn't be pinned is no reason to abandon the rest of the setup -- so
+    # the failure is reported but not propagated.
+    if ! pin_launcher_live; then
+        pin_launcher_config || return 0
+    fi
 }
 
 # --- Dim inactive windows ---
@@ -1002,6 +1165,7 @@ fi
 enable_krohnkite
 configure_krohnkite
 configure_focus_follows_mouse
+configure_launcher_keep_open
 configure_dim_inactive
 configure_desktops
 configure_keyboard_layout

--- a/setup-kde_test
+++ b/setup-kde_test
@@ -52,6 +52,81 @@ MOCK
     chmod +x "$TEST_TMPDIR/bin/$1"
 }
 
+# qdbus6 mock standing in for a running plasmashell: evaluateScript answers
+# with the number of launcher widgets it pinned, the way print() in the Plasma
+# script does. Every other D-Bus call (kwin reconfigure, the effects reload)
+# keeps the default behavior of the plain mock.
+#
+# The service name is matched, not just the method: it's org.kde.plasmashell
+# (what KDBusService registers) while the object and interface are spelled
+# PlasmaShell, so a call to any other service fails the way a real bus does --
+# which is what makes the assertions below able to catch the wrong name.
+add_plasmashell_mock() {
+    cat > "$TEST_TMPDIR/bin/qdbus6" <<MOCK
+#!/bin/sh
+printf "%s\\n" "qdbus6 \$*" >> "$CALLS"
+case "\$1 \$3" in
+    "org.kde.plasmashell org.kde.PlasmaShell.evaluateScript")
+        echo "$1"
+        ;;
+    *" org.kde.PlasmaShell.evaluateScript")
+        echo "Service '\$1' does not exist" >&2
+        exit 1
+        ;;
+esac
+exit 0
+MOCK
+    chmod +x "$TEST_TMPDIR/bin/qdbus6"
+}
+
+# Same, for a session where plasmashell isn't running: the scripting call
+# fails, everything else still answers.
+add_unreachable_plasmashell_mock() {
+    cat > "$TEST_TMPDIR/bin/qdbus6" <<MOCK
+#!/bin/sh
+printf "%s\\n" "qdbus6 \$*" >> "$CALLS"
+case "\$3" in
+    org.kde.PlasmaShell.evaluateScript)
+        echo "Cannot find 'org.kde.plasma.shell'" >&2
+        exit 1
+        ;;
+esac
+exit 0
+MOCK
+    chmod +x "$TEST_TMPDIR/bin/qdbus6"
+}
+
+# A plasma-org.kde.plasma.desktop-appletsrc with the launcher at a group path
+# that isn't guessable -- ids are assigned when a widget is added -- plus a
+# containment and another applet that must be left alone.
+add_appletsrc() {
+    mkdir -p "$TEST_TMPDIR/home/.config"
+    cat > "$TEST_TMPDIR/home/.config/plasma-org.kde.plasma.desktop-appletsrc" <<'CONFIG'
+[Containments][1]
+plugin=org.kde.plasma.folder
+
+[Containments][2][Applets][7]
+plugin=org.kde.plasma.kickoff
+
+[Containments][2][Applets][8]
+plugin=org.kde.plasma.digitalclock
+CONFIG
+}
+
+# kwriteconfig6 that refuses to touch the applet config -- a read-only config
+# directory, a full disk -- while every other write still succeeds.
+add_failing_appletsrc_writes() {
+    cat > "$TEST_TMPDIR/bin/kwriteconfig6" <<MOCK
+#!/bin/sh
+printf "%s\\n" "kwriteconfig6 \$*" >> "$CALLS"
+case "\$*" in
+    *plasma-org.kde.plasma.desktop-appletsrc*) exit 1 ;;
+esac
+exit 0
+MOCK
+    chmod +x "$TEST_TMPDIR/bin/kwriteconfig6"
+}
+
 # Run a copy of setup-kde from a directory with no launcher siblings. In the
 # real repo the launchers live beside setup-kde, so the sibling-directory
 # fallback would find them; tests about genuinely-missing launchers need the
@@ -663,6 +738,69 @@ test_configures_focus_follows_mouse() {
     run_kde --no-install
     assert_status 0 &&
     assert_called "kwriteconfig6 --file kwinrc --group Windows --key FocusPolicy FocusFollowsMouse"
+}
+
+# Focus follows mouse closes Plasma popups the moment the pointer crosses onto
+# another window, because they hide themselves on focus loss. KWin window rules
+# can't exempt them -- the focus-follows-mouse path never consults focus
+# stealing prevention or focus protection -- so the launcher is pinned instead,
+# through plasmashell's scripting API when it's running.
+test_pins_launcher_through_plasmashell() {
+    add_plasmashell_mock 1
+    run_kde --no-install
+    assert_status 0 &&
+    assert_called "qdbus6 org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript" &&
+    assert_called 'widgets("org.kde.plasma.kickoff")' &&
+    assert_called 'writeConfig("pin", true)' &&
+    assert_output_contains "Pinned 1 application launcher(s) open" &&
+    assert_not_called "kwriteconfig6 --file plasma-org.kde.plasma.desktop-appletsrc"
+}
+
+# Nothing to pin is worth saying out loud (the launcher may be one of the other
+# ones, which have no pin), but it isn't a reason to go writing config files.
+test_warns_when_no_launcher_widget_is_pinned() {
+    add_plasmashell_mock 0
+    add_appletsrc
+    run_kde --no-install
+    assert_status 0 &&
+    assert_output_contains "nothing to keep open" &&
+    assert_not_called "kwriteconfig6 --file plasma-org.kde.plasma.desktop-appletsrc"
+}
+
+# Without plasmashell the pin has to go into the applet config, and the group
+# path has to be found rather than assumed -- and only the launcher's own.
+test_pins_launcher_in_config_when_plasmashell_is_unreachable() {
+    add_unreachable_plasmashell_mock
+    add_appletsrc
+    run_kde --no-install
+    assert_status 0 &&
+    assert_called "kwriteconfig6 --file plasma-org.kde.plasma.desktop-appletsrc --group Containments --group 2 --group Applets --group 7 --group Configuration --group General --key pin true" &&
+    assert_not_called "--group Applets --group 8 --group Configuration" &&
+    assert_output_contains "plasmashell picks it up when it next starts"
+}
+
+# pin_launcher_config runs on the left of a ||, so set -e doesn't cover it: a
+# write that fails has to be caught by hand, or the run claims a pin it never
+# made.
+test_failed_launcher_config_write_is_reported() {
+    add_unreachable_plasmashell_mock
+    add_appletsrc
+    add_failing_appletsrc_writes
+    run_kde --no-install
+    assert_status 0 &&
+    assert_output_contains "could not write the pin for the launcher" &&
+    assert_output_lacks "plasmashell picks it up when it next starts"
+}
+
+# A machine with no Plasma config yet (bootstrapping before the first login)
+# has no launcher to pin. Say so and carry on -- the rest of the setup is
+# unaffected.
+test_missing_appletsrc_warns_but_setup_continues() {
+    add_unreachable_plasmashell_mock
+    run_kde --no-install
+    assert_status 0 &&
+    assert_output_contains "the launcher keeps closing on focus loss" &&
+    assert_output_contains "KDE configured successfully"
 }
 
 test_configures_nine_desktops() {
@@ -1278,6 +1416,11 @@ run_test "missing git errors clearly once the fallback is reached" \
     test_missing_git_fallback_errors_clearly
 run_test "enables and configures Krohnkite" test_enables_and_configures_krohnkite
 run_test "configures focus follows mouse" test_configures_focus_follows_mouse
+run_test "pins the launcher through plasmashell" test_pins_launcher_through_plasmashell
+run_test "warns when no launcher widget is pinned" test_warns_when_no_launcher_widget_is_pinned
+run_test "pins the launcher in config when plasmashell is unreachable" test_pins_launcher_in_config_when_plasmashell_is_unreachable
+run_test "a failed launcher config write is reported" test_failed_launcher_config_write_is_reported
+run_test "missing appletsrc warns but setup continues" test_missing_appletsrc_warns_but_setup_continues
 run_test "configures nine desktops" test_configures_nine_desktops
 run_test "configures the session keyboard layout in kxkbrc" \
     test_configures_keyboard_layout


### PR DESCRIPTION
Plasma popups hide themselves as soon as they lose keyboard focus, so with focus follows mouse the launcher closes the moment the pointer crosses onto a window behind it ([KDE bug 431585](https://bugs.kde.org/show_bug.cgi?id=431585)).

**Window rules can't fix this.** The focus-follows-mouse path is `Window::pointerEnterEvent` → `Workspace::requestDelayFocus` → `Workspace::requestFocus`, and none of it consults the rules that focus stealing prevention (`fsplevel`) and focus protection (`fpplevel`) hang off — `checkFSP`/`checkFPP` are only reached from activation *requests* (xdg-activation, `_NET_ACTIVE_WINDOW`, X11 focus-in). A plasmashell rule would only matter if `FocusStealingPreventionLevel` were raised to High or Extreme, which stops the launcher taking focus at all ([bug 377914](https://bugs.kde.org/show_bug.cgi?id=377914)); the existing Medium is right.

What Plasma does expose is the launcher's own "Keep Open" pin, which binds `hideOnWindowDeactivate` to `!configuration.pin`. `setup-kde` sets it:

- through plasmashell's scripting API (`evaluateScript` on `org.kde.plasmashell`) when it's running, so the pin applies to the live session and plasmashell persists it;
- otherwise by writing `pin=true` into the applet's config, searching out the launcher's `[Containments][N][Applets][M]` group rather than assuming ids, and saying it takes effect when plasmashell next starts.

Failure paths (no `qdbus6`, no plasmashell, no applet config, no launcher widget, a config write that fails) each warn and leave the rest of the setup running.

**⚠️ Trade-off — under discussion, don't merge yet.** `hideOnWindowDeactivate` turns out to gate more than focus loss. Kickoff checks the same flag in every close-on-activation path — `AbstractKickoffItemDelegate.qml:144` (launching an entry), `LeaveButtons.qml:121,219` (Sleep / Shut down / Log out), `ActionMenu.qml:86` (context-menu actions) — so a pinned launcher also stays open *after launching something*. What still closes it: the panel button, and Escape via `CompactApplet.qml`'s `Keys.onEscapePressed` (the one unconditional path), which only reaches it while it holds keyboard focus.

Smaller effects: applet popups sit in KWin's `AboveLayer`, so a pinned launcher floats above normal windows until dismissed; and the dim-inactive effect skips applet popups, so an unfocused pinned launcher looks the same as a focused one. The pin is stored applet config and shows as toggled in the header, so it's undoable from the UI.

Scope: the Application Launcher. The digital clock's calendar has the same persisted `pin` knob; system tray and notification popups have none.

Tests: five new cases in `setup-kde_test` covering the live pin (asserting the D-Bus service name), nothing-to-pin, the config-file fallback with its group path, a failed config write, and a missing applet config. `make test` green.

---
_Generated by [Claude Code](https://claude.ai/code/session_016MFz6aLwViu1jEgYdZ9dMk)_