### PR TITLE
Sync codex-review-check.yml with the hub's caller template

### DIFF
--- a/.github/workflows/codex-review-check.yml
+++ b/.github/workflows/codex-review-check.yml
@@ -1,9 +1,9 @@
 name: codex-review-check
 on:
   push:
-  pull_request:
+  pull_request_target:
 permissions:
   contents: read
 jobs:
-  check:
+  codex-review-check:
     uses: mikelward/codex-review/.github/workflows/check-consumer.yml@main


### PR DESCRIPTION
Follow-up to #203. Review on [mikelward/codex-review#8](https://github.com/mikelward/codex-review/pull/8) found two P1s against the caller template after #203 had already copied it in:

- A bare `pull_request` trigger loads the job *definition* from the PR's merge ref, so a PR editing `codex-review-check.yml` could replace the call to the shared reusable workflow with a job that always succeeds — bypassing the check red-or-absent. Fixed upstream with `pull_request_target`, which loads the definition from the default branch instead.
- The job id `check` on both the caller and the reusable workflow's own job reports its required-status context as an ambiguous `check / check`. Renamed both to `codex-review-check` so it's findable by name in branch protection's required-checks search.

This brings the installed file in line with `mikelward/codex-review`'s `templates/codex-review-check.yml` before that hub PR reaches `@main` — otherwise this repository's own `codex-review-check` job would start failing against templates it hadn't been updated to.

## Verification

`python3 ../codex-review/check_consumer.py .` reports this repository correct. `make test` — 47 passing.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JsJZjUurQjWXaeXbeFh7kt)_