### PR TITLE
docs: Cut the Codex verdict rules back to the invariant

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,21 +197,15 @@ reply, no offer to correct it. It is not a finding.
   thread the user is actually reading under machine chatter they didn't ask
   for. Subscribe only when asked to, and unsubscribe as soon as the reason
   for it passes.
-- **Permissions are granted before the session starts, so a rule here can't
-  fix them.** Copy what the unattended loop actually performs into
-  `$HOME/.claude/settings.json`, from the environment's setup script: the
-  scheduler entries — the MCP ones and `ScheduleWakeup`, which is not one —
-  the GitHub MCP entries, reads and writes both, and `Bash(git push:*)`,
-  under full MCP identifiers and both server-name spellings, since bare
-  names match nothing. A session rooted above several repos loads none of
-  their repo-local settings, so anything missing from that file stops the
-  watch at a prompt nobody is there to answer — the failure this exists to
-  prevent. The cost is real and the repo owner has taken it: any repo the
-  account opens can then push, comment and merge unprompted. `curl`,
-  `python3` and `git reset` stay repo-local, since the loop never needs
-  them. Settings load at startup, so writing that file mid-session does
-  nothing for that session; if calls are prompting, say so once and carry
-  on.
+- **Permissions load at session start, so a rule here can't fix them.** The
+  unattended loop needs the scheduler entries (the MCP ones and
+  `ScheduleWakeup`), the GitHub MCP reads and writes, and `git push`. A
+  session rooted above the repo loads no repo-local settings, so those
+  belong in `$HOME/.claude/settings.json`, written by the environment's
+  setup script under both server-name spellings. The cost, which the repo
+  owner has taken: any repo the account opens can push, comment and merge
+  unprompted. Writing that file mid-session does nothing for that session;
+  if calls prompt, say so once and carry on.
 - **Poll your own open PRs — every ~5 minutes while CI or the verdict is
   outstanding, ~30 once only a human is left.** Those two are what nothing
   else reports. Never end a turn idle with one of yours open: arm the next
@@ -333,31 +327,19 @@ reply, no offer to correct it. It is not a finding.
   the SHA and comment count, e.g. `Codex reviewed 87d9f02 — 0 comments`. Tie
   it to the *latest* pushed SHA so a stale review of a superseded commit isn't
   conflated with the current state.
-- **Read the Codex verdict, don't infer it.** It reacts to the PR **body** —
-  `issue_read` → `reactions` — not to a review thread, whose `Useful?` bar a
-  page fetch finds instead and which reads true on any PR Codex has
-  commented on. `eyes` while it reads, `+1` when it finds nothing — or a
-  review reporting no findings, which is the same verdict and names the
-  commit it read. The reaction is revoked as a new push lands, so what you
-  can see belongs to the head you can see: `+1` on green CI is a merge, with
-  nothing further to wait for. A finding is not silence, so the recovery
-  keys on both: nothing at all five minutes after a push — no reaction, no
-  review, no comment — means it never picked the push up; comment `@codex
-  review`, once. A review that *finds* something leaves no reaction at all,
-  so a sweep of reactions alone reads a PR with findings waiting on it as an
-  empty one: read `get_review_comments` and `get_comments` every poll. An
-  unresolved finding blocks the merge whatever the reaction says; one you
-  have answered or fixed does not. Check who left each — the reaction count
-  is anonymous, so leave PR-body reactions to Codex, and a human's review
-  carries the same `commit_id` as Codex's.
-- **Read findings to the last page, and in both places.**
-  `get_review_comments` returns only inline threads, so a top-level comment
-  is invisible to it — read `get_comments` too. Both, and `get_reviews`,
-  page oldest first, so the newest is on the LAST page: `hasNextPage` is the
-  only thing that says you have seen it. Reading a middle page as the latest
-  is how a P1 sat unanswered for two hours, how a second one went unseen
-  while its PR was merged, and how a superseded review got reported as the
-  current verdict.
+- **Read the Codex verdict, don't infer it.** It reacts to the PR body
+  (`issue_read` → `reactions`), not to a review thread, whose `Useful?` bar
+  reads true on any PR it has commented on. `eyes` means reading, `+1` means
+  clean, and Codex revokes it on push — so a visible one belongs to the
+  visible head, and `+1` with green CI is a merge. The count names no
+  author, so leave PR-body reactions to Codex: nobody else's is revoked, and
+  a review is the attributable form, naming the commit it read. Findings
+  arrive as review comments, as a top-level comment, or as a review — read
+  `get_review_comments`, `get_comments` and `get_reviews` to the last page,
+  since all three page oldest first — and they block the merge until fixed
+  or rebutted; an acknowledgement is not an answer. Nothing from Codex since
+  the push, five minutes on, means it never picked it up — comment `@codex
+  review`, once.
 - **Skip echo events silently.** Replies posted via the GitHub MCP come back
   moments later as webhook events authored by the same identity; if the body
   matches a comment you just posted, it's your own echo — continue without


### PR DESCRIPTION
Part of a fourteen-repo pass over the agent guides. The rule as it now stands:

> **Read the Codex verdict, don't infer it.** It reacts to the PR body (`issue_read` → `reactions`), not to a review thread, whose `Useful?` bar reads true on any PR it has commented on. `eyes` means reading, `+1` means clean, and Codex revokes it on push — so a visible one belongs to the visible head, and `+1` with green CI is a merge. The count names no author, so leave PR-body reactions to Codex: nobody else's is revoked, and a review is the attributable form, naming the commit it read. Findings arrive as review comments, as a top-level comment, or as a review — read `get_review_comments`, `get_comments` and `get_reviews` to the last page, since all three page oldest first — and they block the merge until fixed or rebutted; an acknowledgement is not an answer. Nothing from Codex since the push, five minutes on, means it never picked it up — comment `@codex review`, once.

## How it got here

It began as a **trim**. Each round of review had been answered by appending that round's incident to the rule, until the verdict guidance was an essay carrying four anecdotes, an API tour, and two further bullets saying what one clause could say — in a file every session loads whole. Three bullets became one, about 1.4 KB lighter. Codex and the repo owner asked for that independently.

The trim then cut too far, and the next review round put three things back, each with a concrete failure attached:

- **The reaction count is anonymous.** Dropping the "leave PR-body reactions to Codex" convention wasn't neutral: a human's `+1` is *not* revoked by a push, so without that line an ordinary thumbs up reads as a current-head verdict. Restored with its reason, beside the fact that a review is the attributable form of the same verdict.
- **`get_reviews` belongs in the sweep.** A clean pass can arrive as a review with no findings and no reaction, so reading only the two comment endpoints can leave a verdict already given looking like silence.
- **"Answered" is not "fixed".** These guides accept acknowledgement noise as a reply, so `good catch, will do` would have cleared the gate with the defect still in the diff. It now takes a fix or a rebuttal.

And one bug that predated the trim: the recovery condition was unsatisfiable. Old reviews and comments outlive a push, so "no reaction, no review, no comment" is never true on a PR with any history, and `@codex review` would never have fired on a push Codex missed. Scoped first to the push — then to **Codex**, because the guides' own reply order (push, then reply) and CI's own PR comments both guarantee post-push activity from someone else.

## What it deliberately does not fix

Two limits, stated rather than papered over. Both were raised as findings and both are answered on their threads:

- **The verdict has no author.** `issue_read` returns an aggregate; `GET /repos/{owner}/{repo}/issues/{n}/reactions`, which does carry a `user`, returns **403** through this sandbox's egress proxy. So the convention is the mitigation, and a review naming the head is the stronger signal whenever one exists. Requiring that review unconditionally is declined: a clean pass often posts no review at all, which would gate every clean PR permanently.
- **The head can move between reading the verdict and merging.** `mcp__github__merge_pull_request` has no `sha` parameter, so the expected-head guard the REST API supports isn't reachable from here. Read head, reaction and CI in one pass and merge immediately — a narrowed window, not a proof.

## Testing

Documentation only — no executable behavior, so `make test` doesn't apply per this repo's own rule.
