### PR TITLE
Add the zizmor workflow scan to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,12 @@ jobs:
     needs: classify
     if: needs.classify.outputs.docs_only != 'true'
     steps:
-      - uses: actions/checkout@v4
+      # persist-credentials off like the other jobs: this is the one job
+      # that runs PR-controlled code (the PR's own Makefile and tests), so
+      # the token must not sit in .git/config while it does.
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - run: make test
 
   # The one check the ruleset should require. Always runs, always reports —

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,55 @@
+# Scan of the workflows with zizmor (https://docs.zizmor.sh).
+#
+# Required, not advisory -- reversing the posture this was ported with, by
+# the owner's decision: `zizmor` joins `lanes` and `codex` in the fleet's
+# standard required set (the ruleset half is TODO.md's pending step:
+# until the ruleset itself lists `zizmor`, a red scan does not yet hold
+# merges), piloted in mikelward/lanes and mikelward/ci-commit-artifact
+# and rolled out fleet-wide. That is why
+# there is no `paths:` filter: a workflow filtered out by paths creates NO
+# check run at all (unlike a skipped job, which reports "skipped" and
+# satisfies a ruleset), so a required `zizmor` plus a path filter would
+# leave any pull request not touching `.github/**` waiting forever on a
+# check nothing reports. The scan is a free sub-minute job, so it simply
+# runs on every pull request and every push to main.
+#
+# The version is pinned because a new zizmor release adds audits, so an
+# unpinned run could turn red with no change in this repository. Bump it
+# deliberately and re-read the findings. Policy exceptions live in
+# .github/zizmor.yml, beside this file.
+#
+# Cost and reliability: PyPI is free, keyless, and unmetered, so this is
+# $0/month at any run volume. A cold pipx install-and-scan typically finishes
+# in well under a minute; the 5-minute timeout is headroom for a slow PyPI
+# resolve, not the expected case. The one failure mode is a PyPI outage:
+# fetching zizmor is the only network step (--offline covers the scan
+# itself), and once the check is required, an outage fails it and
+# holds merges until a re-run succeeds -- accepted with the decision above.
+#
+# `pull_request` lists its types explicitly because the default set lacks
+# `edited`: a retarget regenerates the merge ref against the new base while
+# the head -- and the green `zizmor` check already attached to it -- stays
+# put, so without `edited` the old target's scan would satisfy the new one
+# unexamined. Title and body edits re-run the scan too; redundant but
+# cheap, the same trade ci.yml makes for the lane jobs.
+name: zizmor
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+permissions:
+  contents: read
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      # --offline, so the scan talks to nothing: the audits that need the
+      # GitHub API are skipped, deterministically, and the only fetch is
+      # zizmor itself.
+      - name: Scan the workflows
+        run: pipx run --spec zizmor==1.29.0 zizmor --no-progress --offline .

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,48 @@
+# Policy for zizmor; the workflow beside this file runs it.
+#
+# The defaults demand hash pins everywhere and refuse pull_request_target
+# outright. Both collide with decisions this repository made deliberately,
+# so the exceptions live here, scoped as narrowly as the tool allows — a
+# NEW workflow reaching for pull_request_target is still flagged, because
+# only the named files are excused.
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # `@main` IS the release for these sibling actions: this repo tracks
+        # them deliberately, there is no release step on their side, and a
+        # pin would be a thing to bump here on every one of their merges.
+        # Enumerated by name, not `mikelward/*` — owner-wide would also
+        # excuse a future workflow pulling any sibling at a mutable ref, and
+        # each exemption should be a decision somebody made. Adding one is
+        # one line here.
+        "mikelward/codex-review": ref-pin
+        # Same repository, but the key is matched whole against the `uses:`
+        # value including the workflow path, so the reusable workflow the
+        # consumer-side check calls needs its own entry — the action
+        # reference above does not cover it.
+        "mikelward/codex-review/.github/workflows/check-consumer.yml": ref-pin
+        # `@main` is likewise the release for the docs-lane engine test.yml
+        # invokes — same repo-tracked-deliberately reasoning as
+        # codex-review above.
+        "mikelward/lanes": ref-pin
+        # Official actions may pin to a tag, as every workflow here does.
+        # Hash-pinning them instead is a deliberate open question, tracked
+        # the same way mikelward/codex-review tracks it for itself.
+        "actions/*": ref-pin
+        # Everything else must pin to a hash.
+        "*": hash-pin
+  dangerous-triggers:
+    # Both triggers are load-bearing and reasoned through in
+    # mikelward/codex-review's docs/CONSUMER.md.
+    ignore:
+      # The sweep: never checks out or executes pull request code at all.
+      - codex-review.yml
+      # The consumer-side check: pull_request_target so the JOB DEFINITION
+      # always loads from the default branch (a bare pull_request would let
+      # a PR editing this file replace the call with one that always
+      # succeeds), and it does check out the PR head — but only to hand it
+      # to check_consumer.py, which parses it as text and executes nothing
+      # from it. See check-consumer.yml in mikelward/codex-review for the
+      # full reasoning.
+      - codex-review-check.yml

--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,14 @@
 
 ## Review and merge gates
 
+- [ ] **Add `zizmor` to the ruleset's required set** once it has reported
+      on a pull request: the new zizmor workflow runs unfiltered on every
+      PR precisely so it can be required (a paths-filtered workflow
+      creates no check run at all on a non-matching PR, which a ruleset
+      waits on forever) — the posture piloted in mikelward/lanes and
+      mikelward/ci-commit-artifact. `repo-rules mikelward/scripts` with
+      no arguments applies the standard `lanes codex zizmor` set.
+
 - [ ] Require the `lanes` check in the ruleset, not `test` — `test` now
       skips on a docs-only diff (see `.github/lanes.conf`), and a skipped
       required check counts as satisfied, so requiring `test` directly


### PR DESCRIPTION
Brings this repo onto the fleet's zizmor posture (piloted in mikelward/lanes and mikelward/ci-commit-artifact, rolled out to the update repos), completing the set this repo needs for the standard `lanes codex zizmor` ruleset — the lanes structure and codex-review machinery are already in place here.

- `.github/workflows/zizmor.yml` runs the pinned scanner (`zizmor==1.29.0 --offline`) on every pull request and push to main, **unfiltered** — a paths-filtered workflow creates no check run at all on a non-matching PR, which a ruleset requiring `zizmor` would wait on forever — with `pull_request` types listed explicitly so a retarget re-scans the regenerated merge ref.
- `.github/zizmor.yml` grants the fleet's narrow enumerated exemptions (codex-review + its reusable check-consumer workflow, the lanes engine, official actions at ref-pin; everything else hash-pin) and excuses the two deliberate `pull_request_target` triggers.
- **The scan's very first run here paid for itself**: it flagged (artipacked) that test.yml's test job used a bare `actions/checkout@v4`, leaving the workflow token in `.git/config` while the one job that runs PR-controlled code executes. Fixed in the second commit — `checkout@v5` with `persist-credentials: false`, matching every other job and the identical fix mikelward/repo already made.
- `TODO.md` records the ruleset-side step: add `zizmor` to the required set once it has reported — `repo-rules mikelward/scripts` with no arguments then applies the standard set.

No test accompanies the workflow additions: CI configuration only, with no script behavior to exercise, and this repository carries no workflow structural tests (the lanes adoption in test.yml set that precedent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ycitMnerj5kvtuGKHjjhy