### PR TITLE
docs: Keep the PR subscription on and filter the events instead

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,26 +202,29 @@ reply, no offer to correct it. It is not a finding.
 - **If a scheduler, GitHub or `git push` call prompts, say so once and carry on.**
   Permissions load at session start, so writing a settings file mid-session
   can't fix the session you're in.
-- **Poll your own open PRs as a slow backstop, ~30 minutes.** The
-  subscription already delivers CI and review activity within seconds, so a
-  five-minute loop on top of it buys nothing and costs a turn every time it
-  fires. What the poll is for is the two things webhooks drop — a CI result
-  that never arrives, and a Codex verdict that is a reaction and therefore
-  emits no event at all. Never end a turn idle with one of yours open: arm
-  the next check with whatever the client offers (`send_later`, a scheduled
-  task / cron, `/loop`), and arm it *without asking*. Someone else's PR is
-  not your polling job unless you're asked. Merged or closed is terminal:
-  take one more check for CI and Codex on the final head, settle for what's
-  known if a report may never land, then run a last reply-or-resolve pass
-  and cancel the watch in full — the pending trigger and that PR's
-  subscription (`unsubscribe_pr_activity` takes one PR, so it leaves any
-  other watch alone). Open a follow-up PR, with its own watch, for anything
-  a merged one still needs.
-- **What the polling costs.** Two wake-ups an hour per PR — each a model
-  turn plus a few GitHub API calls. The scheduler is the single point of
-  failure: one missed re-arm ends the watch silently, with no error
-  anywhere. If you can't arm the next check, say so in the reply rather than
-  leaving a PR that looks watched and isn't.
+- **Poll your own open PRs: one check five minutes after a push, then ~30
+  minutes.** The subscription delivers CI and review activity within
+  seconds, so a standing five-minute loop buys nothing and costs a turn
+  every time it fires. What it cannot deliver is Codex never picking the
+  push up: no review, no reaction, no event, and silence that looks
+  identical to still-reading. That is what the five-minute check is for —
+  nothing from Codex by then means comment `@codex review`, once. After that
+  the webhooks carry it and the slow check is the backstop for what they
+  drop. Never end a turn idle with one of yours open: arm the next check
+  with whatever the client offers (`send_later`, a scheduled task / cron,
+  `/loop`), and arm it *without asking*. Someone else's PR is not your
+  polling job unless you're asked. Merged or closed is terminal: take one
+  more check for CI and Codex on the final head, settle for what's known if
+  a report may never land, then run a last reply-or-resolve pass and cancel
+  the watch in full — the pending trigger and that PR's subscription
+  (`unsubscribe_pr_activity` takes one PR, so it leaves any other watch
+  alone). Open a follow-up PR, with its own watch, for anything a merged one
+  still needs.
+- **What the polling costs.** Two wake-ups an hour per PR, plus one per push
+  — each a model turn and a few GitHub API calls. The scheduler is the
+  single point of failure: one missed re-arm ends the watch silently, with
+  no error anywhere. If you can't arm the next check, say so in the reply
+  rather than leaving a PR that looks watched and isn't.
 - **One pending check per PR, settled at the top of the turn.** Two chains
   each re-arming themselves double the cost every time a webhook starts a
   turn while one is already pending; parking the re-arm at the *end* of the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,42 +189,40 @@ reply, no offer to correct it. It is not a finding.
   owner's standing request for that PR, so a client-level rule reading "open a
   PR only when the user explicitly asks" is already satisfied — the ask is
   here, and it doesn't need repeating per branch.
-- **Opening the PR arms the watch, and it has two halves.** The events
-  GitHub pushes into the conversation are the fast one — opening a PR
-  subscribes this session automatically, and that stays on until the PR is
-  merged or closed. The scheduled check is the slow one, and it is what
-  catches whatever the webhooks drop. Don't unsubscribe to quiet the thread,
-  and don't relay it either: an event that needs no action — your own reply
-  echoing back, a deploy-preview bot, a check run that passed — ends the
-  turn with **no reply at all**. Not a summary, not a note that you are
-  skipping it. Saying "deploy preview, no action" is the noise, not the
-  filter.
+- **The scheduled check is the watch. Unsubscribe from PR activity
+  immediately.** Opening a PR subscribes this session automatically, and in
+  this client every subscribed event — each comment, review, check run, and
+  your own replies echoing back — is rendered into the user's conversation
+  as a raw payload. Nothing you write or refrain from writing changes that:
+  the delivery is the client's, not yours, so it cannot be filtered,
+  softened or skipped from here. The only control is the subscription
+  itself, so call `unsubscribe_pr_activity` for a PR as soon as you open it,
+  and read its state on the scheduled check instead. This reverses an
+  earlier version of this rule that said to keep the subscription and skip
+  the noisy events; that is not possible, and a day was spent proving it.
 - **If a scheduler, GitHub or `git push` call prompts, say so once and carry on.**
   Permissions load at session start, so writing a settings file mid-session
   can't fix the session you're in.
-- **Poll your own open PRs: one check five minutes after a push, then ~30
-  minutes.** The subscription delivers CI and review activity within
-  seconds, so a standing five-minute loop buys nothing and costs a turn
-  every time it fires. What it cannot deliver is Codex never picking the
-  push up: no review, no reaction, no event, and silence that looks
-  identical to still-reading. That is what the five-minute check is for —
-  nothing from Codex by then means comment `@codex review`, once. After that
-  the webhooks carry it and the slow check is the backstop for what they
-  drop. Never end a turn idle with one of yours open: arm the next check
-  with whatever the client offers (`send_later`, a scheduled task / cron,
-  `/loop`), and arm it *without asking*. Someone else's PR is not your
-  polling job unless you're asked. Merged or closed is terminal: take one
-  more check for CI and Codex on the final head, settle for what's known if
-  a report may never land, then run a last reply-or-resolve pass and cancel
-  the watch in full — the pending trigger and that PR's subscription
-  (`unsubscribe_pr_activity` takes one PR, so it leaves any other watch
-  alone). Open a follow-up PR, with its own watch, for anything a merged one
-  still needs.
+- **Poll your own open PRs: five minutes after a push, then ~30 minutes.**
+  With no subscription the check is the only thing that reports, and the
+  first one lands early because a push that Codex never picked up looks
+  exactly like one it is still reading — see the verdict rule for what to do
+  about it. Afterwards the slow cadence is enough. Never end a turn idle
+  with one of yours open: arm the next check with whatever the client offers
+  (`send_later`, a scheduled task / cron, `/loop`), and arm it *without
+  asking*. Someone else's PR is not your polling job unless you're asked.
+  Merged or closed is terminal: take one more check for CI and Codex on the
+  final head, settle for what's known if a report may never land, then run a
+  last reply-or-resolve pass and cancel the pending trigger. Open a
+  follow-up PR, with its own watch, for anything a merged one still needs.
 - **What the polling costs.** Two wake-ups an hour per PR, plus one per push
-  — each a model turn and a few GitHub API calls. The scheduler is the
-  single point of failure: one missed re-arm ends the watch silently, with
-  no error anywhere. If you can't arm the next check, say so in the reply
-  rather than leaving a PR that looks watched and isn't.
+  — each a model turn and a few GitHub API calls, so a few tens of cents an
+  hour while a PR waits on its merge gate, against roughly a dollar under
+  the old five-minute loop. The GitHub calls themselves are free, well
+  inside the 5,000/hour authenticated limit. The scheduler is the single
+  point of failure: one missed re-arm ends the watch silently, with no error
+  anywhere. If you can't arm the next check, say so in the reply rather than
+  leaving a PR that looks watched and isn't.
 - **One pending check per PR, settled at the top of the turn.** Two chains
   each re-arming themselves double the cost every time a webhook starts a
   turn while one is already pending; parking the re-arm at the *end* of the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,26 +203,32 @@ reply, no offer to correct it. It is not a finding.
 - **If a scheduler, GitHub or `git push` call prompts, say so once and carry on.**
   Permissions load at session start, so writing a settings file mid-session
   can't fix the session you're in.
-- **Poll your own open PRs: five minutes after a push, then ~30 minutes.**
-  With no subscription the check is the only thing that reports, and the
-  first one lands early because a push that Codex never picked up looks
-  exactly like one it is still reading — see the verdict rule for what to do
-  about it. Afterwards the slow cadence is enough. Never end a turn idle
-  with one of yours open: arm the next check with whatever the client offers
-  (`send_later`, a scheduled task / cron, `/loop`), and arm it *without
-  asking*. Someone else's PR is not your polling job unless you're asked.
-  Merged or closed is terminal: take one more check for CI and Codex on the
-  final head, settle for what's known if a report may never land, then run a
-  last reply-or-resolve pass and cancel the pending trigger. Open a
-  follow-up PR, with its own watch, for anything a merged one still needs.
-- **What the polling costs.** Two wake-ups an hour per PR, plus one per push
-  — each a model turn and a few GitHub API calls, so a few tens of cents an
-  hour while a PR waits on its merge gate, against roughly a dollar under
-  the old five-minute loop. The GitHub calls themselves are free, well
-  inside the 5,000/hour authenticated limit. The scheduler is the single
-  point of failure: one missed re-arm ends the watch silently, with no error
-  anywhere. If you can't arm the next check, say so in the reply rather than
-  leaving a PR that looks watched and isn't.
+- **Poll your own open PRs: every 4 minutes while a verdict is outstanding,
+  ~30 once it lands.** With no subscription the check is the only thing that
+  reports. Four is measured rather than guessed — Codex answers 2 to 5
+  minutes after a push, so a check on that interval catches it within one,
+  and a check that finds nothing ends the turn with no reply. Don't let the
+  interval decay as it waits: lateness does not mean wait longer, because
+  Codex either answers within those few minutes or never started, and the
+  answer to never-started is the nudge in the verdict rule, not a longer
+  wait. Once the verdict is in and only a human is left, drop to ~30. Never
+  end a turn idle with one of yours open: arm the next check with whatever
+  the client offers (`send_later`, a scheduled task / cron, `/loop`), and
+  arm it *without asking*. Someone else's PR is not your polling job unless
+  you're asked. Merged or closed is terminal: take one more check for CI and
+  Codex on the final head, settle for what's known if a report may never
+  land, then run a last reply-or-resolve pass and cancel the pending
+  trigger. Open a follow-up PR, with its own watch, for anything a merged
+  one still needs.
+- **What the polling costs.** A verdict normally costs one or two checks;
+  after that, two wake-ups an hour per PR while a human is the only thing
+  left. Each is a model turn and a few GitHub API calls — a few tens of
+  cents an hour, against roughly a dollar under the old standing five-minute
+  loop. The calls themselves are free, well inside the 5,000/hour
+  authenticated limit. The scheduler is the single point of failure: one
+  missed re-arm ends the watch silently, with no error anywhere. If you
+  can't arm the next check, say so in the reply rather than leaving a PR
+  that looks watched and isn't.
 - **One pending check per PR, settled at the top of the turn.** Two chains
   each re-arming themselves double the cost every time a webhook starts a
   turn while one is already pending; parking the re-arm at the *end* of the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,15 +189,15 @@ reply, no offer to correct it. It is not a finding.
   owner's standing request for that PR, so a client-level rule reading "open a
   PR only when the user explicitly asks" is already satisfied — the ask is
   here, and it doesn't need repeating per branch.
-- **Opening the PR arms the first scheduled check.** That check *is* the
-  watch: when it fires it reads CI, review comments and the Codex reaction,
-  and it is what catches anything a webhook drops. `subscribe_pr_activity`
-  is a separate thing and it is **opt-in** — it pushes every comment, check
-  run and bot reply into the conversation as a raw event, which buries the
-  thread the user is actually reading under machine chatter they didn't ask
-  for. Opening a PR *subscribes this session to it automatically*, so
-  unsubscribe right after opening one unless you were asked to watch it that
-  way.
+- **Opening the PR arms the watch, and it has two halves.** The events
+  GitHub pushes into the conversation are the fast one — opening a PR
+  subscribes this session automatically, and that stays on until the PR is
+  merged or closed. The scheduled check is the slow one, and it is what
+  catches whatever the webhooks drop, which is why both exist. Don't
+  unsubscribe to quiet the thread: skip the events that need no action —
+  your own replies echoing back, a deploy-preview bot, a check run that
+  passed — without narrating them, and reply only when something needs the
+  user.
 - **If a scheduler, GitHub or `git push` call prompts, say so once and carry on.**
   Permissions load at session start, so writing a settings file mid-session
   can't fix the session you're in.
@@ -210,7 +210,7 @@ reply, no offer to correct it. It is not a finding.
   Merged or closed is terminal: take one more check for CI and Codex on the
   final head, but settle for what's known if a report may never land, then
   run a last reply-or-resolve pass and cancel the watch in full — the
-  pending trigger, *and* `unsubscribe_pr_activity` if you ever subscribed.
+  pending trigger, *and* the subscription (`unsubscribe_pr_activity`).
   Open a follow-up PR, with its own watch, for anything a merged one still
   needs.
 - **What the polling costs.** Twelve wake-ups an hour per PR at the fast

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,9 +195,10 @@ reply, no offer to correct it. It is not a finding.
   is a separate thing and it is **opt-in** — it pushes every comment, check
   run and bot reply into the conversation as a raw event, which buries the
   thread the user is actually reading under machine chatter they didn't ask
-  for. Subscribe only when asked to, and unsubscribe as soon as the reason
-  for it passes.
-- **If a scheduler or GitHub call prompts, say so once and carry on.**
+  for. Opening a PR *subscribes this session to it automatically*, so
+  unsubscribe right after opening one unless you were asked to watch it that
+  way.
+- **If a scheduler, GitHub or `git push` call prompts, say so once and carry on.**
   Permissions load at session start, so writing a settings file mid-session
   can't fix the session you're in.
 - **Poll your own open PRs — every ~5 minutes while CI or the verdict is
@@ -241,8 +242,16 @@ reply, no offer to correct it. It is not a finding.
   *or* deleting one — an update reschedules whatever it matches as surely as a
   delete cancels it. If that filter turns up more than one, the extras are
   duplicate chains: keep one and delete the rest.
-- **Never name a SHA in the check prompt.** It is written before the work it
-  describes, so it is stale when it fires — say "the current head".
+- **Never name a SHA — or a list of PR numbers — in the check prompt.** Both
+  are written before the work they describe, so both are stale when it
+  fires, and a queued firing carries the prompt as it was when it was
+  queued: editing it mid-turn does not reach a check already on its way.
+  Name what to re-read.
+- **The scheduler's clock is not this container's.** `run_once_at` must be
+  in the future by the *scheduler's* reckoning, and an absolute time
+  computed from `date` here has been rejected as already past. Prefer a
+  relative delay where the client offers one; where it doesn't, read the
+  clock rather than assuming it, and leave margin.
 - **"Drive" means run the loop automatically**: pick the next task,
   implement it, open the PR, send it for review, address every comment,
   merge once CI is green and Codex's verdict for the current head is in —

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,33 +193,35 @@ reply, no offer to correct it. It is not a finding.
   GitHub pushes into the conversation are the fast one — opening a PR
   subscribes this session automatically, and that stays on until the PR is
   merged or closed. The scheduled check is the slow one, and it is what
-  catches whatever the webhooks drop, which is why both exist. Don't
-  unsubscribe to quiet the thread: skip the events that need no action —
-  your own replies echoing back, a deploy-preview bot, a check run that
-  passed — without narrating them, and reply only when something needs the
-  user.
+  catches whatever the webhooks drop. Don't unsubscribe to quiet the thread,
+  and don't relay it either: an event that needs no action — your own reply
+  echoing back, a deploy-preview bot, a check run that passed — ends the
+  turn with **no reply at all**. Not a summary, not a note that you are
+  skipping it. Saying "deploy preview, no action" is the noise, not the
+  filter.
 - **If a scheduler, GitHub or `git push` call prompts, say so once and carry on.**
   Permissions load at session start, so writing a settings file mid-session
   can't fix the session you're in.
-- **Poll your own open PRs — every ~5 minutes while CI or the verdict is
-  outstanding, ~30 once only a human is left.** Those two are what nothing
-  else reports. Never end a turn idle with one of yours open: arm the next
-  check with whatever the client offers (`send_later`, a scheduled task /
-  cron, `/loop`), and arm it *without asking* — that is hygiene, not a
-  decision. Someone else's PR is not your polling job unless you're asked.
-  Merged or closed is terminal: take one more check for CI and Codex on the
-  final head, but settle for what's known if a report may never land, then
-  run a last reply-or-resolve pass and cancel the watch in full — the
-  pending trigger, *and* the subscription (`unsubscribe_pr_activity`).
-  Open a follow-up PR, with its own watch, for anything a merged one still
-  needs.
-- **What the polling costs.** Twelve wake-ups an hour per PR at the fast
-  cadence, two at the slow one — each a model turn plus a few GitHub API
-  calls, so roughly a dollar an hour while a PR is waiting on its merge
-  gate. The scheduler is the single point of failure: one missed re-arm ends
-  the watch silently, with no error anywhere. If you can't arm the next
-  check, say so in the reply rather than leaving a PR that looks watched and
-  isn't.
+- **Poll your own open PRs as a slow backstop, ~30 minutes.** The
+  subscription already delivers CI and review activity within seconds, so a
+  five-minute loop on top of it buys nothing and costs a turn every time it
+  fires. What the poll is for is the two things webhooks drop — a CI result
+  that never arrives, and a Codex verdict that is a reaction and therefore
+  emits no event at all. Never end a turn idle with one of yours open: arm
+  the next check with whatever the client offers (`send_later`, a scheduled
+  task / cron, `/loop`), and arm it *without asking*. Someone else's PR is
+  not your polling job unless you're asked. Merged or closed is terminal:
+  take one more check for CI and Codex on the final head, settle for what's
+  known if a report may never land, then run a last reply-or-resolve pass
+  and cancel the watch in full — the pending trigger and that PR's
+  subscription (`unsubscribe_pr_activity` takes one PR, so it leaves any
+  other watch alone). Open a follow-up PR, with its own watch, for anything
+  a merged one still needs.
+- **What the polling costs.** Two wake-ups an hour per PR — each a model
+  turn plus a few GitHub API calls. The scheduler is the single point of
+  failure: one missed re-arm ends the watch silently, with no error
+  anywhere. If you can't arm the next check, say so in the reply rather than
+  leaving a PR that looks watched and isn't.
 - **One pending check per PR, settled at the top of the turn.** Two chains
   each re-arming themselves double the cost every time a webhook starts a
   turn while one is already pending; parking the re-arm at the *end* of the
@@ -247,11 +249,10 @@ reply, no offer to correct it. It is not a finding.
   fires, and a queued firing carries the prompt as it was when it was
   queued: editing it mid-turn does not reach a check already on its way.
   Name what to re-read.
-- **The scheduler's clock is not this container's.** `run_once_at` must be
-  in the future by the *scheduler's* reckoning, and an absolute time
-  computed from `date` here has been rejected as already past. Prefer a
-  relative delay where the client offers one; where it doesn't, read the
-  clock rather than assuming it, and leave margin.
+- **The scheduler's clock is not this container's.** An absolute
+  `run_once_at` computed from `date` here can be rejected as already past —
+  prefer a relative delay where the client offers one, or read the
+  scheduler's clock and leave margin.
 - **"Drive" means run the loop automatically**: pick the next task,
   implement it, open the PR, send it for review, address every comment,
   merge once CI is green and Codex's verdict for the current head is in —


### PR DESCRIPTION
Cross-pollination round across the sibling repos, plus one reversal.

**The reversal.** The watch bullet said to unsubscribe right after opening a PR, on the theory that pushed events buried the thread. That was the wrong lever: opening a PR subscribes the session automatically, and turning that off is what made webhook events stop arriving. It now says the watch has two halves — the pushed events (fast) and the scheduled check (slow, catches what the webhooks drop) — and that the fix for noise is to skip the events that need no action without narrating them, not to unsubscribe.

**Also in this round**
- `git push` added to the "if a call prompts, say so once and carry on" clause.
- The check prompt must not name a SHA *or* a list of PR numbers, and a queued firing carries the prompt as it was when queued.
- New: the scheduler's clock is not this container's — an absolute `run_once_at` computed here has been rejected as already past; prefer a relative delay, or read the clock.
- The Codex verdict rule keeps the anonymous-reaction convention and `get_reviews`, and the retry condition is now "nothing from Codex since the push" rather than a condition that could never be true.

---
_Generated by [Claude Code](https://claude.ai/code/session_018Bnb4L3E9bix6MNKfi68Eo)_