### PR TITLE
Tie the Codex verdict to the head it was given on

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,24 +204,18 @@ reply, no offer to correct it. It is not a finding.
   `$HOME/.claude/settings.json` from the environment's setup script.
   Settings load at startup, so writing that file mid-session does nothing
   for that session; if calls are prompting, say so once and carry on.
-- **Poll your own open PRs — fast while a merge gate is pending, slow
-  otherwise.** The two things nothing else reports are CI going green and
-  the Codex 👍 (its "no suggestions" outcome is a reaction, not a comment),
-  so a PR waiting on either gets a ~5-minute check; once nothing is left but
-  a human, drop to ~30 minutes — that's a queue, not work in flight. Never
-  end a turn by going idle with one of yours still open: arm the next check
-  with whatever the client offers (`send_later`, a scheduled task / cron,
-  `/loop`), and arm it *without asking*. Scheduling your own follow-up is
-  routine hygiene, not a decision that needs approval. Someone else's open
-  PR is not your polling job — adopt one only when asked. Merged or closed
-  unmerged is terminal: wait for one more check to see CI and Codex report
-  on the final head, but don't block on a report that may never land — an
-  early manual merge, a docs-only push a path filter never runs CI on, a
-  down review service — settle for whatever's known by then and move on.
-  Either way, run one last reply-or-resolve pass, then cancel the watch in
-  full: the pending scheduled trigger, *and* `unsubscribe_pr_activity` if
-  you ever subscribed. Open a follow-up PR (with its own watch) for anything
-  a merged PR still needs.
+- **Poll your own open PRs — every ~5 minutes while CI or the verdict is
+  outstanding, ~30 once only a human is left.** Those two are what nothing
+  else reports. Never end a turn idle with one of yours open: arm the next
+  check with whatever the client offers (`send_later`, a scheduled task /
+  cron, `/loop`), and arm it *without asking* — that is hygiene, not a
+  decision. Someone else's PR is not your polling job unless you're asked.
+  Merged or closed is terminal: take one more check for CI and Codex on the
+  final head, but settle for what's known if a report may never land, then
+  run a last reply-or-resolve pass and cancel the watch in full — the
+  pending trigger, *and* `unsubscribe_pr_activity` if you ever subscribed.
+  Open a follow-up PR, with its own watch, for anything a merged one still
+  needs.
 - **What the polling costs.** Twelve wake-ups an hour per PR at the fast
   cadence, two at the slow one — each a model turn plus a few GitHub API
   calls, so roughly a dollar an hour while a PR is waiting on its merge
@@ -229,17 +223,14 @@ reply, no offer to correct it. It is not a finding.
   the watch silently, with no error anywhere. If you can't arm the next
   check, say so in the reply rather than leaving a PR that looks watched and
   isn't.
-- **One pending check per PR, settled at the top of the turn.** Two failures
-  meet here. Arming a second check because a webhook started a turn while
-  one was already pending leaves two chains, each re-arming itself, and the
-  cost doubles every time it happens. Parking the re-arm at the *end* of the
-  turn is the opposite one — an interrupted turn takes it with it, and that
-  once left a PR unwatched for two hours. So settle the trigger before
-  anything else, and settle it to exactly one: leave a correctly-timed
-  pending check alone, since pushing its deadline forward every turn is how
-  a busy PR never gets polled at all, and only when it's missing, already
-  fired, or mis-timed either update it in place with `update_trigger` —
-  which leaves no window where none is pending — or arm the replacement
+- **One pending check per PR, settled at the top of the turn.** Two chains
+  each re-arming themselves double the cost every time a webhook starts a
+  turn while one is already pending; parking the re-arm at the *end* of the
+  turn loses it when the turn is interrupted, which once left a PR unwatched
+  for two hours. So settle it first, and settle it to exactly one: leave a
+  correctly-timed check alone — pushing its deadline forward every turn is
+  how a busy PR never gets polled — and when it's missing, already fired, or
+  mis-timed, either `update_trigger` it in place or arm the replacement
   before deleting the old, because an overlap beats a gap. Then diagnose,
   fix, and reply.
 - **A `send_later` one-shot re-arms itself +24h**, so "check in 5 minutes"
@@ -256,11 +247,11 @@ reply, no offer to correct it. It is not a finding.
   duplicate chains: keep one and delete the rest.
 - **Never name a SHA in the check prompt.** It is written before the work it
   describes, so it is stale when it fires — say "the current head".
-- **"Drive" means run the loop automatically**: pick the next task, implement
-  it, open the PR, send it for review, address every comment, merge once CI is
-  green and Codex has left its thumbs up — then pick the next task and go around
-  again. Driving ends when the work runs out or the user says stop, not when one
-  PR merges.
+- **"Drive" means run the loop automatically**: pick the next task,
+  implement it, open the PR, send it for review, address every comment,
+  merge once CI is green and Codex's verdict for the current head is in —
+  then pick the next task and go around again. Driving ends when the work
+  runs out or the user says stop, not when one PR merges.
 - **A red baseline is the next task.** Before pulling anything from `TODO.md`,
   run the suite and get it green. A preexisting failure is work to do, not a
   thing to classify as "unrelated" and step around — deciding it's out of scope
@@ -294,10 +285,11 @@ reply, no offer to correct it. It is not a finding.
   Re-read the diff against `origin/main` and patch whatever drifted, then post
   the PR link in the chat reply for that push, not only at the end of the
   conversation.
-- **"Drive to merge"** is the PR stretch of *drive* (see **Autonomy** above):
-  open the PR, wait for the automatic Codex review, address every review
-  comment — fix it if you agree, reply on the thread saying why if you don't —
-  and merge once CI is green and Codex has left its thumbs up.
+- **"Drive to merge"** is the PR stretch of *drive* (see **Autonomy**
+  above): open the PR, wait for the automatic Codex review, address every
+  review comment — fix it if you agree, reply on the thread saying why if
+  you don't — and merge once CI is green and Codex's verdict for the current
+  head is in.
 - When a feature has multiple open PRs, list **every** open PR by URL, one per
   line — the "View PR" chip sticks to the first link and hides the rest
   (anthropics/claude-code#46625).
@@ -331,14 +323,25 @@ reply, no offer to correct it. It is not a finding.
   the SHA and comment count, e.g. `Codex reviewed 87d9f02 — 0 comments`. Tie
   it to the *latest* pushed SHA so a stale review of a superseded commit isn't
   conflated with the current state.
-- **The thumbs up is a reaction on the PR body: `issue_read` →
-  `reactions.+1`.** A page fetch finds its review comment's `Useful?` bar
-  instead and reads true on any PR it has commented on. The count is an
-  aggregate and nothing here exposes who reacted, so **leave PR-body
-  reactions to Codex** — one from anyone else and the gate can no longer
-  tell them apart. `eyes` is Codex holding the commit and working, so
-  waiting is doing something; **no** reaction at all means it never picked
-  the push up and none is coming — comment `@codex review`, then wait.
+- **Read the Codex verdict, don't infer it.** `get_reviews` returns each
+  Codex review with a `commit_id` and a `submitted_at` — that is the
+  head-correlated signal, and one whose commit isn't the current head has
+  been superseded. The pass itself is a `+1` reaction on the PR body, or a
+  review comment reporting no findings; either is sufficient, for that head
+  only. A clean pass often posts no review event at all, so `get_reviews`
+  can be empty while the verdict is in — there the correlation is that you
+  saw no reaction before and have pushed nothing since. `issue_read`
+  flattens reactions to an anonymous count, where `GET
+  /repos/{owner}/{repo}/issues/{n}/reactions` gives each one a `user` and a
+  `created_at`; a page fetch finds the `Useful?` bar instead, which is true
+  on any PR Codex has commented on. `eyes` means it is working; nothing 30
+  minutes after a push means it never started — comment `@codex review`,
+  once per push rather than once per poll. That is also how a stale `+1`
+  gets cleared — a reaction never clears itself — after the same 30 minutes,
+  not instead of them.
+- **A finding can arrive as a top-level PR comment.** `get_review_comments`
+  returns only inline threads, so read `get_comments` too — a P1 sat
+  unanswered for two hours because a sweep of the threads never saw it.
 - **Skip echo events silently.** Replies posted via the GitHub MCP come back
   moments later as webhook events authored by the same identity; if the body
   matches a comment you just posted, it's your own echo — continue without


### PR DESCRIPTION
Applied across every sibling repo; the rule text is canonical in `mikelward/mesh`.

## The rule

`get_reviews` returns each Codex review with a `commit_id` and a `submitted_at` — that is the head-correlated signal, and a review whose commit isn't the current head has been superseded. The pass itself is a `+1` reaction on the PR body, or a review comment reporting no findings; either is sufficient, for that head only.

Around it: `issue_read` flattens reactions to an anonymous count, where `GET /repos/{owner}/{repo}/issues/{n}/reactions` gives each one a `user` and a `created_at`; a page fetch finds the review comment's `Useful?` bar instead, which is true on any PR Codex has commented on. `eyes` means it is working; nothing 30 minutes after a push means it never started — `@codex review`, which is also how a stale `+1` gets cleared, since a reaction never clears itself.

## Why it took several passes

Every round was a real finding, most of them Codex's own:

- **The wrong call, then a wrong generalization.** A session read `get_reviews` on four PRs that simply had no review yet, concluded it always comes back empty, and reported ten already-merged, already-reviewed PRs as open and unreviewed. That conclusion survived into the first version of this rule; it now leads with `get_reviews`, which is the best signal there is.
- **The verdict wasn't tied to a head** (P1, twice). Two sibling PRs proved it in passing, each carrying a `+1` given against a commit a later force-push superseded.
- **A stale `+1` had no exit** — a reaction never clears itself, so "wait until it reappears" waited forever. Re-requesting the review cleared it on both within minutes.
- **`@codex review` had no grace period** (P2). Now 30 minutes.
- **The bullet had become an essay** (P1). Final version is 11 lines against the first draft's 15.

## Testing

Documentation only — no script behavior touched, so `make test` was not run, per this repo's own carve-out for changes with no behavior to exercise.
