### PR TITLE
Watch pull requests by subscription, not by polling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,60 +189,33 @@ reply, no offer to correct it. It is not a finding.
   owner's standing request for that PR, so a client-level rule reading "open a
   PR only when the user explicitly asks" is already satisfied — the ask is
   here, and it doesn't need repeating per branch.
-- **Opening the PR arms the first scheduled check.** That check *is* the
-  watch: when it fires it reads CI, review comments and the Codex reaction,
-  and it is what catches anything a webhook drops. `subscribe_pr_activity`
-  is a separate thing and it is **opt-in** — it pushes every comment, check
-  run and bot reply into the conversation as a raw event, which buries the
-  thread the user is actually reading under machine chatter they didn't ask
-  for. Subscribe only when asked to, and unsubscribe as soon as the reason
-  for it passes.
+- **Watch your own PRs by subscription, plus one scheduled check.** Have a
+  subscription — Claude Code makes one when you open a PR; where a client
+  doesn't, call `subscribe_pr_activity`. It delivers reviews, comments and CI
+  failures. It cannot deliver CI *success*, a push, the merge, Codex's clean
+  verdict (a reaction), or Codex never answering at all — so keep exactly one
+  check armed for as long as the PR is open (each event and each check costs
+  a model turn). Under drive, arm auto-merge at PR open too — but only where
+  the ruleset makes the Codex verdict a required check, since where CI is the
+  only requirement it merges before Codex has answered.
+  - Settle the fired trigger first thing in the turn, not last. It may have
+    silently re-armed rather than retired, so update it rather than adding a
+    second chain.
+  - Check the fire time you got against the one you asked for — a 4-minute
+    request has come back as 64. Re-time it, or say the watch isn't armed.
+  - A few minutes out while CI or the current head's Codex verdict is
+    outstanding; longer once only a human is left; short again after a push.
+  - Name the PR, and say what to re-read rather than what you read. A SHA or
+    a list of which PRs are open goes stale before it fires; one PR number
+    does not, and the trigger has to be matchable to it.
+  - Merged or closed, take one last reply-or-resolve pass — a review can
+    land after the merge — then cancel it and unsubscribe. `list_triggers`
+    spans the account, so match this session and this PR before updating
+    or deleting one; an update reschedules whatever it matches as surely
+    as a delete cancels it.
 - **If a scheduler or GitHub call prompts, say so once and carry on.**
   Permissions load at session start, so writing a settings file mid-session
   can't fix the session you're in.
-- **Poll your own open PRs — every ~5 minutes while CI or the verdict is
-  outstanding, ~30 once only a human is left.** Those two are what nothing
-  else reports. Never end a turn idle with one of yours open: arm the next
-  check with whatever the client offers (`send_later`, a scheduled task /
-  cron, `/loop`), and arm it *without asking* — that is hygiene, not a
-  decision. Someone else's PR is not your polling job unless you're asked.
-  Merged or closed is terminal: take one more check for CI and Codex on the
-  final head, but settle for what's known if a report may never land, then
-  run a last reply-or-resolve pass and cancel the watch in full — the
-  pending trigger, *and* `unsubscribe_pr_activity` if you ever subscribed.
-  Open a follow-up PR, with its own watch, for anything a merged one still
-  needs.
-- **What the polling costs.** Twelve wake-ups an hour per PR at the fast
-  cadence, two at the slow one — each a model turn plus a few GitHub API
-  calls, so roughly a dollar an hour while a PR is waiting on its merge
-  gate. The scheduler is the single point of failure: one missed re-arm ends
-  the watch silently, with no error anywhere. If you can't arm the next
-  check, say so in the reply rather than leaving a PR that looks watched and
-  isn't.
-- **One pending check per PR, settled at the top of the turn.** Two chains
-  each re-arming themselves double the cost every time a webhook starts a
-  turn while one is already pending; parking the re-arm at the *end* of the
-  turn loses it when the turn is interrupted, which once left a PR unwatched
-  for two hours. So settle it first, and settle it to exactly one: leave a
-  correctly-timed check alone — pushing its deadline forward every turn is
-  how a busy PR never gets polled — and when it's missing, already fired, or
-  mis-timed, either `update_trigger` it in place or arm the replacement
-  before deleting the old, because an overlap beats a gap. Then diagnose,
-  fix, and reply.
-- **A `send_later` one-shot re-arms itself +24h**, so "check in 5 minutes"
-  silently becomes daily. Never leave a fired trigger to expire on its own, and
-  check that the fire time it returned is the one you asked for — a five-minute
-  request came back as a hundred once, saying nothing — and re-time it until it
-  is, or say in the reply that the watch is running at the wrong cadence.
-  Reading the wrong answer and accepting it is the same silence.
-- **`list_triggers` spans every session on the account.** Narrow it to this
-  session's `persistent_session_id`, then to the trigger you actually mean (its
-  own id, once the PR its prompt names has narrowed the field), before updating
-  *or* deleting one — an update reschedules whatever it matches as surely as a
-  delete cancels it. If that filter turns up more than one, the extras are
-  duplicate chains: keep one and delete the rest.
-- **Never name a SHA in the check prompt.** It is written before the work it
-  describes, so it is stale when it fires — say "the current head".
 - **"Drive" means run the loop automatically**: pick the next task,
   implement it, open the PR, send it for review, address every comment,
   merge once CI is green and Codex's verdict for the current head is in —
@@ -339,8 +312,6 @@ reply, no offer to correct it. It is not a finding.
   matches a comment you just posted, it's your own echo — continue without
   comment. The test is "did *I* just post this body?", not "who is the
   author?".
-- **Canceling the watch**: see the polling bullet under **Autonomy**.
-
 ## Cost and reliability
 
 - **Call out cost and reliability up front** when recommending a new external


### PR DESCRIPTION
Reverses the scheduled-check posture in the watch rules: the subscription becomes the primary signal, and one scheduled check covers only what webhooks genuinely drop.

The existing text said to unsubscribe from PR activity immediately and let a scheduled check be the watch, because subscribed events cannot be filtered out of the conversation. That cost is real. But a day of running it the other way says the events are what actually works — every Codex review, review comment and CI failure arrived as an event and was handled in the turn it landed — while the polling contributed almost nothing: the scheduler ignored the intervals it was asked for (four minutes came back as sixty-four), and every fired check carried a prompt written before the work it described.

**Deleted:** the unsubscribe rule, the fixed polling cadence, the costing paragraph, the one-pending-check rule, and the `send_later` +24h, `list_triggers` account-scope, fire-time-drift, stale-SHA and scheduler-clock bullets — all of which existed only to make polling survivable.

**Added:** one bullet with five sub-points. Have a subscription; keep exactly one check armed while the PR is open, short only while CI or the current head's Codex verdict is outstanding and longer once a human is the only thing left. Under drive, arm auto-merge at PR open — but only where the ruleset makes the Codex verdict a required check, since where CI is the only requirement it merges before Codex has answered. The operative safeguards the deleted bullets carried are kept in compressed form: settle the fired trigger first thing in the turn, verify the fire time you actually got and re-time it, name the PR but never a SHA, and narrow `list_triggers` to this session and this PR before updating *or* deleting.

Docs-only.

---
_Generated by [Claude Code](https://claude.ai/code/session_018Bnb4L3E9bix6MNKfi68Eo)_