### PR TITLE
build: Classify PRs into docs/code lanes via mikelward/lanes

### DIFF
--- a/.github/lanes.conf
+++ b/.github/lanes.conf
@@ -1,0 +1,19 @@
+# Ordered: the FIRST matching rule wins, and anything matching no rule is code.
+#
+# The lane's test is "can this change what CI validates?". Markdown is docs
+# wherever it lives — prose cannot change what a shell test exercises, and
+# `make test` reads none of this repo's markdown — while everything else is
+# code, including .gitignore (ignore rules can hide files from CI's own
+# staging steps) and every script itself, whether or not it has an
+# extension.
+docs **/*.md
+
+# The subject prefixes a commit on this lane must carry, so nothing here can
+# ever read like a bare behavior-change subject. Only the two housekeeping
+# prefixes a markdown-only diff can actually earn: docs: and a todo:-only
+# TODO.md edit.
+prefixes docs todo
+
+# test.yml declares no workflow_dispatch trigger, so no dispatched run is
+# legitimate here: a PR-less dispatch is refused on every ref.
+dispatch-without-pr refuse

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,14 @@ jobs:
     if: needs.classify.outputs.docs_only != 'true'
     steps:
       - uses: actions/checkout@v4
+        with:
+          # A pull_request run's default ref is already the right merge
+          # commit; only a dispatched run needs steering — its default ref
+          # is whatever branch the dispatch targeted, not the PR named by
+          # inputs.pr, so this job would otherwise test the wrong commit
+          # while classify/lanes (which read the PR via the API, not the
+          # checkout) correctly reported on the named PR.
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/pull/{0}/merge', inputs.pr) || github.sha }}
       - run: make test
 
   # The one check the ruleset should require. Always runs, always reports —

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,14 @@ on:
     # as satisfied, so skipping the lane on a "harmless" edit would let a
     # newer skipped run replace a red verdict on the same head.
     types: [opened, synchronize, reopened, edited]
-  # Nothing in this repo dispatches this workflow today; the input exists
-  # so `gh workflow run test.yml -f pr=...` can, naming the PR it reports for.
+  # Nothing in this repo dispatches this workflow today; the input exists so
+  # `gh workflow run test.yml --ref <PR-head-branch> -f pr=<number>` can. The
+  # check-run this produces is attributed to whatever ref was dispatched
+  # against, not to inputs.pr — omitting --ref runs it against main instead,
+  # and the gate then correctly refuses (mikelward/lanes's
+  # verifyDispatchBinding rejects a dispatch whose commit isn't the named
+  # PR's own head), so it can never satisfy that PR's required check either
+  # way. --ref is what makes the two actually agree.
   workflow_dispatch:
     inputs:
       pr:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,23 +12,17 @@ on:
     # as satisfied, so skipping the lane on a "harmless" edit would let a
     # newer skipped run replace a red verdict on the same head.
     types: [opened, synchronize, reopened, edited]
-  # Nothing in this repo dispatches this workflow today; the input exists so
-  # `gh workflow run test.yml --ref <PR-head-branch> -f pr=<number>` can, for
-  # a same-repository PR. The check-run this produces is attributed to
-  # whatever ref was dispatched against, not to inputs.pr — omitting --ref
-  # runs it against main instead, and the gate then correctly refuses
-  # (mikelward/lanes's verifyDispatchBinding rejects a dispatch whose commit
-  # isn't the named PR's own head), so it can never satisfy that PR's
-  # required check either way. --ref is what makes the two actually agree.
-  # A fork PR's head branch isn't a ref in this repository at all, and
-  # workflow_dispatch can only target a branch or tag here — not
-  # refs/pull/<pr>/head — so this recipe has no fork-PR equivalent.
-  workflow_dispatch:
-    inputs:
-      pr:
-        description: Pull request number this run reports for.
-        required: true
-        type: string
+  # No workflow_dispatch: a dispatched run's workflow definition comes from
+  # whichever ref was dispatched against, so dispatching against a PR branch
+  # would run THAT branch's own copy of this file — a PR could rewrite the
+  # lanes job to always succeed and mint its own required check, bypassing
+  # everything mikelward/lanes's verifyDispatchBinding is meant to guard,
+  # since that guard lives inside the file the PR branch controls. There is
+  # no way to make a dispatch validate a PR's head from a trusted copy of
+  # the workflow, because GitHub ties both "which file runs" and "which SHA
+  # the check-run reports on" to the same dispatch ref. See mikelward/lanes
+  # TODO.md for the tracked follow-up (posting a status explicitly via the
+  # API from a trusted ref, instead of relying on the per-job check-run).
 
 # Declared rather than inherited. With no block here the job takes the
 # repository's default GITHUB_TOKEN permission -- a setting no file in the repo
@@ -61,7 +55,7 @@ jobs:
         id: lane
         with:
           mode: classify
-          pr: ${{ github.event.pull_request.number || inputs.pr }}
+          pr: ${{ github.event.pull_request.number }}
 
   test:
     runs-on: ubuntu-latest
@@ -69,14 +63,6 @@ jobs:
     if: needs.classify.outputs.docs_only != 'true'
     steps:
       - uses: actions/checkout@v4
-        with:
-          # A pull_request run's default ref is already the right merge
-          # commit; only a dispatched run needs steering — its default ref
-          # is whatever branch the dispatch targeted, not the PR named by
-          # inputs.pr, so this job would otherwise test the wrong commit
-          # while classify/lanes (which read the PR via the API, not the
-          # checkout) correctly reported on the named PR.
-          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/pull/{0}/merge', inputs.pr) || github.sha }}
       - run: make test
 
   # The one check the ruleset should require. Always runs, always reports —
@@ -97,7 +83,7 @@ jobs:
       - uses: mikelward/lanes@main
         with:
           mode: gate
-          pr: ${{ github.event.pull_request.number || inputs.pr }}
+          pr: ${{ github.event.pull_request.number }}
           classify-result: ${{ needs.classify.result }}
           # Only read on a dispatched run — the base classify recorded before
           # the heavy job ran; a pull_request run takes the same commit from

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,13 +13,16 @@ on:
     # newer skipped run replace a red verdict on the same head.
     types: [opened, synchronize, reopened, edited]
   # Nothing in this repo dispatches this workflow today; the input exists so
-  # `gh workflow run test.yml --ref <PR-head-branch> -f pr=<number>` can. The
-  # check-run this produces is attributed to whatever ref was dispatched
-  # against, not to inputs.pr — omitting --ref runs it against main instead,
-  # and the gate then correctly refuses (mikelward/lanes's
-  # verifyDispatchBinding rejects a dispatch whose commit isn't the named
-  # PR's own head), so it can never satisfy that PR's required check either
-  # way. --ref is what makes the two actually agree.
+  # `gh workflow run test.yml --ref <PR-head-branch> -f pr=<number>` can, for
+  # a same-repository PR. The check-run this produces is attributed to
+  # whatever ref was dispatched against, not to inputs.pr — omitting --ref
+  # runs it against main instead, and the gate then correctly refuses
+  # (mikelward/lanes's verifyDispatchBinding rejects a dispatch whose commit
+  # isn't the named PR's own head), so it can never satisfy that PR's
+  # required check either way. --ref is what makes the two actually agree.
+  # A fork PR's head branch isn't a ref in this repository at all, and
+  # workflow_dispatch can only target a branch or tag here — not
+  # refs/pull/<pr>/head — so this recipe has no fork-PR equivalent.
   workflow_dispatch:
     inputs:
       pr:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,22 @@ on:
   push:
     branches: [main]
   pull_request:
+    # `edited` is here because a retarget changes what the PR's diff is
+    # measured against while the head — and any `lanes` check run already
+    # minted on it — stays put, so a base change must start a fresh run.
+    # Title and body edits re-run the lane too, deliberately: a skipped
+    # job would be worse, because GitHub counts a skipped required check
+    # as satisfied, so skipping the lane on a "harmless" edit would let a
+    # newer skipped run replace a red verdict on the same head.
+    types: [opened, synchronize, reopened, edited]
+  # Nothing in this repo dispatches this workflow today; the input exists
+  # so `gh workflow run test.yml -f pr=...` can, naming the PR it reports for.
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: Pull request number this run reports for.
+        required: true
+        type: string
 
 # Declared rather than inherited. With no block here the job takes the
 # repository's default GITHUB_TOKEN permission -- a setting no file in the repo
@@ -12,10 +28,63 @@ on:
 # runs the test suite; it has never needed to write anything.
 permissions:
   contents: read
+  # The docs lane's classify and lanes steps read the PR's files and commits
+  # through the workflow token; read-only, and still nothing here can write.
+  pull-requests: read
 
 jobs:
+  # Decides whether the test job may skip: true only when every changed
+  # file in the PR is housekeeping (markdown — see .github/lanes.conf for
+  # the rule; the engine is mikelward/lanes). Pushes to main are always
+  # classified as code, so they run everything.
+  classify:
+    name: Classify the diff
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      docs_only: ${{ steps.lane.outputs.docs_only }}
+      base_sha: ${{ steps.lane.outputs.base_sha }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - uses: mikelward/lanes@main
+        id: lane
+        with:
+          mode: classify
+          pr: ${{ github.event.pull_request.number || inputs.pr }}
+
   test:
     runs-on: ubuntu-latest
+    needs: classify
+    if: needs.classify.outputs.docs_only != 'true'
     steps:
       - uses: actions/checkout@v4
       - run: make test
+
+  # The one check the ruleset should require. Always runs, always reports —
+  # green only when the test job succeeded, or when it was skipped and the
+  # skip is INDEPENDENTLY verified as justified: the diff re-derived as
+  # housekeeping-only and every commit subject carrying a housekeeping
+  # prefix. Any other combination is an explicit red, never a silent pass.
+  lanes:
+    name: lanes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [classify, test]
+    if: always()
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - uses: mikelward/lanes@main
+        with:
+          mode: gate
+          pr: ${{ github.event.pull_request.number || inputs.pr }}
+          classify-result: ${{ needs.classify.result }}
+          # Only read on a dispatched run — the base classify recorded before
+          # the heavy job ran; a pull_request run takes the same commit from
+          # its own event payload.
+          base-sha: ${{ needs.classify.outputs.base_sha }}
+          results: >-
+            test=${{ needs.test.result }}

--- a/TODO.md
+++ b/TODO.md
@@ -2,10 +2,12 @@
 
 ## Review and merge gates
 
-- [ ] Require the existing `test` check in the ruleset —
-      `.github/workflows/test.yml` already runs `make test` on every pull
-      request and push to main, so the gate exists and only the
-      requirement is missing.
+- [ ] Require the `lanes` check in the ruleset, not `test` — `test` now
+      skips on a docs-only diff (see `.github/lanes.conf`), and a skipped
+      required check counts as satisfied, so requiring `test` directly
+      would let a docs-only PR through with no check actually enforcing
+      the allowed prefixes or independently re-deriving the skip. `lanes`
+      is the one that always runs and always reports.
 - [ ] Verify the settings half of the fleet's bar — every repository
       works the same: comprehensive automated review, required merge
       gates, and auto-merge. A ruleset on the default branch requiring


### PR DESCRIPTION
## Summary
- Batch of the `mikelward/lanes` gap-fill rollout (root piloted this retrofit pattern, mikelward/root#51).
- Adds `.github/lanes.conf` (docs `**/*.md`, prefixes `docs`/`todo`, `dispatch-without-pr refuse`).
- Adds `classify` and `lanes` jobs to `test.yml`, and gates the existing `test` job behind `needs.classify.outputs.docs_only != 'true'`, per the shared action's fresh-install pattern (require `lanes`, not the heavy job directly).
- This repo's ruleset does not require `test` yet (TODO.md's "Require the existing `test` check" item is still open), so gating it introduces no bypass of anything currently enforced — the ruleset flip to require `lanes` is a separate follow-up, outside this session's reach (no `repo-rules` API access).

## Test plan
- [x] `make test` — full suite green (all listed "N tests, N passed, 0 failed" summaries).
- [x] YAML validated with `python3 -c "import yaml; yaml.safe_load(...)"`.

---
_Generated by [Claude Code](https://claude.ai/code/session_016fX7NJtZkkAARcbbJbKTEr)_