### PR TITLE
Add repo-list, repo-secrets, and repo-setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,4 @@ test:
 	./repo-rules-audit_test
 	./repo-list_test
 	./repo-secrets_test
+	./repo-setup_test

--- a/Makefile
+++ b/Makefile
@@ -24,3 +24,4 @@ test:
 	./repo-rules_test
 	./repo-rules-audit_test
 	./repo-list_test
+	./repo-secrets_test

--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,4 @@ test:
 	./confinst_test
 	./repo-rules_test
 	./repo-rules-audit_test
+	./repo-list_test

--- a/repo-list
+++ b/repo-list
@@ -1,0 +1,217 @@
+#!/bin/sh
+# List a GitHub account's repositories, one OWNER/REPO per line.
+#
+# Usage:
+#     repo-list [--owner OWNER] [--include-forks] [--include-archived]
+#     repo-list
+#     repo-list --owner some-org
+#
+# OWNER defaults to whoever gh is authenticated as. Forks and archived
+# repositories are excluded by default; --include-forks / --include-archived
+# widen that.
+#
+# Requires the gh CLI, authenticated (read access only -- this makes no
+# writes).
+#
+# Cost and reliability: free. A couple of GitHub REST API calls plus one
+# paginated call over the repository list (5,000 authenticated requests an
+# hour). Expect well under a second for a fleet this size.
+#
+# Exit status: 0 on success (zero repositories is a legitimate answer, not a
+# failure), 1 if gh failed, 2 for a usage error.
+#
+# The one property this script exists for: it NEVER prints a partial list.
+# Every fan-out over this fleet (repo-rules-audit, repo-secrets, repo-setup)
+# is meant to loop over this script's output, so an error partway through
+# pagination that still printed the repos read so far would make "missing
+# one" silent -- worse than printing nothing, because a short list still
+# looks like a complete one. So output is buffered to a file and only
+# emitted after every read that built it has exited 0.
+#
+# Private repositories: GET /users/{name}/repos only ever returns PUBLIC
+# repositories, even for your own account authenticated as yourself -- it is
+# not the same as "everything I can see". Listing your own account's private
+# repos needs GET /user/repos instead (no path parameter, defaults to every
+# visibility), and listing an organization's needs GET /orgs/{org}/repos.
+# This script picks between them rather than always using the public-only
+# endpoint, which would silently drop every private repo in the fleet --
+# exactly the failure this tool exists to prevent, caused by this tool.
+
+set -eu
+
+PROGRAM="$(basename "$0")"
+OWNER=""
+OWNER_GIVEN=0
+INCLUDE_FORKS=0
+INCLUDE_ARCHIVED=0
+
+error() {
+    echo "$PROGRAM: $*" >&2
+}
+
+usage() {
+    cat <<EOF
+Usage: $PROGRAM [--owner OWNER] [--include-forks] [--include-archived]
+
+List OWNER's repositories (default: whoever gh is authenticated as), one
+OWNER/REPO per line, sorted. Forks and archived repositories are excluded
+unless asked for.
+
+  --owner OWNER        List this account's repositories instead of the
+                        authenticated user's. If OWNER is not an
+                        organization gh can see, only its public
+                        repositories can be listed -- the API has no way to
+                        list somebody else's private repos regardless of
+                        credentials.
+  --include-forks       Include forks.
+  --include-archived    Include archived repositories.
+  -h, --help            This message.
+EOF
+}
+
+while test $# -gt 0; do
+    case "$1" in
+        --owner) shift; test $# -gt 0 || { error "--owner needs a name"; exit 2; }
+                 OWNER="$1"; OWNER_GIVEN=1; shift ;;
+        --owner=*) OWNER="${1#--owner=}"; OWNER_GIVEN=1; shift ;;
+        --include-forks) INCLUDE_FORKS=1; shift ;;
+        --include-archived) INCLUDE_ARCHIVED=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        --) shift; break ;;
+        -*) error "unknown option '$1'"; usage >&2; exit 2 ;;
+        *) error "unexpected argument '$1'"; usage >&2; exit 2 ;;
+    esac
+done
+
+test $# -eq 0 || { error "unexpected argument '$1'"; usage >&2; exit 2; }
+
+command -v gh >/dev/null 2>&1 || {
+    error "gh is not installed. It carries the authentication this needs;"
+    error "installing it is less work than reimplementing that with curl."
+    exit 1
+}
+
+WORK="$(mktemp -d)"
+# Separate INT/TERM handlers, not one EXIT/INT/TERM trap for all three:
+# setting a trap on INT or TERM replaces sh's default terminate-on-signal
+# action with "run the handler, then resume the script" -- a SIGTERM
+# arriving while gh is running would clean up WORK and then keep executing
+# against a now-deleted directory instead of stopping, exiting with
+# whatever that produces instead of the expected 130/143.
+trap 'rm -rf "$WORK"' EXIT
+trap 'rm -rf "$WORK"; exit 130' INT
+trap 'rm -rf "$WORK"; exit 143' TERM
+
+if SELF="$(gh api user --jq .login)"; then
+    :
+else
+    error "could not determine the authenticated user"
+    exit 1
+fi
+test -n "$SELF" || { error "gh reported an empty authenticated username"; exit 1; }
+
+if test "$OWNER_GIVEN" -eq 1 && test -z "$OWNER"; then
+    # Codex review: an explicitly empty --owner (--owner='' or --owner '')
+    # was indistinguishable from an omitted one once it's just $OWNER --
+    # the fallback below would have silently substituted the authenticated
+    # user, retargeting a batch a wrapper script meant to point elsewhere
+    # (e.g. an unset variable expanded into --owner "$X") onto this
+    # account's own repos instead of failing on the mistake.
+    error "--owner was given an empty value; drop --owner entirely to use"
+    error "the authenticated user, or pass a real account name."
+    exit 2
+fi
+if test -z "$OWNER"; then
+    OWNER="$SELF"
+fi
+
+case "$OWNER" in
+    *[!A-Za-z0-9._-]*)
+        error "'$OWNER' contains characters GitHub does not allow in an account name"
+        exit 2 ;;
+esac
+
+# GitHub account names are case-insensitive (SomeUser and someuser are the
+# same account), but a plain = comparison isn't -- lowercased on both sides
+# so a differently-cased --owner still matches SELF instead of silently
+# falling through to the public-only users/{name}/repos path below and
+# dropping every private repo in the fleet.
+OWNER_LOWER=$(echo "$OWNER" | tr 'A-Z' 'a-z')
+SELF_LOWER=$(echo "$SELF" | tr 'A-Z' 'a-z')
+
+# Extra gh api arguments, only for the user/repos case below.
+AFFILIATION_ARGS=""
+if test "$OWNER_LOWER" = "$SELF_LOWER"; then
+    # The authenticated user's own repos, every visibility they can see --
+    # this is the one endpoint that is not public-only for your own account.
+    # affiliation=owner explicitly: GET /user/repos defaults to
+    # owner,collaborator,organization_member, which also returns repos this
+    # account can merely push to (someone else's, or an org's) -- exactly
+    # the repos a fan-out into repo-secrets/repo-setup must NOT touch.
+    # --method GET because gh api switches to POST the instant a -f field is
+    # given, per `gh api --help`.
+    ENDPOINT="user/repos"
+    AFFILIATION_ARGS="--method GET -f affiliation=owner"
+elif gh api "orgs/$OWNER" >/dev/null 2>"$WORK/org_probe.err"; then
+    # An org the caller can see: this lists every repo visible to them,
+    # private included, same as /user/repos does for a personal account.
+    ENDPOINT="orgs/$OWNER/repos"
+elif grep -q 'HTTP 404' "$WORK/org_probe.err"; then
+    # A genuine "no such org" -- OWNER is (or might be) an individual
+    # account instead. Only THIS specific failure may fall through to the
+    # public-only endpoint.
+    ENDPOINT="users/$OWNER/repos"
+    error "note: '$OWNER' is not an organization gh can see -- only its"
+    error "public repositories can be listed. There is no API that lists"
+    error "somebody else's private repos, whatever credentials are used."
+else
+    # Any OTHER probe failure (403/SSO, a transient 5xx, network) is NOT
+    # proof that OWNER is an individual account -- Codex review: reading it
+    # that way and falling back to the public-only endpoint would have this
+    # exit 0 with a silently incomplete list for a real, existing org this
+    # call merely couldn't reach right now, which is exactly the failure
+    # mode this script exists to prevent (see the header comment).
+    error "could not determine whether '$OWNER' is an organization:"
+    sed 's/^/  /' "$WORK/org_probe.err" >&2
+    exit 1
+fi
+
+# full_name, fork, and archived come back as one @tsv line per repo. Filtered
+# in shell rather than in the --jq expression itself: gh api's --jq is a
+# single fixed program per call (no --arg/--argjson the way a standalone jq
+# binary has), so branching on INCLUDE_FORKS/INCLUDE_ARCHIVED inside the
+# expression means building it as a string -- readable here, in plain shell,
+# instead.
+#
+# $AFFILIATION_ARGS unquoted is deliberate word-splitting: it's either empty
+# or exactly the two fixed tokens set above, never user input.
+if ! gh api --paginate "$ENDPOINT" $AFFILIATION_ARGS \
+    --jq '.[] | [.full_name, .fork, .archived] | @tsv' \
+    > "$WORK/repos.tsv" 2>"$WORK/repos.err"; then
+    error "could not list $OWNER's repositories:"
+    sed 's/^/  /' "$WORK/repos.err" >&2
+    exit 1
+fi
+
+: > "$WORK/repos"
+# `|| test -n "$full_name"` is not a style choice: without it, a final TSV
+# line with no trailing newline (gh --paginate joins pages verbatim, so a
+# truncated last page ends exactly there) is silently dropped by the while
+# loop -- `read` returns nonzero on that line even though it populated the
+# variables, and a plain `while read ...` skips the body on a nonzero read.
+# Caught by this script's own test suite reporting a fixture repo as missing
+# with no error at all -- exactly the silent-gap failure this tool exists to
+# prevent, and it would have been real against any upstream response that
+# happened to end without a trailing newline.
+while IFS="$(printf '\t')" read -r full_name is_fork is_archived || test -n "$full_name"; do
+    test -n "$full_name" || continue
+    if test "$is_fork" = "true" && test "$INCLUDE_FORKS" -ne 1; then
+        continue
+    fi
+    if test "$is_archived" = "true" && test "$INCLUDE_ARCHIVED" -ne 1; then
+        continue
+    fi
+    echo "$full_name" >> "$WORK/repos"
+done < "$WORK/repos.tsv"
+
+sort "$WORK/repos"

--- a/repo-list_test
+++ b/repo-list_test
@@ -1,0 +1,387 @@
+#!/bin/sh
+# Tests for repo-list
+#
+# These put a fake gh on PATH, so nothing here touches the network or needs a
+# token. The fake logs every call, which is what lets the failure tests
+# assert on exactly what did or did not reach stdout -- the property this
+# script exists for is "never print a partial list", and a test that only
+# checked the exit status would pass just as happily with a truncated one.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SUITE_TMP="$(mktemp -d)"
+# Codex review: same trap bug as the scripts under test -- trapping INT/TERM
+# alongside EXIT on one line replaces sh's default terminate-on-signal
+# action with "clean up, then resume the script", so canceling this suite
+# (CI's own timeout/cancel, or a local Ctrl-C) would remove SUITE_TMP and
+# then keep running the remaining test cases against it, reporting
+# confusing unrelated failures instead of actually stopping.
+trap 'rm -rf "$SUITE_TMP"' EXIT
+trap 'rm -rf "$SUITE_TMP"; exit 130' INT
+trap 'rm -rf "$SUITE_TMP"; exit 143' TERM
+REPO_LIST="$SCRIPT_DIR/repo-list"
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+TESTS_SKIPPED=0
+
+# make_gh: build a fake gh in a fresh dir and echo that dir.
+#   $1 = self login          $2 = TSV fixture for user/repos (self)
+#   $3 = org_exists fixture (non-empty = the org probe succeeds)
+#   $4 = TSV fixture for orgs/OWNER/repos
+#   $5 = TSV fixture for users/OWNER/repos (public-only fallback)
+#   $6 = set (non-empty) to make `gh api user` fail
+#   $7 = substring of a call to fail with a simulated error
+#   $8 = when org_exists ($3) is empty, the org probe's stderr text --
+#        defaults to a genuine "HTTP 404" (org doesn't exist) if unset, so a
+#        caller only needs this to simulate a NON-404 probe failure (403,
+#        SSO, a transient 5xx) that must NOT be read as "not an org".
+make_gh() {
+    dir="$(mktemp -d "$SUITE_TMP/fixture.XXXXXX")"
+    mkdir -p "$dir/bin"
+    printf '%s\n' "$1" > "$dir/self_login"
+    printf '%s' "${2-}" > "$dir/repos_user"
+    printf '%s' "${3-}" > "$dir/org_exists"
+    printf '%s' "${4-}" > "$dir/repos_org"
+    printf '%s' "${5-}" > "$dir/repos_public"
+    printf '%s' "${6-}" > "$dir/self_fail"
+    printf '%s' "${7-}" > "$dir/fail_on"
+    printf '%s' "${8-}" > "$dir/org_probe_error"
+    cat > "$dir/bin/gh" <<'EOF'
+#!/bin/sh
+# Fake gh. Logs the call, then answers from the fixture files beside it.
+dir="$(dirname "$(dirname "$0")")"
+echo "$*" >> "$dir/calls"
+
+if test -s "$dir/fail_on" && echo "$*" | grep -qF "$(cat "$dir/fail_on")"; then
+    echo "gh: simulated failure" >&2
+    exit 1
+fi
+
+endpoint=""
+skip=no
+for arg in "$@"; do
+    if test "$skip" = yes; then skip=no; continue; fi
+    case "$arg" in
+        api) ;;
+        --paginate|--silent) ;;
+        --jq|--method|-f) skip=yes ;;
+        -*) echo "gh: unknown flag $arg" >&2; exit 1 ;;
+        *) endpoint="$arg" ;;
+    esac
+done
+
+case "$endpoint" in
+    user)
+        if test -s "$dir/self_fail"; then
+            echo "gh: simulated auth failure" >&2
+            exit 1
+        fi
+        cat "$dir/self_login" ;;
+    user/repos) cat "$dir/repos_user" ;;
+    orgs/*/repos) cat "$dir/repos_org" ;;
+    orgs/*)
+        if test -s "$dir/org_exists"; then
+            exit 0
+        elif test -s "$dir/org_probe_error"; then
+            cat "$dir/org_probe_error" >&2
+            exit 1
+        else
+            echo "gh: HTTP 404: Not Found (https://api.github.com/$endpoint)" >&2
+            exit 1
+        fi ;;
+    users/*/repos) cat "$dir/repos_public" ;;
+    *) echo "gh: unhandled endpoint '$endpoint'" >&2; exit 1 ;;
+esac
+EOF
+    chmod +x "$dir/bin/gh"
+    echo "$dir"
+}
+
+run_repo_list() {
+    dir="$1"; shift
+    set +e
+    output="$(PATH="$dir/bin:$PATH" "$REPO_LIST" "$@" 2>&1)"
+    status=$?
+    set -e
+}
+
+assert_status() {
+    if test "$status" -ne "$1"; then
+        echo "  FAIL: expected exit status $1, got $status"
+        echo "  output: $output"
+        TEST_FAILED=1
+    fi
+}
+
+assert_output() {
+    case "$output" in
+        *"$1"*) ;;
+        *) echo "  FAIL: expected output to contain '$1'"
+           echo "  output: $output"
+           TEST_FAILED=1 ;;
+    esac
+}
+
+assert_no_output() {
+    case "$output" in
+        *"$1"*) echo "  FAIL: expected output NOT to contain '$1'"
+                echo "  output: $output"
+                TEST_FAILED=1 ;;
+    esac
+}
+
+assert_output_equals() {
+    if test "$output" != "$1"; then
+        echo "  FAIL: expected output to equal:"
+        echo "    $1"
+        echo "  got:"
+        echo "    $output"
+        TEST_FAILED=1
+    fi
+}
+
+assert_call() {
+    calls="$(cat "$1/calls" 2>/dev/null || true)"
+    case "$calls" in
+        *"$2"*) ;;
+        *) echo "  FAIL: expected a call matching '$2'"
+           echo "  calls: $calls"
+           TEST_FAILED=1 ;;
+    esac
+}
+
+test_case() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TEST_FAILED=0
+    echo "TEST: $1"
+}
+
+finish_case() {
+    if test "$TEST_FAILED" -eq 0; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo "  PASS"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
+# ---------------------------------------------------------------------------
+
+test_case "lists the authenticated user's repos, sorted, excluding forks and archived"
+dir="$(make_gh mikelward "b/repo	false	false
+a/repo	false	false
+forked/repo	true	false
+old/repo	false	true")"
+run_repo_list "$dir"
+assert_status 0
+assert_output_equals "a/repo
+b/repo"
+assert_call "$dir" "user/repos"
+finish_case
+
+test_case "--include-forks includes a fork"
+dir="$(make_gh mikelward "kept/repo	false	false
+forked/repo	true	false")"
+run_repo_list "$dir" --include-forks
+assert_status 0
+assert_output_equals "forked/repo
+kept/repo"
+finish_case
+
+test_case "--include-archived includes an archived repo"
+dir="$(make_gh mikelward "kept/repo	false	false
+old/repo	false	true")"
+run_repo_list "$dir" --include-archived
+assert_status 0
+assert_output_equals "kept/repo
+old/repo"
+finish_case
+
+test_case "--owner matching self still uses user/repos, not the public-only endpoint"
+dir="$(make_gh mikelward "a/repo	false	false")"
+run_repo_list "$dir" --owner mikelward
+assert_status 0
+assert_call "$dir" "user/repos"
+finish_case
+
+test_case "--owner matching self in a different case still uses user/repos"
+dir="$(make_gh mikelward "a/repo	false	false")"
+run_repo_list "$dir" --owner MikelWard
+assert_status 0
+assert_output_equals "a/repo"
+assert_call "$dir" "user/repos"
+finish_case
+
+test_case "self's own repo listing restricts affiliation to owner, not collaborator/org repos too"
+dir="$(make_gh mikelward "a/repo	false	false")"
+run_repo_list "$dir"
+assert_status 0
+assert_call "$dir" "user/repos --method GET -f affiliation=owner"
+finish_case
+
+test_case "an org listing does not restrict by affiliation -- that flag is only for the self case"
+dir="$(make_gh mikelward "" yes "org/repo	false	false" "")"
+run_repo_list "$dir" --owner some-org
+assert_status 0
+calls="$(cat "$dir/calls")"
+case "$calls" in
+    *"orgs/some-org/repos --method"*|*"orgs/some-org/repos -f"*)
+        echo "  FAIL: org listing must not carry the self-only affiliation args"
+        echo "  calls: $calls"
+        TEST_FAILED=1 ;;
+esac
+finish_case
+
+test_case "--owner for a visible org uses orgs/OWNER/repos"
+dir="$(make_gh mikelward "" yes "org/private-repo	false	false" "")"
+run_repo_list "$dir" --owner some-org
+assert_status 0
+assert_output_equals "org/private-repo"
+assert_call "$dir" "orgs/some-org/repos"
+finish_case
+
+test_case "--owner for another individual account falls back to public-only, with a note"
+dir="$(make_gh mikelward "" "" "" "other/public-repo	false	false")"
+run_repo_list "$dir" --owner someone-else
+assert_status 0
+assert_output "other/public-repo"
+assert_output "public repositories can be listed"
+assert_call "$dir" "users/someone-else/repos"
+finish_case
+
+test_case "an org probe failure that is NOT a 404 (403/SSO/transient) is a hard error, not a silent fallback to public-only"
+# Regression: falling back to the public-only endpoint on ANY org-probe
+# failure would silently produce an incomplete list for a real org this call
+# merely couldn't reach right now (auth/SSO required, a transient 5xx) --
+# exactly the failure mode this script's whole design exists to prevent.
+dir="$(make_gh mikelward "" "" "" "" "" "" "gh: HTTP 403: Forbidden (https://api.github.com/orgs/some-org) - SSO enforcement")"
+run_repo_list "$dir" --owner some-org
+assert_status 1
+assert_output "could not determine whether 'some-org' is an organization"
+assert_output "SSO enforcement"
+assert_no_output "public repositories can be listed"
+finish_case
+
+test_case "a failed page read prints no partial list"
+dir="$(make_gh mikelward "" "" "" "" "" "user/repos")"
+set +e
+stdout_only="$(PATH="$dir/bin:$PATH" "$REPO_LIST" 2>/dev/null)"
+status=$?
+set -e
+if test "$status" -ne 1; then
+    echo "  FAIL: expected exit status 1, got $status"
+    TEST_FAILED=1
+fi
+# Checked against stdout alone, not the combined output assert_output reads:
+# the error text itself says "repositories", so a substring check against
+# 2>&1 output would pass even if a partial list had leaked onto stdout.
+if test -n "$stdout_only"; then
+    echo "  FAIL: expected no stdout at all, got: $stdout_only"
+    TEST_FAILED=1
+fi
+finish_case
+
+test_case "an unauthenticated gh is reported, not treated as an empty fleet"
+dir="$(make_gh "" "" "" "" "" yes)"
+run_repo_list "$dir"
+assert_status 1
+assert_output "could not determine the authenticated user"
+finish_case
+
+test_case "rejects an owner name with disallowed characters"
+dir="$(make_gh mikelward "")"
+run_repo_list "$dir" --owner 'not a name'
+assert_status 2
+finish_case
+
+test_case "rejects an explicitly empty --owner rather than silently falling back to the authenticated user"
+dir="$(make_gh mikelward "")"
+run_repo_list "$dir" --owner ""
+assert_status 2
+assert_output "empty value"
+finish_case
+
+test_case "rejects an explicitly empty --owner= rather than silently falling back to the authenticated user"
+dir="$(make_gh mikelward "")"
+run_repo_list "$dir" --owner=
+assert_status 2
+assert_output "empty value"
+finish_case
+
+test_case "rejects an unexpected positional argument"
+dir="$(make_gh mikelward "")"
+run_repo_list "$dir" extra-arg
+assert_status 2
+finish_case
+
+test_case "an empty fleet is success, not an error"
+dir="$(make_gh mikelward "")"
+run_repo_list "$dir"
+assert_status 0
+assert_output_equals ""
+finish_case
+
+test_case "SIGTERM while gh is running aborts rather than resuming against a deleted WORK"
+# Codex review: trapping INT/TERM alongside EXIT on one `trap ... EXIT INT
+# TERM` line replaces sh's default terminate-on-signal action with "run the
+# handler, then resume the script" -- a SIGTERM arriving while the paginated
+# `gh api --paginate user/repos` call is in flight would clean up WORK and
+# then keep executing, reading/writing against a now-deleted directory
+# instead of stopping, and exiting with whatever that produces (e.g. a
+# "Directory nonexistent" error and status 1) instead of the expected 143.
+# Verified with a real SIGTERM: the fake gh sleeps for a few seconds on the
+# user/repos call, giving a wide, non-racy window to deliver the signal
+# while repo-list is genuinely blocked waiting on that child -- the shell
+# interrupts a foreground wait for a trapped signal immediately, so the
+# signal does not need to land at any precise instant. If the trap is buggy
+# (one combined handler, no exit), the sleep simply finishes and the script
+# produces its normal output/exit instead of aborting on the signal.
+dir="$(make_gh mikelward "owner/repo	false	false")"
+mv "$dir/bin/gh" "$dir/bin/gh.real"
+cat > "$dir/bin/gh" << EOF
+#!/bin/sh
+case " \$* " in
+    *"user/repos"*)
+        touch "$dir/reached-listing"
+        sleep 5 ;;
+esac
+exec "$dir/bin/gh.real" "\$@"
+EOF
+chmod +x "$dir/bin/gh"
+PATH="$dir/bin:$PATH" "$REPO_LIST" >"$dir/run.out" 2>&1 &
+run_pid=$!
+waited=0
+reached=0
+while test "$waited" -lt 10; do
+    if test -f "$dir/reached-listing"; then
+        reached=1
+        break
+    fi
+    sleep 1
+    waited=$((waited + 1))
+done
+if test "$reached" -eq 0; then
+    echo "  FAIL: repo-list never reached the user/repos listing call in 10s"
+    TEST_FAILED=1
+    kill -TERM "$run_pid" 2>/dev/null
+    wait "$run_pid" 2>/dev/null || true
+else
+    kill -TERM "$run_pid"
+    status=0
+    wait "$run_pid" 2>/dev/null || status=$?
+    output="$(cat "$dir/run.out")"
+    assert_status 143
+    if test -n "$output"; then
+        echo "  FAIL: expected no output when killed mid-listing, got: $output"
+        TEST_FAILED=1
+    fi
+fi
+finish_case
+
+# ---------------------------------------------------------------------------
+
+echo
+echo "Tests run: $TESTS_RUN, passed: $TESTS_PASSED, failed: $TESTS_FAILED, skipped: $TESTS_SKIPPED"
+test "$TESTS_FAILED" -eq 0

--- a/repo-secrets
+++ b/repo-secrets
@@ -1,0 +1,549 @@
+#!/bin/bash
+# Set one GitHub Actions secret to one value across one or more repositories.
+#
+# Usage:
+#     repo-secrets [--dry-run] [--force] --name NAME [--env ENV] [--file PATH] OWNER/REPO...
+#     repo-list | xargs repo-secrets --force --name LANES_TOKEN --env lanes --file token.txt
+#
+# The value comes from --file PATH, or from stdin when no --file is given --
+# never from a bare command-line argument, which would land in shell history
+# and in `ps` output for anyone else on the machine. Reading it from an
+# interactive terminal is refused outright rather than attempted with echo
+# left on: there is no portable way to hide terminal input the way `gh
+# secret set`'s own prompt does, and a secret that echoes to the screen
+# while typed is a worse failure than a script that asks you to pipe it in
+# instead.
+#
+# With --env NAME, the secret is scoped to that deployment environment,
+# creating the environment first if it does not already exist -- a PUT to
+# that endpoint upserts either way, so this is safe to run whether or not it
+# is there yet. Without --env, it is a plain repository secret.
+#
+# Requires the gh CLI, authenticated with admin rights on each repository
+# (setting a secret and, with --env, creating an environment both need it),
+# and bash (real arrays for the target-repository list and the plan --
+# see the bash-vs-sh note below).
+#
+# Unlike repo-rules and repo-rules-audit, which speak `gh api` directly
+# against documented REST endpoints, a secret's value has to be sealed-box
+# (libsodium) encrypted with the target repository's public key before
+# GitHub will accept it -- there is no reasonable way to do that from shell
+# alone. `gh secret set` does the encryption internally, so it is what
+# actually writes the value; `gh api` is used everywhere else here, for the
+# parts that need no client-side crypto (listing existing secret names,
+# creating the environment).
+#
+# Before writing, this lists which of NAME's targets already have a secret
+# by that name and prints the plan (new vs. overwrites an existing value),
+# then asks for confirmation -- once for the whole batch, not once per repo,
+# since it is the same NAME and the same value going to every target.
+# --force skips the question, same reasoning as repo-rules' own --force:
+# "I have already decided, stop asking." Run with no terminal on stdin and
+# without --force, it refuses to guess and changes nothing. There is no
+# "already matches, nothing to do" shortcut the way repo-rules has one --
+# GitHub never returns a secret's value, so whether an existing one already
+# equals what is being set is unanswerable, and every write is attempted
+# every time.
+#
+# Every repository is attempted even if an earlier one fails -- a typo in
+# the fourth of twenty repos should not leave the other nineteen unset. The
+# repos that failed are named at the end and the exit status is nonzero if
+# any did; nothing here reports success unless every target actually got
+# the value.
+#
+# bash, not sh: the target-repository list is deduplicated before the plan
+# is built (a repeated OWNER/REPO is always redundant to write twice, and
+# without deduplication the second occurrence's write-time recheck below
+# would see the secret this same run's first occurrence just wrote and
+# misread it as "created by someone else"), and the plan itself is three
+# parallel arrays rather than a "$repo $state $env_state" text file read
+# back line by line. Both need a real array; POSIX sh has none, only
+# newline-delimited strings, which is what a whole line of prior review
+# rounds spent finding fresh ways to misparse.
+#
+# Cost and reliability: free. Two or three GitHub REST API calls per
+# repository (list existing names, ensure the environment, set the secret);
+# well under the 5,000-authenticated-requests-an-hour limit for any
+# realistic fleet size, and well under a second per repository.
+#
+# Exit status: 0 if every target was set (or --dry-run), 1 if any target
+# failed or a read needed to build the plan failed, 2 for a usage error.
+
+set -euo pipefail
+set -f
+
+PROGRAM="$(basename "$0")"
+NAME=""
+ENV=""
+ENV_GIVEN=0
+VALUE_FILE=""
+FILE_GIVEN=0
+DRY_RUN=0
+FORCE=0
+
+error() {
+    echo "$PROGRAM: $*" >&2
+}
+
+usage() {
+    cat <<EOF
+Usage: $PROGRAM [--dry-run] [--force] --name NAME [--env ENV] [--file PATH] OWNER/REPO...
+
+Set the Actions secret NAME to a value on every OWNER/REPO given. The value
+comes from --file PATH, or from stdin (a pipe or redirect, never an
+interactive terminal) when --file is not given. With --env NAME, the secret
+is scoped to that deployment environment, which is created first if missing.
+
+  --name NAME      The secret's name (required).
+  --env NAME       Set an environment-scoped secret instead of a repository
+                    secret, creating the environment if it does not exist.
+  --file PATH      Read the value from this file instead of stdin.
+  --dry-run        Print the plan; make no writes.
+  --force          Apply without asking for confirmation.
+  -h, --help       This message.
+
+Examples:
+  $PROGRAM --name TOKEN --file token.txt owner/repo
+  repo-list | xargs $PROGRAM --force --name LANES_TOKEN --env lanes --file token.txt
+EOF
+}
+
+while (( $# > 0 )); do
+    case "$1" in
+        --name) shift; (( $# > 0 )) || { error "--name needs a value"; exit 2; }
+                NAME="$1"; shift ;;
+        --name=*) NAME="${1#--name=}"; shift ;;
+        --env) shift; (( $# > 0 )) || { error "--env needs a value"; exit 2; }
+               ENV="$1"; ENV_GIVEN=1; shift ;;
+        --env=*) ENV="${1#--env=}"; ENV_GIVEN=1; shift ;;
+        --file) shift; (( $# > 0 )) || { error "--file needs a path"; exit 2; }
+                VALUE_FILE="$1"; FILE_GIVEN=1; shift ;;
+        --file=*) VALUE_FILE="${1#--file=}"; FILE_GIVEN=1; shift ;;
+        --dry-run) DRY_RUN=1; shift ;;
+        --force) FORCE=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        --) shift; break ;;
+        -*) error "unknown option '$1'"; usage >&2; exit 2 ;;
+        *) break ;;
+    esac
+done
+
+[[ -n "$NAME" ]] || { error "--name is required"; usage >&2; exit 2; }
+(( $# >= 1 )) || { error "at least one OWNER/REPO is required"; usage >&2; exit 2; }
+
+# GitHub's own rule for a secret name: letters, digits, underscores; cannot
+# start with a digit; the GITHUB_ prefix is reserved (case-insensitive).
+# Checked here for a clear error rather than left to gh's own rejection,
+# same reasoning as repo-rules-audit's control-character refusal on a CHECK
+# name -- a plain error naming the actual rule beats an opaque API failure.
+case "$NAME" in
+    [A-Za-z_]*) ;;
+    *) error "'$NAME' is not a valid secret name: must start with a letter or underscore"; exit 2 ;;
+esac
+case "$NAME" in
+    *[!A-Za-z0-9_]*)
+        error "'$NAME' is not a valid secret name: only letters, digits, and underscores"
+        exit 2 ;;
+esac
+case "$NAME" in
+    [Gg][Ii][Tt][Hh][Uu][Bb]_*)
+        error "'$NAME' starts with the reserved GITHUB_ prefix; GitHub will refuse it"
+        exit 2 ;;
+esac
+
+if (( ENV_GIVEN == 1 )) && [[ -z "$ENV" ]]; then
+    # Codex review: an explicitly empty --env (--env='' or --env "") is
+    # indistinguishable from an omitted one once it's just $ENV -- every
+    # later non-empty check would silently take the repo-level path
+    # instead, which a wrapper script's own bug (an unset variable expanded
+    # into `--env "$X"`) could trigger and bypass whatever protections the
+    # caller meant to scope this secret behind. Caught here, at the source.
+    error "--env was given an empty value; drop --env entirely for a"
+    error "repository-level secret, or pass a real environment name."
+    exit 2
+fi
+if [[ -n "$ENV" ]]; then
+    case "$ENV" in
+        *[!A-Za-z0-9._-]*)
+            error "'$ENV' contains characters this script does not handle in an"
+            error "environment name (kept to letters, digits, '.', '_', '-' -- refusing"
+            error "rather than guessing how to URL-encode anything wider)."
+            exit 2 ;;
+    esac
+fi
+if (( FILE_GIVEN == 1 )) && [[ -z "$VALUE_FILE" ]]; then
+    # Codex review: an explicitly empty --file (--file='' or --file "")
+    # is indistinguishable from an omitted one once it's just $VALUE_FILE
+    # -- the read-the-value branch below would fall through to stdin
+    # instead, silently reading whatever happens to be piped or redirected
+    # in rather than refusing outright. Caught here, at the source.
+    error "--file was given an empty value; drop --file entirely to read"
+    error "the value from stdin, or pass a real path."
+    exit 2
+fi
+
+for repo in "$@"; do
+    # Strictly OWNER/REPO -- see repo-rules for why: gh expands a literal
+    # '{owner}/{repo}' from the current checkout, which would silently
+    # retarget every call in this script to whatever repository the shell
+    # happens to be in, with admin credentials.
+    case "$repo" in
+        */*/*|/*|*/) error "'$repo' is not OWNER/REPO"; exit 2 ;;
+        */*) ;;
+        *) error "'$repo' is not OWNER/REPO"; exit 2 ;;
+    esac
+    case "$repo" in
+        *[!A-Za-z0-9._/-]*)
+            error "'$repo' contains characters GitHub does not allow in an owner or"
+            error "repository name."
+            exit 2 ;;
+    esac
+done
+
+# Case-insensitive string equality, without `${var,,}` (bash 4+ only, not in
+# macOS's stock 3.2) or a subprocess. Defined here, ahead of the dedup
+# below, rather than down with file_contains_ci -- GitHub repository names
+# resolve case-insensitively, so dedup needs it too.
+ieq() {
+    local a="$1" b="$2"
+    shopt -s nocasematch
+    local result=1
+    [[ "$a" == "$b" ]] && result=0
+    shopt -u nocasematch
+    return "$result"
+}
+
+# Deduplicated, preserving first-occurrence order, case-insensitively --
+# Codex review: Owner/Repo and owner/repo resolve to the same repository on
+# GitHub, so an exact-string dedup let both through as "different" targets.
+# A repeated OWNER/REPO in one invocation (an easy thing for a caller
+# piping repo-list through xargs, or hand-listing repos, to do by accident,
+# and just as easy with a stray casing difference) is always redundant to
+# process twice; without this, the second occurrence's write-time recheck
+# below sees the secret this same run's first occurrence just wrote and
+# refuses it as "created by someone else" -- a false alarm against this
+# script's own prior write within the same run, not a real race.
+REPOS=()
+for repo in "$@"; do
+    already=0
+    for seen in "${REPOS[@]+"${REPOS[@]}"}"; do
+        if ieq "$seen" "$repo"; then
+            already=1
+            break
+        fi
+    done
+    (( already == 1 )) || REPOS+=("$repo")
+done
+
+command -v gh >/dev/null 2>&1 || {
+    error "gh is not installed. It carries the authentication this needs, and"
+    error "does the client-side encryption a secret's value has to have before"
+    error "GitHub will accept it -- both are less work to install than to"
+    error "reimplement."
+    exit 1
+}
+
+WORK="$(mktemp -d)"
+# Separate INT/TERM handlers, not one EXIT/INT/TERM trap for all three:
+# setting a trap on INT or TERM replaces bash's default terminate-on-signal
+# action with "run the handler, then resume the script" -- a Ctrl-C or a
+# `kill` mid-batch (between one repo's write and the next) would clean up
+# $WORK but then carry on writing the secret to the REMAINING repositories,
+# the opposite of what the user just asked for. Each signal's own handler
+# has to end in an explicit exit -- Codex review.
+trap 'rm -rf "$WORK"' EXIT
+trap 'rm -rf "$WORK"; exit 130' INT
+trap 'rm -rf "$WORK"; exit 143' TERM
+
+# file_contains_ci: whether any line of FILE case-insensitively equals
+# NEEDLE. A plain read loop with `ieq` instead of `grep -qxFi` -- see
+# repo-setup's copy of this function for why a failed `< "$file"`
+# redirection is caught explicitly (return 2) rather than trusted to
+# surface as a shell error under set -e: it does not, when called as an
+# `if` condition, and would otherwise silently read as "not found" (return
+# 1) exactly like grep's own exit-status conflation this replaces. Return
+# 0 = found, 1 = genuinely not found, 2 = could not read FILE at all --
+# callers must treat 2 as an error, not "doesn't exist yet".
+file_contains_ci() {
+    local needle="$1" file="$2" line found=1
+    [[ -r "$file" ]] || return 2
+    while IFS= read -r line; do
+        if ieq "$line" "$needle"; then
+            found=0
+            break
+        fi
+    done < "$file" || return 2
+    return "$found"
+}
+
+if [[ -n "$VALUE_FILE" ]]; then
+    [[ -r "$VALUE_FILE" ]] || { error "cannot read '$VALUE_FILE'"; exit 2; }
+    cp "$VALUE_FILE" "$WORK/value"
+else
+    if [[ -t 0 ]]; then
+        error "refusing to read a secret value from an interactive terminal --"
+        error "there is no way to hide it as you type. Pipe the value in, or pass"
+        error "--file PATH."
+        exit 2
+    fi
+    cat > "$WORK/value"
+fi
+[[ -s "$WORK/value" ]] || { error "the secret value is empty"; exit 2; }
+
+PLAN_REPOS=()
+PLAN_STATES=()
+PLAN_ENV_STATES=()
+
+plan_add() {
+    PLAN_REPOS+=("$1")
+    PLAN_STATES+=("$2")
+    PLAN_ENV_STATES+=("$3")
+}
+
+for repo in "${REPOS[@]}"; do
+    if [[ -n "$ENV" ]]; then
+        LIST_ENDPOINT="repos/$repo/environments/$ENV/secrets"
+    else
+        LIST_ENDPOINT="repos/$repo/actions/secrets"
+    fi
+    # ENV_STATE tracks whether $ENV itself exists yet on $repo, separately
+    # from STATE (whether NAME exists within it) -- the write phase needs
+    # this to decide whether creating the environment is safe. A PUT to
+    # repos/$repo/environments/$ENV upserts unconditionally: run against an
+    # environment that already exists, it silently resets that environment's
+    # protection settings (required reviewers, wait timer, deployment-branch
+    # policy) to the endpoint's defaults. So the write phase must call it
+    # ONLY when this phase found the environment missing, never as a blanket
+    # "ensure it exists" on every run.
+    # --paginate: both endpoints default to the first page only (30 items).
+    # Codex review: a target with more secrets than that, where NAME sits
+    # past page 1, would otherwise read as "not found" -- STATE=new -- and
+    # the write phase's `gh secret set` then silently overwrites the
+    # existing value with none of the "OVERWRITES an existing value"
+    # warning this script exists to show.
+    if gh api --paginate "$LIST_ENDPOINT" --jq '.secrets[].name' > "$WORK/names" 2>"$WORK/names.err"; then
+        ENV_STATE=exists
+        if file_contains_ci "$NAME" "$WORK/names"; then
+            STATE=overwrite
+        else
+            membership_status=$?
+            if (( membership_status == 2 )); then
+                error "could not check whether '$NAME' already exists on"
+                error "$repo${ENV:+ (environment $ENV)}"
+                STATE=error
+            else
+                STATE=new
+            fi
+        fi
+    elif [[ -n "$ENV" ]] && [[ "$(cat "$WORK/names.err")" == *"HTTP 404"* ]]; then
+        # A 404 here is ambiguous: GitHub returns the same status whether
+        # $ENV doesn't exist yet on a real, accessible $repo (the expected
+        # case this branch means to handle) or $repo itself doesn't exist
+        # or isn't accessible -- it deliberately doesn't distinguish, to
+        # avoid leaking a private repo's existence. Codex review: trusting
+        # the 404 at face value would label a typo'd or inaccessible repo
+        # "new" and report success on a dry run without ever having read
+        # anything real. Positively confirm $repo exists and is reachable
+        # via its own environment-independent secrets endpoint before
+        # trusting that the environment, not the repo, is what's missing.
+        if gh api "repos/$repo/actions/secrets" --jq '.secrets[].name' \
+            > /dev/null 2>"$WORK/repo_check.err"; then
+            # The environment itself does not exist yet, so there is
+            # nothing on it to overwrite -- creating it happens later, at
+            # write time, not here: this phase only reads.
+            ENV_STATE=missing
+            STATE=new
+        else
+            error "could not confirm $repo exists and is accessible (the"
+            error "environment lookup 404'd too):"
+            sed 's/^/  /' "$WORK/repo_check.err" >&2
+            STATE=error
+            ENV_STATE=unknown
+        fi
+    else
+        # A read failure on one repo does not abort the batch -- it is
+        # recorded the same way a write failure is (see FAILED below), so a
+        # typo'd or inaccessible repo in the middle of a twenty-repo list
+        # does not also cost the nineteen that were fine.
+        error "could not list existing secrets on $repo:"
+        sed 's/^/  /' "$WORK/names.err" >&2
+        STATE=error
+        ENV_STATE=unknown
+    fi
+    plan_add "$repo" "$STATE" "$ENV_STATE"
+done
+
+describe_plan() {
+    local i
+    if [[ -n "$ENV" ]]; then
+        echo "About to set secret '$NAME' (environment '$ENV') on:"
+    else
+        echo "About to set secret '$NAME' (repository-level) on:"
+    fi
+    for (( i = 0; i < ${#PLAN_REPOS[@]}; i++ )); do
+        case "${PLAN_STATES[i]}" in
+            overwrite) echo "  ${PLAN_REPOS[i]}: OVERWRITES an existing value" ;;
+            new)       echo "  ${PLAN_REPOS[i]}: new" ;;
+            error)     echo "  ${PLAN_REPOS[i]}: SKIPPED -- could not read its existing secrets" ;;
+        esac
+    done
+}
+
+plan_has_error() {
+    local state
+    for state in "${PLAN_STATES[@]}"; do
+        [[ "$state" == error ]] && return 0
+    done
+    return 1
+}
+
+plan_all_errors() {
+    local state
+    for state in "${PLAN_STATES[@]}"; do
+        [[ "$state" == error ]] || return 1
+    done
+    return 0
+}
+
+if (( DRY_RUN == 1 )); then
+    describe_plan
+    plan_has_error && exit 1
+    exit 0
+fi
+
+if plan_all_errors; then
+    # Every repo failed the read phase -- nothing left to confirm or write.
+    describe_plan >&2
+    exit 1
+fi
+
+if (( FORCE != 1 )); then
+    if [[ -t 0 ]]; then
+        # To stderr, not stdout, same reasoning as repo-rules: a captured
+        # stdout must not silently swallow the question a script is still
+        # blocking on.
+        describe_plan >&2
+        printf 'Apply this to every repository above? [y/N] ' >&2
+        read -r CONFIRM || CONFIRM=""
+        case "$CONFIRM" in
+            [Yy]|[Yy][Ee][Ss]) ;;
+            *) error "not confirmed; no secrets were changed."; exit 1 ;;
+        esac
+    else
+        error "stdin is not a terminal and --force was not given, so no secrets"
+        error "were changed rather than either blocking on a question nobody can"
+        error "answer or silently applying an unconfirmed change. Pass --force to"
+        error "apply non-interactively, or run this from a terminal."
+        exit 1
+    fi
+fi
+
+FAILED=""
+for (( i = 0; i < ${#PLAN_REPOS[@]}; i++ )); do
+    repo="${PLAN_REPOS[i]}"
+    state="${PLAN_STATES[i]}"
+    env_state="${PLAN_ENV_STATES[i]}"
+    if [[ "$state" == error ]]; then
+        # Already reported when the plan was built; just carried through to
+        # the final summary so one line names every repo nothing happened to.
+        FAILED="$FAILED $repo"
+        continue
+    fi
+    if [[ "$state" == new ]]; then
+        # Codex review, same discipline as the environment recheck below: a
+        # secret classified "new" at plan-build time can have been created
+        # by someone else in the window since -- the confirmation prompt,
+        # or an earlier repo's own writes in a large batch -- and the
+        # unconditional `gh secret set` further down would then silently
+        # overwrite that value with none of the "OVERWRITES an existing
+        # value" warning this whole plan/confirm flow exists to show.
+        # Revalidated immediately before the write; refuse rather than
+        # guess if it's genuinely changed underneath us. (Deduplicating
+        # REPOS up front, above, is what keeps this from firing against
+        # this same run's own prior write to a repeated OWNER/REPO.)
+        if [[ -n "$ENV" ]]; then
+            RECHECK_ENDPOINT="repos/$repo/environments/$ENV/secrets"
+        else
+            RECHECK_ENDPOINT="repos/$repo/actions/secrets"
+        fi
+        if gh api --paginate "$RECHECK_ENDPOINT" --jq '.secrets[].name' \
+            > "$WORK/recheck_names" 2>"$WORK/recheck.err"; then
+            if file_contains_ci "$NAME" "$WORK/recheck_names"; then
+                error "'$NAME' on $repo${ENV:+ (environment $ENV)} was created by"
+                error "someone else since the plan was built; refusing to overwrite"
+                error "it without the confirmation that was given for a different,"
+                error "now-stale plan."
+                FAILED="$FAILED $repo"
+                continue
+            else
+                membership_status=$?
+                if (( membership_status == 2 )); then
+                    error "could not recheck whether '$NAME' already exists on"
+                    error "$repo${ENV:+ (environment $ENV)}"
+                    FAILED="$FAILED $repo"
+                    continue
+                fi
+            fi
+        elif [[ -n "$ENV" ]] && [[ "$(cat "$WORK/recheck.err")" == *"HTTP 404"* ]]; then
+            : # environment still doesn't exist -- nothing on it could have
+              # been created since the plan was built, exactly as planned
+        else
+            error "could not recheck whether '$NAME' still doesn't exist on"
+            error "$repo${ENV:+ (environment $ENV)}:"
+            sed 's/^/  /' "$WORK/recheck.err" >&2
+            FAILED="$FAILED $repo"
+            continue
+        fi
+    fi
+    if [[ -n "$ENV" ]]; then
+        # Only create the environment when the read phase found it missing
+        # -- but that read happened before the confirmation prompt (which
+        # can sit for an arbitrary amount of real time) and, in a large
+        # batch, before every earlier repo's own writes too. Codex review:
+        # trusting that stale env_state alone still lets a since-created
+        # environment (by another admin, or another run) get PUT again
+        # here, resetting whatever protection settings it was just given --
+        # exactly the quiet settings loss this whole check exists to avoid,
+        # just reopened by a later window than the one already closed.
+        # Revalidated immediately before the PUT, right here, rather than
+        # trusting the plan.
+        if [[ "$env_state" == missing ]]; then
+            if gh api "repos/$repo/environments/$ENV" >/dev/null 2>"$WORK/env_recheck.err"; then
+                : # already exists now -- someone else created it since the
+                  # plan was built; leave its settings alone
+            elif [[ "$(cat "$WORK/env_recheck.err")" == *"HTTP 404"* ]]; then
+                if ! gh api --method PUT "repos/$repo/environments/$ENV" >/dev/null 2>"$WORK/env.err"; then
+                    error "could not create environment '$ENV' on $repo:"
+                    sed 's/^/  /' "$WORK/env.err" >&2
+                    FAILED="$FAILED $repo"
+                    continue
+                fi
+            else
+                error "could not recheck whether environment '$ENV' exists on $repo:"
+                sed 's/^/  /' "$WORK/env_recheck.err" >&2
+                FAILED="$FAILED $repo"
+                continue
+            fi
+        fi
+        if gh secret set "$NAME" --repo "$repo" --env "$ENV" < "$WORK/value" 2>"$WORK/set.err"; then
+            echo "$repo: set '$NAME' (environment '$ENV')"
+        else
+            error "could not set '$NAME' on $repo (environment '$ENV'):"
+            sed 's/^/  /' "$WORK/set.err" >&2
+            FAILED="$FAILED $repo"
+        fi
+    else
+        if gh secret set "$NAME" --repo "$repo" < "$WORK/value" 2>"$WORK/set.err"; then
+            echo "$repo: set '$NAME'"
+        else
+            error "could not set '$NAME' on $repo:"
+            sed 's/^/  /' "$WORK/set.err" >&2
+            FAILED="$FAILED $repo"
+        fi
+    fi
+done
+
+if [[ -n "$FAILED" ]]; then
+    error "failed on:$FAILED"
+    exit 1
+fi

--- a/repo-secrets_test
+++ b/repo-secrets_test
@@ -1,0 +1,746 @@
+#!/bin/sh
+# Tests for repo-secrets
+#
+# These put a fake gh on PATH, so nothing here touches the network, needs a
+# token, or ever encrypts anything for real. The fake logs every call and
+# every write's stdin, which is what lets the tests assert on which repos
+# were actually written to (and with what value) rather than just the exit
+# status -- a batch tool's whole point is which targets it did and did not
+# touch, and only the call log can answer that.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SUITE_TMP="$(mktemp -d)"
+# Codex review: same trap bug as the scripts under test -- trapping INT/TERM
+# alongside EXIT on one line replaces bash's default terminate-on-signal
+# action with "clean up, then resume the script", so canceling this suite
+# (CI's own timeout/cancel, or a local Ctrl-C) would remove SUITE_TMP and
+# then keep running the remaining test cases against it, reporting
+# confusing unrelated failures instead of actually stopping.
+trap 'rm -rf "$SUITE_TMP"' EXIT
+trap 'rm -rf "$SUITE_TMP"; exit 130' INT
+trap 'rm -rf "$SUITE_TMP"; exit 143' TERM
+REPO_SECRETS="$SCRIPT_DIR/repo-secrets"
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# make_gh: build a fake gh in a fresh dir and echo that dir.
+#   $1 = newline-separated secret names that already exist (repo-level or,
+#        when $2 is set, on that environment)
+#   $2 = environment name the fixture pretends exists (empty = none yet, so
+#        a "list secrets on this environment" call comes back 404) -- this
+#        governs the PLAN-TIME read only (the /secrets list endpoint).
+#   $3 = substring of a call to fail with a simulated error
+#   $4 = whether the environment exists by the time of the WRITE-TIME
+#        revalidation (the plain, no-/secrets-suffix GET immediately before
+#        the create PUT) -- defaults to the same as $2 when not given, so
+#        every existing caller is unaffected. Set this differently from $2
+#        to simulate the environment being created by someone else in the
+#        window between the plan-build read and this repo's write turn.
+#   $5 = whether the repo itself exists/is accessible at all, gating its
+#        (environment-independent) actions/secrets endpoint -- defaults to
+#        "yes" so every existing caller is unaffected. Set this empty to
+#        simulate a typo'd or inaccessible repo: with $2 also empty (the
+#        environment lookup 404s), this is what tells the fix's repo-exists
+#        recheck apart from an environment that is merely missing.
+#   $6 = newline-separated secret names a SECOND (or later) listing call on
+#        the same secrets-list endpoint sees -- defaults to the same as $1,
+#        so every existing caller is unaffected. Set this differently from
+#        $1 to simulate the secret itself being created by someone else in
+#        the window between the plan-build read and this repo's write-time
+#        recheck (state=new only issues that second call).
+make_gh() {
+    dir="$(mktemp -d "$SUITE_TMP/fixture.XXXXXX")"
+    mkdir -p "$dir/bin"
+    printf '%s\n' "$1" > "$dir/existing_names"
+    printf '%s' "${2-}" > "$dir/env_exists"
+    printf '%s' "${3-}" > "$dir/fail_on"
+    printf '%s' "${4-${2-}}" > "$dir/env_exists_at_recheck"
+    printf '%s' "${5-yes}" > "$dir/repo_exists"
+    printf '%s\n' "${6-$1}" > "$dir/existing_names_at_recheck"
+    cat > "$dir/bin/gh" <<'EOF'
+#!/bin/sh
+# Fake gh. Logs the call, then answers from the fixture files beside it.
+dir="$(dirname "$(dirname "$0")")"
+echo "$*" >> "$dir/calls"
+
+if test -s "$dir/fail_on" && echo "$*" | grep -qF "$(cat "$dir/fail_on")"; then
+    echo "gh: simulated failure" >&2
+    exit 1
+fi
+
+if test "$1" = secret; then
+    # secret set NAME --repo REPO [--env ENV]
+    shift; shift  # drop "secret" "set"
+    name="$1"; shift
+    repo=""
+    env=""
+    while test $# -gt 0; do
+        case "$1" in
+            --repo) shift; repo="$1" ;;
+            --env) shift; env="$1" ;;
+        esac
+        shift
+    done
+    safe="$(echo "$repo" | tr '/' '_')"
+    if test -n "$env"; then
+        cat > "$dir/written.$safe.$env.$name"
+    else
+        cat > "$dir/written.$safe.$name"
+    fi
+    exit 0
+fi
+
+# api [--method PUT] [--paginate] ENDPOINT [--jq EXPR]
+method=""
+endpoint=""
+paginate=no
+skip=no
+want=""
+jqexpr=""
+for arg in "$@"; do
+    if test "$skip" = yes; then
+        skip=no
+        case "$want" in --method) method="$arg" ;; --jq) jqexpr="$arg" ;; esac
+        continue
+    fi
+    case "$arg" in
+        api) ;;
+        --method) skip=yes; want="$arg" ;;
+        --jq) skip=yes; want="$arg" ;;
+        --paginate) paginate=yes ;;
+        -*) echo "gh: unknown flag $arg" >&2; exit 1 ;;
+        *) endpoint="$arg" ;;
+    esac
+done
+
+# Real GitHub secret-listing endpoints return only the first page (30 items)
+# without --paginate -- simulated here by truncating the fixture unless the
+# call actually asked for every page, so a test can tell the two apart.
+#
+# A second (or later) call to the SAME secrets-list endpoint -- the
+# write-phase recheck for a state=new secret -- reads existing_names_at_recheck
+# instead, so a test can diverge what "someone else" did in that window from
+# what the plan originally saw. Tracked per-endpoint by a call counter, since
+# both calls share the identical endpoint shape and there's nothing else to
+# tell them apart by.
+list_names() {
+    counter_file="$dir/list_calls.$(echo "$endpoint" | tr -c 'A-Za-z0-9' '_')"
+    count="$(cat "$counter_file" 2>/dev/null || echo 0)"
+    count=$((count + 1))
+    echo "$count" > "$counter_file"
+    if test "$count" -ge 2; then
+        names_file="$dir/existing_names_at_recheck"
+    else
+        names_file="$dir/existing_names"
+    fi
+    if test "$paginate" = yes; then
+        grep -v '^$' "$names_file" || true
+    else
+        grep -v '^$' "$names_file" | head -30 || true
+    fi
+}
+
+case "$endpoint" in
+    */environments/*/secrets)
+        if test -n "$(cat "$dir/env_exists")"; then
+            # gh api --jq (no @json) prints raw strings, unquoted -- same as
+            # `jq -r`. Quoting them here would test a shape gh never sends.
+            list_names
+        else
+            echo "gh: HTTP 404: Not Found (https://api.github.com/$endpoint)" >&2
+            exit 1
+        fi ;;
+    */environments/*)
+        if test "$method" = PUT; then
+            : # create/update the environment itself -- always succeeds
+        elif test -n "$(cat "$dir/env_exists_at_recheck")"; then
+            : # the revalidation GET immediately before the PUT -- exists
+        else
+            echo "gh: HTTP 404: Not Found (https://api.github.com/$endpoint)" >&2
+            exit 1
+        fi ;;
+    */actions/secrets)
+        if test -n "$(cat "$dir/repo_exists")"; then
+            list_names
+        else
+            echo "gh: HTTP 404: Not Found (https://api.github.com/$endpoint)" >&2
+            exit 1
+        fi ;;
+    *) echo "gh: unhandled endpoint '$endpoint' (jq=$jqexpr method=$method)" >&2; exit 1 ;;
+esac
+EOF
+    chmod +x "$dir/bin/gh"
+    echo "$dir"
+}
+
+run() {
+    dir="$1"; shift
+    set +e
+    output="$(PATH="$dir/bin:$PATH" "$REPO_SECRETS" "$@" 2>&1)"
+    status=$?
+    set -e
+}
+
+# Same shape as run(), but pipes VALUE to stdin instead of leaving it a
+# terminal -- --force alone does not make stdin a non-terminal under the
+# test harness, and every non---file case needs a value source anyway.
+run_with_stdin_value() {
+    dir="$1"; shift
+    value="$1"; shift
+    set +e
+    output="$(printf '%s' "$value" | PATH="$dir/bin:$PATH" "$REPO_SECRETS" "$@" 2>&1)"
+    status=$?
+    set -e
+}
+
+assert_status() {
+    if test "$status" -ne "$1"; then
+        echo "  FAIL: expected exit status $1, got $status"
+        echo "  output: $output"
+        TEST_FAILED=1
+    fi
+}
+
+assert_output() {
+    case "$output" in
+        *"$1"*) ;;
+        *) echo "  FAIL: expected output to contain '$1'"
+           echo "  output: $output"
+           TEST_FAILED=1 ;;
+    esac
+}
+
+assert_no_output() {
+    case "$output" in
+        *"$1"*) echo "  FAIL: expected output NOT to contain '$1'"
+                echo "  output: $output"
+                TEST_FAILED=1 ;;
+    esac
+}
+
+# $1 = fixture dir, $2 = owner_repo with '/' as '_', $3 = secret name,
+# $4 = value expected on that write, $5 = environment name or empty
+assert_written() {
+    d="$1"; safe="$2"; name="$3"; expected="$4"; env="${5-}"
+    if test -n "$env"; then
+        f="$d/written.$safe.$env.$name"
+    else
+        f="$d/written.$safe.$name"
+    fi
+    if ! test -f "$f"; then
+        echo "  FAIL: expected a write to $safe ($name${env:+, env $env}), found none"
+        TEST_FAILED=1
+        return
+    fi
+    got="$(cat "$f")"
+    if test "$got" != "$expected"; then
+        echo "  FAIL: expected written value '$expected', got '$got'"
+        TEST_FAILED=1
+    fi
+}
+
+assert_not_written() {
+    d="$1"; safe="$2"; name="$3"
+    if test -f "$d/written.$safe.$name" || ls "$d"/written."$safe".*."$name" >/dev/null 2>&1; then
+        echo "  FAIL: expected NO write to $safe ($name), but one happened"
+        TEST_FAILED=1
+    fi
+}
+
+test_case() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TEST_FAILED=0
+    echo "TEST: $1"
+}
+
+finish_case() {
+    if test "$TEST_FAILED" -eq 0; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo "  PASS"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
+# ---------------------------------------------------------------------------
+
+test_case "sets a new repository secret from --file, non-interactively with --force"
+dir="$(make_gh "")"
+printf 'sekrit' > "$dir/value.txt"
+run "$dir" --force --name TOKEN --file "$dir/value.txt" owner/repo
+assert_status 0
+assert_output "owner/repo: set 'TOKEN'"
+assert_written "$dir" owner_repo TOKEN sekrit
+finish_case
+
+test_case "sets an environment-scoped secret and creates the environment first, when it does not exist yet"
+dir="$(make_gh "")"
+printf 'sekrit' > "$dir/value.txt"
+run "$dir" --force --name TOKEN --env lanes --file "$dir/value.txt" owner/repo
+assert_status 0
+assert_written "$dir" owner_repo TOKEN sekrit lanes
+grep -q "PUT repos/owner/repo/environments/lanes" "$dir/calls" || { echo "  FAIL: environment was never created"; TEST_FAILED=1; }
+finish_case
+
+test_case "an environment-scoped secret on an ALREADY-EXISTING environment does not re-PUT it"
+# Regression: a PUT to repos/OWNER/REPO/environments/ENV upserts
+# unconditionally, so calling it every run -- even when the environment is
+# already there -- would silently reset its protection settings (required
+# reviewers, wait timer, deployment-branch policy) to the endpoint's
+# defaults. env_exists=lanes makes the fixture's "list secrets on this
+# environment" call succeed instead of 404ing, the same signal the real
+# read phase uses to record ENV_STATE=exists.
+dir="$(make_gh "" lanes)"
+printf 'sekrit' > "$dir/value.txt"
+run "$dir" --force --name TOKEN --env lanes --file "$dir/value.txt" owner/repo
+assert_status 0
+assert_written "$dir" owner_repo TOKEN sekrit lanes
+if grep -q "PUT repos/owner/repo/environments/lanes" "$dir/calls"; then
+    echo "  FAIL: an already-existing environment must not be re-created/reset"
+    TEST_FAILED=1
+fi
+finish_case
+
+test_case "value can come from stdin instead of --file"
+dir="$(make_gh "")"
+run_with_stdin_value "$dir" "piped-value" --force --name TOKEN owner/repo
+assert_status 0
+assert_written "$dir" owner_repo TOKEN piped-value
+finish_case
+
+test_case "sets across every repo given, in one invocation"
+dir="$(make_gh "")"
+printf 'sekrit' > "$dir/value.txt"
+run "$dir" --force --name TOKEN --file "$dir/value.txt" owner/one owner/two owner/three
+assert_status 0
+assert_written "$dir" owner_one TOKEN sekrit
+assert_written "$dir" owner_two TOKEN sekrit
+assert_written "$dir" owner_three TOKEN sekrit
+finish_case
+
+test_case "dry-run reports the plan and writes nothing"
+dir="$(make_gh "TOKEN")"
+printf 'sekrit' > "$dir/value.txt"
+run "$dir" --dry-run --name TOKEN --file "$dir/value.txt" owner/repo
+assert_status 0
+assert_output "OVERWRITES an existing value"
+assert_not_written "$dir" owner_repo TOKEN
+finish_case
+
+test_case "dry-run needs no confirmation and no --force"
+dir="$(make_gh "")"
+printf 'sekrit' > "$dir/value.txt"
+run "$dir" --dry-run --name TOKEN --file "$dir/value.txt" owner/repo
+assert_status 0
+assert_not_written "$dir" owner_repo TOKEN
+finish_case
+
+test_case "an existing secret is reported as an overwrite in the plan"
+dir="$(make_gh "TOKEN
+OTHER")"
+printf 'sekrit' > "$dir/value.txt"
+run "$dir" --dry-run --name TOKEN --file "$dir/value.txt" owner/repo
+assert_status 0
+assert_output "owner/repo: OVERWRITES an existing value"
+finish_case
+
+test_case "an existing secret in a different case is still reported as an overwrite, not new"
+# Regression: GitHub secret names are case-insensitive (stored uppercase
+# internally) -- Codex review. --name token when TOKEN already exists must
+# still warn about the overwrite, not report it as a new secret.
+dir="$(make_gh "TOKEN")"
+printf 'sekrit' > "$dir/value.txt"
+run "$dir" --dry-run --name token --file "$dir/value.txt" owner/repo
+assert_status 0
+assert_output "owner/repo: OVERWRITES an existing value"
+finish_case
+
+test_case "a not-yet-existing secret is reported as new in the plan"
+dir="$(make_gh "OTHER")"
+printf 'sekrit' > "$dir/value.txt"
+run "$dir" --dry-run --name TOKEN --file "$dir/value.txt" owner/repo
+assert_status 0
+assert_output "owner/repo: new"
+finish_case
+
+# The old sh version's existing-secret classification and write-time
+# recheck both used `grep -qxFi "$NAME" ...`, which treats a real grep
+# failure (status 2) identically to "no match" (status 1) and silently
+# proceeds on no real evidence -- previously tested here by shadowing
+# grep's exact `-qxFi` flag shape at each call site. The bash rewrite
+# replaced both grep calls with file_contains_ci(), a plain read loop; a
+# failed `< "$file"` redirection there is caught explicitly and returned
+# as a distinct status (2), with both call sites treating it as an error
+# rather than "not found" -- see repo-secrets' file_contains_ci and its
+# comment for why this needed an explicit check (a redirection failure
+# inside a function called as an `if` condition does not trigger `set -e`,
+# so it silently falls through to whatever the function does next unless
+# caught). There is no black-box way left to force this path the way grep
+# could be shadowed on PATH: the read happens synchronously, in-process,
+# on a file this same script wrote an instant earlier, with no external
+# command and no test hook to intercept in between. Left unexercised here
+# rather than adding a test-only hook to production code; the 0/1/2
+# contract and its two call sites are verified by inspection.
+
+test_case "a repeated OWNER/REPO in one invocation is written once, not misread as a race with itself"
+# Round J: the write-time recheck above (state=new only) exists to catch a
+# secret created by someone ELSE between the plan and the write. Without
+# deduplicating the target list first, a caller passing the same OWNER/REPO
+# twice (an easy accident piping repo-list through xargs, or hand-listing
+# repos) hits that same check against its OWN first occurrence's write --
+# the second occurrence's plan row also read state=new (both reads happened
+# before either write), so at write time the recheck finds the secret this
+# very run just wrote a moment ago and refuses it as "created by someone
+# else", failing the whole batch despite the requested end state (the
+# secret is set) being satisfied.
+dir="$(make_gh "")"
+printf 'sekrit' > "$dir/value.txt"
+run "$dir" --force --name TOKEN --file "$dir/value.txt" owner/repo owner/repo
+assert_status 0
+assert_output "owner/repo: set 'TOKEN'"
+assert_written "$dir" owner_repo TOKEN sekrit
+if test "$(grep -c '^secret set TOKEN --repo owner/repo$' "$dir/calls")" -ne 1; then
+    echo "  FAIL: expected exactly one write to owner/repo, not one per repeated argument"
+    TEST_FAILED=1
+fi
+finish_case
+
+test_case "the same repo in two different cases is deduplicated too, not treated as two targets"
+# Codex review: GitHub repository names resolve case-insensitively, so
+# Owner/Repo and owner/repo are the same repository -- an exact-string
+# dedup let both through, hitting the exact same self-write-mistaken-for-a-
+# race failure as the exact-duplicate case above, just reached via a
+# casing difference instead of a literal repeat.
+dir="$(make_gh "")"
+printf 'sekrit' > "$dir/value.txt"
+run "$dir" --force --name TOKEN --file "$dir/value.txt" Owner/Repo owner/repo
+assert_status 0
+if test "$(grep -c '^secret set TOKEN --repo ' "$dir/calls")" -ne 1; then
+    echo "  FAIL: expected exactly one write across both casings of the same repo"
+    TEST_FAILED=1
+fi
+finish_case
+
+test_case "an existing secret past the first page (>30) is still reported as an overwrite, not misread as new"
+# Regression: GitHub's secret-listing endpoints return only the first page
+# (30 items) by default. Without --paginate this read would silently miss
+# NAME sitting on a later page, mislabel it "new" in the plan, and the write
+# phase would then overwrite the existing value with no warning at all --
+# Codex review.
+existing="$(i=1; while test "$i" -le 35; do echo "OTHER_$i"; i=$((i + 1)); done; echo TOKEN)"
+dir="$(make_gh "$existing")"
+printf 'sekrit' > "$dir/value.txt"
+run "$dir" --dry-run --name TOKEN --file "$dir/value.txt" owner/repo
+assert_status 0
+assert_output "owner/repo: OVERWRITES an existing value"
+grep -q -- "--paginate" "$dir/calls" || { echo "  FAIL: the secrets listing call must use --paginate"; TEST_FAILED=1; }
+finish_case
+
+test_case "a repository whose name legitimately contains the word 'error' is not misread as a failed read"
+# Regression: the error/failure check used to grep -w "error" across the
+# WHOLE plan line ("$repo $STATE $ENV_STATE"), which also matches a repo
+# name containing "error" as its own word -- Codex review. Now it checks
+# only the parsed STATE column.
+dir="$(make_gh "")"
+printf 'sekrit' > "$dir/value.txt"
+run "$dir" --force --name TOKEN --file "$dir/value.txt" owner/my-error-repo
+assert_status 0
+assert_output "owner/my-error-repo: set 'TOKEN'"
+assert_written "$dir" owner_my-error-repo TOKEN sekrit
+finish_case
+
+test_case "an environment that does not exist yet is reported as new, not an error"
+dir="$(make_gh "" "")"
+printf 'sekrit' > "$dir/value.txt"
+run "$dir" --dry-run --name TOKEN --env lanes --file "$dir/value.txt" owner/repo
+assert_status 0
+assert_output "owner/repo: new"
+finish_case
+
+test_case "without --force and without a terminal on stdin, nothing is written"
+dir="$(make_gh "")"
+printf 'sekrit' > "$dir/value.txt"
+run "$dir" --name TOKEN --file "$dir/value.txt" owner/repo
+assert_status 1
+assert_output "stdin is not a terminal"
+assert_not_written "$dir" owner_repo TOKEN
+finish_case
+
+test_case "refuses to read the value from an interactive terminal"
+dir="$(make_gh "")"
+if command -v script >/dev/null 2>&1; then
+    set +e
+    output="$(PATH="$dir/bin:$PATH" script -qec \
+        "$REPO_SECRETS --force --name TOKEN owner/repo" /dev/null 2>&1)"
+    status=$?
+    set -e
+    assert_status 2
+    assert_output "interactive terminal"
+    assert_not_written "$dir" owner_repo TOKEN
+else
+    echo "  SKIP: no script(1) to allocate a PTY with"
+fi
+finish_case
+
+test_case "SIGTERM mid-batch aborts rather than continuing to the next repo"
+# Codex review: trapping INT/TERM alongside EXIT on one `trap ... EXIT INT
+# TERM` line replaces bash's default terminate-on-signal action with "run
+# the handler, then resume the script" -- a Ctrl-C or `kill` mid-batch
+# would clean up $WORK but then carry on writing the remaining repos, the
+# opposite of what the signal asked for. Verified with a real SIGTERM: the
+# fake gh sleeps for a few seconds on the FIRST repo's write (well after
+# its own write has landed, so a correct abort still leaves that first
+# write in place), giving a wide, non-racy window to deliver the signal
+# while repo-secrets is genuinely blocked waiting on that child -- bash
+# interrupts a foreground wait for a trapped signal immediately, so the
+# signal does not need to land at any precise instant, only sometime
+# during those few seconds. If the trap is buggy (one combined handler,
+# no exit), the sleep simply finishes and the batch completes normally
+# instead of aborting.
+dir="$(make_gh "")"
+printf 'sekrit' > "$dir/value.txt"
+mv "$dir/bin/gh" "$dir/bin/gh.real"
+cat > "$dir/bin/gh" << EOF
+#!/bin/sh
+case " \$* " in
+    *" secret set TOKEN --repo owner/one "*)
+        "$dir/bin/gh.real" "\$@"
+        touch "$dir/first-write-landed"
+        sleep 5
+        exit 0 ;;
+esac
+exec "$dir/bin/gh.real" "\$@"
+EOF
+chmod +x "$dir/bin/gh"
+PATH="$dir/bin:$PATH" "$REPO_SECRETS" --force --name TOKEN --file "$dir/value.txt" \
+    owner/one owner/two owner/three >"$dir/run.out" 2>&1 &
+run_pid=$!
+waited=0
+reached=0
+while test "$waited" -lt 10; do
+    if test -f "$dir/first-write-landed"; then
+        reached=1
+        break
+    fi
+    sleep 1
+    waited=$((waited + 1))
+done
+if test "$reached" -eq 0; then
+    echo "  FAIL: repo-secrets never reached the first write in 10s"
+    TEST_FAILED=1
+    kill -TERM "$run_pid" 2>/dev/null
+    wait "$run_pid" 2>/dev/null || true
+else
+    kill -TERM "$run_pid"
+    status=0
+    wait "$run_pid" 2>/dev/null || status=$?
+    output="$(cat "$dir/run.out")"
+    assert_status 143
+    assert_written "$dir" owner_one TOKEN sekrit
+    assert_not_written "$dir" owner_two TOKEN
+    assert_not_written "$dir" owner_three TOKEN
+fi
+finish_case
+
+test_case "one failing repo does not block the others, and the failure is reported"
+dir="$(make_gh "" "" "owner/bad")"
+printf 'sekrit' > "$dir/value.txt"
+run "$dir" --force --name TOKEN --file "$dir/value.txt" owner/good owner/bad owner/also-good
+assert_status 1
+assert_output "failed on:"
+assert_output "owner/bad"
+assert_written "$dir" owner_good TOKEN sekrit
+assert_written "$dir" owner_also-good TOKEN sekrit
+assert_not_written "$dir" owner_bad TOKEN
+finish_case
+
+test_case "a read failure while building the plan aborts before any write"
+dir="$(make_gh "" "" "actions/secrets")"
+printf 'sekrit' > "$dir/value.txt"
+run "$dir" --force --name TOKEN --file "$dir/value.txt" owner/one owner/two
+assert_status 1
+assert_output "could not list existing secrets"
+assert_not_written "$dir" owner_one TOKEN
+assert_not_written "$dir" owner_two TOKEN
+finish_case
+
+test_case "rejects a secret name starting with a digit"
+dir="$(make_gh "")"
+run "$dir" --force --name 1TOKEN owner/repo
+assert_status 2
+finish_case
+
+test_case "rejects a secret name with the reserved GITHUB_ prefix"
+dir="$(make_gh "")"
+run "$dir" --force --name GITHUB_TOKEN owner/repo
+assert_status 2
+finish_case
+
+test_case "rejects a secret name with disallowed characters"
+dir="$(make_gh "")"
+run "$dir" --force --name "TOKEN-NAME" owner/repo
+assert_status 2
+finish_case
+
+test_case "requires --name"
+dir="$(make_gh "")"
+run "$dir" --force owner/repo
+assert_status 2
+finish_case
+
+test_case "requires at least one OWNER/REPO"
+dir="$(make_gh "")"
+run "$dir" --force --name TOKEN
+assert_status 2
+finish_case
+
+test_case "rejects an OWNER/REPO shaped like an owner/repo/extra path"
+dir="$(make_gh "")"
+run "$dir" --force --name TOKEN owner/repo/extra
+assert_status 2
+finish_case
+
+test_case "refuses --file pointing at a file that does not exist"
+dir="$(make_gh "")"
+run "$dir" --force --name TOKEN --file "$dir/nope.txt" owner/repo
+assert_status 2
+finish_case
+
+test_case "refuses an empty secret value"
+dir="$(make_gh "")"
+: > "$dir/empty.txt"
+run "$dir" --force --name TOKEN --file "$dir/empty.txt" owner/repo
+assert_status 2
+assert_output "empty"
+finish_case
+
+test_case "rejects an explicitly empty --env rather than silently setting a repository-level secret"
+# Regression: --env='' or --env "" was indistinguishable from omitting
+# --env entirely once it's just $ENV -- Codex review. A wrapper script's
+# own bug (an unset variable expanded into --env "$X") could silently
+# bypass whatever environment protections the caller meant to scope this
+# secret behind.
+dir="$(make_gh "")"
+printf 'sekrit' > "$dir/value.txt"
+run "$dir" --force --name TOKEN --env "" --file "$dir/value.txt" owner/repo
+assert_status 2
+assert_output "empty value"
+if test -s "$dir/calls"; then
+    echo "  FAIL: expected no gh calls before the usage error"; TEST_FAILED=1
+fi
+finish_case
+
+test_case "rejects an explicitly empty --env= rather than silently setting a repository-level secret"
+dir="$(make_gh "")"
+printf 'sekrit' > "$dir/value.txt"
+run "$dir" --force --name TOKEN --env= --file "$dir/value.txt" owner/repo
+assert_status 2
+assert_output "empty value"
+finish_case
+
+test_case "rejects an explicitly empty --file rather than silently reading stdin instead"
+# Regression: --file='' or --file "" was indistinguishable from omitting
+# --file entirely once it's just $VALUE_FILE -- Codex review. With --force
+# and stdin as a pipe or redirect, this could set the secret from that
+# unrelated stream despite the caller explicitly asking for a named file.
+dir="$(make_gh "")"
+printf 'sekrit' > "$dir/value.txt"
+printf 'unrelated-stdin-value' | run "$dir" --force --name TOKEN --file "" owner/repo
+assert_status 2
+assert_output "empty value"
+if test -s "$dir/calls"; then
+    echo "  FAIL: expected no gh calls before the usage error"; TEST_FAILED=1
+fi
+assert_not_written "$dir" owner_repo TOKEN
+finish_case
+
+test_case "rejects an explicitly empty --file= rather than silently reading stdin instead"
+dir="$(make_gh "")"
+printf 'unrelated-stdin-value' | run "$dir" --force --name TOKEN --file= owner/repo
+assert_status 2
+assert_output "empty value"
+assert_not_written "$dir" owner_repo TOKEN
+finish_case
+
+test_case "an inaccessible repository is not misread as a merely-missing environment"
+# Codex review: GitHub returns the same 404 whether an environment doesn't
+# exist yet on a real repo (the case this script means to treat as "new")
+# or the repo itself doesn't exist or isn't accessible -- it deliberately
+# doesn't distinguish, to avoid leaking a private repo's existence. $2=""
+# (env lookup 404s) with $5="" (the repo-exists recheck 404s too) simulates
+# the second case; this must be reported as a read failure, not "new".
+dir="$(make_gh "" "" "" "" "")"
+printf 'sekrit' > "$dir/value.txt"
+run "$dir" --force --name TOKEN --env lanes --file "$dir/value.txt" owner/typo-repo
+assert_status 1
+assert_output "could not confirm"
+assert_output "owner/typo-repo"
+assert_not_written "$dir" owner_typo-repo TOKEN lanes
+if grep -q "PUT repos/owner/typo-repo/environments/lanes" "$dir/calls"; then
+    echo "  FAIL: must not attempt to create an environment on an unconfirmed repo"
+    TEST_FAILED=1
+fi
+finish_case
+
+test_case "a secret created by someone else between the plan and the write is not silently overwritten"
+# Codex review: state=new was cached at plan-build time, before the
+# (potentially long) confirmation prompt and before any earlier repos in a
+# batch. If NAME is created by someone else in that window, the unconditional
+# `gh secret set` used to overwrite it anyway -- with none of the
+# "OVERWRITES an existing value" warning the plan/confirm flow exists to
+# show, because the plan never knew to show it. $1="" (nothing at plan
+# time) with $6="TOKEN" (it exists by write-time) simulates the race.
+dir="$(make_gh "" "" "" "" "yes" "TOKEN")"
+printf 'sekrit' > "$dir/value.txt"
+run "$dir" --force --name TOKEN --file "$dir/value.txt" owner/repo
+assert_status 1
+assert_output "was created by"
+assert_output "someone else"
+assert_not_written "$dir" owner_repo TOKEN
+finish_case
+
+test_case "the normal case (still new at write time) still creates the secret, revalidation included"
+dir="$(make_gh "")"
+printf 'sekrit' > "$dir/value.txt"
+run "$dir" --force --name TOKEN --file "$dir/value.txt" owner/repo
+assert_status 0
+assert_written "$dir" owner_repo TOKEN sekrit
+finish_case
+
+test_case "an environment created by someone else between the plan and the write is revalidated, not blindly re-created"
+# Regression: env_state was cached at plan-build time, before the
+# (potentially long) confirmation prompt and before any earlier repos in a
+# batch are processed -- Codex review. $2 (missing at plan time) and $4
+# (exists by write time) diverge here to simulate another admin or process
+# creating the environment in that window; the PUT that would reset its
+# settings must not fire.
+dir="$(make_gh "" "" "" yes)"
+printf 'sekrit' > "$dir/value.txt"
+run "$dir" --force --name TOKEN --env lanes --file "$dir/value.txt" owner/repo
+assert_status 0
+assert_written "$dir" owner_repo TOKEN sekrit lanes
+if grep -q "PUT repos/owner/repo/environments/lanes" "$dir/calls"; then
+    echo "  FAIL: an environment that now exists must not be re-created/reset"
+    TEST_FAILED=1
+fi
+finish_case
+
+test_case "the normal case (still missing at write time) still creates the environment, revalidation included"
+dir="$(make_gh "")"
+printf 'sekrit' > "$dir/value.txt"
+run "$dir" --force --name TOKEN --env lanes --file "$dir/value.txt" owner/repo
+assert_status 0
+assert_written "$dir" owner_repo TOKEN sekrit lanes
+grep -q "PUT repos/owner/repo/environments/lanes" "$dir/calls" || {
+    echo "  FAIL: environment was never created"; TEST_FAILED=1
+}
+finish_case
+
+# ---------------------------------------------------------------------------
+
+echo
+echo "Tests run: $TESTS_RUN, passed: $TESTS_PASSED, failed: $TESTS_FAILED"
+test "$TESTS_FAILED" -eq 0

--- a/repo-setup
+++ b/repo-setup
@@ -1,0 +1,734 @@
+#!/bin/bash
+# Bring one repository up to this fleet's standard shape: required checks,
+# fanned-out Actions secrets, and GitHub App installation membership, in
+# one call.
+#
+# Usage:
+#     repo-setup [--dry-run] [--force] [--no-rules] [--rule CHECK]...
+#                [--secret NAME[@ENV]=PATH]... [--app SLUG]... OWNER/REPO
+#     repo-setup --secret LANES_TOKEN@lanes=./token.txt --app codex owner/repo
+#     repo-list | xargs -n1 repo-setup --force --app codex
+#
+# A thin composer, not a reimplementation: the ruleset step shells out to
+# repo-rules and each secret to repo-secrets, so neither's real logic (the
+# never-reported-check guard, the confirm/diff machinery, the sealed-box
+# secret write) is duplicated here. Only the App-installation step is
+# native, because there is no sibling script for it yet.
+#
+# --rule CHECK (repeatable) names an explicit required check for repo-rules;
+# with none given, repo-rules applies its own default set. --no-rules skips
+# the ruleset step entirely. --secret NAME=PATH sets a repository secret
+# from that file's contents; NAME@ENV=PATH scopes it to a deployment
+# environment instead, creating the environment first if needed (see
+# repo-secrets). --app SLUG (repeatable) ensures OWNER/REPO is in that
+# GitHub App's installation -- the fix for a real gap: an installation
+# scoped to "All repositories" gives the App access to every repo you fork
+# too, the instant you fork it, since forking creates a new repo the grant
+# already covers. An explicit, reviewable list closes that.
+#
+# Before writing anything, every requested step runs in its own --dry-run
+# first (the real repo-rules/repo-secrets dry-run, not a re-implementation
+# of it) and the combined plan is printed and confirmed ONCE for the whole
+# repository -- not once per step, which would mean answering the same
+# "yes, do this repo" question three times over. --force skips it, same
+# reasoning as the scripts it wraps: "I have already decided, stop asking."
+# Once confirmed, each step is re-run for real with --force appended, since
+# stdin -- already consumed by this script's own prompt -- has nothing left
+# to answer a second question with. Codex review: both documented
+# `repo-list | xargs` examples above pipe a repo list into this script's
+# stdin, which is then not a terminal -- without --force alongside, every
+# invocation refuses non-interactively (correctly; there's no terminal to
+# confirm on) rather than doing anything, so the advertised fleet workflow
+# silently did nothing. --force is now part of the documented example.
+#
+# Every step is attempted regardless of whether an earlier one failed -- a
+# secret write failing must not also skip fixing the ruleset, or vice
+# versa. Failures are named at the end; the exit status is nonzero if any
+# step failed, whatever else succeeded.
+#
+# The App-installation step's API surface is less battle-tested than the
+# rest of this fleet's tooling: GitHub's /user/installations endpoints
+# predate fine-grained personal access tokens, and whether a fine-grained
+# PAT is accepted there could not be confirmed against GitHub's own docs
+# while this was written (network access to them was unavailable). If it
+# fails with what looks like a permission problem rather than a "not
+# found", a classic PAT is the documented fallback -- said explicitly
+# rather than guessed at further, and surfaced as its own failure rather
+# than silently skipped.
+#
+# Requires bash (real arrays -- RULES/SECRETS/APPS and the App plan below
+# all need to hold an arbitrary-content element, including one containing a
+# newline, without a delimiter collision; POSIX sh has no such type) and
+# the gh CLI, plus repo-rules and repo-secrets on PATH (this repository's
+# own directory, once installed). Written to bash 3.2 (macOS's stock,
+# pre-GPLv3 version) -- no associative arrays, no `${var,,}`, no `mapfile`.
+#
+# Cost and reliability: free -- a handful of GitHub REST API calls per
+# repository, well inside the 5,000-authenticated-requests-an-hour limit.
+#
+# Exit status: 0 if every requested step succeeded (or --dry-run and every
+# step's own dry-run succeeded), 1 if any step failed, 2 for a usage error.
+
+set -euo pipefail
+# Nothing here globs a filename; RULES and SECRETS entries are user-supplied
+# and can legitimately contain '*', '?', or '[' (a check name, an
+# environment, a file path) -- off for the whole script so the unquoted
+# expansions below can't have one read as a pathname pattern.
+set -f
+
+PROGRAM="$(basename "$0")"
+DRY_RUN=0
+FORCE=0
+NO_RULES=0
+RULES=()
+SECRETS=()
+APPS=()
+
+error() {
+    echo "$PROGRAM: $*" >&2
+}
+
+# A rule/secret/app value with an embedded newline would otherwise pass
+# through as a single array element (bash arrays don't split on it the way
+# the old newline-delimited sh strings did), but downstream tools (gh,
+# repo-rules) may still choke on it or behave confusingly -- reject it
+# upfront as a usage error, before any gh call runs.
+reject_newline() {
+    case "$2" in
+        *$'\n'*) error "$1 contains a newline"; exit 2 ;;
+    esac
+}
+
+usage() {
+    cat <<EOF
+Usage: $PROGRAM [--dry-run] [--force] [--no-rules] [--rule CHECK]...
+                [--secret NAME[@ENV]=PATH]... [--app SLUG]... OWNER/REPO
+
+Apply this fleet's standard ruleset (via repo-rules), fan out Actions
+secrets (via repo-secrets), and ensure App installation membership to
+OWNER/REPO, confirming once for the whole repository.
+
+  --rule CHECK        A required check to pass to repo-rules (repeatable).
+                        Omit entirely to use repo-rules' own defaults.
+  --no-rules           Skip the ruleset step.
+  --secret NAME=PATH   Set a repository secret from PATH's contents.
+  --secret NAME@ENV=PATH
+                        Set an environment-scoped secret, creating ENV
+                        first if it does not exist. Repeatable.
+  --app SLUG           Ensure OWNER/REPO is in this App's installation
+                        (repeatable).
+  --dry-run            Print the combined plan; make no writes.
+  --force              Apply without asking for confirmation.
+  -h, --help           This message.
+EOF
+}
+
+while (( $# > 0 )); do
+    case "$1" in
+        --rule) shift; (( $# > 0 )) || { error "--rule needs a check name"; exit 2; }
+                [[ -n "$1" ]] || { error "--rule needs a non-empty check name"; exit 2; }
+                reject_newline "--rule" "$1"
+                RULES+=("$1"); shift ;;
+        --rule=*) rule_value="${1#--rule=}"
+                  [[ -n "$rule_value" ]] || { error "--rule needs a non-empty check name"; exit 2; }
+                  reject_newline "--rule" "$rule_value"
+                  RULES+=("$rule_value"); shift ;;
+        --no-rules) NO_RULES=1; shift ;;
+        --secret) shift; (( $# > 0 )) || { error "--secret needs NAME[@ENV]=PATH"; exit 2; }
+                  [[ -n "$1" ]] || { error "--secret needs a non-empty NAME[@ENV]=PATH"; exit 2; }
+                  reject_newline "--secret" "$1"
+                  SECRETS+=("$1"); shift ;;
+        --secret=*) secret_value="${1#--secret=}"
+                    [[ -n "$secret_value" ]] || { error "--secret needs a non-empty NAME[@ENV]=PATH"; exit 2; }
+                    reject_newline "--secret" "$secret_value"
+                    SECRETS+=("$secret_value"); shift ;;
+        --app) shift; (( $# > 0 )) || { error "--app needs a slug"; exit 2; }
+               [[ -n "$1" ]] || { error "--app needs a non-empty slug"; exit 2; }
+               reject_newline "--app" "$1"
+               APPS+=("$1"); shift ;;
+        --app=*) app_value="${1#--app=}"
+                 [[ -n "$app_value" ]] || { error "--app needs a non-empty slug"; exit 2; }
+                 reject_newline "--app" "$app_value"
+                 APPS+=("$app_value"); shift ;;
+        --dry-run) DRY_RUN=1; shift ;;
+        --force) FORCE=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        --) shift; break ;;
+        -*) error "unknown option '$1'"; usage >&2; exit 2 ;;
+        *) break ;;
+    esac
+done
+
+(( $# == 1 )) || { error "exactly one OWNER/REPO is required"; usage >&2; exit 2; }
+REPO="$1"
+
+case "$REPO" in
+    */*/*|/*|*/) error "'$REPO' is not OWNER/REPO"; exit 2 ;;
+    */*) ;;
+    *) error "'$REPO' is not OWNER/REPO"; exit 2 ;;
+esac
+case "$REPO" in
+    *[!A-Za-z0-9._/-]*)
+        error "'$REPO' contains characters GitHub does not allow in an owner or"
+        error "repository name."
+        exit 2 ;;
+esac
+REPO_OWNER="${REPO%%/*}"
+
+if (( NO_RULES == 1 )) && (( ${#RULES[@]} > 0 )); then
+    error "--no-rules and --rule are contradictory"
+    exit 2
+fi
+
+# NAME[@ENV]=PATH, parsed once up front so a malformed --secret is a usage
+# error before anything runs, not a surprise partway through the plan.
+parse_secret_spec() {
+    local spec="$1" left
+    case "$spec" in
+        *=*) ;;
+        *) error "'--secret $spec' is not NAME[@ENV]=PATH (missing '=')"; exit 2 ;;
+    esac
+    left="${spec%%=*}"
+    SPEC_PATH="${spec#*=}"
+    case "$left" in
+        *@*) SPEC_NAME="${left%%@*}"; SPEC_ENV="${left#*@}"
+             # An @ present, but nothing after it, is a malformed spec, not
+             # "no environment" -- the caller wrote the @, meaning they
+             # wanted an environment scope.
+             [[ -n "$SPEC_ENV" ]] || { error "'--secret $spec' has an empty ENV after '@'"; exit 2; } ;;
+        *)   SPEC_NAME="$left"; SPEC_ENV="" ;;
+    esac
+    [[ -n "$SPEC_NAME" ]] || { error "'--secret $spec' has an empty NAME"; exit 2; }
+    [[ -n "$SPEC_PATH" ]] || { error "'--secret $spec' has an empty PATH"; exit 2; }
+    [[ -r "$SPEC_PATH" ]] || { error "cannot read '$SPEC_PATH' (from --secret $spec)"; exit 2; }
+}
+
+if (( ${#APPS[@]} > 0 )); then
+    for slug in "${APPS[@]}"; do
+        case "$slug" in
+            *[!A-Za-z0-9._-]*)
+                error "'$slug' contains characters this script does not handle in an App slug"
+                exit 2 ;;
+        esac
+    done
+fi
+
+# Case-insensitive string equality, without `${var,,}` (bash 4+ only, not in
+# macOS's stock 3.2) or a subprocess. Defined here, ahead of the duplicate
+# --secret check right below, rather than down by the App-membership code
+# that also uses it -- GitHub secret names are case-insensitive too.
+ieq() {
+    local a="$1" b="$2"
+    shopt -s nocasematch
+    local result=1
+    [[ "$a" == "$b" ]] && result=0
+    shopt -u nocasematch
+    return "$result"
+}
+
+# Every --secret is validated here, not left to the first place that
+# happens to consume it, so a malformed one is a usage error before any gh
+# call runs -- matching what parse_secret_spec's own comment promises. Also
+# rejects two entries targeting the same NAME+ENV scope: Codex review --
+# each --secret's dry-run preview inspects the same not-yet-written remote
+# state independently, so both can report "new" with no warning even
+# though the real apply then writes them in order and the second silently
+# overwrites the first, making the final value depend on argument order.
+# There's no legitimate reason to specify the same secret twice in one
+# invocation, so this rejects it outright rather than trying to make the
+# preview account for a still-pending sibling write. Both NAME and ENV
+# compared case-insensitively -- Codex review: GitHub treats deployment
+# environment names case-insensitively too (not verified independently
+# against GitHub's own docs, same network gap noted elsewhere in this
+# script, but the asymmetric cost of being wrong favors this direction --
+# an over-cautious usage-error false positive on two genuinely distinct,
+# same-named-except-for-case environments, versus a real silent overwrite
+# if they in fact collide).
+SEEN_SECRET_SPECS=()
+if (( ${#SECRETS[@]} > 0 )); then
+    for spec in "${SECRETS[@]}"; do
+        parse_secret_spec "$spec"
+        for seen_spec in "${SEEN_SECRET_SPECS[@]+"${SEEN_SECRET_SPECS[@]}"}"; do
+            seen_name="${seen_spec%%$'\t'*}"
+            seen_env="${seen_spec#*$'\t'}"
+            if ieq "$seen_name" "$SPEC_NAME" && ieq "$seen_env" "$SPEC_ENV"; then
+                error "'--secret $spec' repeats an earlier --secret's NAME[@ENV]"
+                error "(${SPEC_NAME}${SPEC_ENV:+@$SPEC_ENV}) -- the second would silently"
+                error "overwrite the first with no warning; drop one of them."
+                exit 2
+            fi
+        done
+        SEEN_SECRET_SPECS+=("$SPEC_NAME"$'\t'"$SPEC_ENV")
+    done
+fi
+
+command -v gh >/dev/null 2>&1 || {
+    error "gh is not installed. It carries the authentication this needs;"
+    error "installing it is less work than reimplementing that with curl."
+    exit 1
+}
+if (( NO_RULES != 1 )); then
+    command -v repo-rules >/dev/null 2>&1 || {
+        error "repo-rules is not on PATH (needed unless --no-rules is given)"
+        exit 1
+    }
+fi
+if (( ${#SECRETS[@]} > 0 )); then
+    command -v repo-secrets >/dev/null 2>&1 || {
+        error "repo-secrets is not on PATH (needed because --secret was given)"
+        exit 1
+    }
+fi
+
+WORK="$(mktemp -d)"
+# Separate INT/TERM handlers, not one EXIT/INT/TERM trap for all three:
+# setting a trap on INT or TERM replaces bash's default terminate-on-signal
+# action with "run the handler, then resume the script" -- a Ctrl-C or a
+# `kill` mid-apply (repo-rules, repo-secrets, or an App-installation call)
+# would clean up $WORK but then carry on running the REMAINING apply steps,
+# the opposite of what the user just asked for. Each signal's own handler
+# has to end in an explicit exit -- Codex review.
+trap 'rm -rf "$WORK"' EXIT
+trap 'rm -rf "$WORK"; exit 130' INT
+trap 'rm -rf "$WORK"; exit 143' TERM
+
+# Snapshot each --secret's value file now, once, rather than re-reading
+# $SPEC_PATH at every later point (the initial preview, the revalidation
+# recheck right before applying, and the real apply itself) -- Codex
+# review: re-reading the same path three times over the life of one run
+# means a file replaced or edited during the confirmation prompt, the
+# ruleset step, or an earlier secret's own apply deploys DIFFERENT bytes
+# than what informed the plan the user confirmed. The dry-run comparison
+# used for the plan-staleness check can't catch this either -- its output
+# describes the secret's REMOTE state (new/overwrite), never the local
+# file's contents. One private copy, taken here before anything is shown,
+# is what every later step reads from instead.
+if (( ${#SECRETS[@]} > 0 )); then
+    for (( i = 0; i < ${#SECRETS[@]}; i++ )); do
+        parse_secret_spec "${SECRETS[i]}"
+        cp "$SPEC_PATH" "$WORK/secret.$i.value"
+    done
+fi
+
+# ---- App-installation step (native; no sibling script for this yet) ------
+
+# Resolves SLUG to an installation id and its repository_selection, or
+# fails closed: an ambiguous or absent match is refused rather than guessed
+# at, the same discipline repo-rules applies to a ruleset it does not own.
+#
+# user/installations lists every installation the AUTHENTICATED USER can
+# see, across every account they belong to -- personal and every org they
+# are a member of. Filtering on app_slug alone therefore rejects a perfectly
+# unambiguous target whenever the same App happens to be installed on more
+# than one of those accounts (a personal install and an org install, say).
+# REPO_OWNER (derived from the already-validated OWNER/REPO argument, so it
+# carries no shell/jq metacharacters) narrows the match to the one
+# installation actually on the repository's own account, the same way the
+# account itself disambiguates it on GitHub's own UI. Compared via
+# ascii_downcase since GitHub account names are case-insensitive.
+resolve_installation() {
+    local slug="$1" count
+    if ! gh api user/installations --paginate \
+        --jq ".installations[] | select(.app_slug==\"$slug\" and (.account.login | ascii_downcase) == (\"$REPO_OWNER\" | ascii_downcase)) | [.id, .repository_selection] | @tsv" \
+        > "$WORK/install.$slug" 2>"$WORK/install.$slug.err"; then
+        error "could not list App installations (needed for --app $slug):"
+        sed 's/^/  /' "$WORK/install.$slug.err" >&2
+        return 1
+    fi
+    count="$(wc -l < "$WORK/install.$slug" | tr -d ' ')"
+    if (( count == 0 )); then
+        error "no installation of an App with slug '$slug' was found on $REPO_OWNER's account"
+        return 1
+    fi
+    if (( count > 1 )); then
+        error "more than one installation matched App slug '$slug' on $REPO_OWNER's"
+        error "account -- refusing to guess which one"
+        return 1
+    fi
+    return 0
+}
+
+# file_contains_ci: whether any line of FILE case-insensitively equals
+# NEEDLE. A plain read loop with `ieq` instead of `grep -qxFi` -- but a
+# failed redirection on `< "$file"` (permissions, the file vanishing) does
+# NOT abort under `set -e` when this is called as an `if` condition (bash
+# exempts every command inside a function called as an if/while condition,
+# not just the function's own last command), so it falls through to the
+# same "not found" return as a real miss unless caught explicitly. Return
+# 0 = found, 1 = genuinely not found, 2 = could not read FILE at all --
+# callers must treat 2 as an error, not "not a member".
+file_contains_ci() {
+    local needle="$1" file="$2" line found=1
+    [[ -r "$file" ]] || return 2
+    while IFS= read -r line; do
+        if ieq "$line" "$needle"; then
+            found=0
+            break
+        fi
+    done < "$file" || return 2
+    return "$found"
+}
+
+APP_PLAN_SLUGS=()
+APP_PLAN_VERDICTS=()
+APP_PLAN_INSTALL_IDS=()
+
+app_plan_add() {
+    APP_PLAN_SLUGS+=("$1")
+    APP_PLAN_VERDICTS+=("$2")
+    APP_PLAN_INSTALL_IDS+=("${3:-}")
+}
+
+app_plan_line() {
+    local slug="$1" install_id selection membership_status
+    if ! resolve_installation "$slug"; then
+        app_plan_add "$slug" ERROR
+        return 0
+    fi
+    IFS=$'\t' read -r install_id selection < "$WORK/install.$slug"
+    if [[ "$selection" != selected ]]; then
+        # Reporting ALREADY_ALL here, on the strength of the installation's
+        # own scope alone, never actually confirms $REPO itself exists --
+        # unlike ALREADY_MEMBER and ADD below, which both only ever answer
+        # from a real gh api response naming $REPO. An App-only run against
+        # a typo'd or inaccessible repo would otherwise exit 0 claiming
+        # coverage nothing was ever checked.
+        if gh api "repos/$REPO" --jq .id > /dev/null 2>"$WORK/repocheck.$slug.err"; then
+            app_plan_add "$slug" ALREADY_ALL
+        else
+            error "could not confirm $REPO exists and is accessible (needed before"
+            error "treating it as already covered by $slug's 'all repositories' scope):"
+            sed 's/^/  /' "$WORK/repocheck.$slug.err" >&2
+            app_plan_add "$slug" ERROR
+        fi
+        return 0
+    fi
+    if ! gh api "user/installations/$install_id/repositories" --paginate \
+        --jq '.repositories[].full_name' > "$WORK/members.$slug" 2>"$WORK/members.$slug.err"; then
+        error "could not list $slug's installed repositories:"
+        sed 's/^/  /' "$WORK/members.$slug.err" >&2
+        app_plan_add "$slug" ERROR
+        return 0
+    fi
+    # Case-insensitive: GitHub repository names are case-insensitive to
+    # resolve, but .full_name is returned in the repo's own canonical
+    # casing, which can differ from however the caller happened to type
+    # $REPO. An exact-case miss here plans ADD for a repo that's already a
+    # member, which can then fail outright for a credential allowed to list
+    # an installation's repositories but not modify them, reporting failure
+    # on a state that already held.
+    if file_contains_ci "$REPO" "$WORK/members.$slug"; then
+        app_plan_add "$slug" ALREADY_MEMBER
+    else
+        membership_status=$?
+        if (( membership_status == 2 )); then
+            error "could not check whether $REPO is already a member of $slug's installation"
+            app_plan_add "$slug" ERROR
+        else
+            # Codex review: absent from the member list is ambiguous the
+            # same way it is in the ALREADY_ALL branch above -- $REPO can be
+            # genuinely not-yet-added, or it can be a typo'd/inaccessible
+            # repo that would never appear in ANY installation's member
+            # list. The real apply's ADD case already resolves $REPO's id
+            # before adding it and would catch a typo there, but a dry-run
+            # planning ADD on the strength of "not in the list" alone
+            # reports success for a step that would actually fail at apply
+            # time. Confirm $REPO exists here too, same as ALREADY_ALL does.
+            if gh api "repos/$REPO" --jq .id > /dev/null 2>"$WORK/repocheck.$slug.err"; then
+                app_plan_add "$slug" ADD "$install_id"
+            else
+                error "could not confirm $REPO exists and is accessible (needed before"
+                error "planning to add it to $slug's installation):"
+                sed 's/^/  /' "$WORK/repocheck.$slug.err" >&2
+                app_plan_add "$slug" ERROR
+            fi
+        fi
+    fi
+}
+
+if (( ${#APPS[@]} > 0 )); then
+    for slug in "${APPS[@]}"; do
+        app_plan_line "$slug"
+    done
+fi
+
+apply_app_step() {
+    local slug="$1" verdict="$2" install_id="${3:-}" REPO_ID
+    case "$verdict" in
+        ADD)
+            if ! REPO_ID="$(gh api "repos/$REPO" --jq .id 2>"$WORK/repoid.err")"; then
+                error "could not resolve $REPO's numeric id (needed to add it to $slug):"
+                sed 's/^/  /' "$WORK/repoid.err" >&2
+                return 1
+            fi
+            if gh api --method PUT "user/installations/$install_id/repositories/$REPO_ID" \
+                >/dev/null 2>"$WORK/add.$slug.err"; then
+                echo "$REPO: added to $slug's installation"
+                return 0
+            else
+                error "could not add $REPO to $slug's installation:"
+                sed 's/^/  /' "$WORK/add.$slug.err" >&2
+                error "if this looks like a permission problem rather than a 'not"
+                error "found', a classic PAT is the documented fallback -- these"
+                error "endpoints predate fine-grained ones and may not accept them."
+                return 1
+            fi ;;
+        ERROR) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+# ---- Combined plan ---------------------------------------------------------
+
+describe_plan() {
+    local i slug verdict
+    echo "$REPO:"
+    if (( NO_RULES != 1 )); then
+        echo "  ruleset (repo-rules):"
+        sed 's/^/    /' "$WORK/rules.dryrun"
+    fi
+    if (( ${#SECRETS[@]} > 0 )); then
+        echo "  secrets (repo-secrets):"
+        for (( i = 0; i < ${#SECRETS[@]}; i++ )); do
+            parse_secret_spec "${SECRETS[i]}"
+            echo "    --name $SPEC_NAME${SPEC_ENV:+ --env $SPEC_ENV}:"
+            sed 's/^/      /' "$WORK/secret.$i.dryrun"
+        done
+    fi
+    if (( ${#APP_PLAN_SLUGS[@]} > 0 )); then
+        echo "  App installation membership:"
+        for (( i = 0; i < ${#APP_PLAN_SLUGS[@]}; i++ )); do
+            slug="${APP_PLAN_SLUGS[i]}"
+            verdict="${APP_PLAN_VERDICTS[i]}"
+            case "$verdict" in
+                ADD)            echo "    $slug: would add $REPO" ;;
+                ALREADY_MEMBER) echo "    $slug: already a member" ;;
+                ALREADY_ALL)    echo "    $slug: installed with 'All repositories' -- already covered" ;;
+                ERROR)          echo "    $slug: could not determine (see error above)" ;;
+            esac
+        done
+    fi
+}
+
+RULES_DRYRUN_FAILED=0
+if (( NO_RULES != 1 )); then
+    # --force here too, matching the real apply call below: this script's
+    # own confirmation already stands in for repo-rules' own, and this is
+    # also the call that decides whether repo-rules' never-reported guard
+    # fires at all. Without --force, a check that has simply never reported
+    # yet shows here as a hard failure the real (always-forced) apply would
+    # not actually hit.
+    # "${RULES[@]+"${RULES[@]}"}", not "${RULES[@]}": bash before 4.4 throws
+    # "unbound variable" under `set -u` when expanding an empty array's
+    # [@] directly (a genuine bash bug, not a nounset false alarm), and an
+    # empty RULES (no --rule given, using repo-rules' own defaults) is the
+    # normal case here, not a corner one -- this idiom is the portable
+    # workaround, correct on bash 3.2 through current.
+    if repo-rules --dry-run --force "$REPO" "${RULES[@]+"${RULES[@]}"}" \
+        > "$WORK/rules.dryrun" 2>&1; then
+        :
+    else
+        RULES_DRYRUN_FAILED=1
+    fi
+fi
+
+SECRETS_DRYRUN_FAILED=0
+if (( ${#SECRETS[@]} > 0 )); then
+    # Indexed by position, not by "$SPEC_NAME.${SPEC_ENV:-none}": two
+    # entries collide there whenever one omits --env (falling back to the
+    # literal string "none") and another names a real environment actually
+    # called "none" -- a valid environment name under this script's own
+    # character check. The second dry-run preview would silently clobber
+    # the first's file, corrupting the printed plan.
+    for (( i = 0; i < ${#SECRETS[@]}; i++ )); do
+        parse_secret_spec "${SECRETS[i]}"
+        if repo-secrets --dry-run --name "$SPEC_NAME" ${SPEC_ENV:+--env "$SPEC_ENV"} \
+            --file "$WORK/secret.$i.value" "$REPO" \
+            > "$WORK/secret.$i.dryrun" 2>&1; then
+            :
+        else
+            SECRETS_DRYRUN_FAILED=1
+        fi
+    done
+fi
+
+APP_PLAN_HAS_ERROR=0
+for verdict in "${APP_PLAN_VERDICTS[@]:-}"; do
+    [[ "$verdict" == ERROR ]] && APP_PLAN_HAS_ERROR=1
+done
+
+if (( DRY_RUN == 1 )); then
+    describe_plan
+    if (( RULES_DRYRUN_FAILED == 1 )) || (( SECRETS_DRYRUN_FAILED == 1 )) \
+        || (( APP_PLAN_HAS_ERROR == 1 )); then
+        exit 1
+    fi
+    exit 0
+fi
+
+if (( RULES_DRYRUN_FAILED == 1 )) || (( SECRETS_DRYRUN_FAILED == 1 )); then
+    # This used to only gate --dry-run's own exit code, so a real
+    # (non-dry-run) run fell straight through to confirm/apply even when
+    # the preview above already failed -- e.g. a --secret spec that's
+    # well-formed by this script's own coarser NAME[@ENV]=PATH shape but
+    # invalid by repo-secrets' own stricter name/environment rules (a
+    # hyphenated name, a '/' in an environment). With --force, the ruleset
+    # step runs and mutates the repository before repo-secrets' real
+    # invocation finally catches the same problem the preview already saw.
+    # parse_secret_spec's own comment promises a malformed --secret is "a
+    # usage error before anything runs, not a surprise partway through the
+    # plan" -- the preview already proved this run wouldn't fully succeed,
+    # so nothing runs for real on the strength of a confirmation that was
+    # never actually earned.
+    #
+    # APP_PLAN_HAS_ERROR deliberately does NOT gate this: an App-plan ERROR
+    # (no installation found, a listing call that failed) is a genuine
+    # per-step runtime outcome, not a usage error in the ruleset/secrets
+    # spec sense -- it is exactly the kind of independent step failure
+    # "every step is attempted regardless of an earlier one" exists to let
+    # the other steps proceed past, and apply_app_step already reports it
+    # under FAILED the normal way.
+    describe_plan >&2
+    error "the preview above failed; nothing was changed on $REPO."
+    exit 1
+fi
+
+if (( FORCE != 1 )); then
+    if [[ -t 0 ]]; then
+        describe_plan >&2
+        printf 'Apply this to %s? [y/N] ' "$REPO" >&2
+        read -r CONFIRM || CONFIRM=""
+        case "$CONFIRM" in
+            [Yy]|[Yy][Ee][Ss]) ;;
+            *) error "not confirmed; nothing was changed on $REPO."; exit 1 ;;
+        esac
+    else
+        error "stdin is not a terminal and --force was not given, so nothing was"
+        error "changed on $REPO rather than either blocking on a question nobody"
+        error "can answer or silently applying an unconfirmed change. Pass --force"
+        error "to apply non-interactively, or run this from a terminal."
+        exit 1
+    fi
+fi
+
+# ---- Apply ------------------------------------------------------------
+
+FAILED=""
+
+if (( NO_RULES != 1 )); then
+    # Codex review: same plan-staleness risk as secrets (see the comment in
+    # the secrets loop below), applied here to the ruleset -- the
+    # confirmation prompt can sit for an arbitrary amount of real time, and
+    # if the ruleset changes in that window (weakened, reconfigured, or
+    # deleted by someone else), this --force call would silently apply a
+    # DIFFERENT plan than the one shown and confirmed. Revalidated
+    # immediately before applying, by re-running the exact same --dry-run
+    # and comparing its output byte-for-byte against what was shown.
+    #
+    # Codex review: the recheck's own exit status matters, not just its
+    # output -- if the recheck command itself fails (expired auth, GitHub
+    # down, a transient API error), that failure has to be reported as
+    # what it is, not silently folded into "the plan changed" just because
+    # the error text on stderr differs from the confirmed dry-run output.
+    # An `if` is exempt from `set -e`, so the status is captured here
+    # instead of discarded with `|| :`.
+    if repo-rules --dry-run --force "$REPO" "${RULES[@]+"${RULES[@]}"}" \
+        > "$WORK/rules.recheck" 2>&1; then
+        RULES_RECHECK_STATUS=0
+    else
+        RULES_RECHECK_STATUS=$?
+    fi
+    if (( RULES_RECHECK_STATUS != 0 )); then
+        error "revalidating the ruleset plan failed (exit $RULES_RECHECK_STATUS);"
+        error "not applying it. The failure below is from that revalidation"
+        error "attempt, not a problem with the plan itself:"
+        cat "$WORK/rules.recheck" >&2
+        FAILED="$FAILED ruleset"
+    elif ! cmp -s "$WORK/rules.dryrun" "$WORK/rules.recheck"; then
+        error "the plan for the ruleset changed since it was confirmed (likely"
+        error "modified by someone else in the meantime); refusing to apply a"
+        error "stale, unconfirmed plan for it."
+        FAILED="$FAILED ruleset"
+    # Same "${RULES[@]+"${RULES[@]}"}" reasoning as the dry-run call above.
+    elif repo-rules --force "$REPO" "${RULES[@]+"${RULES[@]}"}"; then
+        :
+    else
+        FAILED="$FAILED ruleset"
+    fi
+fi
+
+if (( ${#SECRETS[@]} > 0 )); then
+    for (( i = 0; i < ${#SECRETS[@]}; i++ )); do
+        parse_secret_spec "${SECRETS[i]}"
+        # Codex review: the confirmation can sit for an arbitrary amount of
+        # real time (an interactive prompt, or simply the ruleset step and
+        # any earlier secret in this very loop taking a while), and the
+        # apply just below invokes repo-secrets fresh, as its own process,
+        # which rebuilds its plan from scratch. If this secret, shown here
+        # as "new", was created by someone else in that window, the child
+        # invocation's own plan now reads "overwrite" -- and because that's
+        # not the "new" case, repo-secrets' own late TOCTOU recheck (which
+        # exists specifically for state=new) never runs for it, and
+        # --force suppresses its confirmation/warning too. The result: a
+        # value the user only ever confirmed CREATING gets silently
+        # overwritten, with nothing in this script's own output to say so.
+        # Revalidated here, immediately before THIS secret's own apply
+        # (not once, collectively, before the whole apply section starts --
+        # that left the ruleset step's own duration as an unclosed window),
+        # by re-running the exact same --dry-run and comparing its output
+        # byte-for-byte against what was shown and confirmed. --file reads
+        # the snapshot taken before anything was shown (see above), the
+        # same snapshot the preview and the real apply below both use --
+        # not $SPEC_PATH, which could have been edited or replaced since.
+        #
+        # Codex review: same as the ruleset recheck above -- capture the
+        # recheck's own exit status rather than discarding it with `|| :`,
+        # so a genuine command failure (auth, network, API error) is
+        # reported as that failure and not misattributed to "the plan
+        # changed" just because its stderr differs from the confirmed
+        # dry-run output.
+        if repo-secrets --dry-run --name "$SPEC_NAME" ${SPEC_ENV:+--env "$SPEC_ENV"} \
+            --file "$WORK/secret.$i.value" "$REPO" \
+            > "$WORK/secret.$i.recheck" 2>&1; then
+            SECRET_RECHECK_STATUS=0
+        else
+            SECRET_RECHECK_STATUS=$?
+        fi
+        if (( SECRET_RECHECK_STATUS != 0 )); then
+            error "revalidating the plan for --secret $SPEC_NAME${SPEC_ENV:+@$SPEC_ENV} failed"
+            error "(exit $SECRET_RECHECK_STATUS); not applying it. The failure below is"
+            error "from that revalidation attempt, not a problem with the plan itself:"
+            cat "$WORK/secret.$i.recheck" >&2
+            FAILED="$FAILED secret:$SPEC_NAME"
+            continue
+        fi
+        if ! cmp -s "$WORK/secret.$i.dryrun" "$WORK/secret.$i.recheck"; then
+            error "the plan for --secret $SPEC_NAME${SPEC_ENV:+@$SPEC_ENV} changed since it"
+            error "was confirmed (likely created or changed by someone else in the"
+            error "meantime); refusing to apply a stale, unconfirmed plan for it."
+            FAILED="$FAILED secret:$SPEC_NAME"
+            continue
+        fi
+        if repo-secrets --force --name "$SPEC_NAME" ${SPEC_ENV:+--env "$SPEC_ENV"} \
+            --file "$WORK/secret.$i.value" "$REPO"; then
+            :
+        else
+            FAILED="$FAILED secret:$SPEC_NAME"
+        fi
+    done
+fi
+
+if (( ${#APP_PLAN_SLUGS[@]} > 0 )); then
+    for (( i = 0; i < ${#APP_PLAN_SLUGS[@]}; i++ )); do
+        if apply_app_step "${APP_PLAN_SLUGS[i]}" "${APP_PLAN_VERDICTS[i]}" "${APP_PLAN_INSTALL_IDS[i]}"; then
+            :
+        else
+            FAILED="$FAILED app:${APP_PLAN_SLUGS[i]}"
+        fi
+    done
+fi
+
+if [[ -n "$FAILED" ]]; then
+    error "failed on:$FAILED"
+    exit 1
+fi

--- a/repo-setup_test
+++ b/repo-setup_test
@@ -1,0 +1,1247 @@
+#!/bin/sh
+# Tests for repo-setup
+#
+# repo-setup is a thin composer over the real repo-rules and repo-secrets
+# scripts (not a reimplementation), so these tests put the REAL repo-rules
+# and repo-secrets on PATH alongside repo-setup, backed by one fake gh that
+# answers everything all three need. That exercises the actual subprocess
+# composition -- the flags repo-setup passes through, when it confirms once
+# instead of three times, how it aggregates each step's success/failure --
+# rather than a mock of what repo-rules/repo-secrets are assumed to do. The
+# gh fixture is kept in a fixed "happy path" shape for repo-rules (no
+# existing ruleset, no other rulesets, every requested check already
+# reported, rebase merging allowed) and repo-secrets (no existing secrets,
+# no existing environment): both of those scripts already have their own
+# exhaustive test suites covering their own edge cases, so this suite's job
+# is repo-setup's own orchestration, not re-proving theirs.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SUITE_TMP="$(mktemp -d)"
+# Codex review: same trap bug as the scripts under test -- trapping INT/TERM
+# alongside EXIT on one line replaces bash's default terminate-on-signal
+# action with "clean up, then resume the script", so canceling this suite
+# (CI's own timeout/cancel, or a local Ctrl-C) would remove SUITE_TMP and
+# then keep running the remaining test cases against it, reporting
+# confusing unrelated failures instead of actually stopping.
+trap 'rm -rf "$SUITE_TMP"' EXIT
+trap 'rm -rf "$SUITE_TMP"; exit 130' INT
+trap 'rm -rf "$SUITE_TMP"; exit 143' TERM
+REPO_SETUP="$SCRIPT_DIR/repo-setup"
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+TESTS_SKIPPED=0
+
+# The interactive-confirmation cases need a real pseudo-terminal, the same
+# way repo-rules_test and repo-secrets_test's own confirm-prompt cases do:
+# `test -t 0` is what repo-setup's own prompt gates on, and no plain pipe or
+# file redirect can make that true. See repo-rules_test's own note on why
+# presence of `script(1)` alone is not enough to gate on (macOS's BSD
+# `script` has no `-c`).
+if printf 'x\n' | script -qec true /dev/null >/dev/null 2>&1; then
+    HAVE_PTY=yes
+else
+    HAVE_PTY=no
+    echo "NOTE: script(1) here doesn't support the -qec invocation these tests"
+    echo "      need, so the interactive-confirmation cases will be skipped."
+    echo "      CI runs on ubuntu-latest, which has util-linux's, so the"
+    echo "      coverage is never optional there."
+fi
+
+# make_gh: build a fake gh (plus real repo-rules/repo-secrets on the same
+# PATH) in a fresh dir, and echo that dir.
+#   $1 = newline-separated check-run names the repo has reported (default:
+#        repo-rules' own fleet defaults, "lanes codex zizmor")
+#   $2 = newline-separated secret names that already exist repo-level
+#   $3 = substring of a call to fail with a simulated error
+#   $4 = newline-separated secret names a SECOND (or later) listing call on
+#        the same secrets-list endpoint sees -- defaults to the same as $2,
+#        so every existing caller is unaffected. Set this differently from
+#        $2 to simulate a secret being created by someone else in the
+#        window between repo-setup's own preview and its later revalidation
+#        or real apply (both of which re-invoke repo-secrets fresh).
+#   $5 = newline-separated check-run names a SECOND (or later) check-runs
+#        call sees -- defaults to the same as $1, so every existing caller
+#        is unaffected. Set this differently from $1 to simulate a check
+#        reporting (or a required check disappearing) between repo-setup's
+#        own ruleset preview and its later revalidation/real apply.
+# App-installation fixtures ($dir/installations, $dir/install_members) start
+# empty and are populated per test case with plain `printf`, same as the
+# other suites' post-make_gh fixture tweaks.
+make_gh() {
+    dir="$(mktemp -d "$SUITE_TMP/fixture.XXXXXX")"
+    mkdir -p "$dir/bin"
+    printf '%s\n' "${1-lanes
+codex
+zizmor}" > "$dir/checks"
+    printf '%s\n' "${2-}" > "$dir/existing_secret_names"
+    printf '%s' "${3-}" > "$dir/fail_on"
+    printf '%s\n' "${4-${2-}}" > "$dir/existing_secret_names_at_recheck"
+    printf '%s\n' "${5-${1-lanes
+codex
+zizmor}}" > "$dir/checks_at_recheck"
+    : > "$dir/env_exists"
+    : > "$dir/installations"
+    : > "$dir/install_members"
+    printf '999\n' > "$dir/repo_id"
+    ln -s "$SCRIPT_DIR/repo-rules" "$dir/bin/repo-rules"
+    ln -s "$SCRIPT_DIR/repo-secrets" "$dir/bin/repo-secrets"
+    cat > "$dir/bin/gh" <<'EOF'
+#!/bin/sh
+# Fake gh combining what repo-rules, repo-secrets, and repo-setup's own
+# native App-installation step each need. Logs every call.
+dir="$(dirname "$(dirname "$0")")"
+echo "$*" >> "$dir/calls"
+
+if test -s "$dir/fail_on" && echo "$*" | grep -qF "$(cat "$dir/fail_on")"; then
+    echo "gh: simulated failure" >&2
+    exit 1
+fi
+
+emit_names() {
+    sed 's/\\/\\\\/g; s/"/\\"/g; s/^/"/; s/$/"/' "$1"
+}
+
+# list_secret_names: a SECOND (or later) call to the same secrets-list
+# endpoint sees existing_secret_names_at_recheck instead of
+# existing_secret_names, so a test can simulate a secret being created by
+# someone else between repo-setup's own preview and a later re-invocation
+# of repo-secrets. Tracked per-endpoint (repo-level vs. per-environment
+# secrets are different endpoints, and share no count), since both share
+# the identical shape within their own scope and there's nothing else to
+# tell repeated calls apart by. Same technique as repo-secrets_test's own
+# list_names().
+list_secret_names() {
+    counter_file="$dir/list_calls.$(echo "$1" | tr -c 'A-Za-z0-9' '_')"
+    count="$(cat "$counter_file" 2>/dev/null || echo 0)"
+    count=$((count + 1))
+    echo "$count" > "$counter_file"
+    if test "$count" -ge 2; then
+        # fail_secrets_at_recheck: absent by default (every existing
+        # caller unaffected). When present, a SECOND (or later) call
+        # fails outright instead of returning names -- simulates the
+        # revalidation's own repo-secrets --dry-run genuinely erroring
+        # (auth expired, GitHub down), as distinct from the plan merely
+        # having changed.
+        if test -e "$dir/fail_secrets_at_recheck"; then
+            echo "gh: simulated failure on revalidation" >&2
+            exit 1
+        fi
+        names_file="$dir/existing_secret_names_at_recheck"
+    else
+        names_file="$dir/existing_secret_names"
+    fi
+    grep -v '^$' "$names_file" || true
+}
+
+# list_checks: same call-counting technique as list_secret_names, for the
+# commits/*/check-runs endpoint repo-rules reads -- a SECOND (or later)
+# call sees checks_at_recheck instead of checks, so a test can simulate a
+# check reporting (or a required check disappearing) between repo-setup's
+# own ruleset preview and its later revalidation/real apply.
+list_checks() {
+    counter_file="$dir/list_calls.checkruns"
+    count="$(cat "$counter_file" 2>/dev/null || echo 0)"
+    count=$((count + 1))
+    echo "$count" > "$counter_file"
+    if test "$count" -ge 2; then
+        # fail_checks_at_recheck: same toggle as list_secret_names' own
+        # fail_secrets_at_recheck, for the ruleset's revalidation instead
+        # of a secret's.
+        if test -e "$dir/fail_checks_at_recheck"; then
+            echo "gh: simulated failure on revalidation" >&2
+            exit 1
+        fi
+        emit_names "$dir/checks_at_recheck"
+    else
+        emit_names "$dir/checks"
+    fi
+}
+
+# gh secret set NAME --repo REPO [--env ENV]  (repo-secrets' own encryption path)
+if test "$1" = secret; then
+    shift; shift  # drop "secret" "set"
+    name="$1"; shift
+    repo=""; env=""
+    while test $# -gt 0; do
+        case "$1" in
+            --repo) shift; repo="$1" ;;
+            --env) shift; env="$1" ;;
+        esac
+        shift
+    done
+    safe="$(echo "$repo" | tr '/' '_')"
+    if test -n "$env"; then
+        cat > "$dir/written.$safe.$env.$name"
+    else
+        cat > "$dir/written.$safe.$name"
+    fi
+    exit 0
+fi
+
+# gh api [--method X] ENDPOINT [--jq EXPR] [--paginate] [--input FILE]
+endpoint=""
+method=""
+jqexpr=""
+inputfile=""
+skip=no
+want=""
+for arg in "$@"; do
+    if test "$skip" = yes; then
+        skip=no
+        case "$want" in --method) method="$arg" ;; --jq) jqexpr="$arg" ;; --input) inputfile="$arg" ;; esac
+        continue
+    fi
+    case "$arg" in
+        api) ;;
+        --method|--jq|--input) skip=yes; want="$arg" ;;
+        --paginate|--silent) ;;
+        -*) echo "gh: unknown flag $arg" >&2; exit 1 ;;
+        *) endpoint="$arg" ;;
+    esac
+done
+
+if test -n "$method" && test "$method" != GET; then
+    if test -n "$inputfile" && test "$inputfile" != -; then
+        : # nothing reads the body back in these tests
+    else
+        cat > /dev/null
+    fi
+    echo "$endpoint" >> "$dir/writes"
+    exit 0
+fi
+
+case "$endpoint" in
+    user/installations)
+        # $jqexpr embeds the slug and the target repo's owner as:
+        # select(.app_slug=="SLUG" and (.account.login | ascii_downcase) ==
+        # ("OWNER" | ascii_downcase)). Fixture rows are
+        # slug\tid\tselection\taccount; matched on both, case-insensitively
+        # (tolower), same as the real jq's ascii_downcase comparison.
+        slug="$(printf '%s' "$jqexpr" | sed -n 's/.*app_slug=="\([^"]*\)".*/\1/p')"
+        owner="$(printf '%s' "$jqexpr" | sed -n 's/.*== ("\([^"]*\)" | ascii_downcase).*/\1/p')"
+        awk -F'\t' -v s="$slug" -v o="$owner" \
+            '$1==s && tolower($4)==tolower(o) {printf "%s\t%s\n",$2,$3}' \
+            "$dir/installations" ;;
+    user/installations/*/repositories)
+        id="$(echo "$endpoint" | sed 's#user/installations/##; s#/repositories##')"
+        awk -F'\t' -v i="$id" '$1==i {print $2}' "$dir/install_members" ;;
+    */environments/*/secrets)
+        if test -s "$dir/env_exists"; then
+            list_secret_names "$endpoint"
+        else
+            echo "gh: HTTP 404: Not Found (https://api.github.com/$endpoint)" >&2
+            exit 1
+        fi ;;
+    */environments/*)
+        # A plain GET on the environment itself -- repo-secrets' own
+        # revalidation immediately before the create PUT. The PUT itself
+        # never reaches this case (it short-circuits above on --method).
+        if test -s "$dir/env_exists"; then
+            : # exists -- nothing to print, just exit 0
+        else
+            echo "gh: HTTP 404: Not Found (https://api.github.com/$endpoint)" >&2
+            exit 1
+        fi ;;
+    */actions/secrets)
+        list_secret_names "$endpoint" ;;
+    */rulesets\?includes_parents=true*)
+        : ;; # no other rulesets to conflict with
+    */rulesets*)
+        : ;; # no existing "merge gates" ruleset -- always the create path
+    */commits/*/check-runs*)
+        list_checks ;;
+    */commits/*/status*)
+        : ;;
+    */pulls\?*)
+        : ;;
+    */commits\?*)
+        echo deadbee ;;
+    repos/*)
+        case "$jqexpr" in
+            *allow_rebase_merge*) echo true ;;
+            *default_branch*)     echo main ;;
+            .id)                  cat "$dir/repo_id" ;;
+            *) echo "gh: unhandled repos/ jq '$jqexpr'" >&2; exit 1 ;;
+        esac ;;
+    *) echo "gh: unhandled endpoint '$endpoint'" >&2; exit 1 ;;
+esac
+EOF
+    chmod +x "$dir/bin/gh"
+    echo "$dir"
+}
+
+run() {
+    dir="$1"; shift
+    set +e
+    output="$(PATH="$dir/bin:$PATH" "$REPO_SETUP" "$@" 2>&1)"
+    status=$?
+    set -e
+}
+
+# Like run(), but with stdin from /dev/null explicitly (a plain command
+# substitution's stdin is already not a terminal, but this makes the
+# "non-interactive" property of each of these cases explicit rather than
+# incidental).
+run_noninteractive() {
+    dir="$1"; shift
+    set +e
+    output="$(PATH="$dir/bin:$PATH" "$REPO_SETUP" "$@" < /dev/null 2>&1)"
+    status=$?
+    set -e
+}
+
+quote_args() {
+    out=""
+    for a in "$@"; do
+        out="$out'$(printf '%s' "$a" | sed "s/'/'\\\\''/g")' "
+    done
+    printf '%s' "$out"
+}
+
+# Drives repo-setup with a real pseudo-terminal on stdin (via `script`) and
+# feeds it one line of canned input, so a case can reach the actual
+# confirm/read branch. Same shape as repo-rules_test's run_repo_rules_pty.
+run_pty() {
+    dir="$1"; shift
+    answer="$1"; shift
+    set +e
+    output="$(printf '%s\n' "$answer" | PATH="$dir/bin:$PATH" script -qec \
+        "$REPO_SETUP $(quote_args "$@")" /dev/null 2>&1)"
+    status=$?
+    set -e
+}
+
+assert_status() {
+    if test "$status" -ne "$1"; then
+        echo "  FAIL: expected exit status $1, got $status"
+        echo "  output: $output"
+        TEST_FAILED=1
+    fi
+}
+
+assert_output() {
+    case "$output" in
+        *"$1"*) ;;
+        *) echo "  FAIL: expected output to contain '$1'"
+           echo "  output: $output"
+           TEST_FAILED=1 ;;
+    esac
+}
+
+assert_no_output() {
+    case "$output" in
+        *"$1"*) echo "  FAIL: expected output NOT to contain '$1'"
+                echo "  output: $output"
+                TEST_FAILED=1 ;;
+    esac
+}
+
+assert_written() {
+    d="$1"; safe="$2"; name="$3"; env="${4-}"
+    if test -n "$env"; then
+        f="$d/written.$safe.$env.$name"
+    else
+        f="$d/written.$safe.$name"
+    fi
+    test -f "$f" || { echo "  FAIL: expected a write to $safe ($name${env:+, env $env}), found none"; TEST_FAILED=1; }
+}
+
+assert_not_written() {
+    d="$1"; safe="$2"; name="$3"
+    if test -f "$d/written.$safe.$name" || ls "$d"/written."$safe".*."$name" >/dev/null 2>&1; then
+        echo "  FAIL: expected NO write to $safe ($name), but one happened"
+        TEST_FAILED=1
+    fi
+}
+
+assert_no_writes() {
+    d="$1"
+    if test -s "$d/writes"; then
+        echo "  FAIL: expected no gh writes at all, got:"
+        cat "$d/writes"
+        TEST_FAILED=1
+    fi
+}
+
+assert_call_count() {
+    d="$1"; needle="$2"; expected="$3"
+    got="$(grep -cF "$needle" "$d/calls" || true)"
+    if test "$got" -ne "$expected"; then
+        echo "  FAIL: expected $expected call(s) matching '$needle', got $got"
+        TEST_FAILED=1
+    fi
+}
+
+test_case() {
+    TEST_SKIPPED=0
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TEST_FAILED=0
+    echo "TEST: $1"
+}
+
+skip_case() {
+    TESTS_SKIPPED=$((TESTS_SKIPPED + 1))
+    echo "  SKIP: $1"
+    TEST_SKIPPED=1
+}
+
+finish_case() {
+    if test "${TEST_SKIPPED:-0}" -eq 1; then
+        TESTS_RUN=$((TESTS_RUN - 1))
+        return
+    fi
+    if test "$TEST_FAILED" -eq 0; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo "  PASS"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
+# ---------------------------------------------------------------------------
+
+test_case "--force applies immediately, no prompt, ruleset created"
+dir="$(make_gh)"
+run "$dir" --force owner/repo
+assert_status 0
+assert_call_count "$dir" "POST repos/owner/repo/rulesets" 1
+finish_case
+
+test_case "--dry-run prints the combined plan and makes no writes at all"
+dir="$(make_gh)"
+printf 'sekrit' > "$dir/value.txt"
+printf 'codex\t111\tselected\towner\n' > "$dir/installations"
+run "$dir" --dry-run --secret TOKEN="$dir/value.txt" --app codex owner/repo
+assert_status 0
+assert_output "owner/repo:"
+assert_output "ruleset (repo-rules):"
+assert_output "secrets (repo-secrets):"
+assert_output "App installation membership:"
+assert_output "would add owner/repo"
+assert_no_writes "$dir"
+assert_not_written "$dir" owner_repo TOKEN
+finish_case
+
+test_case "without --force and without a terminal, nothing is changed"
+dir="$(make_gh)"
+run_noninteractive "$dir" owner/repo
+assert_status 1
+assert_output "stdin is not a terminal"
+assert_no_writes "$dir"
+finish_case
+
+test_case "an interactive 'y' confirms once and applies every requested step"
+if test "$HAVE_PTY" = no; then skip_case "needs script(1)"; else
+dir="$(make_gh)"
+printf 'sekrit' > "$dir/value.txt"
+run_pty "$dir" y --secret TOKEN="$dir/value.txt" owner/repo
+assert_status 0
+assert_call_count "$dir" "POST repos/owner/repo/rulesets" 1
+assert_written "$dir" owner_repo TOKEN
+fi
+finish_case
+
+test_case "an interactive 'n' confirms nothing and applies nothing"
+if test "$HAVE_PTY" = no; then skip_case "needs script(1)"; else
+dir="$(make_gh)"
+printf 'sekrit' > "$dir/value.txt"
+run_pty "$dir" n --secret TOKEN="$dir/value.txt" owner/repo
+assert_status 1
+assert_output "not confirmed"
+assert_no_writes "$dir"
+assert_not_written "$dir" owner_repo TOKEN
+fi
+finish_case
+
+test_case "the interactive prompt asks once for the whole repository, not once per step"
+if test "$HAVE_PTY" = no; then skip_case "needs script(1)"; else
+dir="$(make_gh)"
+printf 'sekrit' > "$dir/value.txt"
+run_pty "$dir" y --secret TOKEN="$dir/value.txt" --app codex owner/repo
+# One "Apply this to" prompt, however many steps were requested.
+got="$(printf '%s' "$output" | grep -c "Apply this to" || true)"
+if test "$got" -ne 1; then
+    echo "  FAIL: expected exactly 1 confirmation prompt, got $got"
+    TEST_FAILED=1
+fi
+fi
+finish_case
+
+test_case "--no-rules skips the ruleset step entirely"
+dir="$(make_gh)"
+run "$dir" --force --no-rules owner/repo
+assert_status 0
+assert_no_writes "$dir"
+assert_no_output "ruleset"
+finish_case
+
+test_case "--no-rules and --rule together are a usage error"
+dir="$(make_gh)"
+run "$dir" --no-rules --rule lanes owner/repo
+assert_status 2
+finish_case
+
+test_case "--rule is passed through to repo-rules as the required check"
+dir="$(make_gh "only-this-check")"
+run "$dir" --force --rule only-this-check owner/repo
+assert_status 0
+assert_call_count "$dir" "POST repos/owner/repo/rulesets" 1
+finish_case
+
+test_case "a --rule check name containing a space survives intact to repo-rules"
+# Regression test: RULES used to be handed to repo-rules through an
+# unquoted expansion under the default (space-splitting) IFS, so a name
+# like repo-rules' own documented CodeQL example ("Analyze (actions)")
+# arrived there as two separate, wrong check names instead of one.
+dir="$(make_gh "Analyze (actions)")"
+run "$dir" --dry-run --rule "Analyze (actions)" owner/repo
+assert_status 0
+assert_no_output "never reported"
+finish_case
+
+test_case "a --rule value with an embedded newline is a usage error, not two silent checks"
+# Codex review: RULES/SECRETS/APPS use a newline as the delimiter BETWEEN
+# entries specifically so one entry can contain a space -- but that means a
+# literal newline WITHIN one entry is indistinguishable from two entries.
+# --rule "$(printf 'foo\nbar')" used to silently become two separate
+# required checks passed to repo-rules, bypassing repo-rules' own
+# control-character rejection entirely (it only ever sees the two already-
+# split, clean halves -- never the newline that would have failed its own
+# validation).
+dir="$(make_gh)"
+run "$dir" --force --rule "$(printf 'foo
+bar')" owner/repo
+assert_status 2
+assert_output "contains a newline"
+if test -s "$dir/calls"; then
+    echo "  FAIL: expected no gh calls before the usage error"; TEST_FAILED=1
+fi
+finish_case
+
+test_case "a --secret value with an embedded newline is a usage error, not a second, unrelated write"
+# Codex review, same shape as --rule but worse in effect: a newline inside
+# one --secret spec used to silently split into TWO independent
+# repo-secrets invocations -- one write the caller asked for, plus a second
+# one for a different NAME they never mentioned.
+dir="$(make_gh)"
+printf 'sekrit' > "$dir/value.txt"
+run "$dir" --force --no-rules --secret "$(printf 'TOKEN=%s
+EXTRA=%s' "$dir/value.txt" "$dir/value.txt")" owner/repo
+assert_status 2
+assert_output "contains a newline"
+if test -s "$dir/calls"; then
+    echo "  FAIL: expected no gh calls before the usage error"; TEST_FAILED=1
+fi
+finish_case
+
+test_case "an --app value with an embedded newline is a usage error, not two silent App checks"
+dir="$(make_gh)"
+run "$dir" --force --no-rules --app "$(printf 'foo
+bar')" owner/repo
+assert_status 2
+assert_output "contains a newline"
+if test -s "$dir/calls"; then
+    echo "  FAIL: expected no gh calls before the usage error"; TEST_FAILED=1
+fi
+finish_case
+
+# The old sh version accumulated RULES as a newline-delimited string and
+# filtered it with `grep -v '^$' || true` before the repo-rules call, which
+# is where the grep-exit-status-conflation bug this used to guard against
+# (any grep failure, not just "no matches", silently read as "no rules")
+# lived. The bash rewrite stores RULES as a real array and rejects an empty
+# or newline-containing --rule value at parse time (see the tests above and
+# below), so nothing is ever filtered out of RULES after that point -- it is
+# passed straight through to repo-rules ("${RULES[@]}") with no intervening
+# grep call to fail. The bug class is gone by construction, not patched.
+
+test_case "an empty --rule value is a usage error, not a silent fall-through to repo-rules' own defaults"
+# Codex review: a wrapper that expands an unset value into --rule "" (or
+# --rule=) used to survive parsing -- the empty entry was stripped out of
+# RULES by the newline-filter before the repo-rules call, so it silently
+# ran with zero --rule args and fell through to repo-rules' own defaults
+# ("lanes codex zizmor") instead of the caller's intended set. Caught here.
+dir="$(make_gh)"
+run "$dir" --force --rule "" owner/repo
+assert_status 2
+assert_output "non-empty check name"
+if test -s "$dir/calls"; then
+    echo "  FAIL: expected no gh calls before the usage error"; TEST_FAILED=1
+fi
+finish_case
+
+test_case "an empty --rule= value is a usage error"
+dir="$(make_gh)"
+run "$dir" --force --rule= owner/repo
+assert_status 2
+assert_output "non-empty check name"
+finish_case
+
+test_case "--secret NAME=PATH is passed through to repo-secrets as a repository secret"
+dir="$(make_gh)"
+printf 'sekrit' > "$dir/value.txt"
+run "$dir" --force --no-rules --secret TOKEN="$dir/value.txt" owner/repo
+assert_status 0
+assert_written "$dir" owner_repo TOKEN
+finish_case
+
+test_case "--secret NAME@ENV=PATH is passed through as an environment-scoped secret"
+dir="$(make_gh)"
+printf 'sekrit' > "$dir/value.txt"
+run "$dir" --force --no-rules --secret TOKEN@lanes="$dir/value.txt" owner/repo
+assert_status 0
+assert_written "$dir" owner_repo TOKEN lanes
+assert_call_count "$dir" "PUT repos/owner/repo/environments/lanes" 1
+finish_case
+
+test_case "a --secret PATH containing a space survives intact to repo-secrets"
+# Regression test: SECRETS entries used to be iterated with a plain
+# `for spec in $SECRETS`, which splits on the same default IFS -- a PATH
+# like "my secret.txt" (a realistic filename on any real filesystem)
+# arrived at repo-secrets as two broken arguments instead of one --file.
+dir="$(make_gh)"
+mkdir -p "$dir/my secret dir"
+printf 'sekrit' > "$dir/my secret dir/value.txt"
+run "$dir" --force --no-rules --secret "TOKEN=$dir/my secret dir/value.txt" owner/repo
+assert_status 0
+assert_written "$dir" owner_repo TOKEN
+finish_case
+
+test_case "each --secret's dry-run preview gets its own file, not one keyed by name+env"
+# Codex review: the dry-run preview file used to be keyed by
+# "$SPEC_NAME.${SPEC_ENV:-none}" -- an omitted --env and an explicit
+# --env none both bucket to the literal string "none", so --secret
+# TOKEN=... (repository-level) and --secret TOKEN@none=... (a real
+# environment happening to be named "none", a valid name under this
+# script's own character check) collide on the same file. The second
+# write silently clobbers the first's preview, so the dry-run plan shows
+# the SAME (environment 'none') content twice instead of one
+# (repository-level) preview and one (environment 'none') preview.
+dir="$(make_gh "" "TOKEN")"
+printf yes > "$dir/env_exists"
+printf sekrit > "$dir/value.txt"
+run "$dir" --dry-run --no-rules --secret "TOKEN=$dir/value.txt" --secret "TOKEN@none=$dir/value.txt" owner/repo
+assert_status 0
+assert_output "(environment 'none')"
+if test "$(printf '%s\n' "$output" | grep -c "(repository-level)")" -ne 1; then
+    echo "  FAIL: expected exactly one '(repository-level)' preview, the repository-level"
+    echo "  secret's own -- got the (environment 'none') preview's content instead,"
+    echo "  clobbered onto the same file"
+    TEST_FAILED=1
+fi
+finish_case
+
+test_case "an entirely empty --secret value is a usage error, not a silently dropped entry"
+# Codex review: an empty --secret ("" or --secret=) used to be appended to
+# SECRETS as a lone blank line, and iterating SECRETS with `for spec in
+# $SECRETS` under IFS=newline treats a run of nothing but separator
+# characters as zero fields (leading/trailing IFS whitespace is stripped) --
+# so the loop that would have caught this via parse_secret_spec's own
+# "missing '='" check never ran at all. The step silently did nothing for
+# that entry instead of failing.
+dir="$(make_gh)"
+run "$dir" --force --secret "" owner/repo
+assert_status 2
+assert_output "non-empty"
+if test -s "$dir/calls"; then
+    echo "  FAIL: expected no gh calls before the usage error"; TEST_FAILED=1
+fi
+finish_case
+
+test_case "a malformed --secret spec is a usage error before any gh call runs"
+# Regression test: parse_secret_spec's own comment says a malformed --secret
+# is "a usage error before anything runs, not a surprise partway through the
+# plan" -- but it was only ever called lazily, after gh had already been
+# invoked to build the rest of the plan.
+dir="$(make_gh)"
+run "$dir" --force --secret 'not-a-valid-spec' owner/repo
+assert_status 2
+assert_output "NAME[@ENV]=PATH"
+if test -s "$dir/calls"; then
+    echo "  FAIL: expected no gh calls at all before the usage error, got:"
+    cat "$dir/calls"
+    TEST_FAILED=1
+fi
+finish_case
+
+test_case "a --secret with an empty NAME is a usage error before any gh call runs"
+dir="$(make_gh)"
+run "$dir" --force --secret '=path' owner/repo
+assert_status 2
+if test -s "$dir/calls"; then
+    echo "  FAIL: expected no gh calls before the usage error"; TEST_FAILED=1
+fi
+finish_case
+
+test_case "a --secret with an @ but an empty ENV is a usage error, not a silent repository-level secret"
+# Regression: NAME@=PATH left SPEC_ENV empty, indistinguishable downstream
+# from NAME=PATH (no @ at all) -- Codex review. The user wrote the @,
+# meaning they wanted an environment scope; this must not be silently
+# downgraded to a repository-level secret instead.
+dir="$(make_gh)"
+printf 'sekrit' > "$dir/value.txt"
+run "$dir" --force --secret "TOKEN@=$dir/value.txt" owner/repo
+assert_status 2
+assert_output "empty ENV"
+if test -s "$dir/calls"; then
+    echo "  FAIL: expected no gh calls before the usage error"; TEST_FAILED=1
+fi
+finish_case
+
+test_case "two --secret entries targeting the same NAME+ENV scope is a usage error before any gh call runs"
+# Codex review: each --secret's dry-run preview inspects the same
+# not-yet-written remote state independently, so --secret TOKEN=first
+# --secret TOKEN=second both report "new" with no warning -- but the real
+# apply then writes them in order and the second silently overwrites the
+# first, with the final value depending on argument order. Rejected
+# outright rather than left for the preview to somehow account for a
+# still-pending sibling write.
+dir="$(make_gh)"
+printf first > "$dir/first.txt"
+printf second > "$dir/second.txt"
+run "$dir" --force --secret "TOKEN=$dir/first.txt" --secret "TOKEN=$dir/second.txt" owner/repo
+assert_status 2
+assert_output "repeats an earlier --secret"
+if test -s "$dir/calls"; then
+    echo "  FAIL: expected no gh calls before the usage error"; TEST_FAILED=1
+fi
+finish_case
+
+test_case "two --secret entries with the same NAME but different ENV are not treated as duplicates"
+dir="$(make_gh)"
+printf 'sekrit' > "$dir/value.txt"
+run "$dir" --dry-run --no-rules --secret "TOKEN=$dir/value.txt" --secret "TOKEN@lanes=$dir/value.txt" owner/repo
+assert_status 0
+assert_no_output "repeats an earlier --secret"
+finish_case
+
+test_case "the same NAME+ENV in a different NAME case is still caught as a duplicate"
+# GitHub secret names are case-insensitive (stored uppercase internally),
+# same reasoning as the App-membership and repo-secrets' own NAME checks.
+dir="$(make_gh)"
+printf first > "$dir/first.txt"
+printf second > "$dir/second.txt"
+run "$dir" --force --secret "TOKEN=$dir/first.txt" --secret "token=$dir/second.txt" owner/repo
+assert_status 2
+assert_output "repeats an earlier --secret"
+finish_case
+
+test_case "the same NAME+ENV in a different ENV case is also caught as a duplicate"
+# Codex review: GitHub treats deployment environment names
+# case-insensitively too, same as secret names.
+dir="$(make_gh)"
+printf first > "$dir/first.txt"
+printf second > "$dir/second.txt"
+run "$dir" --force --secret "TOKEN@Prod=$dir/first.txt" --secret "TOKEN@prod=$dir/second.txt" owner/repo
+assert_status 2
+assert_output "repeats an earlier --secret"
+finish_case
+
+test_case "a --secret name invalid to repo-secrets (not just to this script's own coarser check) blocks the whole apply before the ruleset step runs"
+# Codex review: parse_secret_spec only validates the NAME[@ENV]=PATH shape,
+# not repo-secrets' own stricter secret-name rules (letters, digits,
+# underscores only) -- a hyphenated name like BAD-NAME passes this
+# script's own check and is only caught once repo-secrets' own --dry-run
+# preview runs it for real, setting SECRETS_DRYRUN_FAILED. A real --force
+# run used to never check that flag at all (it only gated --dry-run's own
+# exit code), so it fell straight through to apply anyway -- mutating the
+# ruleset before ever reaching the secret step that would report the
+# problem, contradicting parse_secret_spec's own comment that a malformed
+# --secret is "a usage error before anything runs."
+dir="$(make_gh)"
+printf 'sekrit' > "$dir/value.txt"
+run "$dir" --force --secret "BAD-NAME=$dir/value.txt" owner/repo
+assert_status 1
+assert_output "the preview above failed"
+if grep -q "POST repos/owner/repo/rulesets" "$dir/calls"; then
+    echo "  FAIL: the ruleset step must not run when the secrets preview already failed"
+    TEST_FAILED=1
+fi
+finish_case
+
+test_case "a --secret PATH that cannot be read is a usage error before any gh call runs"
+dir="$(make_gh)"
+run "$dir" --force --secret "TOKEN=$dir/does-not-exist.txt" owner/repo
+assert_status 2
+if test -s "$dir/calls"; then
+    echo "  FAIL: expected no gh calls before the usage error"; TEST_FAILED=1
+fi
+finish_case
+
+test_case "--app resolves an installation scoped to 'selected' and not yet a member: adds it"
+dir="$(make_gh)"
+printf 'codex\t111\tselected\towner\n' > "$dir/installations"
+run "$dir" --force --no-rules --app codex owner/repo
+assert_status 0
+assert_call_count "$dir" "PUT user/installations/111/repositories/999" 1
+finish_case
+
+test_case "a 'selected' installation not yet a member still confirms the repo itself exists before planning ADD"
+# Codex review: absent from a 'selected' installation's member list is
+# ambiguous the same way ALREADY_ALL's bare scope check was -- $REPO can be
+# genuinely not-yet-added, or it can be a typo'd/inaccessible repo that
+# would never appear in ANY installation's member list either way. The real
+# apply's ADD case already resolves $REPO's id before adding it and would
+# catch a typo there, but a --dry-run planning ADD purely on "not in the
+# list" reported success for a step that would actually fail at apply time.
+dir="$(make_gh "" "" "repos/owner/typo-repo")"
+printf 'codex\t111\tselected\towner\n' > "$dir/installations"
+run "$dir" --dry-run --no-rules --app codex owner/typo-repo
+assert_status 1
+assert_no_output "would add"
+assert_output "could not confirm owner/typo-repo exists"
+finish_case
+
+test_case "--app disambiguates by account when the same App is installed on more than one account"
+# Regression: user/installations lists every installation the authenticated
+# user can see, across every account they belong to -- filtering on slug
+# alone rejected an unambiguous target whenever the same App was ALSO
+# installed on some other account this user can see (a personal install
+# alongside an org install, say). REPO_OWNER (from owner/repo) is what
+# resolves it, the same way a repo's own account disambiguates it on
+# GitHub's UI.
+dir="$(make_gh)"
+printf 'codex\t222\tselected\tsome-other-org\ncodex\t111\tselected\towner\n' > "$dir/installations"
+run "$dir" --force --no-rules --app codex owner/repo
+assert_status 0
+assert_no_output "more than one installation"
+assert_call_count "$dir" "PUT user/installations/111/repositories/999" 1
+assert_call_count "$dir" "PUT user/installations/222/repositories/999" 0
+finish_case
+
+test_case "--app resolves an installation already scoped to 'all': nothing to add"
+dir="$(make_gh)"
+printf 'codex\t111\tall\towner\n' > "$dir/installations"
+run "$dir" --dry-run --no-rules --app codex owner/repo
+assert_status 0
+assert_output "already covered"
+assert_no_writes "$dir"
+finish_case
+
+test_case "--app on an installation scoped to 'all' still confirms the repo itself exists"
+# Codex review: unlike ALREADY_MEMBER (which only ever reports success from
+# a real gh api response naming the repo), ALREADY_ALL used to report
+# success purely from the installation's own scope, without ever checking
+# $REPO exists. An App-only run against a typo'd or inaccessible repo
+# exited 0 claiming coverage of a repo nothing confirmed was real.
+dir="$(make_gh "" "" "repos/owner/typo-repo")"
+printf 'codex\t111\tall\towner\n' > "$dir/installations"
+run "$dir" --force --no-rules --app codex owner/typo-repo
+assert_status 1
+assert_output "could not confirm owner/typo-repo exists"
+assert_output "failed on:"
+assert_output "app:codex"
+finish_case
+
+test_case "--app resolves an installation already a member: nothing to add"
+dir="$(make_gh)"
+printf 'codex\t111\tselected\towner\n' > "$dir/installations"
+printf '111\towner/repo\n' > "$dir/install_members"
+run "$dir" --dry-run --no-rules --app codex owner/repo
+assert_status 0
+assert_output "already a member"
+assert_no_writes "$dir"
+finish_case
+
+test_case "--app resolves membership case-insensitively against the repo's own canonical casing"
+# Codex review: GitHub's .full_name is returned in the repo's own canonical
+# casing, which can differ from however the caller typed --app's OWNER/REPO
+# argument (repository names resolve case-insensitively). An exact-case
+# miss here planned ADD for a repo that's already a member, which can then
+# fail outright for a credential allowed to list an installation's
+# repositories but not modify them -- reporting failure on a state that
+# already held.
+dir="$(make_gh)"
+printf 'codex\t111\tselected\tOwner\n' > "$dir/installations"
+printf '111\tOwner/Repo\n' > "$dir/install_members"
+run "$dir" --dry-run --no-rules --app codex Owner/repo
+assert_status 0
+assert_output "already a member"
+assert_no_writes "$dir"
+finish_case
+
+# The old sh version's App-membership check was `grep -qxFi "$REPO" ...`,
+# which treats a real grep failure (status 2) identically to "not a member"
+# (status 1) and silently plans ADD on no real evidence -- tested above by
+# shadowing grep's exact `-qxFi` flag shape. The bash rewrite replaced that
+# grep call with file_contains_ci(), a plain read loop over the freshly
+# written member list; a failed `< "$file"` redirection there is caught
+# explicitly (`[[ -r "$file" ]] || return 2`, and `done < "$file" || return
+# 2` around the loop itself) and returned as status 2, distinct from status
+# 1 ("read the whole file, no match"), with the app_plan_line() call site
+# treating 2 as an error rather than ADD -- see repo-setup's file_contains_ci
+# and its comment for why this needed an explicit check rather than relying
+# on `set -e` (a redirection failure inside a function called as an `if`
+# condition does not trigger `set -e`, so it silently falls through to
+# whatever the function does next unless caught). There is no black-box way
+# left to force this path the way grep could be shadowed on PATH: the read
+# happens synchronously, in-process, on a file this same script wrote an
+# instant earlier, with no external command and no test hook to intercept
+# in between -- genuinely unreachable rather than merely rare. Left
+# unexercised here rather than adding a test-only hook to production code;
+# the 0/1/2 contract and its call site are verified by inspection.
+
+test_case "--app names a slug with no installation on this account at all: reported as an error"
+dir="$(make_gh)"
+# $dir/installations stays empty: no App with this slug is installed anywhere.
+run "$dir" --force --no-rules --app not-installed-anywhere owner/repo
+assert_status 1
+assert_output "no installation of an App with slug 'not-installed-anywhere' was found"
+assert_output "failed on:"
+assert_output "app:not-installed-anywhere"
+assert_no_writes "$dir"
+finish_case
+
+test_case "an entirely empty --app value is a usage error, not a silently skipped App step"
+# Codex review: an empty --app ("" or --app=) used to be appended to APPS
+# as a lone blank line. `for slug in $APPS` under IFS=newline treats a
+# string made of nothing but separator characters as zero fields (leading
+# and trailing IFS whitespace is stripped), so the loop that builds and
+# applies the App plan never ran at all -- App installation membership was
+# silently never checked or ensured, while `test -n "$APPS"` still being
+# true made the script print an (empty) "App installation membership:"
+# section and exit 0, reporting success on a step that did nothing.
+dir="$(make_gh)"
+run "$dir" --force --no-rules --app "" owner/repo
+assert_status 2
+assert_output "non-empty slug"
+if test -s "$dir/calls"; then
+    echo "  FAIL: expected no gh calls before the usage error"; TEST_FAILED=1
+fi
+finish_case
+
+test_case "--app --dry-run makes no App-installation writes"
+dir="$(make_gh)"
+printf 'codex\t111\tselected\towner\n' > "$dir/installations"
+run "$dir" --dry-run --no-rules --app codex owner/repo
+assert_status 0
+assert_output "would add owner/repo"
+assert_no_writes "$dir"
+finish_case
+
+test_case "every step is attempted even when an earlier one fails"
+# The ruleset step is forced to fail (the create POST itself), while a
+# secret and an App membership are also requested -- both must still be
+# applied, and the final failure list must name only the step that failed.
+dir="$(make_gh "" "" "POST repos/owner/repo/rulesets")"
+printf 'sekrit' > "$dir/value.txt"
+printf 'codex\t111\tselected\towner\n' > "$dir/installations"
+run "$dir" --force --secret TOKEN="$dir/value.txt" --app codex owner/repo
+assert_status 1
+assert_output "failed on:"
+assert_output "ruleset"
+assert_written "$dir" owner_repo TOKEN
+assert_call_count "$dir" "PUT user/installations/111/repositories/999" 1
+finish_case
+
+test_case "a failing secret does not block the ruleset or App steps"
+dir="$(make_gh "" "" "secret set")"
+printf 'sekrit' > "$dir/value.txt"
+printf 'codex\t111\tselected\towner\n' > "$dir/installations"
+run "$dir" --force --secret TOKEN="$dir/value.txt" --app codex owner/repo
+assert_status 1
+assert_output "failed on:"
+assert_output "secret:TOKEN"
+assert_call_count "$dir" "POST repos/owner/repo/rulesets" 1
+assert_call_count "$dir" "PUT user/installations/111/repositories/999" 1
+finish_case
+
+test_case "a secret plan that changed since it was confirmed is refused, not silently applied"
+# Codex review: the confirmation can sit for an arbitrary amount of real
+# time, and the real apply below invokes repo-secrets fresh, as its own
+# process, which rebuilds its plan from scratch. If a secret shown here as
+# "new" was created by someone else in that window, the child's own plan
+# now reads "overwrite" -- and since that's not the "new" case, neither
+# repo-secrets' own late TOCTOU recheck nor its confirmation prompt (which
+# --force suppresses) catches it, so the value only ever confirmed as a
+# new write would otherwise get silently overwritten. $4="TOKEN" makes the
+# SECOND (or later) call to the secrets-list endpoint see TOKEN as already
+# existing -- the first call (repo-setup's own preview) still sees it as
+# absent, matching the "shown as new, changed before the real apply" shape.
+dir="$(make_gh "" "" "" "TOKEN")"
+printf 'sekrit' > "$dir/value.txt"
+run "$dir" --force --no-rules --secret "TOKEN=$dir/value.txt" owner/repo
+assert_status 1
+assert_output "plan for --secret TOKEN"
+assert_output "changed since it"
+assert_not_written "$dir" owner_repo TOKEN
+finish_case
+
+test_case "a secret revalidation that fails outright is reported as that failure, not as a changed plan"
+# Codex review: same defect as the ruleset revalidation above, for a
+# secret's own recheck -- its exit status used to be discarded (`|| :`)
+# too, so a genuine failure of the recheck itself got misreported as "the
+# plan changed since it was confirmed" instead of as the failure it
+# actually was. fail_secrets_at_recheck makes the SECOND (the
+# revalidation's) call to the secrets-list endpoint fail outright.
+dir="$(make_gh)"
+printf 'sekrit' > "$dir/value.txt"
+touch "$dir/fail_secrets_at_recheck"
+run "$dir" --force --no-rules --secret "TOKEN=$dir/value.txt" owner/repo
+assert_status 1
+assert_output "revalidating the plan for --secret TOKEN failed"
+assert_output "simulated failure on revalidation"
+assert_no_output "changed since it was confirmed"
+assert_not_written "$dir" owner_repo TOKEN
+finish_case
+
+test_case "a stale secret is skipped, but the ruleset step (which ran first and could itself be the delay) is not"
+# Codex review, round 2: the earlier fix revalidated every secret's plan
+# ONCE, collectively, before the whole apply section -- so a stale plan
+# caused by the RULESET step's own duration (it runs first, and can take
+# real time) was still an unclosed window. Now revalidated per secret,
+# immediately before that secret's own apply, inside the same loop as the
+# apply itself -- proven here by running WITH the ruleset step enabled
+# (not --no-rules) and confirming it still applies even though the secret
+# that comes after it is stale and skipped.
+dir="$(make_gh "" "" "" "TOKEN")"
+printf 'sekrit' > "$dir/value.txt"
+run "$dir" --force --secret "TOKEN=$dir/value.txt" owner/repo
+assert_status 1
+assert_output "failed on:"
+assert_output "secret:TOKEN"
+assert_call_count "$dir" "POST repos/owner/repo/rulesets" 1
+assert_not_written "$dir" owner_repo TOKEN
+finish_case
+
+test_case "a ruleset plan that changed since it was confirmed is refused, not silently applied"
+# Codex review: same plan-staleness risk as secrets, but for the ruleset
+# step. The confirmation prompt can sit for an arbitrary amount of real
+# time, and the real apply below invokes repo-rules fresh, as its own
+# process, which rebuilds its plan from scratch -- if the ruleset's own
+# state changed in that window, this --force call would silently apply a
+# DIFFERENT plan than the one shown and confirmed. $1="" (nothing reported
+# at preview time) with $5=the full default set (all reported by recheck
+# time) makes repo-rules' own dry-run output differ between the two calls
+# -- the first mentions checks that have never reported, the second does
+# not.
+dir="$(make_gh "" "" "" "" "lanes
+codex
+zizmor")"
+run "$dir" --force owner/repo
+assert_status 1
+assert_output "plan for the ruleset changed"
+assert_output "changed since it was confirmed"
+if test -s "$dir/writes"; then
+    echo "  FAIL: expected no ruleset write once its plan was found stale"
+    TEST_FAILED=1
+fi
+finish_case
+
+test_case "a ruleset revalidation that fails outright is reported as that failure, not as a changed plan"
+# Codex review: the revalidation's own --dry-run used to have its exit
+# status discarded (`|| :`), so a genuine failure of the recheck itself
+# (expired auth, GitHub unreachable, an API error) produced output that
+# merely differed from the confirmed preview -- and got reported as "the
+# plan changed since it was confirmed", which is wrong and actively
+# misleading about the real cause. fail_checks_at_recheck makes the
+# SECOND (the revalidation's) call to the check-runs endpoint fail
+# outright rather than returning names.
+dir="$(make_gh)"
+touch "$dir/fail_checks_at_recheck"
+run "$dir" --force owner/repo
+assert_status 1
+assert_output "revalidating the ruleset plan failed"
+assert_output "simulated failure on revalidation"
+assert_no_output "changed since it was confirmed"
+if test -s "$dir/writes"; then
+    echo "  FAIL: expected no ruleset write when its revalidation itself failed"
+    TEST_FAILED=1
+fi
+finish_case
+
+test_case "a --secret file edited after the preview deploys the snapshotted bytes, not the new ones"
+# Codex review: the plan-staleness comparison compares the secret's REMOTE
+# state (new/overwrite), never the local file's CONTENTS -- so if
+# --file's target were re-read at every later use, an edit during the
+# confirmation prompt, the ruleset step, or an earlier secret's own apply
+# would deploy DIFFERENT bytes than what was true when the plan was built
+# and shown. Each --secret's value is now snapshotted once, before
+# anything is shown, and every later use (the preview's own dry-run, the
+# revalidation recheck, the real apply) reads that snapshot instead of
+# re-reading $SPEC_PATH. repo-secrets ITSELF already copies --file into
+# its own private work dir before its first gh call, which would mask
+# this bug if the edit landed too early (during the very first repo-
+# secrets invocation) -- so the edit here is timed to the SECOND call to
+# the secrets-list endpoint instead, which is the revalidation recheck's
+# own repo-secrets invocation, reading $SPEC_PATH (or the snapshot) fresh,
+# strictly after the preview's own read already completed.
+# Codex review: a fixed `sleep 2` after the marker only makes the race
+# unlikely, not impossible -- if the test controller (this script) is
+# itself descheduled for more than 2s after the marker file appears (a
+# busy/loaded runner), the fake gh's sleep elapses first and repo-setup
+# proceeds into the real apply before the edit below has happened, so the
+# test would pass even against a reverted fix without ever having
+# exercised it. Replaced with an explicit handshake: the fake gh blocks
+# on a `read` from a FIFO after touching the marker, and nothing unblocks
+# it until this script has made its edit and written to that FIFO --
+# there is no timing window left to race, whatever the runner's load.
+dir="$(make_gh)"
+printf 'original-value' > "$dir/value.txt"
+mkfifo "$dir/release"
+mv "$dir/bin/gh" "$dir/bin/gh.real"
+cat > "$dir/bin/gh" << EOF
+#!/bin/sh
+case " \$* " in
+    *"actions/secrets"*)
+        counter_file="$dir/secrets_list_calls"
+        count="\$(cat "\$counter_file" 2>/dev/null || echo 0)"
+        count=\$((count + 1))
+        echo "\$count" > "\$counter_file"
+        if test "\$count" -eq 2; then
+            touch "$dir/second-list-call-landed"
+            read -r _ < "$dir/release"
+        fi
+        ;;
+esac
+exec "$dir/bin/gh.real" "\$@"
+EOF
+chmod +x "$dir/bin/gh"
+PATH="$dir/bin:$PATH" "$REPO_SETUP" --force --no-rules --secret "TOKEN=$dir/value.txt" \
+    owner/repo >"$dir/run.out" 2>&1 &
+run_pid=$!
+waited=0
+reached=0
+while test "$waited" -lt 10; do
+    if test -f "$dir/second-list-call-landed"; then
+        reached=1
+        break
+    fi
+    sleep 1
+    waited=$((waited + 1))
+done
+if test "$reached" -eq 0; then
+    echo "  FAIL: repo-setup never reached the recheck's secrets-list call in 10s"
+    TEST_FAILED=1
+    kill -TERM "$run_pid" 2>/dev/null
+    # Unblock a fake gh that might be waiting on the FIFO so it isn't left
+    # as an orphan once this test's directory is removed; nothing is
+    # listening if it never reached that point, so don't let this hang.
+    (printf 'go\n' > "$dir/release" 2>/dev/null &)
+    wait "$run_pid" 2>/dev/null || true
+else
+    printf 'edited-after-preview' > "$dir/value.txt"
+    # Only after the edit above is on disk does the fake gh's blocked
+    # read return, so repo-setup cannot reach the real apply any earlier
+    # than this -- the ordering is enforced by the FIFO, not by timing.
+    printf 'go\n' > "$dir/release"
+    status=0
+    wait "$run_pid" 2>/dev/null || status=$?
+    output="$(cat "$dir/run.out")"
+    assert_status 0
+    assert_written "$dir" owner_repo TOKEN
+    if test -f "$dir/written.owner_repo.TOKEN"; then
+        got="$(cat "$dir/written.owner_repo.TOKEN")"
+        if test "$got" != "original-value"; then
+            echo "  FAIL: expected the snapshotted value 'original-value', got '$got'"
+            TEST_FAILED=1
+        fi
+    fi
+fi
+finish_case
+
+test_case "a --dry-run plan for a never-reported check still shows the full plan, not just an error"
+# Regression test: the real apply below always runs repo-rules with
+# --force, which also bypasses repo-rules' own never-reported-check guard
+# (not just its confirmation prompt) -- so the preview has to pass --force
+# too, or a check that simply hasn't reported yet shows here as a dry-run
+# failure the real (always-forced) apply would not actually hit.
+dir="$(make_gh "")"  # nothing has reported anything
+run "$dir" --dry-run --rule brand-new-check owner/repo
+assert_status 0
+assert_output "never reported"
+assert_output "--force given"
+assert_output "would create ruleset"
+finish_case
+
+test_case "SIGTERM during the apply sequence aborts rather than continuing to later steps"
+# Same trap bug/fix as repo-secrets: trapping INT/TERM alongside EXIT on
+# one line replaces bash's default terminate-on-signal action with "run
+# the handler, then resume the script". repo-setup runs three independent
+# apply steps (ruleset, secrets, App membership) in sequence under one
+# WORK dir and one top-level trap, so this matters even more here: a
+# signal during the FIRST step must not let the remaining two run anyway.
+# Every real gh call repo-rules/repo-secrets/repo-setup itself makes goes
+# through this one fake gh, so sleeping on its very first invocation (of
+# any kind) is an early-enough hook to prove the fix aborts before even
+# the ruleset step, let alone secrets, ever completes.
+dir="$(make_gh)"
+printf 'sekrit' > "$dir/value.txt"
+mv "$dir/bin/gh" "$dir/bin/gh.real"
+cat > "$dir/bin/gh" << EOF
+#!/bin/sh
+if test ! -f "$dir/first-call-landed"; then
+    touch "$dir/first-call-landed"
+    "$dir/bin/gh.real" "\$@" > /tmp/first-call-out.\$\$ 2>&1
+    rc=\$?
+    cat /tmp/first-call-out.\$\$
+    rm -f /tmp/first-call-out.\$\$
+    sleep 5
+    exit \$rc
+fi
+exec "$dir/bin/gh.real" "\$@"
+EOF
+chmod +x "$dir/bin/gh"
+PATH="$dir/bin:$PATH" "$REPO_SETUP" --force --secret "TOKEN=$dir/value.txt" owner/repo \
+    >"$dir/run.out" 2>&1 &
+run_pid=$!
+waited=0
+reached=0
+while test "$waited" -lt 10; do
+    if test -f "$dir/first-call-landed"; then
+        reached=1
+        break
+    fi
+    sleep 1
+    waited=$((waited + 1))
+done
+if test "$reached" -eq 0; then
+    echo "  FAIL: repo-setup never reached its first gh call in 10s"
+    TEST_FAILED=1
+    kill -TERM "$run_pid" 2>/dev/null
+    wait "$run_pid" 2>/dev/null || true
+else
+    kill -TERM "$run_pid"
+    status=0
+    wait "$run_pid" 2>/dev/null || status=$?
+    output="$(cat "$dir/run.out")"
+    assert_status 143
+    if ls "$dir"/written.* >/dev/null 2>&1; then
+        echo "  FAIL: expected no secret write once the apply sequence was interrupted"
+        TEST_FAILED=1
+    fi
+fi
+finish_case
+
+test_case "unknown option is a usage error"
+dir="$(make_gh)"
+run "$dir" --nonsense owner/repo
+assert_status 2
+finish_case
+
+test_case "exactly one OWNER/REPO is required"
+dir="$(make_gh)"
+run "$dir" --force
+assert_status 2
+finish_case
+
+test_case "rejects an OWNER/REPO shaped like an owner/repo/extra path"
+dir="$(make_gh)"
+run "$dir" --force owner/repo/extra
+assert_status 2
+finish_case
+
+test_case "--app rejects a slug with characters this script does not handle"
+dir="$(make_gh)"
+run "$dir" --force --app 'not a slug' owner/repo
+assert_status 2
+finish_case
+
+# ---------------------------------------------------------------------------
+
+echo
+echo "Tests run: $TESTS_RUN, passed: $TESTS_PASSED, failed: $TESTS_FAILED, skipped: $TESTS_SKIPPED"
+test "$TESTS_FAILED" -eq 0


### PR DESCRIPTION
## Summary

Three new fleet-management scripts, each with its own test suite (fake `gh` on PATH, no network, no token):

- **`repo-list`** — enumerates every repo an account owns (self, an org, or another user&#39;s public repos), sorted, forks/archived excluded unless asked. Never prints a partial list on a failed page read. POSIX sh.
- **`repo-secrets`** — fans one Actions secret (repo-level or environment-scoped) out across one or more repos, from `--file`/stdin, confirming once for the whole batch. bash.
- **`repo-setup`** — composes the above two as subprocesses (never reimplementing their logic) plus a native GitHub App installation-membership step, confirming once for the whole repository and applying every requested step regardless of an earlier one&#39;s failure. bash.

All three went through many rounds of automated (Codex) review; every finding was independently verified against real `gh`/shell behavior (several with a standalone reproduction) before fixing, and every fix landed with a genuine regression test, mutation-tested by temporarily reverting the fix and confirming the new test actually fails. Highlights across the rounds:

- **Silent scope-widening on `repo-list`**: the self-owner listing defaulted to `affiliation=owner,collaborator,organization_member` (now restricted to `owner`); an org-probe failure other than a genuine 404 (403/SSO/transient) used to fall back to the public-only endpoint instead of failing loudly; account-name comparisons (self-vs-other, `--owner` vs the authenticated login) are now case-insensitive, matching GitHub&#39;s own case-insensitive account names; `--owner &#34;&#34;`/`--owner=` now reject rather than silently falling back to the authenticated user. A SIGTERM/Ctrl-C while `gh` is running now aborts immediately instead of resuming against a deleted work directory (bash&#39;s/sh&#39;s default `trap ... EXIT INT TERM` on one line only *runs the handler*, it doesn&#39;t stop execution unless the handler itself exits — this script had the same bug the other two below had already fixed, just not carried over here).
- **Silent overwrite/scope risk on `repo-secrets`**: the environment create-or-update PUT used to run unconditionally, resetting an existing environment&#39;s protection settings — now gated on the read phase finding it missing, *and* revalidated immediately before the PUT (closing the confirmation-prompt/batch-queue TOCTOU window). Secret-name matching is case-insensitive (GitHub stores names uppercase). The secrets list paginates (a target with &gt;30 secrets doesn&#39;t silently misread an existing one as new). `--env &#34;&#34;`/`--env=` and `--file &#34;&#34;`/`--file=` reject explicitly-empty values instead of silently falling through to a repository-level secret or to reading stdin. A 404 from an environment-scoped listing is positively distinguished from a nonexistent/inaccessible repo (same 404, by GitHub design) via a repo-level recheck. The target repo list is deduplicated (case-insensitively — `Owner/Repo` and `owner/repo` are the same repository) before planning, so a duplicate `OWNER/REPO` (exact or a casing variant) can&#39;t make the second occurrence&#39;s write-time TOCTOU recheck misread the first occurrence&#39;s own just-landed write as a race with someone else. A SIGTERM/Ctrl-C mid-batch now aborts immediately instead of continuing to the next repo.
- **Silent no-op / wrong-target risk on `repo-setup`**: `--rule`, `--secret`, and `--app` reject an empty value, a malformed spec, an embedded newline, or (for `--secret`) a duplicate NAME+ENV scope (case-insensitive on both) at parse time, rather than silently dropping/splitting the entry or letting the second overwrite the first with no warning. `TOKEN@=PATH` (an `@` with nothing after it) is rejected rather than silently becoming a repository-level secret. App-installation resolution disambiguates by the repository&#39;s own owner when the same App is installed on more than one account, and confirms the target repository itself exists before planning to add it (not just when it&#39;s already covered by an &#34;all repositories&#34; scope) — a dry-run against a typo&#39;d repo no longer reports false success for a step that would fail at real apply time. Two `--secret` entries that both omit `--env`/name an environment literally called `none` no longer collide on the same dry-run preview file. **Every step&#39;s plan is revalidated immediately before that step&#39;s own apply**, inside the apply loop/sequence itself rather than once, collectively, up front — a single collective check still left every later step&#39;s own duration as an unclosed window. The confirmation prompt, and every earlier step, can take real time: if the ruleset or a secret shown as one thing gets changed by someone else in that window, this fresh `repo-rules --force`/`repo-secrets --force` invocation would otherwise recompute and silently apply the new plan without showing it to the user. Each step now re-runs its own `--dry-run` immediately before forcing the apply and `cmp -s`s it against the confirmed preview, skipping (not aborting the whole run — earlier steps may already have applied and can&#39;t be undone) on a mismatch — and the revalidation command&#39;s own exit status is captured and reported as its own distinct failure (auth expired, GitHub down, an API error), rather than being discarded and misattributed to &#34;the plan changed.&#34; **Each `--secret`&#39;s file is snapshotted once, before anything is shown to the user**, and every later read of it (preview, recheck, real apply) uses that snapshot — the dry-run comparison alone can&#39;t catch a file edited on disk after the preview, since it describes only the secret&#39;s remote state. A SIGTERM/Ctrl-C mid-apply now aborts immediately instead of finishing the remaining steps anyway.
- **The three test suites had the same signal-handling bug as the scripts they test**: each suite&#39;s own top-level `trap ... EXIT INT TERM` cleaned up its shared temp dir and then resumed instead of stopping, so canceling a suite mid-run (CI&#39;s own timeout/cancel, or a local Ctrl-C) could delete fixtures out from under a still-in-flight test case and produce a confusing unrelated failure instead of a clean abort — verified with a real SIGTERM sent to a running suite. Fixed with the same split-handler pattern used everywhere else in this PR.

**`repo-secrets` and `repo-setup` were later rewritten from POSIX sh to bash.** Six review rounds against the sh versions kept surfacing the same two bug shapes — `grep` exit-status conflation (a real grep failure treated identically to grep&#39;s well-defined &#34;no match&#34;) and list-encoding ambiguity on newline-delimited strings standing in for arrays (an empty accumulator, or a value containing the delimiter, silently misread) — because POSIX sh has no real arrays and every grep call&#39;s exit status has to be checked by hand. bash&#39;s real arrays and a plain read-loop membership check eliminate both bug classes by construction rather than by patching each instance as review found it; several review findings that landed on the bash version turned out to already be moot for exactly this reason (the code path they described no longer exists). Written to bash 3.2 (macOS&#39;s stock, pre-GPLv3 version) — no associative arrays, no `${var,,}`, no `mapfile`, and every `&#34;${array[@]}&#34;` expansion guarded against the pre-4.4 &#34;unbound variable&#34; bug on an empty array. `repo-list` stays POSIX sh (no findings against it needed the array/grep fixes the other two got).

**Not independently verified:** the App-installation step&#39;s endpoints (`/user/installations/...`) predate fine-grained personal access tokens, and whether a fine-grained PAT is accepted there could not be confirmed against GitHub&#39;s own docs — no network access to `docs.github.com` from this sandbox. The script says so explicitly and names a classic PAT as the documented fallback if it fails with what looks like a permission problem rather than a &#34;not found&#34;. The same gap applies to whether GitHub environment names are case-insensitive (taken on Codex&#39;s word, with a comment explaining why the asymmetric cost of being wrong favors fixing it either way).

## Test plan

- `./repo-list_test` — 18/18 passing
- `./repo-secrets_test` — 37/37 passing
- `./repo-setup_test` — 53/53 passing (puts the *real* `repo-rules`/`repo-secrets` on PATH next to a fake `gh`, so it exercises the actual subprocess composition rather than a mock of what they&#39;re assumed to do)
- `make test` — full suite green, 0 failures across every test target

---
_Generated by [Claude Code](https://claude.ai/code/session_016fX7NJtZkkAARcbbJbKTEr)_