### PR TITLE
Move the browser2 launch shortcut to Meta+F

### DIFF
--- a/docs/MACOS.md
+++ b/docs/MACOS.md
@@ -208,7 +208,7 @@ match on all but two rows, which is the muscle memory being preserved.
 | Set master window | `Win+Return` | `Win+Return` | Amethyst `swap-main` |
 | Launcher / Spotlight | — | `Win+Space` | symbolichotkeys (ID 64) |
 | Browser 1 | `Win+G` | `Win+G` | Automator Quick Action |
-| Browser 2 | `Win+H` | `Win+H` | Automator Quick Action |
+| Browser 2 | `Win+F` | `Win+F` | Automator Quick Action |
 | Terminal | `Win+T` | `Win+T` | Automator Quick Action |
 | Terminal on workstation | `Win+W` | `Win+W` | Automator Quick Action |
 | Music | `Win+Y` | `Win+Y` | Automator Quick Action |

--- a/setup-kde
+++ b/setup-kde
@@ -778,7 +778,7 @@ configure_app_shortcuts() {
     remove_stale_app_shortcut_groups
 
     add_app_shortcut "browser1" "Meta+G"
-    add_app_shortcut "browser2" "Meta+H"
+    add_app_shortcut "browser2" "Meta+F"
     add_app_shortcut "terminal" "Meta+T"
     add_app_shortcut "terminal_on_workstation" "Meta+W"
     add_app_shortcut "music" "Meta+Y"

--- a/setup-kde_test
+++ b/setup-kde_test
@@ -1148,6 +1148,19 @@ test_unreachable_daemon_warns_and_continues() {
     assert_output_contains "KDE configured successfully"
 }
 
+# The launcher key map, pinned per launcher. Only browser1's key was asserted
+# before, so browser2 sat on the wrong key (Meta+H) unnoticed; the keys are
+# meant to match setup-macos row for row (see docs/MACOS.md).
+test_launch_shortcut_keys() {
+    run_kde --no-install
+    assert_status 0 &&
+    assert_called "--group shortcut-browser1.desktop --key _launch Meta+G," &&
+    assert_called "--group shortcut-browser2.desktop --key _launch Meta+F," &&
+    assert_called "--group shortcut-terminal.desktop --key _launch Meta+T," &&
+    assert_called "--group shortcut-terminal_on_workstation.desktop --key _launch Meta+W," &&
+    assert_called "--group shortcut-music.desktop --key _launch Meta+Y,"
+}
+
 # A launcher that exists on PATH gets a .desktop file and a [services] _launch
 # shortcut pointing at its resolved path.
 #
@@ -1325,6 +1338,7 @@ run_test "a refused shortcut warns and the run continues" \
     test_failed_live_apply_warns_and_continues
 run_test "an unreachable daemon warns and the run continues" \
     test_unreachable_daemon_warns_and_continues
+run_test "each launcher gets its own key" test_launch_shortcut_keys
 run_test "app shortcut created for present launcher" \
     test_app_shortcut_created_for_present_launcher
 run_test "missing launcher is skipped, not fatal" \

--- a/setup-macos
+++ b/setup-macos
@@ -1164,7 +1164,7 @@ configure_app_shortcuts() {
     #
     # Shortcut keys (physical Win sends Option after the hidutil remap):
     #   Win+G → Option+G → browser1
-    #   Win+H → Option+H → browser2
+    #   Win+F → Option+F → browser2
     #   Win+T → Option+T → terminal
     #   Win+W → Option+W → terminal_on_workstation
     #   Win+Y → Option+Y → music
@@ -1175,7 +1175,7 @@ configure_app_shortcuts() {
     set --
     for entry in \
         "Launch Browser1:browser1:g" \
-        "Launch Browser2:browser2:h" \
+        "Launch Browser2:browser2:f" \
         "Launch Terminal:terminal:t" \
         "Launch Terminal on Workstation:terminal_on_workstation:w" \
         "Launch Music:music:y"; do

--- a/setup-macos_test
+++ b/setup-macos_test
@@ -1168,7 +1168,7 @@ test_assigns_option_key_equivalents() {
     assert_status 0 &&
     assert_called "defaults write pbs NSServicesStatus -dict-add" &&
     assert_called '"key_equivalent" = "~g"' &&
-    assert_called '"key_equivalent" = "~h"' &&
+    assert_called '"key_equivalent" = "~f"' &&
     assert_called '"key_equivalent" = "~t"' &&
     assert_called '"key_equivalent" = "~w"' &&
     assert_called '"key_equivalent" = "~y"'


### PR DESCRIPTION
`setup-kde` bound `browser2` to `Meta+H`, which isn't the key it was meant to have — hence the shortcut appearing broken.

- `setup-kde`: `browser2` → `Meta+F`.
- `setup-macos`: the same launcher map lives there as an Option key equivalent, and `docs/MACOS.md` documents the two columns matching row for row, so the Quick Action moves to `Option+F` and the table row is updated.
- `setup-kde_test`: only `browser1`'s key was ever asserted, which is how the wrong binding survived. New test pins all five launcher keys; it fails on `Meta+H` and passes on `Meta+F`. The macOS key-equivalent test moves from `~h` to `~f`.

No unbind was added for `Meta+F` — the existing unbinds (`Grid View`, `Overview`, `Edit Tiles`) each free a key a Plasma default was holding, and nothing in the config suggests `Meta+F` is taken. If it turns out Plasma grabs it, that's a one-line `unbind_shortcut` follow-up.

`make test` passes in full (all suites green).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gm1LL3Kia1Xr6QhdzquHb4)_