### PR TITLE
Add repo-rules to set a repository's merge gates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,10 @@ has stopped biting.
   placeholders (`/home/user`, `host1`, `git@example.com:org/repo.git`) in
   examples and fixtures. If a bug report contains any of it, paraphrase in
   the commit / PR — don't quote verbatim. When in doubt, ask before pushing.
+- **This account's own public repos are not user data** — decline a privacy
+  finding against `mikelward/lanes`. Then it's a documentation call:
+  `owner/repo` for the shape of an argument, the real name when the example is
+  about that repo.
 - **Script output is not one of those artifacts.** It prints on the user's own
   terminal, and naming hosts, paths and remotes is usually the point of the
   message. Redact only secrets: tokens, keys, and passwords embedded in URLs.

--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,4 @@ test:
 	./kdeshortcut_test
 	./dvorak_test
 	./confinst_test
+	./repo-rules_test

--- a/repo-rules
+++ b/repo-rules
@@ -1,0 +1,634 @@
+#!/bin/sh
+# Manage a GitHub repository's branch ruleset: which checks a merge requires.
+#
+# Usage:
+#     repo-rules [--dry-run] [--force] [--ruleset NAME] OWNER/REPO CHECK...
+#     repo-rules --ruleset=gates owner/repo gate codex
+#
+# Requires the gh CLI, authenticated with admin rights on the repository.
+#
+# Cost and reliability: free. Every call is GitHub's REST API, which allows
+# 5,000 authenticated requests an hour; a typical run spends four or five and
+# a worst case -- a check that has never reported, so every head the bounded
+# scan below offers is walked -- spends about four hundred, whatever the size
+# of the repository. Expect a second or two, up to a minute for that worst
+# case. It is not on any hot path: nothing here runs from
+# a shell prompt. Every failure mode is loud and leaves the ruleset untouched
+# -- no gh (refuses, exit 1), not authenticated or lacking admin (the first
+# call fails, exit 1), GitHub down or rate limited (same), and a failed read
+# never reads as "this check has never reported".
+#
+# What it does: makes CHECK... required on the default branch, via a ruleset
+# it owns by name, so a pull request cannot merge until each one passes --
+# requires every review conversation to be resolved, the branch to be up to
+# date with the base, and allows rebase as the only merge method.
+#
+# Conversation resolution is not optional here, because it closes the gap the
+# checks cannot: a reviewer's comment is not a check, so a finding raised and
+# never answered blocks nothing, and a green tick reads as agreement it never
+# was. Requiring resolution makes "somebody replied" a precondition for merge
+# rather than a courtesy. It requires the threads be RESOLVED, not agreed --
+# resolving a thread you disagree with is one click, so this costs a rebuttal
+# and never a merge.
+#
+# Why a named ruleset rather than editing whatever is there: a repository's
+# protections may include rules this script knows nothing about, and writing
+# the whole object back would silently drop them. It creates its own ruleset,
+# and touches no other.
+#
+# The guard that earns this script: it REFUSES to require a check that has
+# never reported. A required check that never runs blocks every merge
+# forever, with no error anywhere to say why -- and the failure looks exactly
+# like a stuck queue. A typo ("sweeep") or a check that only exists on a
+# branch not yet merged both land there. Pass --force when you are knowingly
+# requiring one that is about to start reporting.
+#
+# Check names are handled one per line throughout, never as a space-separated
+# list. Real names contain spaces -- "Analyze (actions)" is one CodeQL emits
+# -- and a split one produces contexts like "Analyze" and "(actions)" that
+# pass validation individually and then never report, which is the exact
+# failure this script exists to prevent, caused by the script itself.
+
+set -eu
+
+PROGRAM="$(basename "$0")"
+RULESET="merge gates"
+DRY_RUN=0
+FORCE=0
+
+error() {
+    echo "$PROGRAM: $*" >&2
+}
+
+usage() {
+    cat <<EOF
+Usage: $PROGRAM [--dry-run] [--force] [--ruleset NAME] OWNER/REPO CHECK...
+
+Make each CHECK a required status check on OWNER/REPO's default branch,
+require every review conversation to be resolved and the branch to be up to
+date with the base, and allow rebase as the only merge method.
+
+  --dry-run        Print what would change; make no writes.
+  --force          Require a check even if it has never reported.
+  --ruleset NAME   Name of the ruleset to own (default: "$RULESET").
+  -h, --help       This message.
+
+Examples:
+  $PROGRAM owner/repo gate codex
+  $PROGRAM --dry-run owner/other-repo gate codex Vercel
+EOF
+}
+
+while test $# -gt 0; do
+    case "$1" in
+        --dry-run) DRY_RUN=1; shift ;;
+        --force) FORCE=1; shift ;;
+        --ruleset) shift; test $# -gt 0 || { error "--ruleset needs a name"; exit 2; }
+                   RULESET="$1"; shift ;;
+        --ruleset=*) RULESET="${1#--ruleset=}"; shift ;;
+        -h|--help) usage; exit 0 ;;
+        --) shift; break ;;
+        -*) error "unknown option '$1'"; usage >&2; exit 2 ;;
+        *) break ;;
+    esac
+done
+
+test $# -ge 2 || { usage >&2; exit 2; }
+
+REPO="$1"; shift
+# Strictly OWNER/REPO, because `gh api` substitutes `{owner}` and `{repo}` in
+# an endpoint from the current checkout or $GH_REPO. A literal `{owner}/{repo}`
+# passes a shape check and then every call in this script silently retargets
+# whatever repository the shell happens to be in -- with admin credentials, and
+# with the output still naming `{owner}/{repo}`. Only the characters GitHub
+# allows in an owner or a repository name get through.
+case "$REPO" in
+    */*/*|/*|*/) error "'$REPO' is not OWNER/REPO"; exit 2 ;;
+    */*) ;;
+    *) error "'$REPO' is not OWNER/REPO"; exit 2 ;;
+esac
+case "$REPO" in
+    *[!A-Za-z0-9._/-]*)
+        error "'$REPO' contains characters GitHub does not allow in an owner or"
+        error "repository name. Note that gh expands '{owner}' and '{repo}' from"
+        error "the current checkout, so such an argument would target a different"
+        error "repository than the one named."
+        exit 2 ;;
+esac
+
+command -v gh >/dev/null 2>&1 || {
+    error "gh is not installed. It carries the authentication this needs;"
+    error "installing it is less work than reimplementing that with curl."
+    exit 1
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT INT TERM
+
+# The branch to protect, and whether the repository permits a rebase merge at
+# all. The branch is asked for rather than assumed: not every repository calls
+# it main, and requiring checks on a branch that does not exist silently
+# protects nothing.
+if gh api "repos/$REPO" --jq '.default_branch, .allow_rebase_merge' > "$WORK/repo"; then
+    DEFAULT_BRANCH="$(sed -n 1p "$WORK/repo")"
+    ALLOW_REBASE="$(sed -n 2p "$WORK/repo")"
+else
+    error "could not read $REPO"
+    exit 1
+fi
+test -n "$DEFAULT_BRANCH" || { error "could not read $REPO's default branch"; exit 1; }
+
+# A ruleset NARROWS what the repository permits; it cannot enable a method the
+# repository has turned off. So allowing only rebase on a repository with
+# rebase merging disabled leaves the intersection empty and nothing can merge
+# -- the never-merges trap this script exists to prevent, sprung by the script.
+# Refused rather than fixed: turning on a repository-wide merge setting is not
+# something a run asked to set a check list should do behind the operator.
+if test "$ALLOW_REBASE" != true; then
+    error "$REPO has rebase merging disabled, and this ruleset allows only"
+    error "rebase. A ruleset narrows what the repository permits and cannot"
+    error "enable a method, so together they would leave no way to merge"
+    error "anything. Enable 'Allow rebase merging' in the repository's pull"
+    error "request settings first."
+    exit 1
+fi
+
+# A JSON string literal, with the two characters that would otherwise end it
+# escaped. Check names are free text from the caller.
+json_string() {
+    printf '"%s"' "$(printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g')"
+}
+
+# Refused rather than escaped, and for two reasons. JSON requires control
+# characters to be escaped, so an unescaped tab produces a malformed body and
+# a confusing API error instead of a clear refusal here. And a newline would
+# corrupt the line-per-name handling below -- the wanted list, the reported
+# list and `grep -qxF` are all line-based -- so a name containing one could
+# read as two names, neither of which is what the caller asked for.
+reject_control_chars() {
+    case "$1" in
+        *[[:cntrl:]]*)
+            error "$2 contains a control character (tab, newline, or similar)."
+            error "Check names are compared and recorded one per line, so such a"
+            error "name cannot be handled unambiguously. Refusing rather than"
+            error "guessing what was meant."
+            exit 2 ;;
+    esac
+}
+
+reject_control_chars "$RULESET" "the --ruleset name"
+
+# The names asked for, validated once and kept in the JSON encoding the
+# reported list arrives in -- see collect_reported for why it is encoded.
+: > "$WORK/wanted"
+contexts=""
+for check in "$@"; do
+    test -n "$check" || { error "empty check name"; exit 2; }
+    reject_control_chars "$check" "check name '$check'"
+    json_string "$check" >> "$WORK/wanted"
+    printf '\n' >> "$WORK/wanted"
+    contexts="$contexts{\"context\":$(json_string "$check")},"
+done
+contexts="${contexts%,}"
+
+# Whether the repository has no commits at all. Asked of the branch list --
+# documented, and empty only for a repository with nothing pushed -- rather
+# than by matching the text of gh's 409, which is not an interface. A failed
+# call answers "no": the caller then fails closed, which is the right way to
+# be wrong here.
+repo_is_empty() {
+    gh api "repos/$REPO/branches?per_page=1" --jq 'length' > "$WORK/branches" || return 1
+    test "$(cat "$WORK/branches")" = 0
+}
+
+# Whether NAME (JSON-encoded) is in the reported list. grep answers 0 for
+# found and 1 for not found, and 2 or more for "I could not tell you" -- an
+# unreadable file, an I/O error. Reading that third answer as "not found"
+# prints exactly the claim this script exists to make trustworthy, so it
+# aborts instead. The status is captured in the `else` branch, where `$?` is
+# still the condition's; after a whole `if` it would be the if's own 0.
+reported() {
+    if grep -qxF -- "$1" "$WORK/reported"; then
+        return 0
+    else
+        status=$?
+    fi
+    if test "$status" -ne 1; then
+        error "could not search the list of reported checks: grep exited $status."
+        error "Refusing to call a check unreported on the strength of a search"
+        error "that did not finish."
+        exit 1
+    fi
+    return 1
+}
+
+all_wanted_found() {
+    while read -r want; do
+        reported "$want" || return 1
+    done < "$WORK/wanted"
+}
+
+# Every requested check name this repository has reported, into
+# $WORK/reported. Returns non-zero if ANY call failed, rather than letting a
+# rate limit or a permission error look like "this check has never reported"
+# -- which would reject a valid name, or with --force write a ruleset on the
+# strength of a safety check that never completed. A pipeline would report
+# only the last command's status, so each call is checked where it is made.
+#
+# Heads are taken in stages and the walk STOPS as soon as every requested name
+# has been seen. The question is only whether each name has reported anywhere,
+# and the default branch usually settles it; without the early exit a hundred
+# recent pull requests cost two hundred sequential `gh` processes, which is a
+# visible hang and a chunk of the hour's API quota.
+#
+# A run still missing a name walks everything the stages offer -- and those
+# stages are BOUNDED at one page each, so the worst case is around 200 heads
+# and 400 calls whatever the repository's size. An unbounded walk over every
+# open pull request is the version of this that a repository with thousands of
+# them turns into a hang and a rate limit.
+collect_reported() {
+    : > "$WORK/reported"
+    for stage in default open closed; do
+        : > "$WORK/heads"
+        case "$stage" in
+            # `#` is legal in a git ref name and starts a URL fragment, which
+            # is never sent, so naming the branch in the path would quietly
+            # query the wrong one. This endpoint already defaults to it.
+            default)
+                if gh api "repos/$REPO/commits?per_page=1" \
+                    --jq '.[0].sha' > "$WORK/heads"; then
+                    :
+                elif repo_is_empty; then
+                    # A repository with no commits answers 409 here, and that
+                    # is a KNOWN zero-report answer rather than a failed read:
+                    # nothing has ever run because nothing has ever been
+                    # pushed. Failing closed on it would make a brand new
+                    # repository the one place --force cannot do its job --
+                    # setting the gates up before the checks first report.
+                    : > "$WORK/heads"
+                else
+                    return 1
+                fi ;;
+            # One page, most recently updated first -- NOT paginated. A
+            # repository with thousands of open pull requests would otherwise
+            # cost two calls per head with no upper bound, which is a visible
+            # hang and can exhaust the hour's quota outright. The bound is
+            # honest in the safe direction: a name that reported only on some
+            # older head reads as never reported, which refuses and names
+            # --force, rather than passing a check that never runs.
+            open) gh api "repos/$REPO/pulls?state=open&per_page=100&sort=updated&direction=desc" \
+                --jq '.[].head.sha' > "$WORK/heads" || return 1 ;;
+            # A check that runs only on `pull_request` never reports on the
+            # default branch, so a repository with nothing open would look as
+            # though it had never run. One page, deliberately: paginating
+            # `state=all` walks every pull request the repository ever had.
+            closed) gh api "repos/$REPO/pulls?state=closed&per_page=100&sort=updated&direction=desc" \
+                --jq '.[].head.sha' > "$WORK/heads" || return 1 ;;
+        esac
+        while read -r sha; do
+            test -n "$sha" || continue
+            # Check runs and commit statuses are different objects, and a
+            # ruleset can require either -- `codex` is a status, `gate` is a
+            # check run. Both paginate: a name on page two is
+            # indistinguishable from a name that never reported.
+            #
+            # `@json` because this file is one name per line and a name is
+            # free text an app chose: a check run called "build\nand test"
+            # would arrive as two lines, and a caller asking for `build` would
+            # then be told it had reported when nothing of that name ever did
+            # -- the never-reports trap, sprung by the guard against it.
+            gh api --paginate "repos/$REPO/commits/$sha/check-runs" --jq '.check_runs[].name | @json' >> "$WORK/reported" || return 1
+            gh api --paginate "repos/$REPO/commits/$sha/status" --jq '.statuses[].context | @json' >> "$WORK/reported" || return 1
+            if all_wanted_found; then break; fi
+        done < "$WORK/heads"
+        if all_wanted_found; then break; fi
+    done
+    sort -u -o "$WORK/reported" "$WORK/reported"
+}
+
+collect_reported || {
+    error "could not read which checks have reported on $REPO"
+    error "Refusing to guess: an incomplete answer here either rejects a valid"
+    error "check or, with --force, requires one on the strength of a safety"
+    error "check that did not finish."
+    exit 1
+}
+
+: > "$WORK/missing"
+for check in "$@"; do
+    reported "$(json_string "$check")" \
+        || printf '%s\n' "$check" >> "$WORK/missing"
+done
+
+if test -s "$WORK/missing"; then
+    missing="$(sed 's/^/  /' "$WORK/missing")"
+    if test "$FORCE" -eq 1; then
+        error "requiring checks that have never reported on $REPO:"
+        error "$missing"
+        error "(--force given; a merge will block until each one reports)"
+    else
+        error "these checks have never reported on $REPO:"
+        error "$missing"
+        error "A required check that never reports blocks every merge, with no"
+        error "error to say why. Check the spelling, or merge the branch that"
+        error "adds it first. Pass --force to require it anyway."
+        error "(Looked at the default branch's head, the 100 most recently"
+        error "updated open pull requests and the 100 most recently updated"
+        error "closed ones -- bounded, so a name that last reported on an"
+        error "older head than those lands here too.)"
+        exit 1
+    fi
+fi
+
+
+# Update the ruleset this script owns, or create it. Matched by name, so a
+# rerun with a different check list replaces that list rather than adding a
+# second ruleset that quietly ANDs with the first.
+#
+# A failed lookup must NOT read as "there is no ruleset": that would POST a
+# duplicate whose stale check list then ANDs with this one, which is the
+# outcome the whole named-ruleset approach exists to avoid.
+if EXISTING="$(gh api --paginate "repos/$REPO/rulesets?includes_parents=false" --jq ".[] | select(.name == $(json_string "$RULESET")) | .id")"; then
+    :
+else
+    error "could not list $REPO's rulesets, so cannot tell whether '$RULESET'"
+    error "already exists. Creating one now could duplicate it, and two"
+    error "rulesets AND together — the stale one would keep requiring checks"
+    error "this run was meant to replace."
+    exit 1
+fi
+
+# A name match is not ownership. If a ruleset with this name already exists
+# and carries rules this script does not write, replacing its rule list would
+# silently delete protections -- breaking the promise at the top of this file
+# that it touches no other ruleset. A name is just a name; what proves the
+# ruleset is ours is that it contains only the rule types we manage.
+if test -n "$EXISTING"; then
+    # Not `gh ... | sort` -- a pipeline reports the LAST command's status, so
+    # sort's success would mask a failed read. Same shape as the bug this
+    # script was reviewed for; it is easy to write twice.
+    if gh api "repos/$REPO/rulesets/$EXISTING" --jq '.enforcement, (.rules[].type)' > "$WORK/inspect"; then
+        ENFORCEMENT="$(sed -n 1p "$WORK/inspect")"
+        sed 1d "$WORK/inspect" > "$WORK/types"
+        # Deleting the managed types is the test, rather than comparing against
+        # a list of the allowed combinations: with two rule types a ruleset can
+        # legitimately hold either or both, and enumerating those spellings is
+        # a thing to get wrong again the moment a third is added.
+        # No `sort -u` in front of this. It was there to dedupe the error
+        # listing, and it made a pipeline whose status was `sed`'s -- so a
+        # failing sort would have left UNMANAGED empty and read as "nothing
+        # here but our own rules". The third time that shape appeared in this
+        # file, and the answer is to delete the command rather than check it:
+        # a repeated name in an error message costs nothing.
+        UNMANAGED="$(sed '/^required_status_checks$/d; /^pull_request$/d' "$WORK/types")"
+    else
+        error "could not read ruleset '$RULESET' (id $EXISTING) to check what it"
+        error "contains. Refusing to overwrite rules that cannot be inspected."
+        exit 1
+    fi
+    # `evaluate` and `disabled` rulesets do not block anything, so writing a
+    # check list into one and reporting success would name a gate that is not
+    # a gate -- the same lie as a ruleset updated with no checks in it.
+    # Refused rather than activated: enforcement is a deliberate choice this
+    # run was not asked to make, and flipping it is not a side effect of
+    # setting a check list.
+    if test "$ENFORCEMENT" != active; then
+        error "ruleset '$RULESET' (id $EXISTING) on $REPO is '$ENFORCEMENT', not"
+        error "'active', so its rules block nothing. Setting a check list on it"
+        error "would report a gate that does not gate. Activate it, or point this"
+        error "run at a different ruleset with --ruleset."
+        exit 1
+    fi
+    if test -n "$UNMANAGED"; then
+        error "ruleset '$RULESET' (id $EXISTING) on $REPO holds rules this script"
+        error "does not manage:"
+        printf '%s\n' "$UNMANAGED" | sed 's/^/  /' >&2
+        error "Overwriting it would delete them. Rename that ruleset, or point"
+        error "this run at a different one with --ruleset."
+        exit 1
+    fi
+fi
+
+# Rulesets AGGREGATE: a pull request must satisfy every one that applies to
+# the branch, and `allowed_merge_methods` INTERSECTS across them. So another
+# active ruleset allowing only squash turns this one's rebase-only into an
+# empty intersection and nothing can merge. The repository-level check above
+# cannot see that, and an inherited organization ruleset is invisible to the
+# `includes_parents=false` lookup this script uses to find its own.
+#
+# The comparison is against the scope BEING WRITTEN, not the default branch.
+# An update preserves the existing ruleset's conditions, so a managed ruleset
+# scoped to `release` must be checked against what else applies to `release`
+# -- checking `main` there would miss the conflict entirely and report success.
+if test -n "$EXISTING"; then
+    # shellcheck disable=SC2016  # jq program, not shell interpolation
+    SCOPE="$(gh api "repos/$REPO/rulesets/$EXISTING" \
+        --jq '{include: [.conditions.ref_name.include[]?],
+               exclude: [.conditions.ref_name.exclude[]?]} | @json')" || {
+        error "could not read ruleset '$RULESET' (id $EXISTING) to see which"
+        error "branches it covers. Refusing to guess at what else applies there."
+        exit 1
+    }
+else
+    SCOPE='{"include":["~DEFAULT_BRANCH"],"exclude":[]}'
+fi
+
+# Matching is literal -- `~DEFAULT_BRANCH` normalized on both sides, `~ALL` a
+# wildcard -- and GitHub's `fnmatch` patterns are NOT evaluated. But an
+# unevaluated scope is reported rather than passed over: a squash-only ruleset
+# on `refs/heads/*` covers this branch and letting it through silently is the
+# never-merges trap the whole scan exists to prevent. So a ruleset that rules
+# out rebase lands in one of two lists -- a definite conflict, or one whose
+# scope this script cannot decide -- and both stop the run. Refusing to decide
+# beats reimplementing GitHub's ref matching and being wrong about it in
+# silence, and it only ever triggers on a ruleset that really does exclude
+# rebase. Exclusions count as undecidable for the same reason, from the other
+# direction: an `exclude` can carve this branch back out of an overlap, so a
+# literal match with one present is not proof of a conflict.
+find_merge_method_conflicts() {
+    : > "$WORK/conflicts"
+    gh api --paginate "repos/$REPO/rulesets?includes_parents=true" \
+        --jq '.[].id' > "$WORK/all_rulesets" || return 1
+    while read -r id; do
+        test -n "$id" || continue
+        test "$id" != "${EXISTING:-}" || continue
+        # shellcheck disable=SC2016  # jq program, not shell interpolation
+        REPO_RULES_BRANCH="$DEFAULT_BRANCH" REPO_RULES_SCOPE="$SCOPE" \
+        gh api "repos/$REPO/rulesets/$id" --jq '
+            def norm: map(if . == "~DEFAULT_BRANCH"
+                          then "refs/heads/" + env.REPO_RULES_BRANCH
+                          else . end);
+            select(.enforcement == "active")
+            | (env.REPO_RULES_SCOPE | fromjson) as $our
+            | ($our.include | norm) as $ours
+            | ([.conditions.ref_name.include[]?] | norm) as $theirs
+            | select([.rules[]? | select(.type == "pull_request")
+                      | .parameters.allowed_merge_methods // empty]
+                | any(index("rebase") | not))
+            | if (($ours + $theirs) | any(test("[*?[]")))
+                 or (($our.exclude + [.conditions.ref_name.exclude[]?])
+                     | length > 0)
+              then "unknown " + .name
+              elif ($ours | index("~ALL")) or ($theirs | index("~ALL"))
+                   or ([$theirs[] | select(IN($ours[]))] | length > 0)
+              then "conflict " + .name
+              else empty
+              end' >> "$WORK/conflicts" || return 1
+    done < "$WORK/all_rulesets"
+}
+
+find_merge_method_conflicts || {
+    error "could not read $REPO's other rulesets, so cannot tell whether one of"
+    error "them rules out a rebase merge. Refusing to guess: rulesets aggregate,"
+    error "and a conflict would leave no way to merge anything."
+    exit 1
+}
+# A space separates the verdict from the name, and `sed` rather than a
+# pipeline through `grep`: a pipeline reports only the last command's status,
+# which is how a failed read reads as "no conflicts" -- the shape three
+# earlier findings on this script had in common.
+sed -n 's/^conflict //p' "$WORK/conflicts" > "$WORK/definite"
+sed -n 's/^unknown //p' "$WORK/conflicts" > "$WORK/undecidable"
+if test -s "$WORK/definite"; then
+    error "another active ruleset on $REPO excludes rebase from its allowed"
+    error "merge methods, and covers the same branches as this one:"
+    sed 's/^/  /' "$WORK/definite" >&2
+    error "Rulesets aggregate, so together they would leave no method that"
+    error "satisfies both and nothing could merge. Reconcile them first."
+    exit 1
+fi
+if test -s "$WORK/undecidable"; then
+    error "another active ruleset on $REPO excludes rebase from its allowed"
+    error "merge methods, on a scope this script cannot evaluate:"
+    sed 's/^/  /' "$WORK/undecidable" >&2
+    error "Its conditions use a pattern (such as 'refs/heads/*') or an"
+    error "exclusion, and this script matches branch names literally rather"
+    error "than reimplementing GitHub's ref matching. If that ruleset covers"
+    error "this branch the two would leave no way to merge anything, so this"
+    error "refuses rather than guess. Check it, then narrow either scope."
+    exit 1
+fi
+
+# The body. Two paths, and the difference is the point.
+#
+# CREATE builds it from scratch: default branch, actively enforced,
+# `strict_required_status_checks_policy` true -- a check that passed against a
+# stale base has not tested what will land. It serializes merges, and that is
+# accepted. Its `pull_request` rule asks for ZERO approving reviews and no
+# code-owner or last-push approval -- requiring an approval is a policy about
+# who may merge, which is not what this script is for. `allowed_merge_methods`
+# is rebase only: a squash or a merge commit rewrites or hides the commits
+# that were reviewed, and one commit per logical change is the shape these
+# repositories keep. Squash and merge-commit disappear from the pull request's
+# button once this is set.
+#
+# UPDATE does NOT build it. It fetches the existing ruleset and edits only
+# the check list inside it, because a PUT replaces the whole object and this
+# script does not know every field GitHub puts there. Rebuilding cost four
+# review findings in a row -- conditions, enforcement, bypass_actors, the
+# strict policy -- each one a field silently reset as a side effect of
+# setting a check list, and each found only because someone looked. Editing
+# the fetched object preserves the fields nobody has thought of yet, which is
+# the only version of this that stays correct as the API grows.
+#
+# Either managed rule is ADDED when the fetched ruleset lacks it. The
+# ownership check accepts a ruleset holding just one of the two, and a `map`
+# over the rules edits only what is already there -- so without this a ruleset
+# carrying only `pull_request` would take the PUT, report the checks as
+# updated, and require none of them. A gate reported as set and not set is
+# worse than one that failed to write.
+#
+# `integration_id` is why the check list is merged rather than replaced: an
+# entry bound to a GitHub App means only that app can satisfy the check, and
+# rebuilding entries from names alone would drop the binding and let any
+# integration reporting the same name open the gate.
+build_update_body() {
+    # shellcheck disable=SC2016  # $rule/$have/$want/$c are jq variables, not shell
+    REPO_RULES_CONTEXTS="[$contexts]" \
+    gh api "repos/$REPO/rulesets/$EXISTING" --jq '
+        del(.id, .node_id, .source, .source_type, .created_at, .updated_at,
+            ._links, .current_user_can_bypass)
+        | .rules = ((.rules // [])
+            | map(
+                if .type == "required_status_checks" then
+                    . as $rule
+                    | (($rule.parameters.required_status_checks // [])) as $have
+                    | (env.REPO_RULES_CONTEXTS | fromjson) as $want
+                    | .parameters.required_status_checks =
+                        [ $want[] | .context as $c
+                          | (($have[] | select(.context == $c)) // {context: $c}) ]
+                    | .parameters.strict_required_status_checks_policy = true
+                elif .type == "pull_request" then
+                    .parameters.required_review_thread_resolution = true
+                    | .parameters.allowed_merge_methods = ["rebase"]
+                else . end)
+            | if any(.[]; .type == "required_status_checks") then .
+              else . + [{type: "required_status_checks", parameters: {
+                  strict_required_status_checks_policy: true,
+                  required_status_checks:
+                      (env.REPO_RULES_CONTEXTS | fromjson)}}]
+              end
+            | if any(.[]; .type == "pull_request") then .
+              else . + [{type: "pull_request", parameters: {
+                  required_approving_review_count: 0,
+                  dismiss_stale_reviews_on_push: false,
+                  require_code_owner_review: false,
+                  require_last_push_approval: false,
+                  required_review_thread_resolution: true,
+                  allowed_merge_methods: ["rebase"]}}]
+              end)
+    ' > "$WORK/body"
+}
+
+BODY="{
+  \"name\": $(json_string "$RULESET"),
+  \"target\": \"branch\",
+  \"enforcement\": \"active\",
+  \"conditions\": {\"ref_name\": {\"include\": [\"~DEFAULT_BRANCH\"], \"exclude\": []}},
+  \"rules\": [
+    {\"type\": \"required_status_checks\",
+     \"parameters\": {
+       \"strict_required_status_checks_policy\": true,
+       \"required_status_checks\": [$contexts]
+     }},
+    {\"type\": \"pull_request\",
+     \"parameters\": {
+       \"required_review_thread_resolution\": true,
+       \"allowed_merge_methods\": [\"rebase\"],
+       \"required_approving_review_count\": 0,
+       \"dismiss_stale_reviews_on_push\": false,
+       \"require_code_owner_review\": false,
+       \"require_last_push_approval\": false
+     }}
+  ]
+}"
+
+describe_checks() {
+    for check in "$@"; do printf '  %s\n' "$check"; done
+}
+
+if test "$DRY_RUN" -eq 1; then
+    if test -n "$EXISTING"; then
+        # No branch named: an update preserves whatever scope the ruleset
+        # already has, which may not be the default branch at all.
+        echo "$REPO: would update ruleset '$RULESET' (id $EXISTING); scope unchanged"
+    else
+        echo "$REPO: would create ruleset '$RULESET' on $DEFAULT_BRANCH"
+    fi
+    echo "  required checks:"
+    describe_checks "$@"
+    echo "  review conversations must be resolved"
+    echo "  the branch must be up to date with the base"
+    echo "  rebase is the only merge method"
+    exit 0
+fi
+
+if test -n "$EXISTING"; then
+    build_update_body || { error "could not read ruleset '$RULESET' to update it"; exit 1; }
+    gh api --method PUT "repos/$REPO/rulesets/$EXISTING" --input "$WORK/body" >/dev/null
+    echo "$REPO: updated ruleset '$RULESET' (its scope is unchanged)"
+else
+    printf '%s' "$BODY" | gh api --method POST "repos/$REPO/rulesets" --input - >/dev/null
+    echo "$REPO: created ruleset '$RULESET' on $DEFAULT_BRANCH"
+fi
+describe_checks "$@"

--- a/repo-rules_test
+++ b/repo-rules_test
@@ -1,0 +1,944 @@
+#!/bin/sh
+# Tests for repo-rules
+#
+# These put a fake gh on PATH, so nothing here touches the network or needs a
+# token. The fake records every call, which is what lets the write tests
+# assert on the request that WOULD have gone out -- the thing that matters
+# here is the payload, and a test that only checked the exit status would pass
+# just as happily with an empty check list.
+
+set -e
+
+# The update-path cases need a jq BINARY, which the script itself does not:
+# production `gh --jq` has jq embedded, and the fake gh cannot. Rather than
+# assert on the jq program as a string -- which would pass while the program
+# was wrong -- those cases run it for real, and are skipped with a notice
+# where jq is absent (macOS without brew, typically). CI runs on ubuntu-latest,
+# which ships jq, so the coverage is never optional there.
+if command -v jq >/dev/null 2>&1; then
+    HAVE_JQ=yes
+else
+    HAVE_JQ=no
+    echo "NOTE: jq is not installed, so the ruleset-update cases will be skipped."
+    echo "      Install jq to run them ('brew install jq', 'apt install jq')."
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# One directory for every fixture, removed on exit. A per-fixture mktemp with
+# no cleanup left thirty trees behind per run.
+SUITE_TMP="$(mktemp -d)"
+trap 'rm -rf "$SUITE_TMP"' EXIT INT TERM
+REPO_RULES="$SCRIPT_DIR/repo-rules"
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# make_gh: build a fake gh in a fresh dir and echo that dir.
+#   $1 = newline-separated check-run names the repo has reported
+#   $2 = existing ruleset id, or empty for none
+#   $3 = names only a paginated call reaches   $4 = substring of a call to fail
+#   $5 = rule types the existing ruleset holds  $6 = default branch name
+#   $7 = the repository's allow_rebase_merge setting
+#   $8 = the existing ruleset's enforcement
+#   $9 = ids that `includes_parents=true` returns (default: just $2)
+make_gh() {
+    dir="$(mktemp -d "$SUITE_TMP/fixture.XXXXXX")"
+    mkdir -p "$dir/bin"
+    printf '%s\n' "$1" > "$dir/checks"
+    printf '%s' "$2" > "$dir/ruleset_id"
+    printf '%s\n' "${3-}" > "$dir/checks_page2"
+    printf '%s' "${4-}" > "$dir/fail_on"
+    printf '%s\n' "${5-required_status_checks}" > "$dir/rule_types"
+    printf '%s\n' "${8-active}" > "$dir/enforcement"
+    # The ids `rulesets?includes_parents=true` returns. Default: just ours, so
+    # the merge-method conflict scan finds nothing to fetch.
+    printf '%s\n' "${9-$2}" > "$dir/all_ruleset_ids"
+    printf '%s\n' "${10-1}" > "$dir/branch_count"
+    : > "$dir/other_ruleset"
+    : > "$dir/closed_checks"
+    : > "$dir/checks_json"
+    printf '%s\n' "${6-main}" > "$dir/branch"
+    printf '%s\n' "${7-true}" > "$dir/allow_rebase"
+    cat > "$dir/ruleset" <<'RULESET'
+{"id":42,"node_id":"RRS_x","name":"merge gates","target":"branch",
+ "source":"owner/repo","source_type":"Repository","created_at":"t","updated_at":"t",
+ "enforcement":"active",
+ "bypass_actors":[{"actor_id":5,"actor_type":"RepositoryRole","bypass_mode":"always"}],
+ "conditions":{"ref_name":{"include":["refs/heads/release"],"exclude":[]}},
+ "rules":[{"type":"required_status_checks","parameters":{
+    "strict_required_status_checks_policy":true,
+    "required_status_checks":[{"context":"test","integration_id":15368}]}}]}
+RULESET
+    cat > "$dir/bin/gh" <<'EOF'
+#!/bin/sh
+# Fake gh. Logs the call, then answers from the fixture files beside it.
+dir="$(dirname "$(dirname "$0")")"
+echo "$*" >> "$dir/calls"
+# Check names come back JSON-encoded, because the script asks for them with
+# `@json` -- a name is free text and this file is line-based, so the encoding
+# is what keeps one name from arriving as two. Serving them raw would let a
+# script that compared unencoded names pass. `checks_json` is the escape hatch
+# for a fixture that needs to spell the encoding itself, which is the only way
+# to serve a name containing a newline.
+emit_names() {
+    if test -s "$dir/checks_json"; then
+        cat "$dir/checks_json"
+    else
+        sed 's/\\/\\\\/g; s/"/\\"/g; s/^/"/; s/$/"/' "$1"
+    fi
+}
+# A fixture can force a chosen call to fail, so the error paths are exercised.
+if test -s "$dir/fail_on" && echo "$*" | grep -qF "$(cat "$dir/fail_on")"; then
+    echo "gh: simulated failure" >&2
+    exit 1
+fi
+# Parse like gh does, so a call gh would reject fails HERE rather than only
+# in production. `gh api` takes exactly one endpoint; a flag whose value is
+# missing swallows the next argument, which is how `--jq -r EXPR` ends up
+# passing EXPR as a second endpoint.
+method=""
+endpoints=0
+skip=no
+want=""
+jqexpr=""
+inputfile=""
+for arg in "$@"; do
+    if test "$skip" = yes; then
+        skip=no
+        case "$want" in --jq) jqexpr="$arg" ;; --input) inputfile="$arg" ;; esac
+        continue
+    fi
+    case "$arg" in
+        api) ;;
+        --method|--jq|--input|-H|--header|-f|-F) skip=yes; want="$arg" ;;
+        --paginate|--silent) ;;
+        -*) echo "gh: unknown flag $arg" >&2; exit 1 ;;
+        *) endpoints=$((endpoints + 1)) ;;
+    esac
+done
+if test "$endpoints" -ne 1; then
+    echo "gh: accepts 1 arg(s), received $endpoints" >&2
+    exit 1
+fi
+method=""
+prev=""
+for arg in "$@"; do
+    case "$prev" in --method) method="$arg" ;; esac
+    prev="$arg"
+done
+if test -n "$method" && test "$method" != GET; then
+    # Record the payload. `--input -` reads stdin, `--input FILE` reads that
+    # file -- reading stdin unconditionally would hang the suite.
+    if test -n "$inputfile" && test "$inputfile" != -; then
+        cp "$inputfile" "$dir/body"
+    else
+        cat > "$dir/body"
+    fi
+    exit 0
+fi
+paginate=no
+case "$*" in *--paginate*) paginate=yes ;; esac
+case "$*" in
+    # A second ruleset, for the merge-method conflict scan.
+    # `jq -r`, because gh's own --jq prints strings raw. Quoting them here
+    # would hand `@json` output back double-encoded, so a `fromjson` in the
+    # script would see a string where it asked for an array.
+    *"/rulesets/99"*) jq -r "$jqexpr" < "$dir/other_ruleset" ;;
+    *"includes_parents=true"*) cat "$dir/all_ruleset_ids" ;;
+    *"/rulesets/"*)
+        # The one route served as a real object rather than a canned answer,
+        # and piped through real jq: the update body is built by a jq program
+        # inside the script, so a stubbed answer would test nothing about it.
+        case "$jqexpr" in
+            # The inspect call asks for enforcement first, then the rule types.
+            *".rules[].type"*) cat "$dir/enforcement" "$dir/rule_types" ;;
+            "") cat "$dir/ruleset" ;;
+            *) jq -r "$jqexpr" < "$dir/ruleset" ;;
+        esac ;;
+    *"/rulesets"*)  cat "$dir/ruleset_id" ;;
+    *"/commits/closedsha/check-runs"*) emit_names "$dir/closed_checks" ;;
+    *"repos/"*"/commits/"*"/check-runs"*)
+        emit_names "$dir/checks"
+        # Names only a paginated call would reach, so a missing --paginate
+        # shows up as a check that "never reported" rather than as a flag.
+        test "$paginate" = yes && emit_names "$dir/checks_page2" ;;
+    *"repos/"*"/commits/"*"/status"*)     : ;;
+    *"state=closed"*) test -s "$dir/closed_checks" && echo closedsha || : ;;
+    *"/pulls?"*)    : ;;
+    # The default branch's head, reached without naming the branch.
+    *"/commits?"*)  echo "deadbee" ;;
+    # How many branches the repository has, which is how an empty one is told
+    # apart from a failed read. A fixture that does not set it has one.
+    *"/branches"*)  cat "$dir/branch_count" ;;
+    *"/commits/"*)  echo "deadbee" ;;
+    # `repos/OWNER/REPO`: the default branch and whether a rebase merge is
+    # permitted, in the order the script's --jq asks for them.
+    *"repos/"*)     cat "$dir/branch" "$dir/allow_rebase" ;;
+esac
+EOF
+    chmod +x "$dir/bin/gh"
+    echo "$dir"
+}
+
+run_repo_rules() {
+    dir="$1"; shift
+    set +e
+    output="$(PATH="$dir/bin:$PATH" "$REPO_RULES" "$@" 2>&1)"
+    status=$?
+    set -e
+}
+
+# The asserts record a failure and RETURN ZERO, deliberately. `set -e` is on
+# for the fixture setup, so an assert returning non-zero at the top level kills
+# the run at the first failure -- which reported one problem out of however
+# many, and skipped the summary line entirely, leaving `failed: 0` as something
+# that could never print anything else. The exit status at the bottom is what
+# makes the suite red.
+assert_status() {
+    if test "$status" -ne "$1"; then
+        echo "  FAIL: expected exit status $1, got $status"
+        echo "  output: $output"
+        TEST_FAILED=1
+    fi
+}
+
+assert_output() {
+    case "$output" in
+        *"$1"*) ;;
+        *) echo "  FAIL: expected output to contain '$1'"
+           echo "  output: $output"
+           TEST_FAILED=1 ;;
+    esac
+}
+
+assert_no_output() {
+    case "$output" in
+        *"$1"*) echo "  FAIL: expected output NOT to contain '$1'"
+                echo "  output: $output"
+                TEST_FAILED=1 ;;
+    esac
+}
+
+assert_body() {
+    body="$(cat "$1/body" 2>/dev/null || true)"
+    case "$body" in
+        *"$2"*) ;;
+        *) echo "  FAIL: expected request body to contain '$2'"
+           echo "  body: $body"
+           TEST_FAILED=1 ;;
+    esac
+}
+
+# Reads the body the same guarded way assert_body does. An inline
+# `case "$(cat .../body)"` dies under `set -e` when no write happened, which
+# takes the whole run down instead of reporting the case that failed.
+assert_body_lacks() {
+    body="$(cat "$1/body" 2>/dev/null || true)"
+    case "$body" in
+        *"$2"*) echo "  FAIL: expected request body NOT to contain '$2'"
+                echo "  body: $body"
+                TEST_FAILED=1 ;;
+    esac
+}
+
+# The call log, read the same guarded way: a run that made no call at all
+# leaves no file, and an unguarded `cat` there kills the suite under `set -e`.
+assert_call() {
+    calls="$(cat "$1/calls" 2>/dev/null || true)"
+    case "$calls" in
+        *"$2"*) ;;
+        *) echo "  FAIL: expected a call matching '$2'"
+           echo "  calls: $calls"
+           TEST_FAILED=1 ;;
+    esac
+}
+
+assert_no_call() {
+    calls="$(cat "$1/calls" 2>/dev/null || true)"
+    case "$calls" in
+        *"$2"*) echo "  FAIL: expected NO call matching '$2'"
+                echo "  calls: $calls"
+                TEST_FAILED=1 ;;
+    esac
+}
+
+assert_no_write() {
+    if test -f "$1/body"; then
+        echo "  FAIL: a write request was made when none was expected"
+        echo "  body: $(cat "$1/body")"
+        TEST_FAILED=1
+    fi
+}
+
+TESTS_SKIPPED=0
+
+# Skip the current case, loudly. A silently skipped test is the false-pass
+# shape this suite exists to avoid, so it is counted and named in the summary.
+skip_case() {
+    TESTS_SKIPPED=$((TESTS_SKIPPED + 1))
+    echo "  SKIP: $1"
+    TEST_SKIPPED=1
+}
+
+test_case() {
+    TEST_SKIPPED=0
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TEST_FAILED=0
+    echo "TEST: $1"
+}
+
+finish_case() {
+    if test "${TEST_SKIPPED:-0}" -eq 1; then
+        TESTS_RUN=$((TESTS_RUN - 1))
+        return
+    fi
+    if test "$TEST_FAILED" -eq 0; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo "  PASS"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
+# ---------------------------------------------------------------------------
+
+test_case "requires checks that have reported"
+dir="$(make_gh 'test
+codex
+sweep' '')"
+run_repo_rules "$dir" mikelward/lanes test codex sweep
+assert_status 0
+assert_output "created ruleset"
+assert_body "$dir" '"context":"test"'
+assert_body "$dir" '"context":"codex"'
+assert_body "$dir" '"context":"sweep"'
+assert_body "$dir" '"~DEFAULT_BRANCH"'
+finish_case
+
+test_case "refuses a check that has never reported"
+# The whole reason this script exists: a required check that never reports
+# blocks every merge forever, and nothing says why.
+dir="$(make_gh 'test
+codex' '')"
+run_repo_rules "$dir" mikelward/lanes test codex sweeep
+assert_status 1
+assert_output "never reported"
+assert_output "sweeep"
+assert_no_write "$dir"
+finish_case
+
+test_case "--force requires it anyway, and says so"
+dir="$(make_gh 'test' '')"
+run_repo_rules "$dir" --force mikelward/lanes test sweep
+assert_status 0
+assert_output "never reported"
+assert_body "$dir" '"context":"sweep"'
+finish_case
+
+test_case "updates the ruleset it owns instead of creating a second"
+# Two rulesets both requiring checks would AND together, so a stale one keeps
+# demanding a check that no longer exists.
+dir="$(make_gh 'test
+codex' '42')"
+run_repo_rules "$dir" mikelward/lanes test codex
+assert_status 0
+assert_output "updated ruleset"
+grep -q "PUT repos/mikelward/lanes/rulesets/42" "$dir/calls" || {
+    echo "  FAIL: expected a PUT to the existing ruleset"
+    echo "  calls: $(cat "$dir/calls")"
+    TEST_FAILED=1
+}
+finish_case
+
+test_case "--dry-run writes nothing"
+dir="$(make_gh 'test
+codex' '')"
+run_repo_rules "$dir" --dry-run mikelward/lanes test codex
+assert_status 0
+assert_output "would create"
+assert_no_write "$dir"
+finish_case
+
+test_case "--ruleset takes both forms"
+for form in "--ruleset gates" "--ruleset=gates"; do
+    dir="$(make_gh 'test' '')"
+    # shellcheck disable=SC2086
+    run_repo_rules "$dir" $form --dry-run mikelward/lanes test
+    assert_status 0
+    assert_output "'gates'"
+done
+finish_case
+
+test_case "rejects bad usage"
+dir="$(make_gh 'test' '')"
+run_repo_rules "$dir" mikelward/lanes
+assert_status 2
+run_repo_rules "$dir" lanes test
+assert_status 2
+assert_output "not OWNER/REPO"
+run_repo_rules "$dir" --nonsense mikelward/lanes test
+assert_status 2
+assert_output "unknown option"
+finish_case
+
+test_case "--help exits 0 and writes nothing"
+dir="$(make_gh 'test' '')"
+run_repo_rules "$dir" --help
+assert_status 0
+assert_output "Usage:"
+assert_no_write "$dir"
+finish_case
+
+test_case "keeps a check name with spaces as one context"
+# Real names have spaces in them -- "Analyze (actions)" is one CodeQL emits.
+# Splitting it produces "Analyze" and "(actions)", which each pass validation
+# on their own and then never report: the script causing the exact failure it
+# exists to prevent.
+dir="$(make_gh 'Analyze (actions)
+test' '')"
+run_repo_rules "$dir" mikelward/lanes "Analyze (actions)" test
+assert_status 0
+assert_body "$dir" '"context":"Analyze (actions)"'
+assert_no_output "never reported"
+assert_body_lacks "$dir" '"context":"Analyze"'
+assert_body_lacks "$dir" '"context":"(actions)"'
+finish_case
+
+test_case "escapes a check name that would break the JSON"
+dir="$(make_gh 'say "hi"' '')"
+run_repo_rules "$dir" mikelward/lanes 'say "hi"'
+assert_status 0
+assert_body "$dir" '\"hi\"'
+finish_case
+
+test_case "sees a check that only a paginated response reaches"
+# A name on page two is indistinguishable from one that never reported, so
+# without --paginate this is refused and the merge gate is never set.
+dir="$(make_gh 'test' '' 'late-reporter')"
+run_repo_rules "$dir" mikelward/lanes test late-reporter
+assert_status 0
+assert_body "$dir" '"context":"late-reporter"'
+finish_case
+
+test_case "stops when the reported-checks lookup fails"
+# A rate limit or a permission error must not read as "never reported": that
+# rejects a valid check, or with --force writes on the strength of a safety
+# check that did not finish.
+dir="$(make_gh 'test' '' '' '/check-runs')"
+run_repo_rules "$dir" mikelward/lanes test
+assert_status 1
+assert_output "could not read which checks have reported"
+assert_no_write "$dir"
+finish_case
+
+test_case "--force does not paper over a failed lookup"
+dir="$(make_gh 'test' '' '' '/check-runs')"
+run_repo_rules "$dir" --force mikelward/lanes test
+assert_status 1
+assert_no_write "$dir"
+finish_case
+
+test_case "stops when the ruleset lookup fails"
+# Reading a failure as "no ruleset exists" would POST a duplicate, and two
+# rulesets AND together -- the stale one keeps requiring what this run
+# replaced.
+dir="$(make_gh 'test' '' '' '/rulesets')"
+run_repo_rules "$dir" mikelward/lanes test
+assert_status 1
+assert_output "cannot tell whether"
+assert_no_write "$dir"
+finish_case
+
+test_case "refuses a same-named ruleset holding rules it does not manage"
+if test "$HAVE_JQ" = no; then skip_case "needs a jq binary"; finish_case; else
+# A name match is not ownership. Replacing the rule list of someone else's
+# ruleset would silently delete protections, breaking the promise that this
+# touches no other ruleset.
+dir="$(make_gh 'test' '42' '' '' 'deletion
+required_status_checks')"
+run_repo_rules "$dir" mikelward/lanes test
+assert_status 1
+assert_output "does not manage"
+assert_output "deletion"
+assert_no_write "$dir"
+finish_case
+fi
+
+test_case "updates one that holds only the rule it manages"
+if test "$HAVE_JQ" = no; then skip_case "needs a jq binary"; finish_case; else
+dir="$(make_gh 'test' '42' '' '' 'required_status_checks')"
+run_repo_rules "$dir" mikelward/lanes test
+assert_status 0
+assert_output "updated ruleset"
+finish_case
+fi
+
+test_case "stops when the ruleset contents cannot be read"
+if test "$HAVE_JQ" = no; then skip_case "needs a jq binary"; finish_case; else
+dir="$(make_gh 'test' '42' '' '/rulesets/42')"
+run_repo_rules "$dir" mikelward/lanes test
+assert_status 1
+assert_output "cannot be inspected"
+assert_no_write "$dir"
+finish_case
+fi
+
+test_case "refuses a name containing a control character"
+# Refused rather than escaped: JSON needs control characters escaped, and a
+# newline would corrupt the line-per-name handling into two names.
+dir="$(make_gh 'test' '')"
+run_repo_rules "$dir" mikelward/lanes "$(printf 'a\tb')"
+assert_status 2
+assert_output "control character"
+assert_no_write "$dir"
+run_repo_rules "$dir" --ruleset="$(printf 'x\ty')" mikelward/lanes test
+assert_status 2
+assert_output "control character"
+finish_case
+
+test_case "updating changes the check list and nothing else"
+if test "$HAVE_JQ" = no; then skip_case "needs a jq binary"; finish_case; else
+# A PUT replaces the whole ruleset, so rebuilding the body from this script's
+# defaults resets every field it does not know about. Four review findings
+# came in one at a time -- conditions, enforcement, bypass_actors, the strict
+# policy -- which is why the update now EDITS the fetched object instead.
+dir="$(make_gh 'test
+codex' '42')"
+run_repo_rules "$dir" mikelward/lanes test codex
+assert_status 0
+assert_body "$dir" 'refs/heads/release'          # conditions
+assert_body "$dir" '"enforcement": "active"'     # round-tripped, not rebuilt
+assert_body "$dir" 'RepositoryRole'              # bypass actors
+assert_body "$dir" '"strict_required_status_checks_policy": true'  # set, not preserved
+assert_body "$dir" '"integration_id": 15368'     # app binding on an existing check
+assert_body "$dir" '"context": "codex"'          # the new one still added
+assert_no_output '~DEFAULT_BRANCH'
+# Read-only fields must not be echoed back.
+assert_body_lacks "$dir" '"node_id"'
+assert_body_lacks "$dir" '"source_type"'
+finish_case
+fi
+
+test_case "the update message does not claim the default branch"
+if test "$HAVE_JQ" = no; then skip_case "needs a jq binary"; finish_case; else
+# The scope is preserved, so it may not be the default branch at all, and an
+# operator reading "on main" would believe something the run did not do.
+dir="$(make_gh 'test' '42')"
+run_repo_rules "$dir" --dry-run mikelward/lanes test
+assert_status 0
+assert_output "would update ruleset"
+assert_no_output "on main"
+finish_case
+fi
+
+test_case "the ruleset lookup excludes inherited rulesets"
+# The repository endpoint includes organization-level rulesets by default, so
+# an org ruleset sharing this name would be mistaken for ours -- and the
+# repository-scoped PUT that followed would fail.
+dir="$(make_gh 'test' '')"
+run_repo_rules "$dir" --dry-run mikelward/lanes test
+assert_status 0
+grep -q "includes_parents=false" "$dir/calls" || {
+    echo "  FAIL: the rulesets lookup must exclude inherited rulesets"
+    TEST_FAILED=1
+}
+finish_case
+
+test_case "creating chooses the default branch, actively enforced"
+dir="$(make_gh 'test' '')"
+run_repo_rules "$dir" mikelward/lanes test
+assert_status 0
+assert_body "$dir" '~DEFAULT_BRANCH'
+assert_body "$dir" '"enforcement": "active"'
+finish_case
+
+test_case "sees a check that only ever reported on a closed pull request"
+# A check running only on `pull_request` never reports on the default branch,
+# so a repository with nothing open would look as though it had never run.
+dir="$(make_gh 'test' '')"
+printf 'pr-only-check\n' > "$dir/closed_checks"
+run_repo_rules "$dir" mikelward/lanes test pr-only-check
+assert_status 0
+assert_body "$dir" '"context":"pr-only-check"'
+finish_case
+
+test_case "creating also requires resolution and allows rebase only"
+# A reviewer's comment is not a check, so a finding nobody answered blocks
+# nothing without this rule -- and the approval count stays 0, because
+# requiring a review is a policy about who may merge, not what this sets.
+# Rebase alone, because a squash or merge commit rewrites or hides the commits
+# that were reviewed.
+dir="$(make_gh 'test' '')"
+run_repo_rules "$dir" mikelward/lanes test
+assert_status 0
+assert_body "$dir" '"required_review_thread_resolution": true'
+assert_body "$dir" '"required_approving_review_count": 0'
+assert_body "$dir" '"allowed_merge_methods": ["rebase"]'
+assert_body_lacks "$dir" 'squash'
+assert_body_lacks "$dir" '"merge"'
+finish_case
+
+test_case "updating adds the conversation rule when the ruleset lacks it"
+if test "$HAVE_JQ" = no; then skip_case "needs a jq binary"; finish_case; else
+# The fixture ruleset holds only required_status_checks, which is what every
+# ruleset this script created before today looks like.
+dir="$(make_gh 'test' '42')"
+run_repo_rules "$dir" mikelward/lanes test
+assert_status 0
+assert_body "$dir" '"required_review_thread_resolution": true'
+# `gh api --jq` pretty-prints, so the array spans lines: assert the field and
+# its one member, and that neither other method survives.
+assert_body "$dir" '"allowed_merge_methods"'
+assert_body "$dir" '"rebase"'
+assert_body_lacks "$dir" 'squash'
+assert_body_lacks "$dir" '"merge"'
+finish_case
+fi
+
+test_case "updating an existing conversation rule keeps its other settings"
+if test "$HAVE_JQ" = no; then skip_case "needs a jq binary"; finish_case; else
+# Same reasoning as the check list: edit the fetched rule rather than replace
+# it, or a repository that asks for two approvals silently stops doing so.
+dir="$(make_gh 'test' '42')"
+cat > "$dir/ruleset" <<'RULESET'
+{"id":42,"name":"merge gates","target":"branch","enforcement":"active",
+ "conditions":{"ref_name":{"include":["~DEFAULT_BRANCH"],"exclude":[]}},
+ "rules":[{"type":"required_status_checks","parameters":{
+    "strict_required_status_checks_policy":false,
+    "required_status_checks":[{"context":"test"}]}},
+   {"type":"pull_request","parameters":{
+    "required_approving_review_count":2,
+    "require_code_owner_review":true,
+    "allowed_merge_methods":["merge","squash","rebase"],
+    "required_review_thread_resolution":false}}]}
+RULESET
+printf 'pull_request\nrequired_status_checks\n' > "$dir/rule_types"
+run_repo_rules "$dir" mikelward/lanes test
+assert_status 0
+assert_body "$dir" '"required_review_thread_resolution": true'
+assert_body "$dir" '"required_approving_review_count": 2'
+assert_body "$dir" '"require_code_owner_review": true'
+# The two fields this script manages are set rather than preserved: a ruleset
+# already allowing squash is narrowed, which is the point of running it.
+assert_body "$dir" '"allowed_merge_methods"'
+assert_body "$dir" '"rebase"'
+assert_body_lacks "$dir" 'squash'
+assert_body_lacks "$dir" '"merge"'
+finish_case
+fi
+
+test_case "a ruleset holding both managed rules is still ours to update"
+if test "$HAVE_JQ" = no; then skip_case "needs a jq binary"; finish_case; else
+dir="$(make_gh 'test' '42' '' '' 'pull_request
+required_status_checks')"
+run_repo_rules "$dir" mikelward/lanes test
+assert_status 0
+assert_output "updated ruleset"
+finish_case
+fi
+
+test_case "a reported name containing a newline is not split into two"
+# A check-run name is free text an app chose, so one really can be called
+# "build\nand test". Recorded line by line that becomes two names, and a
+# request for `build` then passes a guard for a check that never reported --
+# the never-reports trap, sprung by the thing that exists to prevent it.
+# Only the negative direction is testable from here: asking for the whole
+# name is impossible, since an argument containing a newline is refused.
+dir="$(make_gh 'test' '')"
+printf '%s\n' '"build\nand test"' > "$dir/checks_json"
+run_repo_rules "$dir" mikelward/lanes build
+assert_status 1
+assert_output "never reported"
+assert_no_write "$dir"
+finish_case
+
+test_case "updating adds the check rule when the ruleset holds only the other"
+if test "$HAVE_JQ" = no; then skip_case "needs a jq binary"; finish_case; else
+# The ownership check accepts a ruleset holding just one managed rule, and a
+# map over the rules edits only what is there -- so this would otherwise take
+# the PUT, report the checks as updated, and require none of them.
+dir="$(make_gh 'test' '42')"
+cat > "$dir/ruleset" <<'RULESET'
+{"id":42,"name":"merge gates","target":"branch","enforcement":"active",
+ "conditions":{"ref_name":{"include":["~DEFAULT_BRANCH"],"exclude":[]}},
+ "rules":[{"type":"pull_request","parameters":{
+    "required_approving_review_count":0,
+    "required_review_thread_resolution":true}}]}
+RULESET
+printf 'pull_request\n' > "$dir/rule_types"
+run_repo_rules "$dir" mikelward/lanes test
+assert_status 0
+assert_body "$dir" '"required_status_checks"'
+assert_body "$dir" '"context": "test"'
+finish_case
+fi
+
+test_case "updating turns the up-to-date requirement on"
+if test "$HAVE_JQ" = no; then skip_case "needs a jq binary"; finish_case; else
+# A check that passed against a stale base has not tested what will land, so
+# this is set rather than preserved -- an existing false must become true.
+dir="$(make_gh 'test' '42')"
+sed 's/"strict_required_status_checks_policy":true/"strict_required_status_checks_policy":false/' \
+    "$dir/ruleset" > "$dir/ruleset.new" && mv "$dir/ruleset.new" "$dir/ruleset"
+run_repo_rules "$dir" mikelward/lanes test
+assert_status 0
+assert_body "$dir" '"strict_required_status_checks_policy": true'
+finish_case
+fi
+
+test_case "refuses a gh placeholder as the repository"
+# `gh api` substitutes {owner} and {repo} from the current checkout, so a
+# literal one would retarget every call at whatever repo the shell is in --
+# with admin credentials, while the output still names the argument.
+dir="$(make_gh 'test' '')"
+run_repo_rules "$dir" '{owner}/{repo}' test
+assert_status 2
+assert_no_write "$dir"
+if test -f "$dir/calls"; then
+    echo "  FAIL: an API call was made before the argument was rejected"
+    TEST_FAILED=1
+fi
+finish_case
+
+test_case "stops scanning heads once every requested check is found"
+# Two calls per head times a hundred recent pull requests is a visible hang
+# and a chunk of the hour's API quota, and the default branch usually settles
+# the question. The closed-pull-request listing must not even be reached.
+dir="$(make_gh 'test' '')"
+run_repo_rules "$dir" mikelward/lanes test
+assert_status 0
+if grep -q "state=closed" "$dir/calls"; then
+    echo "  FAIL: kept scanning after every requested check was found"
+    TEST_FAILED=1
+fi
+finish_case
+
+test_case "refuses when another ruleset rules out a rebase merge"
+if test "$HAVE_JQ" = no; then skip_case "needs a jq binary"; finish_case; else
+# Rulesets aggregate and allowed_merge_methods intersects across them, so a
+# squash-only ruleset beside this rebase-only one leaves nothing able to
+# merge. The repository-level allow_rebase_merge check cannot see that.
+dir="$(make_gh 'test' '' '' '' 'required_status_checks' 'main' 'true' 'active' '99')"
+cat > "$dir/other_ruleset" <<'RULESET'
+{"id":99,"name":"org squash policy","enforcement":"active",
+ "conditions":{"ref_name":{"include":["~DEFAULT_BRANCH"],"exclude":[]}},
+ "rules":[{"type":"pull_request","parameters":{
+    "allowed_merge_methods":["squash"]}}]}
+RULESET
+run_repo_rules "$dir" mikelward/lanes test
+assert_status 1
+assert_output "org squash policy"
+assert_output "excludes rebase"
+assert_no_write "$dir"
+finish_case
+fi
+
+test_case "another ruleset that still allows rebase is no conflict"
+if test "$HAVE_JQ" = no; then skip_case "needs a jq binary"; finish_case; else
+dir="$(make_gh 'test' '' '' '' 'required_status_checks' 'main' 'true' 'active' '99')"
+cat > "$dir/other_ruleset" <<'RULESET'
+{"id":99,"name":"org policy","enforcement":"active",
+ "conditions":{"ref_name":{"include":["~DEFAULT_BRANCH"],"exclude":[]}},
+ "rules":[{"type":"pull_request","parameters":{
+    "allowed_merge_methods":["squash","rebase"]}}]}
+RULESET
+run_repo_rules "$dir" mikelward/lanes test
+assert_status 0
+assert_body "$dir" '"context":"test"'
+finish_case
+fi
+
+test_case "checks conflicts against the scope being written, not the default"
+if test "$HAVE_JQ" = no; then skip_case "needs a jq binary"; finish_case; else
+# An update preserves the existing ruleset's conditions, and the fixture is
+# scoped to refs/heads/release. A squash-only ruleset on `release` conflicts;
+# checking the default branch instead would miss it and report success.
+dir="$(make_gh 'test' '42' '' '' 'required_status_checks' 'main' 'true' 'active' '42
+99')"
+cat > "$dir/other_ruleset" <<'RULESET'
+{"id":99,"name":"release squash policy","enforcement":"active",
+ "conditions":{"ref_name":{"include":["refs/heads/release"],"exclude":[]}},
+ "rules":[{"type":"pull_request","parameters":{
+    "allowed_merge_methods":["squash"]}}]}
+RULESET
+run_repo_rules "$dir" mikelward/lanes test
+assert_status 1
+assert_output "release squash policy"
+assert_no_write "$dir"
+finish_case
+fi
+
+test_case "a squash-only ruleset on another branch is not a conflict"
+if test "$HAVE_JQ" = no; then skip_case "needs a jq binary"; finish_case; else
+# The fixture's own scope is refs/heads/release; a squash-only ruleset that
+# only covers the default branch shares no branch with it.
+dir="$(make_gh 'test' '42' '' '' 'required_status_checks' 'main' 'true' 'active' '42
+99')"
+cat > "$dir/other_ruleset" <<'RULESET'
+{"id":99,"name":"main squash policy","enforcement":"active",
+ "conditions":{"ref_name":{"include":["~DEFAULT_BRANCH"],"exclude":[]}},
+ "rules":[{"type":"pull_request","parameters":{
+    "allowed_merge_methods":["squash"]}}]}
+RULESET
+run_repo_rules "$dir" mikelward/lanes test
+assert_status 0
+assert_body "$dir" '"context": "test"'
+finish_case
+fi
+
+test_case "refuses a squash-only ruleset scoped by a pattern it cannot evaluate"
+if test "$HAVE_JQ" = no; then skip_case "needs a jq binary"; finish_case; else
+# `refs/heads/*` covers the default branch, and this script matches literally.
+# Passing it over would install rebase-only beside a squash-only ruleset and
+# leave nothing able to merge -- the trap the whole scan exists to prevent.
+dir="$(make_gh 'test' '' '' '' 'required_status_checks' 'main' 'true' 'active' '99')"
+cat > "$dir/other_ruleset" <<'RULESET'
+{"id":99,"name":"wildcard squash policy","enforcement":"active",
+ "conditions":{"ref_name":{"include":["refs/heads/*"],"exclude":[]}},
+ "rules":[{"type":"pull_request","parameters":{
+    "allowed_merge_methods":["squash"]}}]}
+RULESET
+run_repo_rules "$dir" mikelward/lanes test
+assert_status 1
+assert_output "wildcard squash policy"
+assert_output "cannot evaluate"
+assert_no_write "$dir"
+finish_case
+fi
+
+test_case "refuses a squash-only ruleset carrying an exclusion"
+if test "$HAVE_JQ" = no; then skip_case "needs a jq binary"; finish_case; else
+# An `exclude` can carve this branch back out of an overlap, so a literal
+# match with one present is not proof either way -- undecidable, not clear.
+dir="$(make_gh 'test' '' '' '' 'required_status_checks' 'main' 'true' 'active' '99')"
+cat > "$dir/other_ruleset" <<'RULESET'
+{"id":99,"name":"excluding squash policy","enforcement":"active",
+ "conditions":{"ref_name":{"include":["~ALL"],"exclude":["refs/heads/main"]}},
+ "rules":[{"type":"pull_request","parameters":{
+    "allowed_merge_methods":["squash"]}}]}
+RULESET
+run_repo_rules "$dir" mikelward/lanes test
+assert_status 1
+assert_output "excluding squash policy"
+assert_output "cannot evaluate"
+assert_no_write "$dir"
+finish_case
+fi
+
+test_case "a wildcard ruleset that still allows rebase is no conflict"
+if test "$HAVE_JQ" = no; then skip_case "needs a jq binary"; finish_case; else
+# The pattern is only undecidable where it would matter. A ruleset that keeps
+# rebase available cannot empty the intersection whatever it covers, so
+# refusing on the pattern alone would block runs for no reason.
+dir="$(make_gh 'test' '' '' '' 'required_status_checks' 'main' 'true' 'active' '99')"
+cat > "$dir/other_ruleset" <<'RULESET'
+{"id":99,"name":"wildcard policy","enforcement":"active",
+ "conditions":{"ref_name":{"include":["refs/heads/*"],"exclude":["refs/heads/x"]}},
+ "rules":[{"type":"pull_request","parameters":{
+    "allowed_merge_methods":["squash","rebase"]}}]}
+RULESET
+run_repo_rules "$dir" mikelward/lanes test
+assert_status 0
+assert_body "$dir" '"context":"test"'
+finish_case
+fi
+
+test_case "does not paginate the open pull request listing"
+# A repository with thousands of open pull requests would otherwise cost two
+# calls per head with no upper bound: a visible hang, and past 2,400 heads it
+# exhausts the hour's 5,000-request allowance outright. One page bounds it.
+dir="$(make_gh 'some-other-check')"
+run_repo_rules "$dir" mikelward/lanes missing-check
+assert_status 1
+assert_no_call "$dir" "--paginate repos/mikelward/lanes/pulls?state=open"
+assert_call "$dir" "repos/mikelward/lanes/pulls?state=open&per_page=100&sort=updated&direction=desc"
+assert_output "bounded"
+finish_case
+
+test_case "an empty repository is zero reports, not a failed read"
+# GitHub answers 409 on the commits endpoint when nothing has been pushed.
+# Failing closed there would make a brand new repository the one place
+# --force cannot do its job -- setting the gates up before anything reports.
+dir="$(make_gh 'test' '' '' '/commits?per_page=1' 'required_status_checks' \
+    'main' 'true' 'active' '' '0')"
+run_repo_rules "$dir" --force mikelward/lanes test
+assert_status 0
+assert_body "$dir" '"context":"test"'
+finish_case
+
+test_case "an empty repository still refuses without --force"
+# The checks genuinely have not reported, so the guard still holds; what the
+# empty case buys is that --force is reachable at all.
+dir="$(make_gh 'test' '' '' '/commits?per_page=1' 'required_status_checks' \
+    'main' 'true' 'active' '' '0')"
+run_repo_rules "$dir" mikelward/lanes test
+assert_status 1
+assert_output "never reported"
+assert_no_write "$dir"
+finish_case
+
+test_case "a failed commits read on a non-empty repository still stops the run"
+# The empty-repository case is a KNOWN zero-report answer. A rate limit or a
+# permission error is not, and reading one as "nothing has reported" would
+# require a check on the strength of a lookup that never completed.
+dir="$(make_gh 'test' '' '' '/commits?per_page=1')"
+run_repo_rules "$dir" --force mikelward/lanes test
+assert_status 1
+assert_output "could not read which checks have reported"
+assert_no_write "$dir"
+finish_case
+
+test_case "a failing grep is not read as a check that never reported"
+# grep exits 2 or more when it could not search at all -- an unreadable file,
+# an I/O error. Reading that as "not found" prints the never-reported claim
+# this script exists to make trustworthy, on a search that did not finish.
+dir="$(make_gh 'test')"
+cat > "$dir/bin/grep" <<'EOF'
+#!/bin/sh
+exit 2
+EOF
+chmod +x "$dir/bin/grep"
+run_repo_rules "$dir" --force mikelward/lanes test
+assert_status 1
+assert_output "grep exited 2"
+assert_no_write "$dir"
+finish_case
+
+test_case "refuses a ruleset that is not actively enforced"
+if test "$HAVE_JQ" = no; then skip_case "needs a jq binary"; finish_case; else
+# An `evaluate` ruleset blocks nothing, so writing a check list into one and
+# reporting success would name a gate that does not gate.
+dir="$(make_gh 'test' '42' '' '' 'required_status_checks' 'main' 'true' 'evaluate')"
+run_repo_rules "$dir" mikelward/lanes test
+assert_status 1
+assert_output "'evaluate'"
+assert_output "does not gate"
+assert_no_write "$dir"
+finish_case
+fi
+
+test_case "refuses a repository with rebase merging disabled"
+# A ruleset narrows what the repository permits and cannot enable a method, so
+# allowing only rebase where the repository has it turned off leaves nothing
+# able to merge -- the trap this script exists to prevent, sprung by it.
+dir="$(make_gh 'test' '' '' '' 'required_status_checks' 'main' 'false')"
+run_repo_rules "$dir" mikelward/lanes test
+assert_status 1
+assert_output "rebase merging disabled"
+assert_no_write "$dir"
+finish_case
+
+test_case "asks for the default branch head without naming it in the path"
+# `#` is legal in a git ref name and starts a URL fragment, which is never
+# sent, so `release#1` interpolated into the endpoint would query `release`.
+# The fixture fails any call naming the branch; reaching exit 0 means none did.
+dir="$(make_gh 'test' '' '' '/commits/release' 'required_status_checks' 'release#1')"
+run_repo_rules "$dir" mikelward/lanes test
+assert_status 0
+finish_case
+
+# ---------------------------------------------------------------------------
+
+echo
+echo "Tests run: $TESTS_RUN, passed: $TESTS_PASSED, failed: $TESTS_FAILED, skipped: $TESTS_SKIPPED"
+test "$TESTS_FAILED" -eq 0


### PR DESCRIPTION
Requiring a merge gate is a per-repository setting, and there is no shortcut: an organization ruleset could cover many repos by name pattern, but a personal account doesn't get them. Ten repositories is ten trips through the UI, times each time the check list changes. It's a REST endpoint, so it can be a script.

```sh
repo-rules owner/repo            gate codex
repo-rules --dry-run owner/repo  gate codex Vercel
```

It sets four things on the default branch, through a ruleset it owns by name.

## The checks named on the command line

**The guard that makes it worth writing: it refuses to require a check that has never reported on that repository.**

A required check that never runs blocks every merge forever, with no error anywhere saying why — and it looks exactly like a stuck queue. Two ordinary ways in: a typo (`sweeep`), and a check that so far exists only on a branch not yet merged. Both are silent.

That is not hypothetical. A sibling repository's merge was rejected while this was open with *"2 of 3 required status checks have not succeeded"*; the name turned out to be `sweep`, which **had reported success three times on that very commit** and was still "expected". This script exists to make the configurable half of that impossible by accident.

Seven details the guard depends on, six of them found in review:

- **Check runs and commit statuses both count.** A ruleset can require either, and they are different objects — `gate` is a check run, `codex` and `Vercel` are commit statuses. Looking at only one would reject a valid name.
- **Heads come from the default branch, then open pull requests, then recently closed ones** — a check that runs only on `pull_request` never reports on the default branch. The walk **stops as soon as every requested name has been seen**, and the later listings are not even fetched: the question is only whether each name has reported anywhere, and two calls per head across a hundred recent pull requests is a visible hang and a chunk of the hour's API quota.
- **And the stages are bounded — one page each, most recently updated first.** A run still missing a name walks everything they offer, which is about 200 heads and 400 calls *whatever the size of the repository*. Paginating the open listing instead makes a repository with thousands of open pull requests a hang, and past ~2,400 heads it exhausts the 5,000-request hourly allowance outright. The bound is honest in the safe direction: a check whose only report is on an older head reads as never reported, which refuses and names `--force`, and the failure message says what was examined.
- **An empty repository is a known zero-report answer, not a failed read.** GitHub answers 409 on the commits endpoint when nothing has been pushed, and failing closed there made a brand new repository the one place `--force` could not do its documented job. It is told apart by asking the branch list rather than by matching gh's error text — one extra call, on the failure path only — so a rate limit, a permission error or an outage still stops the run.
- **The search itself can fail, and that is a third answer.** `grep` exits 0 for found, 1 for not found, and 2 or more for "could not search". Reading the third as "not found" prints the never-reported claim on a search that never finished, so it aborts naming the status instead.
- **Everything else paginates.** A check-run name on page two of a *head* is indistinguishable from a name that never reported.
- **Names are compared in their JSON encoding.** A check-run name is free text an app chose, so one really can be called `build⏎and test`; collected line by line that becomes two names, and a request for `build` would pass a guard for a check that never reported.

`--force` requires anyway and says so — but deliberately does **not** override a *failed lookup*. It means "require a check I know hasn't reported yet", not "proceed without knowing".

## Resolution of every review conversation

Not a status check, and that is why it is here: a reviewer's comment is not a check, so a finding raised and never answered blocks nothing, and a green tick reads as agreement it never was. Requiring resolution makes "somebody replied" a precondition for merge rather than a courtesy.

It requires threads be **resolved, not agreed** — resolving one you disagree with is a single click — so the cost is a rebuttal, never a merge.

## The branch up to date with the base

`strict_required_status_checks_policy` is `true`. A check that passed against a stale base has not tested what will actually land. It serializes merges, and that is accepted.

## Rebase as the only merge method

`allowed_merge_methods` is `["rebase"]`. The commits that were reviewed are then the commits that land; a squash rewrites them into one and a merge commit buries them, and one commit per logical change is the shape these repositories keep.

**And the run refuses outright if the repository has rebase merging disabled.** A ruleset *narrows* what the repository permits and cannot enable a method it has turned off, so allowing only rebase on a squash-only repository leaves an empty intersection and nothing can merge — the never-merges trap this script exists to prevent, sprung by the script. The setting comes back on the `repos/{owner}/{repo}` call already being made for the default branch, so it costs no extra request. Refused rather than enabled: flipping a repository-wide merge setting behind an operator who asked to set a check list is exactly the quiet side effect the clobbered-field findings were about.

**Rulesets also aggregate with each other, and `allowed_merge_methods` intersects across them** — so another *active* ruleset allowing only squash springs the same trap, and the repository-level setting cannot see it. Before writing, the run lists rulesets with `includes_parents=true` (an inherited organization one is invisible to the `false` lookup it uses to find its own) and refuses if any of them rules out rebase where it might matter. Three things decide that:

- **The scope compared is the one being written, not the default branch.** An update preserves the existing ruleset's `conditions`, so a managed ruleset scoped to `release` is checked against what else applies to `release`.
- **Matching is literal** — `~DEFAULT_BRANCH` normalized on both sides, `~ALL` a wildcard — and GitHub's `fnmatch` patterns are *not* evaluated.
- **So an unevaluatable scope is reported, not passed over.** A pattern character on either side, or an `exclude` list on either side (an exclusion can carve this branch back out of an apparent overlap), makes the answer undecidable, and undecidable stops the run with a message saying so. Refusing to decide beats reimplementing GitHub's ref matching and being wrong about it in silence.

It stays narrow: all of that only applies to rulesets whose `allowed_merge_methods` already exclude rebase. A wildcard ruleset that keeps rebase available cannot empty the intersection whatever it covers, and is not refused.

The `pull_request` rule it writes asks for **zero** approving reviews, and no code-owner or last-push approval. Requiring an approval is a policy about *who* may merge; that is a different decision and this does not make it.

## It owns one ruleset by name

Rather than editing whatever protections exist. It looks up a ruleset by name (default `merge gates`, with `includes_parents=false` so an inherited organization ruleset of the same name isn't mistaken for this repository's), and before touching it checks that the only rules it carries are the two this script manages — a name match is not ownership, and replacing a stranger's rule list would delete protections. The test is *deleting* the managed types and seeing what is left, rather than comparing against the list of allowed combinations, which is a thing to get wrong again the moment a third is added.

**On update it does not build a request body at all.** It fetches the existing ruleset and edits only the two rules inside it, so every other field survives — `conditions`, `enforcement`, `bypass_actors`, and any field the API grows later. The check list is *merged* rather than replaced, so a context bound to a GitHub App keeps its `integration_id`; the conversation rule is edited in place, so a repository asking for two approvals keeps asking for two. The four settings this script manages are *set* rather than preserved — a ruleset already allowing squash gets narrowed, which is the point of running it. **Either managed rule is added when the fetched ruleset lacks it**, since editing only what is there would take the PUT on a ruleset holding just the other one, report the checks as updated, and require none of them.

A failed lookup stops the run rather than reading as "none exists", which would produce a duplicate ruleset ANDing with the real one.

**No ownership marker**, decided by the repo owner. With the update editing the fetched object the blast radius is exactly the four managed settings; a marker would buy nothing against that, while refusing a `merge gates` made by hand and now wanted managed, and it can only vouch for rulesets created after it existed.

## Review findings

Twenty-eight threads, all addressed. **Five of them were this script one detail away from causing the exact failure it exists to prevent**, which is the theme worth reading:

**Check names were flattened into a space-separated string and then re-split (P1).** `Analyze (actions)` — a real name CodeQL emits — would have been required as two contexts, `Analyze` and `(actions)`. Each passes validation alone and then never reports. Names are one-per-line end to end now, JSON-escaped, and control characters in an *argument* are refused outright.

**The same corruption, entering from the other side (P2).** `reject_control_chars` guards what the caller typed; a check-run name arrives from the API and bypasses it entirely. Fixed by encoding rather than rejecting — the collection calls ask for `| @json`, so a name occupies exactly one line whatever it contains. Rejecting would have been wrong here: unlike an argument, such a check is real and someone may need to require it.

**Rebase-only on a repository with rebase disabled (P1).** The one that would have bricked the repository rather than blocked a merge — see above. **A sibling ruleset that rules out rebase (P1)** is the same empty intersection arriving from a ruleset rather than a repository setting, and one an inherited organization ruleset can cause invisibly. Two follow-up findings on that scan: it compared against the default branch while an update preserves the existing ruleset's own scope, and it then passed over `refs/heads/*` — a wildcard that really does cover the branch — because matching is literal. Both fixed, the second by reporting what it cannot decide rather than evaluating it.

**An unbounded scan behind a bounded claim (P2).** The header promised a worst case of a couple of hundred calls while the open-pull-request listing paginated without limit; on a repository with thousands of them that is a hang and a rate limit. Fixed by bounding the scan to match the claim, not by rewriting the claim.

**Failing closed on an empty repository (P2).** The 409 that GitHub answers when nothing has been pushed was treated like an outage, so the one repository that most needs `--force` — a new one, gates set up before any check has run — was the one where it could not be reached.

**Three answers read as two (P2).** `grep`'s error statuses were folded into "not found", so an unreadable list printed the never-reported claim on a search that never finished.

**`gh api --jq -r EXPR` (P1).** `-r` is jq's flag, not `gh api`'s, so `-r` became the expression and `EXPR` a second endpoint — every update aborted before the PUT. The more useful half was that **the fake `gh` never noticed**: a stub that accepts anything tests my idea of the CLI rather than the CLI. It now parses arguments the way `gh` does and requires exactly one endpoint, which catches the whole class. The same fake had to be fixed twice more for the same reason — it served names raw where `gh` serves them encoded, and quoted strings where `gh --jq` prints them raw.

**Four findings in a row were one finding (P1 ×4).** `conditions`, `enforcement`, `bypass_actors`, the strict policy and app bindings were each reported clobbered, separately. Preserving fields one at a time as review finds them is a losing game — the answer was to stop rebuilding an object I do not fully know, and edit the fetched one instead. That single change closed all of them, including the sharpest: dropping `integration_id` *weakens* a gate, letting any integration satisfy a check only one app was meant to.

**A gate reported as set and not set (P1).** Widening the ownership check to accept `pull_request` made "a ruleset with no `required_status_checks` rule" reachable, and the update was still a `map` over the rules already present — so the PUT would succeed, the run would print `updated ruleset 'merge gates'`, and nothing would be required.

**The same lesson as the four, applied without being asked twice.** The default branch was interpolated into an endpoint path, and `#` is legal in a git ref name but starts a URL fragment — a branch called `release#1` would query `release`. The fix is not an encoder for the characters that break a URL; it is `repos/{owner}/{repo}/commits?per_page=1`, which already defaults to the default branch.

The rest: missing `--paginate` on the per-head calls; a pipeline hiding `gh` failures behind `sort`'s exit status; a `|| true` on the ruleset lookup — the exact construct this repo's error-handling rule names; inherited rulesets in the lookup; closed pull-request heads; two hundred sequential `gh` processes where two would do; a success message claiming a default-branch scope the update preserves away from; a header giving neither a cost figure nor the user-visible failure behavior; the fake `gh` requiring a separate `jq` binary the script does not need; and fixture directories never cleaned up.

**One declined**, and the repo owner agreed: naming `mikelward/lanes` in a test fixture is not a privacy violation. It is a public repository on the same account, linked from this pull request. `AGENTS.md` now says so, so the next round does not repeat it.

## Tests

`repo-rules_test` puts a fake `gh` on PATH, so it needs no network and no token. It asserts the **request body** and the **call log**, not just the exit status — a run that posted an empty check list, or paginated a listing it was meant to bound, would exit 0 just as happily.

Forty-seven cases, including: a name with spaces surviving as one context *and* not appearing as its fragments; a name with quotes; a control character refused; a check run named `build⏎and test` that must not let `build` through; a check reachable only through pagination; one that only ever reported on a closed pull request; the walk stopping before the closed-pull-request listing when the default head already answers; the open listing taking one page and not paginating; an empty repository writing under `--force`, refusing without it, and a failed commits read on a *non-empty* repository still stopping the run; a `grep` that exits 2 aborting rather than reading as "never reported"; a default branch named `release#1` whose name must not appear in any request path; a repository with rebase merging disabled refused before any write; a squash-only sibling ruleset refused and a rebase-allowing one not; that conflict judged against a `refs/heads/release` scope rather than the default branch; a squash-only ruleset on a branch this one does not cover correctly not a conflict; `refs/heads/*` and an `exclude` list each refused as undecidable while a wildcard ruleset that still allows rebase writes normally; a create that requires conversation resolution with zero approvals and rebase alone; an update that adds either managed rule to a ruleset holding only the other; an update that narrows a ruleset allowing squash and turns an existing `strict` false to true while leaving its two-approval setting alone; an update carrying `bypass_actors`, `evaluate`, a `refs/heads/release` scope and an app-bound context through untouched; a foreign rule type refused; and every lookup failure stopping the run.

The update-path cases pipe a realistic ruleset fixture through **real jq**, so the script's own jq program is what runs rather than a stub's idea of it. Where no jq binary exists — macOS without brew — those skip **loudly**: a printed notice and a counted `skipped:` in the summary, never a silent gap. CI runs ubuntu-latest, which ships jq, so the coverage is never optional where it gates a merge.

The asserts record a failure and return **zero**, which is deliberate: `set -e` is on for the fixture setup, so an assert returning non-zero killed the run at the first failure — reporting one problem out of however many and skipping the summary line, which left `failed: 0` as a number that could never print anything else. The suite's exit status is what makes it red.

Each guard was verified by reintroducing the defect it forbids and watching the suite go red — including every review fix.

`make test` green across the repo; shellcheck clean.

**One caveat the green suite would otherwise imply away: this write path has never run against the real API.** There is no admin token in this environment, so PUT semantics, the read-only field list, the `pull_request` rule's required fields and the `bypass_actors` round-trip are read from the docs and exercised against a fixture. `--dry-run` before the first real invocation is worth it.

## Notes

- Named `repo-rules` rather than `setup-repo` to stay out of the `setup` / `setup-kde` / `setup-macos` family, which sets up *machines*.
- Branch name is the one this environment pinned and doesn't describe the change; happy to move it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015qLfPUeA3bYhqdrDT9YFmL