### PR TITLE
repo-rules, repo-rules-audit: default CHECK to lanes codex zizmor

### DIFF
--- a/repo-rules
+++ b/repo-rules
@@ -2,8 +2,13 @@
 # Manage a GitHub repository's branch ruleset: which checks a merge requires.
 #
 # Usage:
-#     repo-rules [--dry-run] [--force] [--ruleset NAME] OWNER/REPO CHECK...
+#     repo-rules [--dry-run] [--force] [--ruleset NAME] OWNER/REPO [CHECK...]
 #     repo-rules --ruleset=gates owner/repo lanes codex
+#
+# CHECK defaults to `lanes codex zizmor` -- this fleet's usual merge gates
+# (the docs-vs-code lane split, Codex's review verdict, zizmor's workflow-
+# injection scan) -- when none is named, so the common case needs no typing.
+# Pass explicit names to require a different or additional set.
 #
 # Requires the gh CLI, authenticated with admin rights on the repository.
 #
@@ -55,6 +60,11 @@ PROGRAM="$(basename "$0")"
 RULESET="merge gates"
 DRY_RUN=0
 FORCE=0
+# This fleet's usual three: the lanes docs-vs-code split, Codex's review
+# verdict, and zizmor's workflow-injection scan. Kept as one shell variable
+# rather than duplicated into both usage() and the arg-parsing default below,
+# so the two cannot drift apart the way a copy-pasted literal would.
+DEFAULT_CHECKS="lanes codex zizmor"
 
 error() {
     echo "$PROGRAM: $*" >&2
@@ -62,11 +72,12 @@ error() {
 
 usage() {
     cat <<EOF
-Usage: $PROGRAM [--dry-run] [--force] [--ruleset NAME] OWNER/REPO CHECK...
+Usage: $PROGRAM [--dry-run] [--force] [--ruleset NAME] OWNER/REPO [CHECK...]
 
 Make each CHECK a required status check on OWNER/REPO's default branch,
 require every review conversation to be resolved and the branch to be up to
-date with the base, and allow rebase as the only merge method.
+date with the base, and allow rebase as the only merge method. CHECK
+defaults to: $DEFAULT_CHECKS
 
   --dry-run        Print what would change; make no writes.
   --force          Require a check even if it has never reported.
@@ -74,6 +85,7 @@ date with the base, and allow rebase as the only merge method.
   -h, --help       This message.
 
 Examples:
+  $PROGRAM owner/repo
   $PROGRAM owner/repo lanes codex
   $PROGRAM --dry-run owner/other-repo lanes codex Vercel
 EOF
@@ -93,9 +105,17 @@ while test $# -gt 0; do
     esac
 done
 
-test $# -ge 2 || { usage >&2; exit 2; }
+test $# -ge 1 || { usage >&2; exit 2; }
 
 REPO="$1"; shift
+# No CHECK named: fall back to this fleet's usual three rather than refusing.
+# `set --` replaces the positional parameters with the default list, so every
+# check below (validation, the reported-check scan, the request body) sees
+# exactly what it would if the caller had typed the names out.
+if test $# -eq 0; then
+    # shellcheck disable=SC2086  # word-splitting is the point: three names, not one
+    set -- $DEFAULT_CHECKS
+fi
 # Strictly OWNER/REPO, because `gh api` substitutes `{owner}` and `{repo}` in
 # an endpoint from the current checkout or $GH_REPO. A literal `{owner}/{repo}`
 # passes a shape check and then every call in this script silently retargets

--- a/repo-rules-audit
+++ b/repo-rules-audit
@@ -3,8 +3,11 @@
 # merge gates, reading GitHub's own merged view rather than any one ruleset.
 #
 # Usage:
-#     repo-rules-audit [--branch NAME] OWNER/REPO CHECK...
+#     repo-rules-audit [--branch NAME] OWNER/REPO [CHECK...]
 #     repo-rules-audit owner/repo lanes codex
+#
+# CHECK defaults to `lanes codex zizmor` -- the same default repo-rules
+# uses -- when none is named.
 #
 # Requires the gh CLI, authenticated on the repository (read access only --
 # this makes no writes). See repo-rules for the companion tool that sets
@@ -47,6 +50,11 @@ set -eu
 
 PROGRAM="$(basename "$0")"
 BRANCH=""
+# Same list and same reasoning as repo-rules' DEFAULT_CHECKS: one shell
+# variable, not a literal repeated in usage() and the arg-parsing default
+# below, so auditing can't silently drift from what repo-rules sets by
+# default.
+DEFAULT_CHECKS="lanes codex zizmor"
 
 error() {
     echo "$PROGRAM: $*" >&2
@@ -54,12 +62,13 @@ error() {
 
 usage() {
     cat <<EOF
-Usage: $PROGRAM [--branch NAME] OWNER/REPO CHECK...
+Usage: $PROGRAM [--branch NAME] OWNER/REPO [CHECK...]
 
 Report whether OWNER/REPO's branch (default: the repository's default
 branch) requires each CHECK to pass, requires conversation resolution and
 an up-to-date branch before merging, and blocks force pushes and deletion.
 Also reports any bypass actor on a ruleset that plainly covers the branch.
+CHECK defaults to: $DEFAULT_CHECKS
 
   --branch NAME   Check this branch instead of the repository's default.
   -h, --help      This message.
@@ -67,6 +76,7 @@ Also reports any bypass actor on a ruleset that plainly covers the branch.
 Exit status: 0 clean, 1 a gap was found (or could not be read), 2 usage.
 
 Examples:
+  $PROGRAM owner/repo
   $PROGRAM owner/repo lanes codex
   $PROGRAM --branch release owner/other-repo lanes
 EOF
@@ -84,9 +94,16 @@ while test $# -gt 0; do
     esac
 done
 
-test $# -ge 2 || { usage >&2; exit 2; }
+test $# -ge 1 || { usage >&2; exit 2; }
 
 REPO="$1"; shift
+# No CHECK named: fall back to the same default repo-rules uses, same
+# mechanism as there -- see its comment for why `set --` rather than a
+# separate variable threaded through every check below.
+if test $# -eq 0; then
+    # shellcheck disable=SC2086  # word-splitting is the point: three names, not one
+    set -- $DEFAULT_CHECKS
+fi
 # Strictly OWNER/REPO -- see repo-rules for why: gh expands a literal
 # '{owner}/{repo}' from the current checkout, which would silently retarget
 # every call in this script to whatever repository the shell happens to be
@@ -102,8 +119,6 @@ case "$REPO" in
         error "repository name."
         exit 2 ;;
 esac
-
-test $# -ge 1 || { error "at least one CHECK is required"; usage >&2; exit 2; }
 
 # Refused rather than escaped, same as repo-rules: json_string below only
 # escapes the two characters that would otherwise end a JSON string, not a

--- a/repo-rules-audit_test
+++ b/repo-rules-audit_test
@@ -424,10 +424,31 @@ assert_status 2
 assert_output "is not OWNER/REPO"
 finish_case
 
-test_case "refuses with no CHECK named"
+test_case "refuses with no REPO named"
 dir="$(make_gh)"
-run "$dir" mikelward/lanes
+run "$dir"
 assert_status 2
+finish_case
+
+test_case "defaults to lanes, codex and zizmor when no CHECK is named"
+dir="$(make_gh)"
+printf '%s' "$CLEAN_RULES" \
+    | jq '(.[] | select(.type == "required_status_checks") | .parameters.required_status_checks) = [{"context":"lanes"},{"context":"codex"},{"context":"zizmor"}]' \
+    > "$dir/rules.json"
+run "$dir" mikelward/lanes
+assert_status 0
+assert_output "[ok] 'lanes' is a required status check"
+assert_output "[ok] 'codex' is a required status check"
+assert_output "[ok] 'zizmor' is a required status check"
+finish_case
+
+test_case "an explicit CHECK list overrides the default rather than adding to it"
+dir="$(make_gh)"
+run "$dir" mikelward/lanes sweep
+assert_status 1
+assert_output "[GAP] 'sweep' is NOT a required status check"
+assert_no_output "'lanes' is a required status check"
+assert_no_output "'zizmor' is a required status check"
 finish_case
 
 test_case "a failed read of the effective rules is reported, not read as a gap"

--- a/repo-rules_test
+++ b/repo-rules_test
@@ -371,7 +371,7 @@ finish_case
 
 test_case "rejects bad usage"
 dir="$(make_gh 'test' '')"
-run_repo_rules "$dir" mikelward/lanes
+run_repo_rules "$dir"
 assert_status 2
 run_repo_rules "$dir" lanes test
 assert_status 2
@@ -379,6 +379,27 @@ assert_output "not OWNER/REPO"
 run_repo_rules "$dir" --nonsense mikelward/lanes test
 assert_status 2
 assert_output "unknown option"
+finish_case
+
+test_case "defaults to lanes, codex and zizmor when no CHECK is named"
+dir="$(make_gh 'lanes
+codex
+zizmor' '')"
+run_repo_rules "$dir" mikelward/lanes
+assert_status 0
+assert_body "$dir" '"context":"lanes"'
+assert_body "$dir" '"context":"codex"'
+assert_body "$dir" '"context":"zizmor"'
+finish_case
+
+test_case "an explicit CHECK list overrides the default rather than adding to it"
+dir="$(make_gh 'sweep' '')"
+run_repo_rules "$dir" mikelward/lanes sweep
+assert_status 0
+assert_body "$dir" '"context":"sweep"'
+assert_body_lacks "$dir" '"context":"lanes"'
+assert_body_lacks "$dir" '"context":"codex"'
+assert_body_lacks "$dir" '"context":"zizmor"'
 finish_case
 
 test_case "--help exits 0 and writes nothing"


### PR DESCRIPTION
## Summary

Both `repo-rules` and `repo-rules-audit` took `CHECK...` as required free-text arguments with no default, so requiring or auditing this fleet's usual merge gates meant typing the same names out every time. `zizmor` is being promoted from an advisory-only CI job to a required check on several repos now that its findings are clean across the fleet — that's what prompted adding a real default instead of a fourth name to keep typing everywhere.

- `CHECK` is now **optional** on both scripts; when omitted, `lanes codex zizmor` is used.
- An explicit `CHECK` list still **overrides** the default entirely (not additive) — same behavior as passing any other explicit list today.
- The default lives in one `DEFAULT_CHECKS` variable per script, shared between the usage text and the arg-parsing fallback, so the two can't drift.
- Usage/docstring text in both scripts updated to show `OWNER/REPO [CHECK...]` and name the default.

## Test plan

- [x] `sh repo-rules_test` — 49/49 pass (added: defaulting case, explicit-list-overrides-default case; updated the bad-usage case since bare `OWNER/REPO` is now valid input, not a usage error)
- [x] `sh repo-rules-audit_test` — 29/29 pass (same shape of additions/updates)
- [x] `shellcheck repo-rules repo-rules-audit` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01VqbmQYWotDetLoj6mspXnE)_