### PR TITLE
Trust the Codex reaction, which is revoked on push

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,12 +198,19 @@ reply, no offer to correct it. It is not a finding.
   for. Subscribe only when asked to, and unsubscribe as soon as the reason
   for it passes.
 - **Permissions are granted before the session starts, so a rule here can't
-  fix them.** Copy this repo's `.claude/settings.json` allowlist — GitHub
-  calls as well as scheduler ones, under full MCP identifiers and both
-  server-name spellings, since bare names match nothing — into
-  `$HOME/.claude/settings.json` from the environment's setup script.
-  Settings load at startup, so writing that file mid-session does nothing
-  for that session; if calls are prompting, say so once and carry on.
+  fix them.** Copy the scheduler entries — the MCP ones and
+  `ScheduleWakeup`, which is not one — and the GitHub MCP entries, reads and
+  writes both, from this repo's `.claude/settings.json` into
+  `$HOME/.claude/settings.json`, from the environment's setup script, under
+  full MCP identifiers and both server-name spellings, since bare names
+  match nothing. Global writes are a deliberate trade the repo owner has
+  taken: any repo the account opens can then merge and comment unprompted,
+  and in exchange a session rooted above a repo — which loads no repo-local
+  settings — never stalls the watch on a prompt nobody is there to answer.
+  The `Bash` entries stay repo-local: `git push` and `curl` everywhere is
+  wider than the loop needs. Settings load at startup, so writing that file
+  mid-session does nothing for that session; if calls are prompting, say so
+  once and carry on.
 - **Poll your own open PRs — every ~5 minutes while CI or the verdict is
   outstanding, ~30 once only a human is left.** Those two are what nothing
   else reports. Never end a turn idle with one of yours open: arm the next
@@ -301,8 +308,10 @@ reply, no offer to correct it. It is not a finding.
 
 ## Reviews
 
-- **Codex is the automated reviewer on this repo** — not Copilot. Its reviews
-  are triggered automatically; you don't request them.
+- **Codex is the automated reviewer on this repo** — not Copilot. Its
+  reviews are triggered automatically; you don't request them, except when
+  nothing has come back five minutes after a push — that means it never
+  picked the push up.
 - **Address Codex comments automatically — don't wait to be asked.** Read
   each one, decide whether it's a real issue or a false positive, and if it's
   real, fix it in the same PR. Fold the fix into the commit it belongs to
@@ -323,22 +332,23 @@ reply, no offer to correct it. It is not a finding.
   the SHA and comment count, e.g. `Codex reviewed 87d9f02 — 0 comments`. Tie
   it to the *latest* pushed SHA so a stale review of a superseded commit isn't
   conflated with the current state.
-- **Read the Codex verdict, don't infer it.** `get_reviews` returns each
-  Codex review with a `commit_id` and a `submitted_at` — that is the
-  head-correlated signal, and one whose commit isn't the current head has
-  been superseded. The pass itself is a `+1` reaction on the PR body, or a
-  review comment reporting no findings; either is sufficient, for that head
-  only. A clean pass often posts no review event at all, so `get_reviews`
-  can be empty while the verdict is in — there the correlation is that you
-  saw no reaction before and have pushed nothing since. `issue_read`
-  flattens reactions to an anonymous count, where `GET
-  /repos/{owner}/{repo}/issues/{n}/reactions` gives each one a `user` and a
-  `created_at`; a page fetch finds the `Useful?` bar instead, which is true
-  on any PR Codex has commented on. `eyes` means it is working; nothing 30
-  minutes after a push means it never started — comment `@codex review`,
-  once per push rather than once per poll. That is also how a stale `+1`
-  gets cleared — a reaction never clears itself — after the same 30 minutes,
-  not instead of them.
+- **Read the Codex verdict, don't infer it.** It reacts to the PR **body** —
+  `issue_read` → `reactions` — not to a review thread, whose `Useful?` bar a
+  page fetch finds instead and which reads true on any PR Codex has
+  commented on. `eyes` while it reads, `+1` when it finds nothing — or a
+  review reporting no findings, which is the same verdict and names the
+  commit it read. The reaction is revoked as a new push lands, so what you
+  can see belongs to the head you can see: `+1` on green CI is a merge, with
+  nothing further to wait for. A finding is not silence, so the recovery
+  keys on both: nothing at all five minutes after a push — no reaction, no
+  review, no comment — means it never picked the push up; comment `@codex
+  review`, once. A review that *finds* something leaves no reaction at all,
+  so a sweep of reactions alone reads a PR with findings waiting on it as an
+  empty one: read `get_review_comments` and `get_comments` every poll. An
+  unresolved finding blocks the merge whatever the reaction says; one you
+  have answered or fixed does not. Check who left each — the reaction count
+  is anonymous, so leave PR-body reactions to Codex, and a human's review
+  carries the same `commit_id` as Codex's.
 - **A finding can arrive as a top-level PR comment.** `get_review_comments`
   returns only inline threads, so read `get_comments` too — a P1 sat
   unanswered for two hours because a sweep of the threads never saw it.


### PR DESCRIPTION
Follow-up to #191. Part of a fourteen-repo pass over the agent guides.

## The rule

> **Read the Codex verdict, don't infer it.** Codex reacts to the PR body — `eyes` while it reads, `+1` when it finds nothing — and revokes it the moment a new push lands, faster than a poll can catch, so a reaction you can see is a verdict on the head you can see. Leave PR-body reactions to Codex, since the count is anonymous and one from anyone else is indistinguishable. Findings arrive as review comments or as a top-level PR comment, and `get_reviews` names the commit each review read: findings on the current head fail the gate whatever the reaction says. No reaction 30 minutes after a push means it never picked the push up — comment `@codex review`, once.

Beside it: a finding can arrive as a **top-level PR comment**, which `get_review_comments` never returns — read `get_comments` too. And permissions: copy only the scheduler and GitHub **MCP** entries into `$HOME/.claude/settings.json`; the `Bash` entries beside them (`git push`, `git reset`, `curl`, `python3`) would otherwise be granted without approval in every unrelated repo the account opens.

## What this replaced, and why

The morning was spent building defences against a stale thumbs up — a reaction left on an old head being read as approval of a new one. **That hazard is largely imaginary.** Codex revokes the reaction as the push lands, faster than a poll can observe, then runs `eyes` → `+1` against the new head in about two minutes.

Measured on the conf sibling: `+1` at 11:17, push at 11:19, `total_count: 0` immediately after. Eight PRs in this set did the same across an earlier push.

So these are deleted rather than refined: a `created_at` comparison against the push time; watching for a none-to-`+1` transition; restricting the reaction to a head "never pushed over"; and the claim that a reaction never clears itself. Their real cost was the opposite failure — gating verdicts that had already arrived, which is what #191's review comments kept warning about from the other side.

What survives is what the reaction genuinely cannot do: it carries no author (`issue_read` gives an anonymous count, and `api.github.com` is blocked by sandbox egress, 403 even with the token present), so the convention that only Codex reacts to a PR body is what makes it attributable; and a current-head review with findings fails the gate regardless.

## Testing

Documentation only — no script behavior touched, so `make test` was not run, per this repo's own carve-out.
