### PR TITLE
docs: Cut the permissions rule to the part an agent can act on

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,15 +197,9 @@ reply, no offer to correct it. It is not a finding.
   thread the user is actually reading under machine chatter they didn't ask
   for. Subscribe only when asked to, and unsubscribe as soon as the reason
   for it passes.
-- **Permissions load at session start, so a rule here can't fix them.** The
-  unattended loop needs the scheduler entries (the MCP ones and
-  `ScheduleWakeup`), the GitHub MCP reads and writes, and `git push`. A
-  session rooted above the repo loads no repo-local settings, so those
-  belong in `$HOME/.claude/settings.json`, written by the environment's
-  setup script under both server-name spellings. The cost, which the repo
-  owner has taken: any repo the account opens can push, comment and merge
-  unprompted. Writing that file mid-session does nothing for that session;
-  if calls prompt, say so once and carry on.
+- **If a scheduler or GitHub call prompts, say so once and carry on.**
+  Permissions load at session start, so writing a settings file mid-session
+  can't fix the session you're in.
 - **Poll your own open PRs — every ~5 minutes while CI or the verdict is
   outstanding, ~30 once only a human is left.** Those two are what nothing
   else reports. Never end a turn idle with one of yours open: arm the next


### PR DESCRIPTION
Nine lines of the permissions rule were addressed to whoever maintains the environment's setup script — which entries the unattended loop needs, both server-name spellings, the cost the repo owner accepted by making the grants global. The agent reading this file can't act on any of it: permissions load before the session exists, so by the time the rule is in context the outcome is already fixed.

**Before** (nine lines, in every session's context):

> **Permissions load at session start, so a rule here can't fix them.** The unattended loop needs the scheduler entries (the MCP ones and `ScheduleWakeup`), the GitHub MCP reads and writes, and `git push`. A session rooted above the repo loads no repo-local settings, so those belong in `$HOME/.claude/settings.json`, written by the environment's setup script under both server-name spellings. The cost, which the repo owner has taken: any repo the account opens can push, comment and merge unprompted. Writing that file mid-session does nothing for that session; if calls prompt, say so once and carry on.

**After** (two):

> **If a scheduler or GitHub call prompts, say so once and carry on.** Permissions load at session start, so writing a settings file mid-session can't fix the session you're in.

That clause is the only part that changes what an agent does, and it earns its place: an agent once spent a turn writing `$HOME/.claude/settings.json` to fix prompts in the session it was already in. The setup-script detail is dropped rather than relocated — the allowlist files themselves are the record of which entries exist.

About 440 characters back per repo, from a file whose own first rule is to say each thing once in the fewest words that carry the why.

## Testing

Documentation only — no executable behavior, so `make test` doesn't apply per this repo's own rule.


---
_Generated by [Claude Code](https://claude.ai/code/session_018Bnb4L3E9bix6MNKfi68Eo)_