### PR TITLE
docs: Say what auto-merge needs, and how to recover a stale PR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,11 +206,26 @@ reply, no offer to correct it. It is not a finding.
     request has come back as 64. Re-time it, or say the watch isn't armed.
   - A few minutes out while CI or the current head's Codex verdict is
     outstanding; longer once only a human is left; short again after a push.
+  - A PR reading `dirty` — always — or `behind` where the ruleset requires
+    branches up to date, takes: both refs
+    fetched by explicit refspec (`+refs/heads/<x>:refs/remotes/origin/<x>`;
+    a bare fetch, or one naming the branches, updates neither in the
+    single-branch clone a shallow one implies), `git fetch --unshallow` if
+    the clone is shallow, a rebase onto the fetched `origin/<base>` — not
+    always `main`, never the local branch — then `git push
+    --force-with-lease --force-if-includes`, both flags, since the fetch
+    refreshes the ref the lease compares against. A rejection means someone
+    else pushed to the head: integrate their tip and retry. Nothing reports
+    a base advance, so only the check catches it.
   - Name the PR, and say what to re-read rather than what you read. A SHA or
     a list of which PRs are open goes stale before it fires; one PR number
     does not, and the trigger has to be matchable to it.
-  - Merged or closed, take one last reply-or-resolve pass — a review can
-    land after the merge — then cancel it and unsubscribe. `list_triggers`
+  - Merged or closed, take one last reply-and-resolve pass — a review can
+    land after the merge. Nothing is holding the PR now, so on a merged one
+    anything real goes to a follow-up PR, named on the thread, before you
+    resolve it; leaving it open records the work nowhere. A closed-unmerged
+    PR is a stop — the work was abandoned, so answer, resolve, and open
+    nothing. Then cancel the check and unsubscribe. `list_triggers`
     spans the account, so match this session and this PR before updating
     or deleting one; an update reschedules whatever it matches as surely
     as a delete cancels it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,8 +196,9 @@ reply, no offer to correct it. It is not a finding.
   verdict (a reaction), or Codex never answering at all — so keep exactly one
   check armed for as long as the PR is open (each event and each check costs
   a model turn). Under drive, arm auto-merge at PR open too — but only where
-  the ruleset makes the Codex verdict a required check, since where CI is the
-  only requirement it merges before Codex has answered.
+  the ruleset makes the Codex verdict a required check AND requires
+  conversations resolved: where CI is the only requirement it merges before
+  Codex has answered, and an open review comment holds nothing back on its own.
   - Settle the fired trigger first thing in the turn, not last. It may have
     silently re-armed rather than retired, so update it rather than adding a
     second chain.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -282,8 +282,9 @@ reply, no offer to correct it. It is not a finding.
   Group several small fixes into one commit when they share a topic.
 - **Judge every review comment on merit, whoever wrote it.** Verify the claim
   before acting; if it doesn't hold up, reply saying why and decline.
-- **Never leave a review comment thread silently dismissed.** Either reply on
-  the thread *or* resolve it. When you think a comment is a false positive,
+- **Never leave a review comment thread silently dismissed.** Answer on the thread, then
+  resolve it once the fix is on the head or the point is rebutted — a disagreement is an
+  answer, so say why and resolve; anything still to do stays open. When you think a comment is a false positive,
   say *why* on the thread (one or two sentences). Acknowledgement noise is
   fine and preferred over silence.
 - **`resolve_review_thread` works — pass the `PRRT_*` thread node ID** from


### PR DESCRIPTION
Three documentation commits, each one policy. This is the lead repo for the change — once it's clean the settled text goes to the ten siblings.

**`docs: Say that auto-merge needs conversations resolved too`** — arming auto-merge is only safe where the ruleset makes the Codex verdict a required check **and** requires conversations resolved. With CI as the only requirement it merges before Codex has answered, and an open review comment holds nothing back on its own.

**`docs: Resolve an answered thread instead of leaving it open`** — "reply **or** resolve" read as a choice, so answered threads stayed open. Codex never resolves anything itself, and GitHub only ever marks a thread *outdated*, so under *require conversations resolved* an answered comment blocks the merge exactly as an ignored one does. Now: answer, then resolve once the fix is on the head or the point is rebutted; anything still to do stays open. On a merged PR nothing is being held, so anything real goes to a follow-up PR named on the thread before resolving — but a **closed-unmerged** PR is a stop, since the work was abandoned and an automatic follow-up would resurrect it.

**`docs: Rebase a pull request that has fallen behind its base`** — nothing reports that the base advanced, so only the scheduled check catches it. A PR reading `dirty` takes this recovery under **every** ruleset; `behind` only where branches must be up to date. Each detail below cost a review round, and the ones marked ✅ were reproduced locally rather than reasoned about:

- ✅ both refs fetched by **explicit refspec** — a bare `git fetch origin`, *and* `git fetch origin <base> <head>`, update neither tracking ref in the single-branch clone a shallow one implies;
- ✅ `git fetch --unshallow` first, or the rebase finds no merge base and replays the head as a root commit;
- rebase onto the fetched `origin/<base>`, never the local branch a fetch doesn't fast-forward;
- `--force-if-includes` is a no-op alone, so it pairs with `--force-with-lease`;
- ✅ and a rejection means someone else pushed to the head — integrate their tip and retry. Without that clause the sequence dead-ends.

Prose only. `make test` not run: this repo's testing rule exempts changes with no behavior to exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)