### PR TITLE
docs: Record this repository's review-and-merge gaps in TODO.md

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,13 @@
+# TODO
+
+## Review and merge gates
+
+- [ ] Require the existing `test` check in the ruleset —
+      `.github/workflows/test.yml` already runs `make test` on every pull
+      request and push to main, so the gate exists and only the
+      requirement is missing.
+- [ ] Verify the settings half of the fleet's bar — every repository
+      works the same: comprehensive automated review, required merge
+      gates, and auto-merge. A ruleset on the default branch requiring
+      the gates, the `codex` status, conversation resolution and
+      up-to-date branches, with the auto-merge setting enabled.


### PR DESCRIPTION
Every repository is meant to work the same — comprehensive automated review, required merge gates, and auto-merge. This records what is missing here (a CI gate or a recorded decision that there is nothing to run, plus verifying the ruleset and auto-merge settings), in this repository's own TODO.md per the tracking convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VeuSw79bLuEHpPqMZDH7L6

---
_Generated by [Claude Code](https://claude.ai/code/session_01VeuSw79bLuEHpPqMZDH7L6)_