### PR TITLE
Rename repo-rules' example check from gate to lanes

### DIFF
--- a/repo-rules
+++ b/repo-rules
@@ -3,7 +3,7 @@
 #
 # Usage:
 #     repo-rules [--dry-run] [--force] [--ruleset NAME] OWNER/REPO CHECK...
-#     repo-rules --ruleset=gates owner/repo gate codex
+#     repo-rules --ruleset=gates owner/repo lanes codex
 #
 # Requires the gh CLI, authenticated with admin rights on the repository.
 #
@@ -74,8 +74,8 @@ date with the base, and allow rebase as the only merge method.
   -h, --help       This message.
 
 Examples:
-  $PROGRAM owner/repo gate codex
-  $PROGRAM --dry-run owner/other-repo gate codex Vercel
+  $PROGRAM owner/repo lanes codex
+  $PROGRAM --dry-run owner/other-repo lanes codex Vercel
 EOF
 }
 
@@ -288,7 +288,7 @@ collect_reported() {
         while read -r sha; do
             test -n "$sha" || continue
             # Check runs and commit statuses are different objects, and a
-            # ruleset can require either -- `codex` is a status, `gate` is a
+            # ruleset can require either -- `codex` is a status, `lanes` is a
             # check run. Both paginate: a name on page two is
             # indistinguishable from a name that never reported.
             #

--- a/repo-rules-audit
+++ b/repo-rules-audit
@@ -4,7 +4,7 @@
 #
 # Usage:
 #     repo-rules-audit [--branch NAME] OWNER/REPO CHECK...
-#     repo-rules-audit owner/repo gate codex
+#     repo-rules-audit owner/repo lanes codex
 #
 # Requires the gh CLI, authenticated on the repository (read access only --
 # this makes no writes). See repo-rules for the companion tool that sets
@@ -67,8 +67,8 @@ Also reports any bypass actor on a ruleset that plainly covers the branch.
 Exit status: 0 clean, 1 a gap was found (or could not be read), 2 usage.
 
 Examples:
-  $PROGRAM owner/repo gate codex
-  $PROGRAM --branch release owner/other-repo gate
+  $PROGRAM owner/repo lanes codex
+  $PROGRAM --branch release owner/other-repo lanes
 EOF
 }
 


### PR DESCRIPTION
## Summary
- `mikelward/lanes` renamed its consumer-facing required check from `gate` to `lanes` (vague as a required-check name) — [mikelward/lanes#9](https://github.com/mikelward/lanes/pull/9).
- Updates `repo-rules`' and `repo-rules-audit`'s usage examples and the "`codex` is a status, `lanes` is a check run" comment.
- Updates `repo-rules-audit_test` fixtures that exercise the tool against the real `mikelward/lanes` repo — those used "gate" as the real, current check name, not an arbitrary placeholder, so they were about to go stale.
- Left alone: ruleset display names ("merge gates", "release gates") and generic wordplay ("does not gate", "open the gate") — those are the English word, not a check name.

## Test plan
- [x] `./repo-rules_test` — 47/47 passing.
- [x] `./repo-rules-audit_test` — 27/27 passing.

---
_Generated by [Claude Code](https://claude.ai/code/session_016fX7NJtZkkAARcbbJbKTEr)_