### PR TITLE
Publish the Codex verdict as a commit status

### DIFF
--- a/.github/workflows/codex-review-listener.yml
+++ b/.github/workflows/codex-review-listener.yml
@@ -1,0 +1,21 @@
+name: codex-review-listener
+
+# Hears the one verdict delivery the sweep's own triggers cannot safely hear.
+# `pull_request_review` is a merge-ref event -- GitHub runs the workflow file
+# from refs/pull/<n>/merge, the pull request's own version -- so it must never
+# appear on a workflow that can write commit statuses. This listener holds
+# nothing: no permissions, no secrets, one no-op step. Its completion starts
+# the sweep in codex-review.yml via `workflow_run`, whose definition GitHub
+# always takes from the default branch.
+on:
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+
+permissions: {}
+
+jobs:
+  heard:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - run: 'true'

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -1,0 +1,68 @@
+# Republishes Codex's review verdict as the `codex` commit status the main
+# ruleset requires. The sweep itself — the minute loop, the freshness bounds,
+# the unanswered-head decay — lives in mikelward/codex-review, shared across
+# the repos, with its own tests and its design written up in its README and
+# source. This file keeps only what has to stay in the CONSUMER repo, and
+# every line of it is deliberate:
+#
+# - The triggers: pushes and comments start a run within seconds (both take
+#   the workflow definition from the default branch, so a PR cannot bring its
+#   own sweep); `closed` clears a shared-head failure the moment a duplicate
+#   PR goes away; `edited` hears a nudge edited into an existing comment;
+#   `workflow_run` relays `pull_request_review` from the unprivileged
+#   listener — findings submitted as a review with no inline comments emit
+#   neither a comment event nor a reaction, and that event is merge-ref
+#   (the PR supplies the definition), so it must not start this
+#   status-writing workflow directly. The
+#   HOURLY schedule is only the backstop for the fail-closed states nothing
+#   emits an event for (a dropped webhook, a reaction after the loop parked) —
+#   any comment on the PR clears those on demand too, and on a private repo
+#   each idle fire bills a full minute, so hourly (~720 min/month) is the
+#   deliberate trade against `*/15`'s ~2,900.
+# - No `workflow_dispatch`: it took a ref, and GitHub runs the workflow file
+#   from that ref — a branch could ship its own sweep and publish
+#   `codex: success` for itself.
+# - The permissions grant the action's token exactly what a sweep needs, and
+#   this workflow must remain the ONLY one holding `statuses: write` — a
+#   second writer is an ordering race with the verdict (the deleted
+#   codex-verdict-reset workflow was that bug). A test pins all of this.
+# - `@main`, not a tag or SHA: the action has no build step and no
+#   dependencies, so the file that runs is the file you can read — and its
+#   repo is first-party. Pinning would only delay fixes reaching the gate.
+name: codex-review
+
+on:
+  schedule:
+    - cron: '23 * * * *'
+  pull_request_target:
+    types: [opened, reopened, ready_for_review, synchronize, closed]
+  issue_comment:
+    types: [created, edited]
+  pull_request_review_comment:
+    types: [created, edited]
+  workflow_run:
+    workflows: [codex-review-listener]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: read
+  checks: read
+  statuses: write
+
+concurrency:
+  group: codex-review
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    # Ten minutes past the action's 55-minute loop, so a hung API call cannot
+    # hold the runner (and the concurrency queue behind it) to the 6-hour
+    # job default.
+    timeout-minutes: 65
+    steps:
+      # No checkout, on purpose: the sweep needs nothing from this
+      # repository's tree, and a checkout would only put a token-bearing
+      # .git/config within reach of a job that writes statuses.
+      - uses: mikelward/codex-review@main

--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,4 @@ test:
 	./kdeshortcut_test
 	./dvorak_test
 	./confinst_test
+	./codex-review_test

--- a/codex-review_test
+++ b/codex-review_test
@@ -1,0 +1,142 @@
+#!/bin/bash
+# Tests for the codex-review workflow pair, which republishes Codex's review
+# verdict as the `codex` commit status the ruleset requires. The sweep itself
+# lives in mikelward/codex-review and is tested there; what this pins is the
+# part that has to be right in the CONSUMER repo, where getting it wrong is
+# silent:
+#
+#   - a workflow that can write commit statuses must never take its
+#     definition from a pull request's own ref, or a branch could publish
+#     `codex: success` for itself;
+#   - it must be the ONLY workflow holding `statuses: write`, since a second
+#     writer races the verdict;
+#   - the listener exists precisely because `pull_request_review` is a
+#     merge-ref event, so it must hold no permissions at all.
+#
+# These are properties of the files, so the tests read the files. Following
+# the runenv_test conventions.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WORKFLOWS="$SCRIPT_DIR/.github/workflows"
+SWEEP="$WORKFLOWS/codex-review.yml"
+LISTENER="$WORKFLOWS/codex-review-listener.yml"
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+setup() { :; }
+teardown() { :; }
+
+fail() {
+  echo "  FAIL: $1"
+  TEST_FAILED=1
+}
+
+assert_file_contains() {
+  if ! grep -qF "$2" "$1"; then
+    fail "$(basename "$1") is missing '$2'"
+  fi
+}
+
+assert_file_lacks() {
+  if grep -qF "$2" "$1"; then
+    fail "$(basename "$1") must not contain '$2'"
+  fi
+}
+
+# These files explain themselves at length, and the comments name the very
+# triggers the tests forbid ("No `workflow_dispatch`: it took a ref"). Strip
+# comment lines before asserting about configuration, or the prose fails the
+# test it is describing.
+config_only() {
+  grep -v '^[[:space:]]*#' "$1"
+}
+
+assert_config_lacks() {
+  if config_only "$1" | grep -qF "$2"; then
+    fail "$(basename "$1") must not configure '$2'"
+  fi
+}
+
+run_test() {
+  TESTS_RUN=$((TESTS_RUN + 1))
+  setup
+  TEST_FAILED=
+  if "$2" && test -z "$TEST_FAILED"; then
+    echo "ok $TESTS_RUN $1"; TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo "not ok $TESTS_RUN $1"; TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+  teardown
+}
+
+test_both_workflows_exist() {
+  test -f "$SWEEP" || fail "codex-review.yml is missing"
+  test -f "$LISTENER" || fail "codex-review-listener.yml is missing"
+}
+
+# Unpinned on purpose: the action has no build step and no dependencies, so
+# the file that runs is the file you can read, and pinning would only delay
+# fixes reaching the gate.
+test_runs_the_shared_action_with_no_checkout() {
+  assert_file_contains "$SWEEP" "uses: mikelward/codex-review@main"
+  # A checkout would leave a token-bearing .git/config within reach of a job
+  # that writes statuses.
+  assert_config_lacks "$SWEEP" "actions/checkout"
+}
+
+# workflow_dispatch takes a ref and GitHub runs the workflow file from it, so
+# a branch could ship its own sweep and approve itself.
+test_no_ref_taking_trigger_on_the_status_writer() {
+  assert_config_lacks "$SWEEP" "workflow_dispatch"
+  # pull_request_review is a merge-ref event; it reaches the sweep only via
+  # the listener's workflow_run, whose definition comes from the default
+  # branch.
+  assert_config_lacks "$SWEEP" "pull_request_review:"
+  assert_file_contains "$SWEEP" "workflows: [codex-review-listener]"
+}
+
+test_listener_holds_nothing() {
+  assert_file_contains "$LISTENER" "pull_request_review:"
+  assert_file_contains "$LISTENER" "permissions: {}"
+  assert_config_lacks "$LISTENER" "statuses: write"
+  assert_config_lacks "$LISTENER" "actions/checkout"
+}
+
+test_is_the_only_writer_of_commit_statuses() {
+  local f
+  for f in "$WORKFLOWS"/*.yml "$WORKFLOWS"/*.yaml; do
+    test -e "$f" || continue
+    test "$f" = "$SWEEP" && continue
+    if config_only "$f" | grep -qF "statuses: write"; then
+      fail "$(basename "$f") also writes commit statuses; that races the verdict"
+    fi
+  done
+}
+
+# Hourly, off the hour: the schedule is only the backstop for states nothing
+# emits an event for, and on a private repo each idle fire bills a minute.
+test_backstop_schedule_is_hourly_off_the_hour() {
+  if ! grep -qE "cron: '[1-5][0-9] \* \* \* \*'" "$SWEEP"; then
+    fail "expected an hourly cron at a non-zero minute"
+  fi
+}
+
+test_loop_envelope_is_bounded() {
+  assert_file_contains "$SWEEP" "cancel-in-progress: false"
+  assert_file_contains "$SWEEP" "timeout-minutes:"
+}
+
+run_test "both workflows are present" test_both_workflows_exist
+run_test "runs the shared action, unpinned, with no checkout" test_runs_the_shared_action_with_no_checkout
+run_test "the status writer takes no ref-taking trigger" test_no_ref_taking_trigger_on_the_status_writer
+run_test "the listener holds no permissions" test_listener_holds_nothing
+run_test "it is the only workflow writing commit statuses" test_is_the_only_writer_of_commit_statuses
+run_test "the backstop schedule is hourly, off the hour" test_backstop_schedule_is_hourly_off_the_hour
+run_test "the loop envelope is bounded" test_loop_envelope_is_bounded
+
+echo "$TESTS_PASSED/$TESTS_RUN tests passed"
+test "$TESTS_FAILED" -eq 0


### PR DESCRIPTION
scripts is the last repo without the codex-review sweep, so the `codex` commit status the ruleset can require is never published here — Codex only reacts to the PR body. That gap showed up an hour ago on #199: I blocked its merge waiting for a `codex` status that this repo has no way to produce.

**`codex-review.yml`** runs the shared `mikelward/codex-review` action, which reads the verdict and republishes it as the `codex` status. **`codex-review-listener.yml`** holds `permissions: {}` and one no-op step; it exists because `pull_request_review` is a merge-ref event, so it is caught there and relayed by `workflow_run`, whose definition always comes from the default branch. Both files are copied verbatim from the sibling repos so a fix lands in one place.

`codex-review_test` pins the three properties that are the consumer repo's to get right and that fail *silently* when wrong:

- the status writer takes no ref-taking trigger and no checkout — either would let a branch ship its own sweep and approve itself;
- the listener holds no permissions, which is the whole reason it exists;
- nothing else under `.github/workflows` writes commit statuses, since a second writer races the verdict.

Plus the backstop schedule is hourly off the hour and the loop envelope is bounded. Each guard was verified by reintroducing the defect and watching it go red (`statuses: write` in `test.yml` → test 5 fails; `workflow_dispatch:` in `codex-review.yml` → test 3 fails).

The assertions strip comment lines before matching: these workflows name the very triggers they forbid in their own prose, so a naive grep fails the file for describing itself.

Listed in the `Makefile` `test:` target in the same commit, per the testing rule. `make test` is green — 30 test files, `codex-review_test` 7/7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018Bnb4L3E9bix6MNKfi68Eo)_