### PR TITLE
build: Take the dispatchable consumer check

### DIFF
--- a/.github/workflows/codex-review-check.yml
+++ b/.github/workflows/codex-review-check.yml
@@ -2,6 +2,7 @@ name: codex-review-check
 on:
   push:
   pull_request_target:
+  workflow_dispatch:
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
One line: `codex-review-check.yml` gains `workflow_dispatch`, copied from [mikelward/codex-review](https://github.com/mikelward/codex-review)'s `templates/` where it landed in codex-review#16.

## Why the trigger exists

A pull request created by `GITHUB_TOKEN` triggers no `on: pull_request`-family workflow — GitHub's loop-prevention rule, with no per-repository opt-out — and that suppresses the branch `push` too. On a repository whose pull requests are opened by an unattended job, this check would then have no run at all on that head, and requiring it would block those merges forever. Dispatch is the documented exception.

**Nothing here opens pull requests that way**, so this changes nothing about how this repository behaves. It is a template sync.

## Why it is worth doing anyway

The pin accepts a *set* of shapes so a template change need not break every consumer at once (codex-review#15). The outgoing shape is recorded as `templates/superseded/push-only/`, and every consumer still on it reports:

```
notice: matches the superseded shape `push-only` rather than the current templates
```

Green, with a standing reminder. That set closes — and the pin returns to a single shape — only when the last consumer has moved and the superseded directory is deleted. This is one of seven remaining.

`python3 ../codex-review/check_consumer.py .` green: still byte-identical to the template.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JsJZjUurQjWXaeXbeFh7kt)_