### PR TITLE
Print the plan under --force and skip the value on a dry run

### DIFF
--- a/repo-secrets
+++ b/repo-secrets
@@ -34,16 +34,23 @@
 # creating the environment).
 #
 # Before writing, this lists which of NAME's targets already have a secret
-# by that name and prints the plan (new vs. overwrites an existing value),
-# then asks for confirmation -- once for the whole batch, not once per repo,
-# since it is the same NAME and the same value going to every target.
-# --force skips the question, same reasoning as repo-rules' own --force:
-# "I have already decided, stop asking." Run with no terminal on stdin and
-# without --force, it refuses to guess and changes nothing. There is no
-# "already matches, nothing to do" shortcut the way repo-rules has one --
-# GitHub never returns a secret's value, so whether an existing one already
-# equals what is being set is unanswerable, and every write is attempted
-# every time.
+# by that name and prints the plan (new vs. overwrites an existing value)
+# -- always, including under --force, which skips only the confirmation
+# question, not the plan itself, so an unattended run still leaves the
+# OVERWRITES-an-existing-value warning in its own output -- then asks for
+# confirmation -- once for the whole batch, not once per repo, since it is
+# the same NAME and the same value going to every target. --force skips the
+# question, same reasoning as repo-rules' own --force: "I have already
+# decided, stop asking." Run with no terminal on stdin and without --force,
+# it refuses to guess and changes nothing. There is no "already matches,
+# nothing to do" shortcut the way repo-rules has one -- GitHub never
+# returns a secret's value, so whether an existing one already equals what
+# is being set is unanswerable, and every write is attempted every time.
+#
+# The secret value is read only once a write might actually happen --
+# neither --dry-run nor the every-repo-failed early exit ever needs it, so
+# neither is refused for one it will never touch (an interactive --dry-run
+# with no --file, in particular).
 #
 # Every repository is attempted even if an earlier one fails -- a typo in
 # the fourth of twenty repos should not leave the other nineteen unset. The
@@ -276,20 +283,6 @@ file_contains_ci() {
     return "$found"
 }
 
-if [[ -n "$VALUE_FILE" ]]; then
-    [[ -r "$VALUE_FILE" ]] || { error "cannot read '$VALUE_FILE'"; exit 2; }
-    cp "$VALUE_FILE" "$WORK/value"
-else
-    if [[ -t 0 ]]; then
-        error "refusing to read a secret value from an interactive terminal --"
-        error "there is no way to hide it as you type. Pipe the value in, or pass"
-        error "--file PATH."
-        exit 2
-    fi
-    cat > "$WORK/value"
-fi
-[[ -s "$WORK/value" ]] || { error "the secret value is empty"; exit 2; }
-
 PLAN_REPOS=()
 PLAN_STATES=()
 PLAN_ENV_STATES=()
@@ -417,12 +410,30 @@ if plan_all_errors; then
     exit 1
 fi
 
+if [[ -n "$VALUE_FILE" ]]; then
+    [[ -r "$VALUE_FILE" ]] || { error "cannot read '$VALUE_FILE'"; exit 2; }
+    cp "$VALUE_FILE" "$WORK/value"
+else
+    if [[ -t 0 ]]; then
+        error "refusing to read a secret value from an interactive terminal --"
+        error "there is no way to hide it as you type. Pipe the value in, or pass"
+        error "--file PATH."
+        exit 2
+    fi
+    cat > "$WORK/value"
+fi
+[[ -s "$WORK/value" ]] || { error "the secret value is empty"; exit 2; }
+
+# To stderr, not stdout, same reasoning as repo-rules: a captured stdout
+# must not silently swallow output a script is still working from. Printed
+# unconditionally -- including under --force -- so a forced, unattended
+# run still leaves the OVERWRITES-an-existing-value warning in its own
+# output, not just silently applied. --force skips the *question* below,
+# not this.
+describe_plan >&2
+
 if (( FORCE != 1 )); then
     if [[ -t 0 ]]; then
-        # To stderr, not stdout, same reasoning as repo-rules: a captured
-        # stdout must not silently swallow the question a script is still
-        # blocking on.
-        describe_plan >&2
         printf 'Apply this to every repository above? [y/N] ' >&2
         read -r CONFIRM || CONFIRM=""
         case "$CONFIRM" in

--- a/repo-secrets_test
+++ b/repo-secrets_test
@@ -26,6 +26,21 @@ TESTS_RUN=0
 TESTS_PASSED=0
 TESTS_FAILED=0
 
+# The interactive-terminal cases need a real pseudo-terminal, and `command
+# -v script` alone is not enough to gate on: macOS ships a `script` too, but
+# the BSD one has no `-c`/`-e` -- its synopsis is `script [-adkpqr] [-t time]
+# [file [command ...]]`, nothing that takes a command string. A presence-only
+# check would set HAVE_PTY=yes there and then fail every PTY case on the
+# unrecognized flags, mistaking "this script(1) is a different program" for
+# a real regression (see repo-rules_test's own copy of this probe). So this
+# probes the actual invocation those cases use (a trivial `true`) and trusts
+# its exit status instead of the binary's mere existence.
+if printf 'x\n' | script -qec true /dev/null >/dev/null 2>&1; then
+    HAVE_PTY=yes
+else
+    HAVE_PTY=no
+fi
+
 # make_gh: build a fake gh in a fresh dir and echo that dir.
 #   $1 = newline-separated secret names that already exist (repo-level or,
 #        when $2 is set, on that environment)
@@ -338,6 +353,38 @@ assert_status 0
 assert_not_written "$dir" owner_repo TOKEN
 finish_case
 
+test_case "--force still prints the plan, not just the confirmation"
+# Regression: --force is "I have already decided, stop asking" -- not
+# "apply silently". An unattended run still needs the OVERWRITES-an-
+# existing-value warning in its own output.
+dir="$(make_gh "TOKEN")"
+printf 'sekrit' > "$dir/value.txt"
+run "$dir" --force --name TOKEN --file "$dir/value.txt" owner/repo
+assert_status 0
+assert_output "About to set secret 'TOKEN' (repository-level) on:"
+assert_output "OVERWRITES an existing value"
+assert_no_output "Apply this to every repository above?"
+finish_case
+
+test_case "dry-run needs no value at all, even on a real terminal with no --file"
+# Regression: the value can't affect the plan and nothing gets written, so
+# a dry run doesn't need it -- an interactive --dry-run with no --file must
+# not be refused for a value it will never read.
+dir="$(make_gh "")"
+if test "$HAVE_PTY" = yes; then
+    set +e
+    output="$(PATH="$dir/bin:$PATH" script -qec \
+        "$REPO_SECRETS --dry-run --name TOKEN owner/repo" /dev/null 2>&1)"
+    status=$?
+    set -e
+    assert_status 0
+    assert_no_output "interactive terminal"
+    assert_output "About to set secret 'TOKEN' (repository-level) on:"
+else
+    echo "  SKIP: no script(1) to allocate a PTY with"
+fi
+finish_case
+
 test_case "an existing secret is reported as an overwrite in the plan"
 dir="$(make_gh "TOKEN
 OTHER")"
@@ -471,7 +518,7 @@ finish_case
 
 test_case "refuses to read the value from an interactive terminal"
 dir="$(make_gh "")"
-if command -v script >/dev/null 2>&1; then
+if test "$HAVE_PTY" = yes; then
     set +e
     output="$(PATH="$dir/bin:$PATH" script -qec \
         "$REPO_SECRETS --force --name TOKEN owner/repo" /dev/null 2>&1)"


### PR DESCRIPTION
## Summary

Two small latent gaps in `repo-secrets`, found while porting it to Python in
[mikelward/repo](https://github.com/mikelward/repo) (`repo secrets`) and
verifying its behavior against this source directly. Both are in the shell
script as it stands today, not introduced by that port.

1. **`describe_plan` sits inside `if (( FORCE != 1 ))`.** `--force` is meant
   to skip only the confirmation *question* ("I have already decided, stop
   asking" -- same reasoning as `repo-rules`' own `--force`), but today it
   also skips printing the plan, so an unattended run loses the
   `OVERWRITES an existing value` warning entirely -- exactly the audit
   output the plan/confirm flow exists to show.
2. **The value is read before the `--dry-run` check.** A dry run never uses
   the value (it can't affect the plan and nothing gets written), but the
   script reads it anyway -- refusing an interactive `--dry-run` with no
   `--file` outright, or consuming stdin on a piped one, for a value it
   will never touch.

## Fix

- `describe_plan >&2` moved out of the `FORCE` conditional, so it always
  runs before applying (confirmed or forced) -- `--force` now skips only
  the `y/N` prompt.
- The value-read block moved to after both the `--dry-run` and
  every-repo-failed early exits, so neither needs a value it will never use.

## Test plan

- Two new tests: `--force still prints the plan, not just the
  confirmation`, and `dry-run needs no value at all, even on a real
  terminal with no --file` (uses the same `script(1)`-PTY pattern as the
  existing interactive-terminal test).
- Manually mutation-tested both fixes in isolation (reverting the
  `describe_plan` move, and reverting the value-read reorder) -- each
  correctly fails only its own new test, confirmed and restored.
- `./repo-secrets_test`: 39/39 passing.
- `make test`: all 27 test files, 0 failures across the whole repo.

## Review round 2

Codex caught a real portability bug in the new PTY-based test: it gated on
`command -v script` alone, but macOS ships a BSD `script` with no `-c`/`-e`
flags, so the check would pass there and then fail on the unrecognized
flags. Fixed using the `HAVE_PTY` invocation-probe pattern already
established in `repo-rules_test` -- and applied it to the pre-existing
"refuses to read the value from an interactive terminal" test too, which
had the identical presence-only bug already sitting in the file.

---
_Generated by [Claude Code](https://claude.ai/code/session_016fX7NJtZkkAARcbbJbKTEr)_