### PR TITLE
repo-rules: ask before changing a ruleset, add --force to skip

### DIFF
--- a/repo-rules
+++ b/repo-rules
@@ -48,6 +48,21 @@
 # branch not yet merged both land there. Pass --force when you are knowingly
 # requiring one that is about to start reporting.
 #
+# Before writing, if the computed ruleset differs from what already exists on
+# GitHub (or nothing exists there yet), this prints what would change and
+# asks for confirmation. Applying an admin-level change to a repository's
+# merge gates is not something a rerun, a typo'd argument, or a script running
+# unattended should ever do silently -- the same reasoning as the never-
+# reported guard above, aimed at the write itself rather than at one check
+# name. --force skips the question, the same flag that skips the
+# never-reported guard, since both mean "I have already decided; stop
+# asking." Run with no terminal on stdin and without --force, it refuses to
+# guess which answer was meant and leaves the ruleset untouched -- silently
+# applying an unconfirmed change would defeat the point of asking, and
+# blocking on a question nobody can answer would hang whatever ran it.
+# Nothing to change (the computed ruleset already matches what is there)
+# skips the question entirely, since there is nothing to confirm.
+#
 # Check names are handled one per line throughout, never as a space-separated
 # list. Real names contain spaces -- "Analyze (actions)" is one CodeQL emits
 # -- and a split one produces contexts like "Analyze" and "(actions)" that
@@ -80,7 +95,8 @@ date with the base, and allow rebase as the only merge method. CHECK
 defaults to: $DEFAULT_CHECKS
 
   --dry-run        Print what would change; make no writes.
-  --force          Require a check even if it has never reported.
+  --force          Require a check even if it has never reported, and apply
+                   the change without asking for confirmation.
   --ruleset NAME   Name of the ruleset to own (default: "$RULESET").
   -h, --help       This message.
 
@@ -562,13 +578,20 @@ fi
 # entry bound to a GitHub App means only that app can satisfy the check, and
 # rebuilding entries from names alone would drop the binding and let any
 # integration reporting the same name open the gate.
+#
+# Also reports whether anything would actually change, as its first line of
+# output -- "unchanged" or "changed" -- ahead of the body on the rest. This
+# is what lets the confirmation step below know there is nothing to ask about
+# without a second read of the ruleset, and jq's `==` compares the two
+# objects structurally, so key order and how the two were assembled cannot
+# manufacture a false "changed".
 build_update_body() {
-    # shellcheck disable=SC2016  # $rule/$have/$want/$c are jq variables, not shell
+    # shellcheck disable=SC2016  # $rule/$have/$want/$c/$orig/$rules/$target are jq variables, not shell
     REPO_RULES_CONTEXTS="[$contexts]" \
     gh api "repos/$REPO/rulesets/$EXISTING" --jq '
-        del(.id, .node_id, .source, .source_type, .created_at, .updated_at,
-            ._links, .current_user_can_bypass)
-        | .rules = ((.rules // [])
+        (del(.id, .node_id, .source, .source_type, .created_at, .updated_at,
+             ._links, .current_user_can_bypass)) as $orig
+        | (($orig.rules // [])
             | map(
                 if .type == "required_status_checks" then
                     . as $rule
@@ -596,8 +619,11 @@ build_update_body() {
                   require_last_push_approval: false,
                   required_review_thread_resolution: true,
                   allowed_merge_methods: ["rebase"]}}]
-              end)
-    ' > "$WORK/body"
+              end) as $rules
+        | ($orig + {rules: $rules}) as $target
+        | (if $orig == $target then "unchanged" else "changed" end),
+          $target
+    ' > "$WORK/transform"
 }
 
 BODY="{
@@ -627,7 +653,23 @@ describe_checks() {
     for check in "$@"; do printf '  %s\n' "$check"; done
 }
 
-if test "$DRY_RUN" -eq 1; then
+# Computed once, ahead of both --dry-run and the real write, so each reports
+# the same answer: whether there is anything to change at all. A create has
+# nothing to compare against and always needs one; an update asks the
+# ruleset itself, via build_update_body's own "unchanged"/"changed" verdict
+# -- so this never re-derives that comparison a second way that could drift
+# from what the write actually does.
+NEEDS_WRITE=1
+if test -n "$EXISTING"; then
+    build_update_body || { error "could not read ruleset '$RULESET' to compute the update"; exit 1; }
+    CHANGE_STATUS="$(sed -n 1p "$WORK/transform")"
+    sed 1d "$WORK/transform" > "$WORK/body"
+    test "$CHANGE_STATUS" = unchanged && NEEDS_WRITE=0
+fi
+
+# Shared by --dry-run and the confirmation prompt below, so what is asked
+# and what is merely reported read identically.
+describe_plan() {
     if test -n "$EXISTING"; then
         # No branch named: an update preserves whatever scope the ruleset
         # already has, which may not be the default branch at all.
@@ -640,11 +682,39 @@ if test "$DRY_RUN" -eq 1; then
     echo "  review conversations must be resolved"
     echo "  the branch must be up to date with the base"
     echo "  rebase is the only merge method"
+}
+
+if test -n "$EXISTING" && test "$NEEDS_WRITE" -eq 0; then
+    echo "$REPO: ruleset '$RULESET' (id $EXISTING) already matches; nothing to do"
     exit 0
 fi
 
+if test "$DRY_RUN" -eq 1; then
+    describe_plan "$@"
+    exit 0
+fi
+
+if test "$FORCE" -ne 1; then
+    if test -t 0; then
+        describe_plan "$@"
+        printf 'Apply this change to %s? [y/N] ' "$REPO"
+        read -r CONFIRM || CONFIRM=""
+        case "$CONFIRM" in
+            [Yy]|[Yy][Ee][Ss]) ;;
+            *) error "not confirmed; leaving $REPO's ruleset '$RULESET' unchanged."
+               exit 1 ;;
+        esac
+    else
+        error "stdin is not a terminal and --force was not given, so leaving"
+        error "$REPO's ruleset '$RULESET' unchanged rather than either blocking on"
+        error "a question nobody can answer or silently applying a change nobody"
+        error "confirmed. Pass --force to apply it non-interactively, or run this"
+        error "from a terminal."
+        exit 1
+    fi
+fi
+
 if test -n "$EXISTING"; then
-    build_update_body || { error "could not read ruleset '$RULESET' to update it"; exit 1; }
     gh api --method PUT "repos/$REPO/rulesets/$EXISTING" --input "$WORK/body" >/dev/null
     echo "$REPO: updated ruleset '$RULESET' (its scope is unchanged)"
 else

--- a/repo-rules
+++ b/repo-rules
@@ -161,33 +161,48 @@ command -v gh >/dev/null 2>&1 || {
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT INT TERM
 
-# The branch to protect, and whether the repository permits a rebase merge at
-# all. The branch is asked for rather than assumed: not every repository calls
-# it main, and requiring checks on a branch that does not exist silently
-# protects nothing.
-if gh api "repos/$REPO" --jq '.default_branch, .allow_rebase_merge' > "$WORK/repo"; then
-    DEFAULT_BRANCH="$(sed -n 1p "$WORK/repo")"
-    ALLOW_REBASE="$(sed -n 2p "$WORK/repo")"
+# The branch to protect, established once: not every repository calls it
+# main, and requiring checks on a branch that does not exist silently
+# protects nothing. Never re-read after this -- SCOPE's normalization and
+# every merge-method comparison below are pinned to this one value, and
+# letting it drift mid-run would desynchronize them from each other in a
+# way nothing here is built to detect.
+if gh api "repos/$REPO" --jq '.default_branch' > "$WORK/repo"; then
+    DEFAULT_BRANCH="$(cat "$WORK/repo")"
 else
     error "could not read $REPO"
     exit 1
 fi
 test -n "$DEFAULT_BRANCH" || { error "could not read $REPO's default branch"; exit 1; }
 
+# Whether the repository still permits a rebase merge at all, on its own
+# because -- unlike the default branch -- this genuinely can change between
+# an early check and a later one, and the write must reflect its state AT
+# THE WRITE, not whatever it was when the plan was drawn.
+#
 # A ruleset NARROWS what the repository permits; it cannot enable a method the
 # repository has turned off. So allowing only rebase on a repository with
 # rebase merging disabled leaves the intersection empty and nothing can merge
 # -- the never-merges trap this script exists to prevent, sprung by the script.
 # Refused rather than fixed: turning on a repository-wide merge setting is not
 # something a run asked to set a check list should do behind the operator.
-if test "$ALLOW_REBASE" != true; then
-    error "$REPO has rebase merging disabled, and this ruleset allows only"
-    error "rebase. A ruleset narrows what the repository permits and cannot"
-    error "enable a method, so together they would leave no way to merge"
-    error "anything. Enable 'Allow rebase merging' in the repository's pull"
-    error "request settings first."
-    exit 1
-fi
+check_allow_rebase() {
+    ALLOW_REBASE="$(gh api "repos/$REPO" --jq '.allow_rebase_merge')" || {
+        error "could not read $REPO to check whether rebase merging is still"
+        error "allowed. Refusing to guess."
+        return 1
+    }
+    if test "$ALLOW_REBASE" != true; then
+        error "$REPO has rebase merging disabled, and this ruleset allows only"
+        error "rebase. A ruleset narrows what the repository permits and cannot"
+        error "enable a method, so together they would leave no way to merge"
+        error "anything. Enable 'Allow rebase merging' in the repository's pull"
+        error "request settings first."
+        return 1
+    fi
+}
+
+check_allow_rebase || exit 1
 
 # A JSON string literal, with the two characters that would otherwise end it
 # escaped. Check names are free text from the caller.
@@ -377,6 +392,14 @@ if test -s "$WORK/missing"; then
 fi
 
 
+# The query that finds a ruleset named $RULESET, used to establish EXISTING
+# below and, on the create path, run again right before the write to catch
+# one that appeared in the meantime -- see the write section.
+lookup_existing_ruleset() {
+    gh api --paginate "repos/$REPO/rulesets?includes_parents=false" \
+        --jq ".[] | select(.name == $(json_string "$RULESET")) | .id"
+}
+
 # Update the ruleset this script owns, or create it. Matched by name, so a
 # rerun with a different check list replaces that list rather than adding a
 # second ruleset that quietly ANDs with the first.
@@ -384,7 +407,7 @@ fi
 # A failed lookup must NOT read as "there is no ruleset": that would POST a
 # duplicate whose stale check list then ANDs with this one, which is the
 # outcome the whole named-ruleset approach exists to avoid.
-if EXISTING="$(gh api --paginate "repos/$REPO/rulesets?includes_parents=false" --jq ".[] | select(.name == $(json_string "$RULESET")) | .id")"; then
+if EXISTING="$(lookup_existing_ruleset)"; then
     :
 else
     error "could not list $REPO's rulesets, so cannot tell whether '$RULESET'"
@@ -399,11 +422,17 @@ fi
 # silently delete protections -- breaking the promise at the top of this file
 # that it touches no other ruleset. A name is just a name; what proves the
 # ruleset is ours is that it contains only the rule types we manage.
-if test -n "$EXISTING"; then
+#
+# Takes the id as an argument rather than reading $EXISTING directly, so the
+# write section can re-run it against the SAME id it already has right
+# before the write -- catching enforcement flipped off, or an unmanaged rule
+# added, in whatever time an interactive user spent on the confirm prompt.
+check_ruleset_ownership() {
+    ruleset_id="$1"
     # Not `gh ... | sort` -- a pipeline reports the LAST command's status, so
     # sort's success would mask a failed read. Same shape as the bug this
     # script was reviewed for; it is easy to write twice.
-    if gh api "repos/$REPO/rulesets/$EXISTING" --jq '.enforcement, (.rules[].type)' > "$WORK/inspect"; then
+    if gh api "repos/$REPO/rulesets/$ruleset_id" --jq '.enforcement, (.rules[].type)' > "$WORK/inspect"; then
         ENFORCEMENT="$(sed -n 1p "$WORK/inspect")"
         sed 1d "$WORK/inspect" > "$WORK/types"
         # Deleting the managed types is the test, rather than comparing against
@@ -418,9 +447,9 @@ if test -n "$EXISTING"; then
         # a repeated name in an error message costs nothing.
         UNMANAGED="$(sed '/^required_status_checks$/d; /^pull_request$/d' "$WORK/types")"
     else
-        error "could not read ruleset '$RULESET' (id $EXISTING) to check what it"
+        error "could not read ruleset '$RULESET' (id $ruleset_id) to check what it"
         error "contains. Refusing to overwrite rules that cannot be inspected."
-        exit 1
+        return 1
     fi
     # `evaluate` and `disabled` rulesets do not block anything, so writing a
     # check list into one and reporting success would name a gate that is not
@@ -429,20 +458,24 @@ if test -n "$EXISTING"; then
     # run was not asked to make, and flipping it is not a side effect of
     # setting a check list.
     if test "$ENFORCEMENT" != active; then
-        error "ruleset '$RULESET' (id $EXISTING) on $REPO is '$ENFORCEMENT', not"
+        error "ruleset '$RULESET' (id $ruleset_id) on $REPO is '$ENFORCEMENT', not"
         error "'active', so its rules block nothing. Setting a check list on it"
         error "would report a gate that does not gate. Activate it, or point this"
         error "run at a different ruleset with --ruleset."
-        exit 1
+        return 1
     fi
     if test -n "$UNMANAGED"; then
-        error "ruleset '$RULESET' (id $EXISTING) on $REPO holds rules this script"
+        error "ruleset '$RULESET' (id $ruleset_id) on $REPO holds rules this script"
         error "does not manage:"
         printf '%s\n' "$UNMANAGED" | sed 's/^/  /' >&2
         error "Overwriting it would delete them. Rename that ruleset, or point"
         error "this run at a different one with --ruleset."
-        exit 1
+        return 1
     fi
+}
+
+if test -n "$EXISTING"; then
+    check_ruleset_ownership "$EXISTING" || exit 1
 fi
 
 # Rulesets AGGREGATE: a pull request must satisfy every one that applies to
@@ -745,25 +778,48 @@ if test "$FORCE" -ne 1; then
     fi
 fi
 
+# Every check below is re-run right before writing, not reused from what the
+# confirmation prompt was built from: another admin or process could have
+# changed the repository or the ruleset in whatever time an interactive user
+# spent deciding -- disabled rebase merging, flipped enforcement off, added
+# an unmanaged rule, moved the ruleset to a different branch, or (on the
+# create path) created a same-named ruleset of its own. None of these close
+# their window to zero -- another write could still land between these
+# calls and the actual PUT/POST -- but together they shrink "however long a
+# human takes to answer a prompt" down to a handful of API round trips.
+check_allow_rebase || exit 1
+
 if test -n "$EXISTING"; then
-    # Both re-run right before writing, not reused from what the
-    # confirmation prompt was built from: another admin or process could
-    # have changed the ruleset -- including moving it to a different
-    # branch -- in whatever time an interactive user spent deciding.
-    # Re-validating the scope catches a conflict the earlier check couldn't
-    # have seen yet (or clears one that no longer applies); refreshing the
-    # body keeps a stale snapshot from silently discarding a concurrent
-    # change when it's written. Neither closes the window to zero -- another
-    # write could still land between these calls and the PUT below -- but
-    # together they shrink "however long a human takes to answer a prompt"
-    # down to a couple of API round trips. CREATE has no scope to
-    # re-validate here: it's always the default branch, fixed for the whole
-    # run, so only the update path needs this.
+    check_ruleset_ownership "$EXISTING" || exit 1
+    # CREATE has no scope to re-validate here: it's always the default
+    # branch, fixed for the whole run, so only the update path needs this.
     validate_merge_method_scope || exit 1
     refresh_body || { error "could not re-read ruleset '$RULESET' to write it"; exit 1; }
     gh api --method PUT "repos/$REPO/rulesets/$EXISTING" --input "$WORK/body" >/dev/null
     echo "$REPO: updated ruleset '$RULESET' (its scope is unchanged)"
 else
+    # The create-path counterpart of the ownership re-check above: nothing
+    # existed under this name a moment ago, but a rerun of this script, or
+    # another admin, could have created one while this one was waiting on
+    # confirmation. Proceeding would POST a duplicate that ANDs with it --
+    # the exact outcome the whole named-ruleset design exists to avoid -- so
+    # this refuses rather than silently switching to the update path, which
+    # would mean re-running every check the update path already did earlier
+    # against a ruleset this run never validated ownership of at all.
+    if JUST_CREATED="$(lookup_existing_ruleset)"; then
+        if test -n "$JUST_CREATED"; then
+            error "ruleset '$RULESET' now exists on $REPO (id $JUST_CREATED) --"
+            error "created while this was waiting on confirmation. Refusing to"
+            error "create a duplicate, which would AND with it. Rerun to update"
+            error "it instead."
+            exit 1
+        fi
+    else
+        error "could not check whether '$RULESET' was created on $REPO in the"
+        error "meantime. Refusing to guess: creating now could produce a"
+        error "duplicate that ANDs with it."
+        exit 1
+    fi
     printf '%s' "$BODY" | gh api --method POST "repos/$REPO/rulesets" --input - >/dev/null
     echo "$REPO: created ruleset '$RULESET' on $DEFAULT_BRANCH"
 fi

--- a/repo-rules
+++ b/repo-rules
@@ -653,6 +653,16 @@ describe_checks() {
     for check in "$@"; do printf '  %s\n' "$check"; done
 }
 
+# Wraps build_update_body with the split of its two-line output into the
+# change verdict and the body file, so both call sites below -- the early
+# one that decides NEEDS_WRITE and the later one that refreshes the
+# snapshot right before writing -- share the same parsing.
+refresh_body() {
+    build_update_body || return 1
+    CHANGE_STATUS="$(sed -n 1p "$WORK/transform")"
+    sed 1d "$WORK/transform" > "$WORK/body"
+}
+
 # Computed once, ahead of both --dry-run and the real write, so each reports
 # the same answer: whether there is anything to change at all. A create has
 # nothing to compare against and always needs one; an update asks the
@@ -661,9 +671,7 @@ describe_checks() {
 # from what the write actually does.
 NEEDS_WRITE=1
 if test -n "$EXISTING"; then
-    build_update_body || { error "could not read ruleset '$RULESET' to compute the update"; exit 1; }
-    CHANGE_STATUS="$(sed -n 1p "$WORK/transform")"
-    sed 1d "$WORK/transform" > "$WORK/body"
+    refresh_body || { error "could not read ruleset '$RULESET' to compute the update"; exit 1; }
     test "$CHANGE_STATUS" = unchanged && NEEDS_WRITE=0
 fi
 
@@ -696,8 +704,14 @@ fi
 
 if test "$FORCE" -ne 1; then
     if test -t 0; then
-        describe_plan "$@"
-        printf 'Apply this change to %s? [y/N] ' "$REPO"
+        # To stderr, not stdout: stdin being a terminal doesn't mean stdout
+        # is one too (`output=$(repo-rules ...)` from an interactive shell
+        # has both), and a prompt that lands in a captured stdout is a
+        # question nobody sees asked while the script still blocks on an
+        # answer. Piping stdout elsewhere is common enough to guard against
+        # on its own, without also requiring stdout to be a terminal.
+        describe_plan "$@" >&2
+        printf 'Apply this change to %s? [y/N] ' "$REPO" >&2
         read -r CONFIRM || CONFIRM=""
         case "$CONFIRM" in
             [Yy]|[Yy][Ee][Ss]) ;;
@@ -715,6 +729,15 @@ if test "$FORCE" -ne 1; then
 fi
 
 if test -n "$EXISTING"; then
+    # Refreshed right before writing, not reused from the snapshot the
+    # confirmation prompt showed: another admin or process could have
+    # changed the ruleset in whatever time an interactive user spent
+    # deciding, and writing that stale snapshot back would silently discard
+    # the concurrent change. This can't close the window to zero -- another
+    # write could still land between this fetch and the PUT below -- but it
+    # shrinks "however long a human takes to answer a prompt" down to one
+    # API round trip.
+    refresh_body || { error "could not re-read ruleset '$RULESET' to write it"; exit 1; }
     gh api --method PUT "repos/$REPO/rulesets/$EXISTING" --input "$WORK/body" >/dev/null
     echo "$REPO: updated ruleset '$RULESET' (its scope is unchanged)"
 else

--- a/repo-rules
+++ b/repo-rules
@@ -161,12 +161,8 @@ command -v gh >/dev/null 2>&1 || {
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT INT TERM
 
-# The branch to protect, established once: not every repository calls it
-# main, and requiring checks on a branch that does not exist silently
-# protects nothing. Never re-read after this -- SCOPE's normalization and
-# every merge-method comparison below are pinned to this one value, and
-# letting it drift mid-run would desynchronize them from each other in a
-# way nothing here is built to detect.
+# The branch to protect: not every repository calls it main, and requiring
+# checks on a branch that does not exist silently protects nothing.
 if gh api "repos/$REPO" --jq '.default_branch' > "$WORK/repo"; then
     DEFAULT_BRANCH="$(cat "$WORK/repo")"
 else
@@ -174,6 +170,31 @@ else
     exit 1
 fi
 test -n "$DEFAULT_BRANCH" || { error "could not read $REPO's default branch"; exit 1; }
+
+# Re-reading this is safe, and once is not enough: `~DEFAULT_BRANCH` in a
+# ruleset's own conditions is a live GitHub-resolved token, never expanded
+# to a literal name by anything this script writes -- so a later refresh
+# here cannot desynchronize a write body, only make the merge-method
+# conflict scan (the one place $DEFAULT_BRANCH is actually compared against
+# something) agree with what GitHub will apply the written ruleset to. If
+# the repository's default branch itself changes while an interactive user
+# is still deciding, the early scan checked the wrong branch entirely --
+# same shape as every other write-time revalidation here, just one level
+# up. Also updates the create-path "on $DEFAULT_BRANCH" message, which
+# reporting the stale name would otherwise leave subtly wrong too.
+refresh_default_branch() {
+    NEW_DEFAULT_BRANCH="$(gh api "repos/$REPO" --jq '.default_branch')" || {
+        error "could not read $REPO to check whether its default branch has"
+        error "changed. Refusing to guess which branch a $DEFAULT_BRANCH"
+        error "written as ~DEFAULT_BRANCH would actually apply to."
+        return 1
+    }
+    test -n "$NEW_DEFAULT_BRANCH" || {
+        error "could not read $REPO's default branch."
+        return 1
+    }
+    DEFAULT_BRANCH="$NEW_DEFAULT_BRANCH"
+}
 
 # Whether the repository still permits a rebase merge at all, on its own
 # because -- unlike the default branch -- this genuinely can change between
@@ -797,7 +818,10 @@ fi
 # branch), but the OTHER rulesets it might conflict with are not -- one
 # could be added, or narrowed to exclude rebase, on that branch while this
 # was waiting on confirmation, same as the update path's scope can move
-# into a conflict that did not exist when the early check ran.
+# into a conflict that did not exist when the early check ran. Refreshed
+# right before, so "the default branch" means the same thing here as it
+# will to GitHub when the write actually lands.
+refresh_default_branch || exit 1
 validate_merge_method_scope || exit 1
 
 if test -n "$EXISTING"; then

--- a/repo-rules
+++ b/repo-rules
@@ -791,9 +791,16 @@ check_allow_rebase || exit 1
 
 if test -n "$EXISTING"; then
     check_ruleset_ownership "$EXISTING" || exit 1
-    # CREATE has no scope to re-validate here: it's always the default
-    # branch, fixed for the whole run, so only the update path needs this.
-    validate_merge_method_scope || exit 1
+fi
+
+# Applies to both paths: CREATE's own scope is fixed (always the default
+# branch), but the OTHER rulesets it might conflict with are not -- one
+# could be added, or narrowed to exclude rebase, on that branch while this
+# was waiting on confirmation, same as the update path's scope can move
+# into a conflict that did not exist when the early check ran.
+validate_merge_method_scope || exit 1
+
+if test -n "$EXISTING"; then
     refresh_body || { error "could not re-read ruleset '$RULESET' to write it"; exit 1; }
     gh api --method PUT "repos/$REPO/rulesets/$EXISTING" --input "$WORK/body" >/dev/null
     echo "$REPO: updated ruleset '$RULESET' (its scope is unchanged)"

--- a/repo-rules
+++ b/repo-rules
@@ -456,18 +456,20 @@ fi
 # An update preserves the existing ruleset's conditions, so a managed ruleset
 # scoped to `release` must be checked against what else applies to `release`
 # -- checking `main` there would miss the conflict entirely and report success.
-if test -n "$EXISTING"; then
-    # shellcheck disable=SC2016  # jq program, not shell interpolation
-    SCOPE="$(gh api "repos/$REPO/rulesets/$EXISTING" \
-        --jq '{include: [.conditions.ref_name.include[]?],
-               exclude: [.conditions.ref_name.exclude[]?]} | @json')" || {
-        error "could not read ruleset '$RULESET' (id $EXISTING) to see which"
-        error "branches it covers. Refusing to guess at what else applies there."
-        exit 1
-    }
-else
-    SCOPE='{"include":["~DEFAULT_BRANCH"],"exclude":[]}'
-fi
+compute_scope() {
+    if test -n "$EXISTING"; then
+        # shellcheck disable=SC2016  # jq program, not shell interpolation
+        SCOPE="$(gh api "repos/$REPO/rulesets/$EXISTING" \
+            --jq '{include: [.conditions.ref_name.include[]?],
+                   exclude: [.conditions.ref_name.exclude[]?]} | @json')" || {
+            error "could not read ruleset '$RULESET' (id $EXISTING) to see which"
+            error "branches it covers. Refusing to guess at what else applies there."
+            return 1
+        }
+    else
+        SCOPE='{"include":["~DEFAULT_BRANCH"],"exclude":[]}'
+    fi
+}
 
 # Matching is literal -- `~DEFAULT_BRANCH` normalized on both sides, `~ALL` a
 # wildcard -- and GitHub's `fnmatch` patterns are NOT evaluated. But an
@@ -513,37 +515,52 @@ find_merge_method_conflicts() {
     done < "$WORK/all_rulesets"
 }
 
-find_merge_method_conflicts || {
-    error "could not read $REPO's other rulesets, so cannot tell whether one of"
-    error "them rules out a rebase merge. Refusing to guess: rulesets aggregate,"
-    error "and a conflict would leave no way to merge anything."
-    exit 1
+# Ties compute_scope and find_merge_method_conflicts together into one
+# refusal-or-nothing check, so it can be run twice: once early (fail fast,
+# before showing a plan for a write that might not even be possible), and
+# once more right before the actual write, on whatever the ruleset's scope
+# is BY THEN -- an admin could move a managed ruleset from one branch to
+# another while an interactive user is still looking at the confirmation
+# prompt, and the merge-method conflict this creates or resolves has to be
+# checked against the scope actually being written, not the one that was
+# true when the prompt was drawn.
+validate_merge_method_scope() {
+    compute_scope || return 1
+
+    find_merge_method_conflicts || {
+        error "could not read $REPO's other rulesets, so cannot tell whether one of"
+        error "them rules out a rebase merge. Refusing to guess: rulesets aggregate,"
+        error "and a conflict would leave no way to merge anything."
+        return 1
+    }
+    # A space separates the verdict from the name, and `sed` rather than a
+    # pipeline through `grep`: a pipeline reports only the last command's
+    # status, which is how a failed read reads as "no conflicts" -- the shape
+    # three earlier findings on this script had in common.
+    sed -n 's/^conflict //p' "$WORK/conflicts" > "$WORK/definite"
+    sed -n 's/^unknown //p' "$WORK/conflicts" > "$WORK/undecidable"
+    if test -s "$WORK/definite"; then
+        error "another active ruleset on $REPO excludes rebase from its allowed"
+        error "merge methods, and covers the same branches as this one:"
+        sed 's/^/  /' "$WORK/definite" >&2
+        error "Rulesets aggregate, so together they would leave no method that"
+        error "satisfies both and nothing could merge. Reconcile them first."
+        return 1
+    fi
+    if test -s "$WORK/undecidable"; then
+        error "another active ruleset on $REPO excludes rebase from its allowed"
+        error "merge methods, on a scope this script cannot evaluate:"
+        sed 's/^/  /' "$WORK/undecidable" >&2
+        error "Its conditions use a pattern (such as 'refs/heads/*') or an"
+        error "exclusion, and this script matches branch names literally rather"
+        error "than reimplementing GitHub's ref matching. If that ruleset covers"
+        error "this branch the two would leave no way to merge anything, so this"
+        error "refuses rather than guess. Check it, then narrow either scope."
+        return 1
+    fi
 }
-# A space separates the verdict from the name, and `sed` rather than a
-# pipeline through `grep`: a pipeline reports only the last command's status,
-# which is how a failed read reads as "no conflicts" -- the shape three
-# earlier findings on this script had in common.
-sed -n 's/^conflict //p' "$WORK/conflicts" > "$WORK/definite"
-sed -n 's/^unknown //p' "$WORK/conflicts" > "$WORK/undecidable"
-if test -s "$WORK/definite"; then
-    error "another active ruleset on $REPO excludes rebase from its allowed"
-    error "merge methods, and covers the same branches as this one:"
-    sed 's/^/  /' "$WORK/definite" >&2
-    error "Rulesets aggregate, so together they would leave no method that"
-    error "satisfies both and nothing could merge. Reconcile them first."
-    exit 1
-fi
-if test -s "$WORK/undecidable"; then
-    error "another active ruleset on $REPO excludes rebase from its allowed"
-    error "merge methods, on a scope this script cannot evaluate:"
-    sed 's/^/  /' "$WORK/undecidable" >&2
-    error "Its conditions use a pattern (such as 'refs/heads/*') or an"
-    error "exclusion, and this script matches branch names literally rather"
-    error "than reimplementing GitHub's ref matching. If that ruleset covers"
-    error "this branch the two would leave no way to merge anything, so this"
-    error "refuses rather than guess. Check it, then narrow either scope."
-    exit 1
-fi
+
+validate_merge_method_scope || exit 1
 
 # The body. Two paths, and the difference is the point.
 #
@@ -729,14 +746,20 @@ if test "$FORCE" -ne 1; then
 fi
 
 if test -n "$EXISTING"; then
-    # Refreshed right before writing, not reused from the snapshot the
-    # confirmation prompt showed: another admin or process could have
-    # changed the ruleset in whatever time an interactive user spent
-    # deciding, and writing that stale snapshot back would silently discard
-    # the concurrent change. This can't close the window to zero -- another
-    # write could still land between this fetch and the PUT below -- but it
-    # shrinks "however long a human takes to answer a prompt" down to one
-    # API round trip.
+    # Both re-run right before writing, not reused from what the
+    # confirmation prompt was built from: another admin or process could
+    # have changed the ruleset -- including moving it to a different
+    # branch -- in whatever time an interactive user spent deciding.
+    # Re-validating the scope catches a conflict the earlier check couldn't
+    # have seen yet (or clears one that no longer applies); refreshing the
+    # body keeps a stale snapshot from silently discarding a concurrent
+    # change when it's written. Neither closes the window to zero -- another
+    # write could still land between these calls and the PUT below -- but
+    # together they shrink "however long a human takes to answer a prompt"
+    # down to a couple of API round trips. CREATE has no scope to
+    # re-validate here: it's always the default branch, fixed for the whole
+    # run, so only the update path needs this.
+    validate_merge_method_scope || exit 1
     refresh_body || { error "could not re-read ruleset '$RULESET' to write it"; exit 1; }
     gh api --method PUT "repos/$REPO/rulesets/$EXISTING" --input "$WORK/body" >/dev/null
     echo "$REPO: updated ruleset '$RULESET' (its scope is unchanged)"

--- a/repo-rules_test
+++ b/repo-rules_test
@@ -1463,6 +1463,69 @@ assert_no_write "$dir"
 finish_case
 fi
 
+test_case "refuses to create if a conflicting ruleset appears while the prompt is open"
+if test "$HAVE_PTY" = no || test "$HAVE_JQ" = no; then skip_case "needs script(1) and jq"; finish_case; else
+# The create path's own scope is fixed (~DEFAULT_BRANCH for the whole run),
+# but what it might conflict with is not: a squash-only ruleset added to the
+# default branch while the prompt is open has nothing to conflict with on
+# the early check (it doesn't exist yet) and everything to conflict with on
+# the late one, right before the POST.
+dir="$(mktemp -d "$SUITE_TMP/fixture.XXXXXX")"
+mkdir -p "$dir/bin"
+cat > "$dir/other-ruleset" <<'RULESET'
+{"id":99,"name":"org squash policy","enforcement":"active",
+ "conditions":{"ref_name":{"include":["~DEFAULT_BRANCH"],"exclude":[]}},
+ "rules":[{"type":"pull_request","parameters":{
+    "allowed_merge_methods":["squash"]}}]}
+RULESET
+printf '0\n' > "$dir/conflict_reads"
+cat > "$dir/bin/gh" <<'GHEOF'
+#!/bin/sh
+d="$(dirname "$(dirname "$0")")"
+echo "$*" >> "$d/calls"
+skip=no; want=""; jqexpr=""
+for arg in "$@"; do
+    if test "$skip" = yes; then
+        skip=no
+        case "$want" in --jq) jqexpr="$arg" ;; esac
+        continue
+    fi
+    case "$arg" in
+        --method|--jq|--input|-H|--header) skip=yes; want="$arg" ;;
+        *) ;;
+    esac
+done
+case "$*" in
+    *"/rulesets/99"*) jq -r "$jqexpr" < "$d/other-ruleset" ;;
+    *"includes_parents=false"*) : ;;
+    *"includes_parents=true"*)
+        n="$(cat "$d/conflict_reads")"
+        if test "$n" -eq 0; then
+            :
+            printf '1\n' > "$d/conflict_reads"
+        else
+            echo 99
+        fi ;;
+    *"repos/"*"/commits/"*"/check-runs"*) echo '"test"' ;;
+    *"repos/"*"/commits/"*"/status"*) : ;;
+    *"/pulls?"*) : ;;
+    *"/commits?"*) echo deadbee ;;
+    *"repos/"*)
+        case "$jqexpr" in
+            *allow_rebase_merge*) echo true ;;
+            *) echo main ;;
+        esac ;;
+esac
+GHEOF
+chmod +x "$dir/bin/gh"
+run_repo_rules_pty "$dir" 'y' mikelward/lanes test
+assert_status 1
+assert_output "excludes rebase"
+assert_output "org squash policy"
+assert_no_write "$dir"
+finish_case
+fi
+
 # ---------------------------------------------------------------------------
 
 echo

--- a/repo-rules_test
+++ b/repo-rules_test
@@ -306,7 +306,7 @@ test_case "requires checks that have reported"
 dir="$(make_gh 'test
 codex
 sweep' '')"
-run_repo_rules "$dir" mikelward/lanes test codex sweep
+run_repo_rules "$dir" --force mikelward/lanes test codex sweep
 assert_status 0
 assert_output "created ruleset"
 assert_body "$dir" '"context":"test"'
@@ -340,7 +340,7 @@ test_case "updates the ruleset it owns instead of creating a second"
 # demanding a check that no longer exists.
 dir="$(make_gh 'test
 codex' '42')"
-run_repo_rules "$dir" mikelward/lanes test codex
+run_repo_rules "$dir" --force mikelward/lanes test codex
 assert_status 0
 assert_output "updated ruleset"
 grep -q "PUT repos/mikelward/lanes/rulesets/42" "$dir/calls" || {
@@ -385,7 +385,7 @@ test_case "defaults to lanes, codex and zizmor when no CHECK is named"
 dir="$(make_gh 'lanes
 codex
 zizmor' '')"
-run_repo_rules "$dir" mikelward/lanes
+run_repo_rules "$dir" --force mikelward/lanes
 assert_status 0
 assert_body "$dir" '"context":"lanes"'
 assert_body "$dir" '"context":"codex"'
@@ -394,7 +394,7 @@ finish_case
 
 test_case "an explicit CHECK list overrides the default rather than adding to it"
 dir="$(make_gh 'sweep' '')"
-run_repo_rules "$dir" mikelward/lanes sweep
+run_repo_rules "$dir" --force mikelward/lanes sweep
 assert_status 0
 assert_body "$dir" '"context":"sweep"'
 assert_body_lacks "$dir" '"context":"lanes"'
@@ -417,7 +417,7 @@ test_case "keeps a check name with spaces as one context"
 # exists to prevent.
 dir="$(make_gh 'Analyze (actions)
 test' '')"
-run_repo_rules "$dir" mikelward/lanes "Analyze (actions)" test
+run_repo_rules "$dir" --force mikelward/lanes "Analyze (actions)" test
 assert_status 0
 assert_body "$dir" '"context":"Analyze (actions)"'
 assert_no_output "never reported"
@@ -427,7 +427,7 @@ finish_case
 
 test_case "escapes a check name that would break the JSON"
 dir="$(make_gh 'say "hi"' '')"
-run_repo_rules "$dir" mikelward/lanes 'say "hi"'
+run_repo_rules "$dir" --force mikelward/lanes 'say "hi"'
 assert_status 0
 assert_body "$dir" '\"hi\"'
 finish_case
@@ -436,7 +436,7 @@ test_case "sees a check that only a paginated response reaches"
 # A name on page two is indistinguishable from one that never reported, so
 # without --paginate this is refused and the merge gate is never set.
 dir="$(make_gh 'test' '' 'late-reporter')"
-run_repo_rules "$dir" mikelward/lanes test late-reporter
+run_repo_rules "$dir" --force mikelward/lanes test late-reporter
 assert_status 0
 assert_body "$dir" '"context":"late-reporter"'
 finish_case
@@ -488,7 +488,7 @@ fi
 test_case "updates one that holds only the rule it manages"
 if test "$HAVE_JQ" = no; then skip_case "needs a jq binary"; finish_case; else
 dir="$(make_gh 'test' '42' '' '' 'required_status_checks')"
-run_repo_rules "$dir" mikelward/lanes test
+run_repo_rules "$dir" --force mikelward/lanes test
 assert_status 0
 assert_output "updated ruleset"
 finish_case
@@ -525,7 +525,7 @@ if test "$HAVE_JQ" = no; then skip_case "needs a jq binary"; finish_case; else
 # policy -- which is why the update now EDITS the fetched object instead.
 dir="$(make_gh 'test
 codex' '42')"
-run_repo_rules "$dir" mikelward/lanes test codex
+run_repo_rules "$dir" --force mikelward/lanes test codex
 assert_status 0
 assert_body "$dir" 'refs/heads/release'          # conditions
 assert_body "$dir" '"enforcement": "active"'     # round-tripped, not rebuilt
@@ -567,7 +567,7 @@ finish_case
 
 test_case "creating chooses the default branch, actively enforced"
 dir="$(make_gh 'test' '')"
-run_repo_rules "$dir" mikelward/lanes test
+run_repo_rules "$dir" --force mikelward/lanes test
 assert_status 0
 assert_body "$dir" '~DEFAULT_BRANCH'
 assert_body "$dir" '"enforcement": "active"'
@@ -578,7 +578,7 @@ test_case "sees a check that only ever reported on a closed pull request"
 # so a repository with nothing open would look as though it had never run.
 dir="$(make_gh 'test' '')"
 printf 'pr-only-check\n' > "$dir/closed_checks"
-run_repo_rules "$dir" mikelward/lanes test pr-only-check
+run_repo_rules "$dir" --force mikelward/lanes test pr-only-check
 assert_status 0
 assert_body "$dir" '"context":"pr-only-check"'
 finish_case
@@ -590,7 +590,7 @@ test_case "creating also requires resolution and allows rebase only"
 # Rebase alone, because a squash or merge commit rewrites or hides the commits
 # that were reviewed.
 dir="$(make_gh 'test' '')"
-run_repo_rules "$dir" mikelward/lanes test
+run_repo_rules "$dir" --force mikelward/lanes test
 assert_status 0
 assert_body "$dir" '"required_review_thread_resolution": true'
 assert_body "$dir" '"required_approving_review_count": 0'
@@ -604,7 +604,7 @@ if test "$HAVE_JQ" = no; then skip_case "needs a jq binary"; finish_case; else
 # The fixture ruleset holds only required_status_checks, which is what every
 # ruleset this script created before today looks like.
 dir="$(make_gh 'test' '42')"
-run_repo_rules "$dir" mikelward/lanes test
+run_repo_rules "$dir" --force mikelward/lanes test
 assert_status 0
 assert_body "$dir" '"required_review_thread_resolution": true'
 # `gh api --jq` pretty-prints, so the array spans lines: assert the field and
@@ -634,7 +634,7 @@ cat > "$dir/ruleset" <<'RULESET'
     "required_review_thread_resolution":false}}]}
 RULESET
 printf 'pull_request\nrequired_status_checks\n' > "$dir/rule_types"
-run_repo_rules "$dir" mikelward/lanes test
+run_repo_rules "$dir" --force mikelward/lanes test
 assert_status 0
 assert_body "$dir" '"required_review_thread_resolution": true'
 assert_body "$dir" '"required_approving_review_count": 2'
@@ -652,7 +652,7 @@ test_case "a ruleset holding both managed rules is still ours to update"
 if test "$HAVE_JQ" = no; then skip_case "needs a jq binary"; finish_case; else
 dir="$(make_gh 'test' '42' '' '' 'pull_request
 required_status_checks')"
-run_repo_rules "$dir" mikelward/lanes test
+run_repo_rules "$dir" --force mikelward/lanes test
 assert_status 0
 assert_output "updated ruleset"
 finish_case
@@ -687,7 +687,7 @@ cat > "$dir/ruleset" <<'RULESET'
     "required_review_thread_resolution":true}}]}
 RULESET
 printf 'pull_request\n' > "$dir/rule_types"
-run_repo_rules "$dir" mikelward/lanes test
+run_repo_rules "$dir" --force mikelward/lanes test
 assert_status 0
 assert_body "$dir" '"required_status_checks"'
 assert_body "$dir" '"context": "test"'
@@ -701,7 +701,7 @@ if test "$HAVE_JQ" = no; then skip_case "needs a jq binary"; finish_case; else
 dir="$(make_gh 'test' '42')"
 sed 's/"strict_required_status_checks_policy":true/"strict_required_status_checks_policy":false/' \
     "$dir/ruleset" > "$dir/ruleset.new" && mv "$dir/ruleset.new" "$dir/ruleset"
-run_repo_rules "$dir" mikelward/lanes test
+run_repo_rules "$dir" --force mikelward/lanes test
 assert_status 0
 assert_body "$dir" '"strict_required_status_checks_policy": true'
 finish_case
@@ -726,7 +726,7 @@ test_case "stops scanning heads once every requested check is found"
 # and a chunk of the hour's API quota, and the default branch usually settles
 # the question. The closed-pull-request listing must not even be reached.
 dir="$(make_gh 'test' '')"
-run_repo_rules "$dir" mikelward/lanes test
+run_repo_rules "$dir" --force mikelward/lanes test
 assert_status 0
 if grep -q "state=closed" "$dir/calls"; then
     echo "  FAIL: kept scanning after every requested check was found"
@@ -763,7 +763,7 @@ cat > "$dir/other_ruleset" <<'RULESET'
  "rules":[{"type":"pull_request","parameters":{
     "allowed_merge_methods":["squash","rebase"]}}]}
 RULESET
-run_repo_rules "$dir" mikelward/lanes test
+run_repo_rules "$dir" --force mikelward/lanes test
 assert_status 0
 assert_body "$dir" '"context":"test"'
 finish_case
@@ -801,7 +801,7 @@ cat > "$dir/other_ruleset" <<'RULESET'
  "rules":[{"type":"pull_request","parameters":{
     "allowed_merge_methods":["squash"]}}]}
 RULESET
-run_repo_rules "$dir" mikelward/lanes test
+run_repo_rules "$dir" --force mikelward/lanes test
 assert_status 0
 assert_body "$dir" '"context": "test"'
 finish_case
@@ -858,7 +858,7 @@ cat > "$dir/other_ruleset" <<'RULESET'
  "rules":[{"type":"pull_request","parameters":{
     "allowed_merge_methods":["squash","rebase"]}}]}
 RULESET
-run_repo_rules "$dir" mikelward/lanes test
+run_repo_rules "$dir" --force mikelward/lanes test
 assert_status 0
 assert_body "$dir" '"context":"test"'
 finish_case
@@ -954,9 +954,116 @@ test_case "asks for the default branch head without naming it in the path"
 # sent, so `release#1` interpolated into the endpoint would query `release`.
 # The fixture fails any call naming the branch; reaching exit 0 means none did.
 dir="$(make_gh 'test' '' '' '/commits/release' 'required_status_checks' 'release#1')"
-run_repo_rules "$dir" mikelward/lanes test
+run_repo_rules "$dir" --force mikelward/lanes test
 assert_status 0
 finish_case
+
+test_case "refuses to write without --force when stdin is not a terminal"
+# The suite's own stdin is never a terminal, so this is the ordinary case for
+# every other test here -- what makes this one distinct is that it omits
+# --force on purpose, to pin the refusal itself: applying an unconfirmed
+# admin-level change non-interactively would defeat the point of asking, and
+# blocking on a question nobody can answer would hang whatever ran it.
+dir="$(make_gh 'test' '')"
+run_repo_rules "$dir" mikelward/lanes test
+assert_status 1
+assert_output "not a terminal"
+assert_output "--force"
+assert_no_write "$dir"
+finish_case
+
+test_case "an update also refuses without --force when stdin is not a terminal"
+if test "$HAVE_JQ" = no; then skip_case "needs a jq binary"; finish_case; else
+# Same refusal, on the update path -- a real change is computed (this
+# fixture's ruleset lacks a pull_request rule, so one would be added), so
+# this is NOT the already-matches shortcut below; it is the confirmation
+# gate declining to write unconfirmed.
+dir="$(make_gh 'test' '42')"
+run_repo_rules "$dir" mikelward/lanes test
+assert_status 1
+assert_output "not a terminal"
+assert_no_write "$dir"
+finish_case
+fi
+
+test_case "a ruleset that already matches is left alone, even without --force"
+if test "$HAVE_JQ" = no; then skip_case "needs a jq binary"; finish_case; else
+# Nothing to confirm when nothing would change -- the confirmation step
+# (and its refusal above) never applies here, so no --force is needed either.
+dir="$(make_gh 'test' '42' '' '' 'required_status_checks
+pull_request')"
+cat > "$dir/ruleset" <<'RULESET'
+{"id":42,"name":"merge gates","target":"branch","enforcement":"active",
+ "conditions":{"ref_name":{"include":["~DEFAULT_BRANCH"],"exclude":[]}},
+ "rules":[{"type":"required_status_checks","parameters":{
+    "strict_required_status_checks_policy":true,
+    "required_status_checks":[{"context":"test"}]}},
+   {"type":"pull_request","parameters":{
+    "required_approving_review_count":0,
+    "dismiss_stale_reviews_on_push":false,
+    "require_code_owner_review":false,
+    "require_last_push_approval":false,
+    "required_review_thread_resolution":true,
+    "allowed_merge_methods":["rebase"]}}]}
+RULESET
+run_repo_rules "$dir" mikelward/lanes test
+assert_status 0
+assert_output "already matches"
+assert_no_write "$dir"
+finish_case
+fi
+
+test_case "--dry-run also reports a ruleset that already matches"
+if test "$HAVE_JQ" = no; then skip_case "needs a jq binary"; finish_case; else
+dir="$(make_gh 'test' '42' '' '' 'required_status_checks
+pull_request')"
+cat > "$dir/ruleset" <<'RULESET'
+{"id":42,"name":"merge gates","target":"branch","enforcement":"active",
+ "conditions":{"ref_name":{"include":["~DEFAULT_BRANCH"],"exclude":[]}},
+ "rules":[{"type":"required_status_checks","parameters":{
+    "strict_required_status_checks_policy":true,
+    "required_status_checks":[{"context":"test"}]}},
+   {"type":"pull_request","parameters":{
+    "required_approving_review_count":0,
+    "dismiss_stale_reviews_on_push":false,
+    "require_code_owner_review":false,
+    "require_last_push_approval":false,
+    "required_review_thread_resolution":true,
+    "allowed_merge_methods":["rebase"]}}]}
+RULESET
+run_repo_rules "$dir" --dry-run mikelward/lanes test
+assert_status 0
+assert_output "already matches"
+assert_no_write "$dir"
+finish_case
+fi
+
+test_case "--force still skips the write when nothing would change"
+if test "$HAVE_JQ" = no; then skip_case "needs a jq binary"; finish_case; else
+# --force means "don't ask", not "write regardless" -- a real PUT here would
+# be a no-op API call for no reason, on every rerun of an already-correct repo.
+dir="$(make_gh 'test' '42' '' '' 'required_status_checks
+pull_request')"
+cat > "$dir/ruleset" <<'RULESET'
+{"id":42,"name":"merge gates","target":"branch","enforcement":"active",
+ "conditions":{"ref_name":{"include":["~DEFAULT_BRANCH"],"exclude":[]}},
+ "rules":[{"type":"required_status_checks","parameters":{
+    "strict_required_status_checks_policy":true,
+    "required_status_checks":[{"context":"test"}]}},
+   {"type":"pull_request","parameters":{
+    "required_approving_review_count":0,
+    "dismiss_stale_reviews_on_push":false,
+    "require_code_owner_review":false,
+    "require_last_push_approval":false,
+    "required_review_thread_resolution":true,
+    "allowed_merge_methods":["rebase"]}}]}
+RULESET
+run_repo_rules "$dir" --force mikelward/lanes test
+assert_status 0
+assert_output "already matches"
+assert_no_write "$dir"
+finish_case
+fi
 
 # ---------------------------------------------------------------------------
 

--- a/repo-rules_test
+++ b/repo-rules_test
@@ -197,9 +197,14 @@ case "$*" in
     # apart from a failed read. A fixture that does not set it has one.
     *"/branches"*)  cat "$dir/branch_count" ;;
     *"/commits/"*)  echo "deadbee" ;;
-    # `repos/OWNER/REPO`: the default branch and whether a rebase merge is
-    # permitted, in the order the script's --jq asks for them.
-    *"repos/"*)     cat "$dir/branch" "$dir/allow_rebase" ;;
+    # `repos/OWNER/REPO`: the default branch (asked once, early) and whether
+    # a rebase merge is permitted (asked separately, and asked again right
+    # before a write -- see check_allow_rebase in the script).
+    *"repos/"*)
+        case "$jqexpr" in
+            *allow_rebase_merge*) cat "$dir/allow_rebase" ;;
+            *) cat "$dir/branch" ;;
+        esac ;;
 esac
 EOF
     chmod +x "$dir/bin/gh"
@@ -1217,7 +1222,11 @@ case "$*" in
     *"repos/"*"/commits/"*"/status"*) : ;;
     *"/pulls?"*) : ;;
     *"/commits?"*) echo deadbee ;;
-    *"repos/"*) echo main; echo true ;;
+    *"repos/"*)
+        case "$jqexpr" in
+            *allow_rebase_merge*) echo true ;;
+            *) echo main ;;
+        esac ;;
 esac
 GHEOF
 chmod +x "$dir/bin/gh"
@@ -1322,7 +1331,11 @@ case "$*" in
     *"repos/"*"/commits/"*"/status"*) : ;;
     *"/pulls?"*) : ;;
     *"/commits?"*) echo deadbee ;;
-    *"repos/"*) echo main; echo true ;;
+    *"repos/"*)
+        case "$jqexpr" in
+            *allow_rebase_merge*) echo true ;;
+            *) echo main ;;
+        esac ;;
 esac
 GHEOF
 chmod +x "$dir/bin/gh"
@@ -1330,6 +1343,122 @@ run_repo_rules_pty "$dir" 'y' mikelward/lanes test
 assert_status 1
 assert_output "excludes rebase"
 assert_output "org squash policy"
+assert_no_write "$dir"
+finish_case
+fi
+
+test_case "refuses to write if rebase merging is disabled while the prompt is open"
+if test "$HAVE_PTY" = no; then skip_case "needs script(1)"; finish_case; else
+# The create path: simplest place to prove check_allow_rebase is re-run,
+# since it needs no jq and no existing ruleset. The repository answers
+# `true` on the early check (so the prompt is even reached) and `false` on
+# the one right before the write, as if an admin turned it off in between.
+dir="$(mktemp -d "$SUITE_TMP/fixture.XXXXXX")"
+mkdir -p "$dir/bin"
+printf '0\n' > "$dir/rebase_reads"
+cat > "$dir/bin/gh" <<'GHEOF'
+#!/bin/sh
+d="$(dirname "$(dirname "$0")")"
+echo "$*" >> "$d/calls"
+skip=no; want=""; jqexpr=""
+for arg in "$@"; do
+    if test "$skip" = yes; then
+        skip=no
+        case "$want" in --jq) jqexpr="$arg" ;; esac
+        continue
+    fi
+    case "$arg" in
+        --method|--jq|--input|-H|--header) skip=yes; want="$arg" ;;
+        *) ;;
+    esac
+done
+case "$*" in
+    *"includes_parents=false"*) : ;;
+    *"repos/"*"/commits/"*"/check-runs"*) echo '"test"' ;;
+    *"repos/"*"/commits/"*"/status"*) : ;;
+    *"/pulls?"*) : ;;
+    *"/commits?"*) echo deadbee ;;
+    *"repos/"*)
+        case "$jqexpr" in
+            *allow_rebase_merge*)
+                n="$(cat "$d/rebase_reads")"
+                if test "$n" -eq 0; then
+                    echo true
+                    printf '1\n' > "$d/rebase_reads"
+                else
+                    echo false
+                fi ;;
+            *) echo main ;;
+        esac ;;
+esac
+GHEOF
+chmod +x "$dir/bin/gh"
+run_repo_rules_pty "$dir" 'y' mikelward/lanes test
+assert_status 1
+assert_output "rebase merging disabled"
+assert_no_write "$dir"
+finish_case
+fi
+
+test_case "refuses to create a duplicate if the name appeared while the prompt is open"
+if test "$HAVE_PTY" = no; then skip_case "needs script(1)"; finish_case; else
+# The create path's counterpart to the update path's ownership re-check:
+# the name-search answers empty on the early lookup (so this run commits to
+# creating) and non-empty on the one right before the POST, as if another
+# run -- or another admin -- created the same name in the meantime.
+dir="$(mktemp -d "$SUITE_TMP/fixture.XXXXXX")"
+mkdir -p "$dir/bin"
+printf '0\n' > "$dir/lookup_reads"
+cat > "$dir/bin/gh" <<'GHEOF'
+#!/bin/sh
+d="$(dirname "$(dirname "$0")")"
+echo "$*" >> "$d/calls"
+skip=no; want=""; jqexpr=""; inputfile=""; method=""
+for arg in "$@"; do
+    if test "$skip" = yes; then
+        skip=no
+        case "$want" in --jq) jqexpr="$arg" ;; --input) inputfile="$arg" ;; esac
+        continue
+    fi
+    case "$arg" in
+        --method|--jq|--input|-H|--header) skip=yes; want="$arg" ;;
+        *) ;;
+    esac
+done
+prev=""
+for arg in "$@"; do
+    case "$prev" in --method) method="$arg" ;; esac
+    prev="$arg"
+done
+if test -n "$method" && test "$method" != GET; then
+    if test -n "$inputfile" && test "$inputfile" != -; then cp "$inputfile" "$d/body"
+    else cat > "$d/body"; fi
+    exit 0
+fi
+case "$*" in
+    *"includes_parents=false"*)
+        n="$(cat "$d/lookup_reads")"
+        if test "$n" -eq 0; then
+            printf '1\n' > "$d/lookup_reads"
+        else
+            echo 77
+        fi ;;
+    *"repos/"*"/commits/"*"/check-runs"*) echo '"test"' ;;
+    *"repos/"*"/commits/"*"/status"*) : ;;
+    *"/pulls?"*) : ;;
+    *"/commits?"*) echo deadbee ;;
+    *"repos/"*)
+        case "$jqexpr" in
+            *allow_rebase_merge*) echo true ;;
+            *) echo main ;;
+        esac ;;
+esac
+GHEOF
+chmod +x "$dir/bin/gh"
+run_repo_rules_pty "$dir" 'y' mikelward/lanes test
+assert_status 1
+assert_output "now exists"
+assert_output "id 77"
 assert_no_write "$dir"
 finish_case
 fi

--- a/repo-rules_test
+++ b/repo-rules_test
@@ -25,18 +25,28 @@ fi
 
 # The interactive-confirmation cases need a real pseudo-terminal: the script
 # only prompts when `test -t 0` says stdin is one, and no plain pipe or file
-# redirect can make that true. `script` (util-linux) allocates one and
-# forwards its own stdin to it, which is the only way to feed a canned
-# y/n answer to the actual confirm/read branch rather than the
-# always-non-interactive refusal every other case in this suite exercises.
-if command -v script >/dev/null 2>&1; then
+# redirect can make that true. `script` allocates one and forwards its own
+# stdin to it, which is the only way to feed a canned y/n answer to the
+# actual confirm/read branch rather than the always-non-interactive refusal
+# every other case in this suite exercises.
+#
+# Presence alone is not enough to gate on: macOS ships a `script` too, but
+# the BSD one has no `-c`/`-e` -- its synopsis is `script [-adkpqr] [-t time]
+# [file [command ...]]`, nothing that takes a command string. A presence-only
+# check would set HAVE_PTY=yes there and then fail every case on the
+# unrecognized flags, mistaking "this script(1) is a different program" for
+# a real regression. So this probes the actual invocation the PTY cases use
+# (a trivial `true`) and trusts its exit status instead of the binary's mere
+# existence.
+if printf 'x\n' | script -qec true /dev/null >/dev/null 2>&1; then
     HAVE_PTY=yes
 else
     HAVE_PTY=no
-    echo "NOTE: script(1) is not installed, so the interactive-confirmation"
-    echo "      cases will be skipped. It ships with util-linux on Linux; CI"
-    echo "      runs on ubuntu-latest, which has it, so the coverage is never"
-    echo "      optional there."
+    echo "NOTE: script(1) here doesn't support the -qec invocation these tests"
+    echo "      need (present but not util-linux's, or not installed at all),"
+    echo "      so the interactive-confirmation cases will be skipped. CI runs"
+    echo "      on ubuntu-latest, which has util-linux's, so the coverage is"
+    echo "      never optional there."
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -1225,6 +1235,101 @@ dir="$(make_gh 'test' '42')"
 run_repo_rules_pty "$dir" 'nope' mikelward/lanes test
 assert_status 1
 assert_output "not confirmed"
+assert_no_write "$dir"
+finish_case
+fi
+
+test_case "refuses when the ruleset's scope moved into conflict while the prompt was open"
+if test "$HAVE_PTY" = no || test "$HAVE_JQ" = no; then skip_case "needs script(1) and jq"; finish_case; else
+# Simulates an admin moving the managed ruleset from `release` to the
+# default branch while an interactive user is still looking at the
+# confirmation prompt, at the exact moment a squash-only ruleset already
+# sits on the default branch. The FIRST scope check (before the prompt) has
+# nothing to conflict with -- release and main don't overlap -- so it must
+# pass and reach the prompt at all; only the SECOND check, re-run right
+# before the write, can see the conflict this move just created.
+dir="$(mktemp -d "$SUITE_TMP/fixture.XXXXXX")"
+mkdir -p "$dir/bin"
+cat > "$dir/ruleset-v1" <<'RULESET'
+{"id":42,"name":"merge gates","target":"branch","enforcement":"active",
+ "conditions":{"ref_name":{"include":["refs/heads/release"],"exclude":[]}},
+ "rules":[{"type":"required_status_checks","parameters":{
+    "strict_required_status_checks_policy":true,
+    "required_status_checks":[{"context":"test"}]}}]}
+RULESET
+cat > "$dir/ruleset-v2" <<'RULESET'
+{"id":42,"name":"merge gates","target":"branch","enforcement":"active",
+ "conditions":{"ref_name":{"include":["~DEFAULT_BRANCH"],"exclude":[]}},
+ "rules":[{"type":"required_status_checks","parameters":{
+    "strict_required_status_checks_policy":true,
+    "required_status_checks":[{"context":"test"}]}}]}
+RULESET
+cat > "$dir/other-ruleset" <<'RULESET'
+{"id":99,"name":"org squash policy","enforcement":"active",
+ "conditions":{"ref_name":{"include":["~DEFAULT_BRANCH"],"exclude":[]}},
+ "rules":[{"type":"pull_request","parameters":{
+    "allowed_merge_methods":["squash"]}}]}
+RULESET
+printf '0\n' > "$dir/scope_reads"
+cat > "$dir/bin/gh" <<'GHEOF'
+#!/bin/sh
+d="$(dirname "$(dirname "$0")")"
+echo "$*" >> "$d/calls"
+skip=no; want=""; jqexpr=""; inputfile=""; method=""
+for arg in "$@"; do
+    if test "$skip" = yes; then
+        skip=no
+        case "$want" in --jq) jqexpr="$arg" ;; --input) inputfile="$arg" ;; esac
+        continue
+    fi
+    case "$arg" in
+        --method|--jq|--input|-H|--header) skip=yes; want="$arg" ;;
+        *) ;;
+    esac
+done
+prev=""
+for arg in "$@"; do
+    case "$prev" in --method) method="$arg" ;; esac
+    prev="$arg"
+done
+if test -n "$method" && test "$method" != GET; then
+    if test -n "$inputfile" && test "$inputfile" != -; then cp "$inputfile" "$d/body"
+    else cat > "$d/body"; fi
+    exit 0
+fi
+case "$*" in
+    *"/rulesets/99"*) jq -r "$jqexpr" < "$d/other-ruleset" ;;
+    *"/rulesets/42"*)
+        case "$jqexpr" in
+            *".rules[].type"*) echo active; echo required_status_checks ;;
+            # compute_scope's own query -- the one this test's swap targets.
+            *"ref_name.exclude"*)
+                n="$(cat "$d/scope_reads")"
+                if test "$n" -eq 0; then
+                    jq -r "$jqexpr" < "$d/ruleset-v1"
+                    printf '1\n' > "$d/scope_reads"
+                else
+                    jq -r "$jqexpr" < "$d/ruleset-v2"
+                fi ;;
+            # build_update_body always sees the same (post-move) ruleset --
+            # this test is about the scope check, not about the body refresh
+            # already covered by the sibling race-condition test above.
+            *) jq -r "$jqexpr" < "$d/ruleset-v2" ;;
+        esac ;;
+    *"includes_parents=false"*) echo 42 ;;
+    *"includes_parents=true"*) echo 42; echo 99 ;;
+    *"repos/"*"/commits/"*"/check-runs"*) echo '"test"' ;;
+    *"repos/"*"/commits/"*"/status"*) : ;;
+    *"/pulls?"*) : ;;
+    *"/commits?"*) echo deadbee ;;
+    *"repos/"*) echo main; echo true ;;
+esac
+GHEOF
+chmod +x "$dir/bin/gh"
+run_repo_rules_pty "$dir" 'y' mikelward/lanes test
+assert_status 1
+assert_output "excludes rebase"
+assert_output "org squash policy"
 assert_no_write "$dir"
 finish_case
 fi

--- a/repo-rules_test
+++ b/repo-rules_test
@@ -1526,6 +1526,69 @@ assert_no_write "$dir"
 finish_case
 fi
 
+test_case "refuses to create if the default branch itself moved while the prompt is open"
+if test "$HAVE_PTY" = no; then skip_case "needs script(1)"; finish_case; else
+# ~DEFAULT_BRANCH is a live GitHub-resolved token, not a name this script
+# ever expands into the write body -- so if the repository's default branch
+# itself changes while the prompt is open (main -> trunk here), a
+# conflicting ruleset scoped to the NEW default branch has to be checked
+# against the new name, not the one read before the prompt.
+dir="$(mktemp -d "$SUITE_TMP/fixture.XXXXXX")"
+mkdir -p "$dir/bin"
+cat > "$dir/other-ruleset" <<'RULESET'
+{"id":99,"name":"trunk squash policy","enforcement":"active",
+ "conditions":{"ref_name":{"include":["refs/heads/trunk"],"exclude":[]}},
+ "rules":[{"type":"pull_request","parameters":{
+    "allowed_merge_methods":["squash"]}}]}
+RULESET
+printf '0\n' > "$dir/branch_reads"
+cat > "$dir/bin/gh" <<'GHEOF'
+#!/bin/sh
+d="$(dirname "$(dirname "$0")")"
+echo "$*" >> "$d/calls"
+skip=no; want=""; jqexpr=""
+for arg in "$@"; do
+    if test "$skip" = yes; then
+        skip=no
+        case "$want" in --jq) jqexpr="$arg" ;; esac
+        continue
+    fi
+    case "$arg" in
+        --method|--jq|--input|-H|--header) skip=yes; want="$arg" ;;
+        *) ;;
+    esac
+done
+case "$*" in
+    *"/rulesets/99"*) jq -r "$jqexpr" < "$d/other-ruleset" ;;
+    *"includes_parents=false"*) : ;;
+    *"includes_parents=true"*) echo 99 ;;
+    *"repos/"*"/commits/"*"/check-runs"*) echo '"test"' ;;
+    *"repos/"*"/commits/"*"/status"*) : ;;
+    *"/pulls?"*) : ;;
+    *"/commits?"*) echo deadbee ;;
+    *"repos/"*)
+        case "$jqexpr" in
+            *allow_rebase_merge*) echo true ;;
+            *)
+                n="$(cat "$d/branch_reads")"
+                if test "$n" -eq 0; then
+                    echo main
+                    printf '1\n' > "$d/branch_reads"
+                else
+                    echo trunk
+                fi ;;
+        esac ;;
+esac
+GHEOF
+chmod +x "$dir/bin/gh"
+run_repo_rules_pty "$dir" 'y' mikelward/lanes test
+assert_status 1
+assert_output "excludes rebase"
+assert_output "trunk squash policy"
+assert_no_write "$dir"
+finish_case
+fi
+
 # ---------------------------------------------------------------------------
 
 echo

--- a/repo-rules_test
+++ b/repo-rules_test
@@ -23,6 +23,22 @@ else
     echo "      Install jq to run them ('brew install jq', 'apt install jq')."
 fi
 
+# The interactive-confirmation cases need a real pseudo-terminal: the script
+# only prompts when `test -t 0` says stdin is one, and no plain pipe or file
+# redirect can make that true. `script` (util-linux) allocates one and
+# forwards its own stdin to it, which is the only way to feed a canned
+# y/n answer to the actual confirm/read branch rather than the
+# always-non-interactive refusal every other case in this suite exercises.
+if command -v script >/dev/null 2>&1; then
+    HAVE_PTY=yes
+else
+    HAVE_PTY=no
+    echo "NOTE: script(1) is not installed, so the interactive-confirmation"
+    echo "      cases will be skipped. It ships with util-linux on Linux; CI"
+    echo "      runs on ubuntu-latest, which has it, so the coverage is never"
+    echo "      optional there."
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # One directory for every fixture, removed on exit. A per-fixture mktemp with
 # no cleanup left thirty trees behind per run.
@@ -184,6 +200,36 @@ run_repo_rules() {
     dir="$1"; shift
     set +e
     output="$(PATH="$dir/bin:$PATH" "$REPO_RULES" "$@" 2>&1)"
+    status=$?
+    set -e
+}
+
+# Single-quotes each argument, escaping any embedded single quote, so it can
+# be embedded literally inside the double-quoted `script -c` command string
+# below. Only needed for the PTY cases: their arguments are fixed literals
+# chosen for this suite, not caller-supplied text, so a simpler quoting
+# scheme than the rest of this file's JSON-escaping is fine here.
+quote_args() {
+    out=""
+    for a in "$@"; do
+        out="$out'$(printf '%s' "$a" | sed "s/'/'\\\\''/g")' "
+    done
+    printf '%s' "$out"
+}
+
+# Like run_repo_rules, but drives repo-rules with a real pseudo-terminal on
+# stdin (via `script`) and feeds it one line of canned input, so a case can
+# reach the actual confirm/read branch instead of the always-non-interactive
+# refusal every other case here exercises. `2>&1` is on the OUTER command,
+# not inside the `script -c` string, so it also captures what repo-rules now
+# writes to its own stderr (the prompt and the plan, moved there so a
+# captured stdout doesn't hide them -- see repo-rules itself).
+run_repo_rules_pty() {
+    dir="$1"; shift
+    answer="$1"; shift
+    set +e
+    output="$(printf '%s\n' "$answer" | PATH="$dir/bin:$PATH" script -qec \
+        "$REPO_RULES $(quote_args "$@")" /dev/null 2>&1)"
     status=$?
     set -e
 }
@@ -1061,6 +1107,124 @@ RULESET
 run_repo_rules "$dir" --force mikelward/lanes test
 assert_status 0
 assert_output "already matches"
+assert_no_write "$dir"
+finish_case
+fi
+
+test_case "an interactive yes applies the change"
+if test "$HAVE_PTY" = no; then skip_case "needs script(1)"; finish_case; else
+dir="$(make_gh 'test' '')"
+run_repo_rules_pty "$dir" 'y' mikelward/lanes test
+assert_status 0
+assert_output "Apply this change to mikelward/lanes?"
+assert_output "created ruleset"
+assert_body "$dir" '"context":"test"'
+finish_case
+fi
+
+test_case "an interactive no leaves the ruleset unwritten"
+if test "$HAVE_PTY" = no; then skip_case "needs script(1)"; finish_case; else
+dir="$(make_gh 'test' '')"
+run_repo_rules_pty "$dir" 'n' mikelward/lanes test
+assert_status 1
+assert_output "Apply this change to mikelward/lanes?"
+assert_output "not confirmed"
+assert_no_write "$dir"
+finish_case
+fi
+
+test_case "writes the ruleset as it is right before the write, not as it was at the prompt"
+if test "$HAVE_PTY" = no || test "$HAVE_JQ" = no; then skip_case "needs script(1) and jq"; finish_case; else
+# Simulates a concurrent change landing while an interactive user is still
+# looking at the confirmation prompt: the fake gh here swaps the served
+# ruleset content the moment it has been read once for the full transform
+# (the same read the confirmation prompt is built from), so a second read
+# -- the refresh right before the PUT -- sees a DIFFERENT object. If the
+# write used the snapshot from the prompt instead, the "concurrent" bypass
+# rule added below would silently vanish from what gets pushed.
+dir="$(mktemp -d "$SUITE_TMP/fixture.XXXXXX")"
+mkdir -p "$dir/bin"
+cat > "$dir/ruleset-v1" <<'RULESET'
+{"id":42,"name":"merge gates","target":"branch","enforcement":"active",
+ "conditions":{"ref_name":{"include":["~DEFAULT_BRANCH"],"exclude":[]}},
+ "rules":[{"type":"required_status_checks","parameters":{
+    "strict_required_status_checks_policy":true,
+    "required_status_checks":[{"context":"test"}]}}]}
+RULESET
+cat > "$dir/ruleset-v2" <<'RULESET'
+{"id":42,"name":"merge gates","target":"branch","enforcement":"active",
+ "bypass_actors":[{"actor_id":9,"actor_type":"Team","bypass_mode":"always"}],
+ "conditions":{"ref_name":{"include":["~DEFAULT_BRANCH"],"exclude":[]}},
+ "rules":[{"type":"required_status_checks","parameters":{
+    "strict_required_status_checks_policy":true,
+    "required_status_checks":[{"context":"test"}]}}]}
+RULESET
+cp "$dir/ruleset-v1" "$dir/ruleset"
+printf '0\n' > "$dir/transform_reads"
+cat > "$dir/bin/gh" <<'GHEOF'
+#!/bin/sh
+d="$(dirname "$(dirname "$0")")"
+echo "$*" >> "$d/calls"
+skip=no; want=""; jqexpr=""; inputfile=""; method=""
+for arg in "$@"; do
+    if test "$skip" = yes; then
+        skip=no
+        case "$want" in --jq) jqexpr="$arg" ;; --input) inputfile="$arg" ;; esac
+        continue
+    fi
+    case "$arg" in
+        --method|--jq|--input|-H|--header) skip=yes; want="$arg" ;;
+        *) ;;
+    esac
+done
+prev=""
+for arg in "$@"; do
+    case "$prev" in --method) method="$arg" ;; esac
+    prev="$arg"
+done
+if test -n "$method" && test "$method" != GET; then
+    if test -n "$inputfile" && test "$inputfile" != -; then cp "$inputfile" "$d/body"
+    else cat > "$d/body"; fi
+    exit 0
+fi
+case "$*" in
+    *"/rulesets/42"*)
+        case "$jqexpr" in
+            *".rules[].type"*) echo active; echo required_status_checks ;;
+            *"REPO_RULES_CONTEXTS"*)
+                n="$(cat "$d/transform_reads")"
+                if test "$n" -eq 0; then
+                    jq -r "$jqexpr" < "$d/ruleset-v1"
+                    printf '1\n' > "$d/transform_reads"
+                else
+                    jq -r "$jqexpr" < "$d/ruleset-v2"
+                fi ;;
+            *) jq -r "$jqexpr" < "$d/ruleset" ;;
+        esac ;;
+    *"includes_parents=false"*) echo 42 ;;
+    *"includes_parents=true"*) echo 42 ;;
+    *"repos/"*"/commits/"*"/check-runs"*) echo '"test"' ;;
+    *"repos/"*"/commits/"*"/status"*) : ;;
+    *"/pulls?"*) : ;;
+    *"/commits?"*) echo deadbee ;;
+    *"repos/"*) echo main; echo true ;;
+esac
+GHEOF
+chmod +x "$dir/bin/gh"
+run_repo_rules_pty "$dir" 'y' mikelward/lanes test
+assert_status 0
+assert_body "$dir" '"actor_id": 9'
+finish_case
+fi
+
+test_case "an interactive non-yes answer on an update declines too"
+if test "$HAVE_PTY" = no || test "$HAVE_JQ" = no; then skip_case "needs script(1) and jq"; finish_case; else
+# Same refusal on the update path, where a real change is computed (this
+# fixture's ruleset lacks a pull_request rule, so one would be added).
+dir="$(make_gh 'test' '42')"
+run_repo_rules_pty "$dir" 'nope' mikelward/lanes test
+assert_status 1
+assert_output "not confirmed"
 assert_no_write "$dir"
 finish_case
 fi


### PR DESCRIPTION
## What

Before writing, `repo-rules` now compares the computed ruleset against what's already on GitHub and asks for confirmation when they differ, printing the same plan `--dry-run` shows. `--force` skips the question — same flag that already skips the never-reported guard, same reasoning: "I've already decided, stop asking." Without `--force` and without a terminal on stdin, the write is skipped rather than either hanging on a prompt nobody can answer or silently applying an unconfirmed admin-level change. A ruleset that already matches what's requested skips the question entirely (there's nothing to confirm), with or without `--force`.

The prompt and plan write to stderr, not stdout — stdin being a terminal doesn't mean stdout is one too, so a captured stdout (`output=$(repo-rules ...)`) doesn't hide the question. Every write-time invariant is revalidated right before the write, not reused from what the confirmation prompt was built from, on both the create and update paths: the ruleset body, the repository's own default branch (`~DEFAULT_BRANCH` is a live GitHub-resolved token, so a rename mid-run has to be checked against the new name), merge-method-conflict scope (a moved ruleset, or another ruleset that newly conflicts even when this one's own scope is the fixed default branch), whether the repository still permits a rebase merge, whether an existing ruleset is still active and still holds only managed rule types, and whether a same-named ruleset has appeared where none existed a moment ago. None of this closes the window to zero (another write could still land between these checks and the actual write), but it shrinks "however long a human takes to answer a prompt" down to a handful of API round trips, and refuses rather than silently guessing or switching paths wherever something has drifted.

## How

`build_update_body` now also emits an `unchanged`/`changed` verdict ahead of the body, using jq's structural `==` between the original ruleset (after the same field deletions the PUT body already applies) and the computed target — so key order and how each was assembled can't manufacture a false "changed". That comparison runs once, ahead of both `--dry-run` and the real write. `compute_scope` + `find_merge_method_conflicts` are wrapped in `validate_merge_method_scope`, called for both paths right before the write, preceded by `refresh_default_branch`; the repo-settings and ownership/enforcement checks are each their own function (`check_allow_rebase`, `check_ruleset_ownership`); and the create path's existence lookup is `lookup_existing_ruleset`. Every one of these is callable twice: once early (fail fast, before showing a plan for a write that might not even be possible) and once more right before the write.

## Tests

Every existing test that expected a real write now passes `--force`, since the suite's own stdin is never a terminal — that doubles as coverage for the new non-interactive refusal (every one of those tests would fail without `--force` after this change; verified by reverting the guard and watching them fail). New tests, via `script(1)`-allocated PTYs (gated behind a `HAVE_PTY` check that probes the actual invocation rather than just checking the binary is on PATH, so a BSD `script` on macOS degrades to a clean skip), cover the actual confirm/read branch — yes applies, a non-yes answer declines on both create and update — plus a dedicated regression test for each revalidated invariant: the write reflects a concurrent ruleset change rather than the stale snapshot; a write is refused if a concurrent change moves the ruleset into a scope another active ruleset conflicts with (update) or a conflicting ruleset newly appears on the fixed default-branch scope (create); a write is refused if the repository's default branch itself changes mid-run; a write is refused if rebase merging gets disabled concurrently; and a create is refused if a same-named ruleset appears concurrently. Mutation-tested every new guard by disabling it and confirming the right tests go red, then restored.

`sh -n` and `shellcheck -s sh` clean on both files. Full suite: 63/63 passing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VqbmQYWotDetLoj6mspXnE)_