### PR TITLE
Add repo-rules-audit to check a branch's merge gates, read-only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,4 @@ test:
 	./dvorak_test
 	./confinst_test
 	./repo-rules_test
+	./repo-rules-audit_test

--- a/repo-rules-audit
+++ b/repo-rules-audit
@@ -1,0 +1,354 @@
+#!/bin/sh
+# Report whether a repository's default branch actually enforces a set of
+# merge gates, reading GitHub's own merged view rather than any one ruleset.
+#
+# Usage:
+#     repo-rules-audit [--branch NAME] OWNER/REPO CHECK...
+#     repo-rules-audit owner/repo gate codex
+#
+# Requires the gh CLI, authenticated on the repository (read access only --
+# this makes no writes). See repo-rules for the companion tool that sets
+# these gates; this one only reports whether they hold, and checks things
+# repo-rules does not touch (see below).
+#
+# Cost and reliability: free. Every call is GitHub's REST API (5,000
+# authenticated requests an hour); a run costs three or four calls per
+# repository plus one per branch ruleset found on it -- a handful, in
+# practice. Expect well under a second. Every failure mode is loud: no gh
+# (refuses, exit 1), not authenticated (the first call fails, exit 1),
+# GitHub down or rate limited (same) -- a failed read is never reported as a
+# gap, because "could not tell" and "found a gap" are different findings and
+# conflating them would print a false all-clear as easily as a false alarm.
+# Also requires a separate jq binary, unlike repo-rules: this script parses
+# the rules array to decide what to print, rather than shaping it through
+# gh's own bundled --jq, so the two dependencies are both real here.
+#
+# What this checks that repo-rules does not set: repo-rules manages
+# required_status_checks and pull_request (conversation resolution, up to
+# date, rebase-only) through a ruleset it owns by name, and deliberately
+# leaves every other field of that ruleset untouched on update -- including
+# bypass_actors, which this script reads back and reports on every branch
+# ruleset whose conditions plainly cover the target branch (literal match
+# only, same discipline as repo-rules -- a pattern such as "refs/heads/*"
+# is reported as unevaluated rather than guessed at). It also checks
+# non_fast_forward and deletion, two rule types repo-rules has no opinion on:
+# a required check means nothing if the branch it protects can be force-
+# pushed or deleted out from under it. When no --branch is given, it also
+# flags a default branch not literally named "main" -- this fleet's tooling
+# and docs assume that name, and a repo answering something else is a real
+# inconsistency, invisible from the branch's own rules.
+#
+# Exit status: 0 if every check and property held, 1 if anything did not (or
+# could not be read), 2 for a usage error. Scriptable: loop this over a
+# fleet of repositories and let the exit status say which ones need
+# attention rather than reading a wall of output for the word "GAP".
+
+set -eu
+
+PROGRAM="$(basename "$0")"
+BRANCH=""
+
+error() {
+    echo "$PROGRAM: $*" >&2
+}
+
+usage() {
+    cat <<EOF
+Usage: $PROGRAM [--branch NAME] OWNER/REPO CHECK...
+
+Report whether OWNER/REPO's branch (default: the repository's default
+branch) requires each CHECK to pass, requires conversation resolution and
+an up-to-date branch before merging, and blocks force pushes and deletion.
+Also reports any bypass actor on a ruleset that plainly covers the branch.
+
+  --branch NAME   Check this branch instead of the repository's default.
+  -h, --help      This message.
+
+Exit status: 0 clean, 1 a gap was found (or could not be read), 2 usage.
+
+Examples:
+  $PROGRAM owner/repo gate codex
+  $PROGRAM --branch release owner/other-repo gate
+EOF
+}
+
+while test $# -gt 0; do
+    case "$1" in
+        --branch) shift; test $# -gt 0 || { error "--branch needs a name"; exit 2; }
+                  BRANCH="$1"; shift ;;
+        --branch=*) BRANCH="${1#--branch=}"; shift ;;
+        -h|--help) usage; exit 0 ;;
+        --) shift; break ;;
+        -*) error "unknown option '$1'"; usage >&2; exit 2 ;;
+        *) break ;;
+    esac
+done
+
+test $# -ge 2 || { usage >&2; exit 2; }
+
+REPO="$1"; shift
+# Strictly OWNER/REPO -- see repo-rules for why: gh expands a literal
+# '{owner}/{repo}' from the current checkout, which would silently retarget
+# every call in this script to whatever repository the shell happens to be
+# in, and then report the result under the name that was actually asked for.
+case "$REPO" in
+    */*/*|/*|*/) error "'$REPO' is not OWNER/REPO"; exit 2 ;;
+    */*) ;;
+    *) error "'$REPO' is not OWNER/REPO"; exit 2 ;;
+esac
+case "$REPO" in
+    *[!A-Za-z0-9._/-]*)
+        error "'$REPO' contains characters GitHub does not allow in an owner or"
+        error "repository name."
+        exit 2 ;;
+esac
+
+test $# -ge 1 || { error "at least one CHECK is required"; usage >&2; exit 2; }
+
+# Refused rather than escaped, same as repo-rules: json_string below only
+# escapes the two characters that would otherwise end a JSON string, not a
+# full JSON encoder (no \n, \t, \u00XX). A CHECK containing a raw control
+# character would then compare unequal to jq's own fully-escaped @json
+# encoding of the same name in the reports below, and a real match would be
+# reported missing every time. Refusing is honest about what this script can
+# compare; check names do not need control characters in practice.
+for check in "$@"; do
+    case "$check" in
+        *[[:cntrl:]]*)
+            error "check name '$check' contains a control character (tab,"
+            error "newline, or similar). Check names are compared as JSON"
+            error "string literals, and this script does not fully JSON-encode"
+            error "them, so such a name cannot be compared correctly. Refusing"
+            error "rather than silently reporting it as missing."
+            exit 2 ;;
+    esac
+done
+
+command -v gh >/dev/null 2>&1 || {
+    error "gh is not installed. It carries the authentication this needs;"
+    error "installing it is less work than reimplementing that with curl."
+    exit 1
+}
+command -v jq >/dev/null 2>&1 || {
+    error "jq is not installed. This script parses the rules array itself"
+    error "rather than shaping it through gh's own bundled --jq, so a"
+    error "separate binary is genuinely required here."
+    exit 1
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT INT TERM
+
+ASKED_DEFAULT=0
+if test -z "$BRANCH"; then
+    ASKED_DEFAULT=1
+    if BRANCH="$(gh api "repos/$REPO" --jq .default_branch)"; then
+        :
+    else
+        error "could not read $REPO"
+        exit 1
+    fi
+    test -n "$BRANCH" || { error "could not read $REPO's default branch"; exit 1; }
+fi
+
+GAP=0
+ok() { echo "  [ok] $*"; }
+gap() { echo "  [GAP] $*"; GAP=1; }
+
+echo "$REPO (@$BRANCH)"
+
+# Flagged, not just noted: this fleet's tooling (repo-rules' own
+# ~DEFAULT_BRANCH ruleset scope aside, which asks GitHub rather than assuming
+# a name) and its docs both say "main" in the singular, so a repo answering
+# something else is a real inconsistency to fix, not a preference to leave
+# alone -- and it is invisible from the branch's own rules, which look
+# identical under any name.
+if test "$ASKED_DEFAULT" -eq 1; then
+    if test "$BRANCH" = main; then
+        ok "the default branch is named 'main'"
+    else
+        gap "the default branch is '$BRANCH', not 'main'"
+    fi
+fi
+
+# Percent-encoded: the argument is a URL path segment, and `#` -- legal in a
+# git ref name -- otherwise starts a fragment gh never sends, silently
+# querying the branch name truncated at it.
+encoded_branch="$(printf '%s' "$BRANCH" | jq -sRr @uri)"
+if ! gh api "repos/$REPO/rules/branches/$encoded_branch" > "$WORK/rules" 2>"$WORK/rules.err"; then
+    error "could not read $REPO's effective rules for $BRANCH:"
+    sed 's/^/  /' "$WORK/rules.err" >&2
+    exit 1
+fi
+
+has_rule() {
+    # $1 = jq boolean expression over the rules array (as $rules). jq -e
+    # documents its exit status precisely: 1 means the result was false or
+    # null, 2 or more means jq itself failed (bad input, a program error).
+    # Only status 1 is a real "no" -- anything else is treated as a jq
+    # failure and aborts loudly, so a malformed response cannot be read as
+    # "this gate is missing" when the true answer is "could not check."
+    jq -e --argjson rules "$(cat "$WORK/rules")" -n "\$rules | $1" >/dev/null 2>"$WORK/jq.err"
+    status=$?
+    case "$status" in
+        0) return 0 ;;
+        1) return 1 ;;
+        *)
+            error "jq failed evaluating '$1': exit $status"
+            sed 's/^/  /' "$WORK/jq.err" >&2
+            error "refusing to report a gap on the strength of a check that did not finish"
+            exit 1 ;;
+    esac
+}
+
+if has_rule 'any(.[]; .type == "pull_request")'; then
+    ok "a pull request is required before merging"
+else
+    gap "no pull_request rule -- direct pushes to $BRANCH are allowed"
+fi
+
+if has_rule 'any(.[]; .type == "pull_request" and .parameters.required_review_thread_resolution == true)'; then
+    ok "review conversations must be resolved"
+else
+    gap "conversation resolution is not required"
+fi
+
+# A JSON string literal, with the two characters that would otherwise end it
+# escaped -- same helper repo-rules uses, for the same reason: a check name
+# is free text, and one containing a newline must not silently split across
+# lines below, where it would make a fragment of that name compare equal to
+# the whole thing.
+json_string() {
+    printf '"%s"' "$(printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g')"
+}
+
+if has_rule 'any(.[]; .type == "required_status_checks")'; then
+    # @json, not -r on the bare string: it keeps one context to one line even
+    # when the context itself contains a newline, the same reason repo-rules
+    # collects reported check names the same way.
+    jq -r '.[] | select(.type == "required_status_checks") | .parameters.required_status_checks[]?.context | @json' \
+        "$WORK/rules" > "$WORK/contexts"
+    for check in "$@"; do
+        if grep -qxF -- "$(json_string "$check")" "$WORK/contexts"; then
+            ok "'$check' is a required status check"
+        else
+            gap "'$check' is NOT a required status check"
+        fi
+    done
+    if has_rule 'any(.[]; .type == "required_status_checks" and .parameters.strict_required_status_checks_policy == true)'; then
+        ok "the branch must be up to date with the base before merging"
+    else
+        gap "branches do NOT need to be up to date before merging (a stale-base pass could still merge)"
+    fi
+else
+    gap "no required_status_checks rule at all -- named: $*"
+fi
+
+if has_rule 'any(.[]; .type == "non_fast_forward")'; then
+    ok "force pushes are blocked"
+else
+    gap "force pushes are allowed (a required check's history can be rewritten out from under it)"
+fi
+
+if has_rule 'any(.[]; .type == "deletion")'; then
+    ok "branch deletion is blocked"
+else
+    gap "branch deletion is allowed"
+fi
+
+# Bypass actors are a property of the ruleset that carries a rule, not of the
+# effective rule itself, so they are read back from the rulesets directly --
+# every branch ruleset that reaches this repository, org- or enterprise-owned
+# included (includes_parents=true: the whole point of that parameter is that
+# a parent-owned ruleset binds here just as surely as a repo-owned one, so
+# omitting it would let an inherited bypass actor go unreported and print a
+# false all-clear), restricted to ones actually enforced (evaluate/disabled
+# blocks nothing, so its bypass actors bypass nothing either) and covering
+# $BRANCH: matched literally, same discipline as repo-rules -- reimplementing
+# GitHub's ref-pattern matching (globs) risks a false alarm this script must
+# not raise, so a pattern it cannot resolve is reported as unevaluated rather
+# than guessed at either way. GitHub's two special tokens are both handled:
+# ~ALL covers every branch unconditionally, and ~DEFAULT_BRANCH resolves
+# against the repository's real default (fetched once, lazily, only when
+# some ruleset's conditions actually reference it) -- not against whatever
+# branch this run happens to be checking. An exclude entry that literally
+# names $BRANCH wins
+# over an include match; any other exclude entry is, like an unresolvable
+# include pattern, a reason to call the ruleset unevaluated rather than
+# either clean or a gap.
+REAL_DEFAULT=""
+default_branch_matches() {
+    if test "$ASKED_DEFAULT" -eq 1; then
+        return 0
+    fi
+    if test -z "$REAL_DEFAULT"; then
+        if REAL_DEFAULT="$(gh api "repos/$REPO" --jq .default_branch)"; then
+            test -n "$REAL_DEFAULT" || { error "could not read $REPO's default branch"; exit 1; }
+        else
+            error "could not read $REPO's default branch (needed to resolve a ~DEFAULT_BRANCH ruleset scope)"
+            exit 1
+        fi
+    fi
+    test "$REAL_DEFAULT" = "$BRANCH"
+}
+
+if gh api --paginate "repos/$REPO/rulesets?includes_parents=true" \
+    --jq '.[] | select(.target == "branch" and .enforcement == "active") | .id' > "$WORK/ruleset_ids"; then
+    : > "$WORK/bypassers"
+    : > "$WORK/unevaluated"
+    while read -r id; do
+        test -n "$id" || continue
+        gh api "repos/$REPO/rulesets/$id" > "$WORK/ruleset.$id" || {
+            error "could not read ruleset $id on $REPO"
+            exit 1
+        }
+        dm=false
+        if grep -q '~DEFAULT_BRANCH' "$WORK/ruleset.$id"; then
+            default_branch_matches && dm=true
+        fi
+        verdict=$(jq -r --arg b "refs/heads/$BRANCH" --argjson dm "$dm" '
+            def is_literal: test("[*?\\[]") | not;
+            def matches_branch: . == $b or . == "~ALL" or (. == "~DEFAULT_BRANCH" and $dm);
+            (.conditions.ref_name.include // []) as $inc
+            | (.conditions.ref_name.exclude // []) as $exc
+            | ($inc | any(matches_branch)) as $inc_literal
+            | ($inc | any(is_literal | not)) as $inc_pattern
+            | ($exc | any(matches_branch)) as $exc_literal
+            | ($exc | any(is_literal | not)) as $exc_pattern
+            | if $inc_literal then
+                if $exc_literal then "excluded"
+                elif $exc_pattern then "unevaluated"
+                else "covers" end
+              elif $inc_pattern then "unevaluated"
+              else "not-covering" end
+        ' "$WORK/ruleset.$id") || { error "could not evaluate ruleset $id's branch conditions on $REPO"; exit 1; }
+        name=$(jq -r .name "$WORK/ruleset.$id") || { error "could not read ruleset $id's name on $REPO"; exit 1; }
+        case "$verdict" in
+            covers)
+                jq -r --arg name "$name" \
+                    '.bypass_actors[]? | "  \($name): \(.actor_type) \(.actor_id // "-") (\(.bypass_mode))"' \
+                    "$WORK/ruleset.$id" >> "$WORK/bypassers" \
+                    || { error "could not read ruleset $id's bypass actors on $REPO"; exit 1; } ;;
+            unevaluated)
+                pattern=$(jq -r '.conditions.ref_name.include | join(", ")' "$WORK/ruleset.$id") \
+                    || { error "could not read ruleset $id's conditions on $REPO"; exit 1; }
+                printf '  %s (matches: %s)\n' "$name" "$pattern" >> "$WORK/unevaluated" ;;
+            excluded|not-covering) : ;;
+        esac
+    done < "$WORK/ruleset_ids"
+    if test -s "$WORK/bypassers"; then
+        gap "bypass actors configured on a ruleset covering $BRANCH:"
+        cat "$WORK/bypassers"
+    else
+        ok "no bypass actor on any ruleset that plainly covers $BRANCH"
+    fi
+    if test -s "$WORK/unevaluated"; then
+        echo "  [CHECK] rulesets with a pattern this script did not evaluate -- check by hand:"
+        cat "$WORK/unevaluated"
+    fi
+else
+    error "could not list $REPO's rulesets to check for bypass actors"
+    exit 1
+fi
+
+exit "$GAP"

--- a/repo-rules-audit_test
+++ b/repo-rules-audit_test
@@ -1,0 +1,446 @@
+#!/bin/sh
+# Tests for repo-rules-audit
+#
+# Same shape as repo-rules_test: a fake gh on PATH, recording every call, so
+# nothing here touches the network or needs a token, and the real jq binary
+# parses the fixtures the same way it would parse a live response -- a
+# stubbed jq would test nothing about whether the parsing is right.
+
+set -e
+
+if command -v jq >/dev/null 2>&1; then
+    HAVE_JQ=yes
+else
+    HAVE_JQ=no
+    echo "NOTE: jq is not installed, so this whole suite is skipped -- the"
+    echo "      script itself refuses to run without it."
+    echo "      Install jq to run these ('brew install jq', 'apt install jq')."
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SUITE_TMP="$(mktemp -d)"
+trap 'rm -rf "$SUITE_TMP"' EXIT INT TERM
+REPO_RULES_AUDIT="$SCRIPT_DIR/repo-rules-audit"
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+TESTS_SKIPPED=0
+
+# A rules array with every gate this script checks for present and clean,
+# for CHECK named "gate" and "codex". Individual tests copy this and edit
+# out one property at a time, so each case shows exactly what it removed.
+CLEAN_RULES='[
+  {"type":"pull_request","parameters":{"required_review_thread_resolution":true}},
+  {"type":"required_status_checks","parameters":{
+     "strict_required_status_checks_policy":true,
+     "required_status_checks":[{"context":"gate"},{"context":"codex"}]}},
+  {"type":"non_fast_forward","parameters":{}},
+  {"type":"deletion","parameters":{}}
+]'
+
+# make_gh: build a fake gh in a fresh dir and echo that dir.
+#   $1 = default branch name (used only if the script has to ask for it)
+make_gh() {
+    dir="$(mktemp -d "$SUITE_TMP/fixture.XXXXXX")"
+    mkdir -p "$dir/bin"
+    printf '%s\n' "${1:-main}" > "$dir/default_branch"
+    : > "$dir/ruleset_ids"
+    printf '%s' "$CLEAN_RULES" > "$dir/rules.json"
+    : > "$dir/fail_on"
+    cat > "$dir/bin/gh" <<'EOF'
+#!/bin/sh
+dir="$(dirname "$(dirname "$0")")"
+echo "$*" >> "$dir/calls"
+if test -s "$dir/fail_on" && echo "$*" | grep -qF "$(cat "$dir/fail_on")"; then
+    echo "gh: simulated failure" >&2
+    exit 1
+fi
+case "$*" in
+    *"/rules/branches/"*) cat "$dir/rules.json" ;;
+    *"/rulesets?"*)       cat "$dir/ruleset_ids" ;;
+    *"/rulesets/"*)
+        id="${*##*/rulesets/}"
+        cat "$dir/ruleset.$id.json" ;;
+    *"repos/"*)           cat "$dir/default_branch" ;;
+esac
+EOF
+    chmod +x "$dir/bin/gh"
+    echo "$dir"
+}
+
+run() {
+    dir="$1"; shift
+    set +e
+    output="$(PATH="$dir/bin:$PATH" "$REPO_RULES_AUDIT" "$@" 2>&1)"
+    status=$?
+    set -e
+}
+
+assert_status() {
+    if test "$status" -ne "$1"; then
+        echo "  FAIL: expected exit status $1, got $status"
+        echo "  output: $output"
+        TEST_FAILED=1
+    fi
+}
+
+assert_output() {
+    case "$output" in
+        *"$1"*) ;;
+        *) echo "  FAIL: expected output to contain '$1'"
+           echo "  output: $output"
+           TEST_FAILED=1 ;;
+    esac
+}
+
+assert_no_output() {
+    case "$output" in
+        *"$1"*) echo "  FAIL: expected output NOT to contain '$1'"
+                echo "  output: $output"
+                TEST_FAILED=1 ;;
+    esac
+}
+
+assert_call() {
+    calls="$(cat "$1/calls" 2>/dev/null || true)"
+    case "$calls" in
+        *"$2"*) ;;
+        *) echo "  FAIL: expected a call matching '$2'"
+           echo "  calls: $calls"
+           TEST_FAILED=1 ;;
+    esac
+}
+
+assert_no_call() {
+    calls="$(cat "$1/calls" 2>/dev/null || true)"
+    case "$calls" in
+        *"$2"*) echo "  FAIL: expected NO call matching '$2'"
+                echo "  calls: $calls"
+                TEST_FAILED=1 ;;
+    esac
+}
+
+skip_case() {
+    TESTS_SKIPPED=$((TESTS_SKIPPED + 1))
+    echo "  SKIP: $1"
+    TEST_SKIPPED=1
+}
+
+test_case() {
+    TEST_SKIPPED=0
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TEST_FAILED=0
+    echo "TEST: $1"
+}
+
+finish_case() {
+    if test "${TEST_SKIPPED:-0}" -eq 1; then
+        TESTS_RUN=$((TESTS_RUN - 1))
+        return
+    fi
+    if test "$TEST_FAILED" -eq 0; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo "  PASS"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
+if test "$HAVE_JQ" = no; then
+    echo "Tests run: 0, passed: 0, failed: 0, skipped: 0 (no jq)"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+
+test_case "a fully gated branch reports clean and exits 0"
+dir="$(make_gh)"
+run "$dir" mikelward/lanes gate codex
+assert_status 0
+assert_output "[ok] a pull request is required"
+assert_output "[ok] 'gate' is a required status check"
+assert_output "[ok] 'codex' is a required status check"
+assert_output "[ok] the branch must be up to date"
+assert_output "[ok] force pushes are blocked"
+assert_output "[ok] branch deletion is blocked"
+assert_output "[ok] no bypass actor"
+assert_output "[ok] the default branch is named 'main'"
+assert_no_output "GAP"
+finish_case
+
+test_case "missing pull_request rule is a gap"
+dir="$(make_gh)"
+printf '%s' "$CLEAN_RULES" | jq 'del(.[] | select(.type == "pull_request"))' > "$dir/rules.json"
+run "$dir" mikelward/lanes gate
+assert_status 1
+assert_output "[GAP] no pull_request rule"
+finish_case
+
+test_case "missing conversation resolution is a gap"
+dir="$(make_gh)"
+printf '%s' "$CLEAN_RULES" \
+    | jq '(.[] | select(.type == "pull_request") | .parameters.required_review_thread_resolution) = false' \
+    > "$dir/rules.json"
+run "$dir" mikelward/lanes gate
+assert_status 1
+assert_output "[GAP] conversation resolution is not required"
+finish_case
+
+test_case "a named check missing from required_status_checks is a gap"
+dir="$(make_gh)"
+run "$dir" mikelward/lanes gate codex sweep
+assert_status 1
+assert_output "[ok] 'gate' is a required status check"
+assert_output "[GAP] 'sweep' is NOT a required status check"
+finish_case
+
+test_case "non-strict required_status_checks is a gap"
+dir="$(make_gh)"
+printf '%s' "$CLEAN_RULES" \
+    | jq '(.[] | select(.type == "required_status_checks") | .parameters.strict_required_status_checks_policy) = false' \
+    > "$dir/rules.json"
+run "$dir" mikelward/lanes gate
+assert_status 1
+assert_output "[GAP] branches do NOT need to be up to date"
+finish_case
+
+test_case "no required_status_checks rule at all is a gap, naming the wanted checks"
+dir="$(make_gh)"
+printf '%s' "$CLEAN_RULES" | jq 'del(.[] | select(.type == "required_status_checks"))' > "$dir/rules.json"
+run "$dir" mikelward/lanes gate codex
+assert_status 1
+assert_output "[GAP] no required_status_checks rule at all -- named: gate codex"
+finish_case
+
+test_case "missing non_fast_forward (force push allowed) is a gap"
+dir="$(make_gh)"
+printf '%s' "$CLEAN_RULES" | jq 'del(.[] | select(.type == "non_fast_forward"))' > "$dir/rules.json"
+run "$dir" mikelward/lanes gate
+assert_status 1
+assert_output "[GAP] force pushes are allowed"
+finish_case
+
+test_case "missing deletion protection is a gap"
+dir="$(make_gh)"
+printf '%s' "$CLEAN_RULES" | jq 'del(.[] | select(.type == "deletion"))' > "$dir/rules.json"
+run "$dir" mikelward/lanes gate
+assert_status 1
+assert_output "[GAP] branch deletion is allowed"
+finish_case
+
+test_case "a bypass actor on a ruleset literally covering the branch is a gap"
+dir="$(make_gh)"
+echo 42 > "$dir/ruleset_ids"
+cat > "$dir/ruleset.42.json" <<'EOF'
+{"id":42,"name":"merge gates",
+ "conditions":{"ref_name":{"include":["~DEFAULT_BRANCH"],"exclude":[]}},
+ "bypass_actors":[{"actor_id":5,"actor_type":"RepositoryRole","bypass_mode":"always"}]}
+EOF
+run "$dir" mikelward/lanes gate
+assert_status 1
+assert_output "[GAP] bypass actors configured"
+assert_output "RepositoryRole 5 (always)"
+finish_case
+
+test_case "a ruleset with no bypass actors covering the branch stays clean"
+dir="$(make_gh)"
+echo 42 > "$dir/ruleset_ids"
+cat > "$dir/ruleset.42.json" <<'EOF'
+{"id":42,"name":"merge gates",
+ "conditions":{"ref_name":{"include":["~DEFAULT_BRANCH"],"exclude":[]}},
+ "bypass_actors":[]}
+EOF
+run "$dir" mikelward/lanes gate
+assert_status 0
+assert_output "[ok] no bypass actor"
+finish_case
+
+test_case "a ruleset whose pattern isn't a literal match is reported unevaluated, not a gap"
+# Same discipline as repo-rules: a glob such as refs/heads/release-* is not
+# reimplemented, so a bypass actor there must not silently pass as clean --
+# but it also must not fail the run on a branch it may never actually reach.
+dir="$(make_gh)"
+echo 42 > "$dir/ruleset_ids"
+cat > "$dir/ruleset.42.json" <<'EOF'
+{"id":42,"name":"release gates",
+ "conditions":{"ref_name":{"include":["refs/heads/release-*"],"exclude":[]}},
+ "bypass_actors":[{"actor_id":5,"actor_type":"RepositoryRole","bypass_mode":"always"}]}
+EOF
+run "$dir" mikelward/lanes gate
+assert_status 0
+assert_output "[CHECK] rulesets with a pattern this script did not evaluate"
+assert_output "release gates"
+assert_no_output "[GAP] bypass"
+finish_case
+
+test_case "an active ruleset scoped by ~ALL covers the branch unconditionally"
+dir="$(make_gh)"
+echo 42 > "$dir/ruleset_ids"
+cat > "$dir/ruleset.42.json" <<'EOF'
+{"id":42,"name":"org gate",
+ "conditions":{"ref_name":{"include":["~ALL"],"exclude":[]}},
+ "bypass_actors":[{"actor_id":5,"actor_type":"RepositoryRole","bypass_mode":"always"}]}
+EOF
+run "$dir" mikelward/lanes gate
+assert_status 1
+assert_output "[GAP] bypass actors configured"
+finish_case
+
+test_case "a required check name containing a newline cannot be matched by a fragment of it"
+# Before the fix, `jq -r` on the bare context split "build\nand test" into
+# two lines, so asking for a check literally named "build" found a line that
+# was only ever half of the real name.
+dir="$(make_gh)"
+printf '%s' "$CLEAN_RULES" \
+    | jq '(.[] | select(.type == "required_status_checks") | .parameters.required_status_checks) = [{"context":"build\nand test"}]' \
+    > "$dir/rules.json"
+run "$dir" mikelward/lanes build
+assert_status 1
+assert_output "[GAP] 'build' is NOT a required status check"
+finish_case
+
+test_case "refuses a CHECK argument containing a control character"
+# json_string only escapes \ and ", not a full JSON encoder -- a raw
+# newline in a CHECK would compare unequal to jq's fully-escaped @json
+# encoding of the same name and always be reported missing. Refuse instead.
+dir="$(make_gh)"
+run "$dir" mikelward/lanes "$(printf 'build\nand test')"
+assert_status 2
+assert_output "contains a control character"
+finish_case
+
+test_case "an exact full check name with no control characters still matches"
+# The regression case for the finding above: confirms the fix didn't break
+# ordinary matching in the process of refusing the unsafe case.
+dir="$(make_gh)"
+printf '%s' "$CLEAN_RULES" \
+    | jq '(.[] | select(.type == "required_status_checks") | .parameters.required_status_checks) = [{"context":"gate"},{"context":"codex"}]' \
+    > "$dir/rules.json"
+run "$dir" mikelward/lanes gate codex
+assert_status 0
+assert_output "[ok] 'gate' is a required status check"
+assert_output "[ok] 'codex' is a required status check"
+finish_case
+
+test_case "a branch name containing # is percent-encoded in the rules-lookup path"
+# `#` is legal in a git ref name and starts a URL fragment gh never sends;
+# unencoded, this would silently query "release" and label it "release#1".
+dir="$(make_gh)"
+run "$dir" --branch 'release#1' mikelward/lanes gate
+assert_status 0
+assert_call "$dir" "/rules/branches/release%231"
+assert_no_call "$dir" "/rules/branches/release#1"
+finish_case
+
+test_case "a ~DEFAULT_BRANCH ruleset does not cover an explicitly named branch that isn't the real default"
+# The bug this guards: treating ~DEFAULT_BRANCH as matching whatever branch
+# this run happens to be checking, rather than the repository's real default.
+dir="$(make_gh other-default)"
+echo 42 > "$dir/ruleset_ids"
+cat > "$dir/ruleset.42.json" <<'EOF'
+{"id":42,"name":"merge gates",
+ "conditions":{"ref_name":{"include":["~DEFAULT_BRANCH"],"exclude":[]}},
+ "bypass_actors":[{"actor_id":5,"actor_type":"RepositoryRole","bypass_mode":"always"}]}
+EOF
+run "$dir" --branch release mikelward/lanes gate
+assert_status 0
+assert_call "$dir" "repos/mikelward/lanes --jq .default_branch"
+assert_no_output "[GAP] bypass"
+assert_no_output "[CHECK]"
+finish_case
+
+test_case "an exclude entry that literally names the branch overrides an include match -- not a gap"
+dir="$(make_gh)"
+echo 42 > "$dir/ruleset_ids"
+cat > "$dir/ruleset.42.json" <<'EOF'
+{"id":42,"name":"merge gates",
+ "conditions":{"ref_name":{"include":["~DEFAULT_BRANCH"],"exclude":["refs/heads/main"]}},
+ "bypass_actors":[{"actor_id":5,"actor_type":"RepositoryRole","bypass_mode":"always"}]}
+EOF
+run "$dir" mikelward/lanes gate
+assert_status 0
+assert_no_output "[GAP] bypass"
+finish_case
+
+test_case "a non-literal exclude entry downgrades an include match to unevaluated, not clean"
+# The exclude COULD reach the branch (a glob), so this must not claim clean.
+dir="$(make_gh)"
+echo 42 > "$dir/ruleset_ids"
+cat > "$dir/ruleset.42.json" <<'EOF'
+{"id":42,"name":"merge gates",
+ "conditions":{"ref_name":{"include":["~DEFAULT_BRANCH"],"exclude":["refs/heads/other-*"]}},
+ "bypass_actors":[{"actor_id":5,"actor_type":"RepositoryRole","bypass_mode":"always"}]}
+EOF
+run "$dir" mikelward/lanes gate
+assert_status 0
+assert_output "[CHECK] rulesets with a pattern this script did not evaluate"
+assert_no_output "[GAP] bypass"
+finish_case
+
+test_case "lists rulesets with includes_parents=true, so an inherited org/enterprise ruleset is not skipped"
+dir="$(make_gh)"
+run "$dir" mikelward/lanes gate
+assert_status 0
+assert_call "$dir" "includes_parents=true"
+finish_case
+
+test_case "a jq failure evaluating a rule is reported and aborts, never printed as a gap"
+dir="$(make_gh)"
+echo 'not valid json' > "$dir/rules.json"
+run "$dir" mikelward/lanes gate
+assert_status 1
+assert_output "jq failed"
+assert_no_output "[GAP]"
+finish_case
+
+test_case "--branch overrides the default, skips asking for it, and skips the main-name check"
+dir="$(make_gh unused-branch)"
+run "$dir" --branch release mikelward/lanes gate
+assert_status 0
+assert_call "$dir" "/rules/branches/release"
+assert_no_call "$dir" "repos/mikelward/lanes --jq .default_branch"
+assert_no_output "the default branch is"
+finish_case
+
+test_case "asks for the default branch when --branch is not given, and flags a non-main name"
+dir="$(make_gh custom-default)"
+run "$dir" mikelward/lanes gate
+assert_status 1
+assert_call "$dir" "/rules/branches/custom-default"
+assert_output "[GAP] the default branch is 'custom-default', not 'main'"
+finish_case
+
+test_case "a default branch literally named main is not flagged"
+dir="$(make_gh main)"
+run "$dir" mikelward/lanes gate
+assert_status 0
+assert_output "[ok] the default branch is named 'main'"
+finish_case
+
+test_case "refuses a bad OWNER/REPO shape"
+dir="$(make_gh)"
+run "$dir" not-owner-slash-repo gate
+assert_status 2
+assert_output "is not OWNER/REPO"
+finish_case
+
+test_case "refuses with no CHECK named"
+dir="$(make_gh)"
+run "$dir" mikelward/lanes
+assert_status 2
+finish_case
+
+test_case "a failed read of the effective rules is reported, not read as a gap"
+dir="$(make_gh)"
+echo "/rules/branches/" > "$dir/fail_on"
+run "$dir" mikelward/lanes gate
+assert_status 1
+assert_output "could not read"
+assert_no_output "[GAP]"
+finish_case
+
+# ---------------------------------------------------------------------------
+
+echo
+echo "Tests run: $TESTS_RUN, passed: $TESTS_PASSED, failed: $TESTS_FAILED, skipped: $TESTS_SKIPPED"
+test "$TESTS_FAILED" -eq 0


### PR DESCRIPTION
Companion to `repo-rules`: that script *sets* required checks, conversation resolution, and an up-to-date-branch requirement via a ruleset it owns by name, deliberately leaving every other field of an existing ruleset untouched on update. This one reads back a branch's actual merged rule set (`GET .../rules/branches/BRANCH`) and reports gaps `repo-rules` has no way to catch after the fact:

- whether the named checks are really required
- whether the branch must be up to date before merging
- whether conversations must be resolved
- whether force pushes and deletion are blocked
- whether any active ruleset — repo-owned, or inherited from an org/enterprise — that plainly covers the branch still carries a bypass actor
- (when no `--branch` is given) whether the repository's default branch is actually named `main`

Ruleset scope is resolved properly: both of GitHub's special tokens (`~ALL`, `~DEFAULT_BRANCH` — the latter against the repository's real default, not whatever branch this run happens to check) and `ref_name.exclude` are handled, and a pattern this script genuinely can't evaluate (a glob) is reported as unevaluated rather than guessed at either way, same discipline as `repo-rules`' own merge-method conflict scan. Branch names are percent-encoded before hitting the API. Required-check names are compared JSON-encoded on the API side (`@json`), and a CHECK argument containing a control character is refused outright rather than silently miscompared, since this script's own `json_string` isn't a full JSON encoder — same "refuse, don't guess" choice repo-rules makes for the same problem.

Exit status is 0 clean / 1 gap found or unreadable / 2 usage — meant to be looped over a fleet of repositories and read by exit code, not by scanning output for the word GAP.

Verified: `make test` (74 tests total, 27 new) green, `shellcheck` clean on both files. Confirmed every fix in this PR actually catches its regression by reverting it locally and re-running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfXBVWMJH9npr4pKjwBbNz