### PR TITLE
Target main and master in the ruleset, and warn if a repo has one

### DIFF
--- a/repo-rules
+++ b/repo-rules
@@ -26,7 +26,17 @@
 # What it does: makes CHECK... required on the default branch, via a ruleset
 # it owns by name, so a pull request cannot merge until each one passes --
 # requires every review conversation to be resolved, the branch to be up to
-# date with the base, and allows rebase as the only merge method.
+# date with the base, and allows rebase as the only merge method. A ruleset
+# this script CREATES targets ~DEFAULT_BRANCH together with the literal
+# refs/heads/main and refs/heads/master, not the default branch alone: a
+# repository whose default branch was ever renamed away from "master" (or
+# one that never got renamed) can still have a branch literally called
+# master sitting around, and a push or merge straight into it would bypass
+# every check this script exists to require. An UPDATE leaves an existing
+# ruleset's targeting alone, the same as every other field this script does
+# not manage -- see the CREATE-vs-UPDATE split lower down, and
+# repo-rules-audit for what flags a ruleset that predates this and never
+# picked up the wider targeting.
 #
 # Conversation resolution is not optional here, because it closes the gap the
 # checks cannot: a reviewer's comment is not a check, so a finding raised and
@@ -180,8 +190,9 @@ test -n "$DEFAULT_BRANCH" || { error "could not read $REPO's default branch"; ex
 # the repository's default branch itself changes while an interactive user
 # is still deciding, the early scan checked the wrong branch entirely --
 # same shape as every other write-time revalidation here, just one level
-# up. Also updates the create-path "on $DEFAULT_BRANCH" message, which
-# reporting the stale name would otherwise leave subtly wrong too.
+# up. Also updates the create-path "on $DEFAULT_BRANCH, main and master"
+# message, which reporting the stale name would otherwise leave subtly
+# wrong too.
 refresh_default_branch() {
     NEW_DEFAULT_BRANCH="$(gh api "repos/$REPO" --jq '.default_branch')" || {
         error "could not read $REPO to check whether its default branch has"
@@ -414,8 +425,10 @@ fi
 
 
 # The query that finds a ruleset named $RULESET, used to establish EXISTING
-# below and, on the create path, run again right before the write to catch
-# one that appeared in the meantime -- see the write section.
+# below and run again right before the write on both paths -- on create, to
+# catch one that appeared in the meantime; on update, to catch $RULESET
+# having been renamed away from id $EXISTING (or onto a different ruleset
+# entirely) -- see the write section.
 lookup_existing_ruleset() {
     gh api --paginate "repos/$REPO/rulesets?includes_parents=false" \
         --jq ".[] | select(.name == $(json_string "$RULESET")) | .id"
@@ -510,6 +523,10 @@ fi
 # An update preserves the existing ruleset's conditions, so a managed ruleset
 # scoped to `release` must be checked against what else applies to `release`
 # -- checking `main` there would miss the conflict entirely and report success.
+# The create path's own scope is fixed rather than read back, so it has to be
+# kept in sync by hand with BODY's own conditions below: ~DEFAULT_BRANCH,
+# refs/heads/main and refs/heads/master together, so master is never the one
+# branch a freshly created ruleset forgets to cover.
 compute_scope() {
     if test -n "$EXISTING"; then
         # shellcheck disable=SC2016  # jq program, not shell interpolation
@@ -521,7 +538,7 @@ compute_scope() {
             return 1
         }
     else
-        SCOPE='{"include":["~DEFAULT_BRANCH"],"exclude":[]}'
+        SCOPE='{"include":["~DEFAULT_BRANCH","refs/heads/main","refs/heads/master"],"exclude":[]}'
     fi
 }
 
@@ -627,7 +644,15 @@ validate_merge_method_scope || exit 1
 # is rebase only: a squash or a merge commit rewrites or hides the commits
 # that were reviewed, and one commit per logical change is the shape these
 # repositories keep. Squash and merge-commit disappear from the pull request's
-# button once this is set.
+# button once this is set. `conditions.ref_name.include` names three refs, not
+# one: `~DEFAULT_BRANCH` together with the literal `refs/heads/main` and
+# `refs/heads/master`, so a branch literally called master -- a leftover from
+# a rename, or one that was simply never renamed -- cannot be pushed or merged
+# into with none of this applied. Listing `refs/heads/main` alongside
+# `~DEFAULT_BRANCH` when main IS the default is redundant, not wrong: GitHub
+# accepts the duplicate, and the alternative is knowing in advance which of
+# the three names the default branch is, which is exactly what this script
+# cannot assume (see the header comment above).
 #
 # UPDATE does NOT build it. It fetches the existing ruleset and edits only
 # the check list inside it, because a PUT replaces the whole object and this
@@ -701,7 +726,7 @@ BODY="{
   \"name\": $(json_string "$RULESET"),
   \"target\": \"branch\",
   \"enforcement\": \"active\",
-  \"conditions\": {\"ref_name\": {\"include\": [\"~DEFAULT_BRANCH\"], \"exclude\": []}},
+  \"conditions\": {\"ref_name\": {\"include\": [\"~DEFAULT_BRANCH\", \"refs/heads/main\", \"refs/heads/master\"], \"exclude\": []}},
   \"rules\": [
     {\"type\": \"required_status_checks\",
      \"parameters\": {
@@ -754,7 +779,7 @@ describe_plan() {
         # already has, which may not be the default branch at all.
         echo "$REPO: would update ruleset '$RULESET' (id $EXISTING); scope unchanged"
     else
-        echo "$REPO: would create ruleset '$RULESET' on $DEFAULT_BRANCH"
+        echo "$REPO: would create ruleset '$RULESET' on $DEFAULT_BRANCH, main and master"
     fi
     echo "  required checks:"
     describe_checks "$@"
@@ -803,11 +828,12 @@ fi
 # confirmation prompt was built from: another admin or process could have
 # changed the repository or the ruleset in whatever time an interactive user
 # spent deciding -- disabled rebase merging, flipped enforcement off, added
-# an unmanaged rule, moved the ruleset to a different branch, or (on the
-# create path) created a same-named ruleset of its own. None of these close
-# their window to zero -- another write could still land between these
-# calls and the actual PUT/POST -- but together they shrink "however long a
-# human takes to answer a prompt" down to a handful of API round trips.
+# an unmanaged rule, moved the ruleset to a different branch, renamed it away
+# from '$RULESET' (or renamed a different one onto it), or (on the create
+# path) created a same-named ruleset of its own. None of these close their
+# window to zero -- another write could still land between these calls and
+# the actual PUT/POST -- but together they shrink "however long a human
+# takes to answer a prompt" down to a handful of API round trips.
 check_allow_rebase || exit 1
 
 if test -n "$EXISTING"; then
@@ -825,6 +851,36 @@ refresh_default_branch || exit 1
 validate_merge_method_scope || exit 1
 
 if test -n "$EXISTING"; then
+    # The rename TOCTOU check_ruleset_ownership's own re-check above cannot
+    # close: that call re-inspects id $EXISTING's enforcement and rule types,
+    # which catches someone editing what id $EXISTING points to, but not
+    # someone RENAMING it away, or renaming a DIFFERENT ruleset onto
+    # '$RULESET', while this was waiting on confirmation. Either way,
+    # '$RULESET' no longer names the ruleset this run validated ownership
+    # of by id, so the PUT below -- addressed by id, never by name -- would
+    # silently modify whatever ruleset now holds id $EXISTING under a claim
+    # of having updated the one named '$RULESET'. Re-resolving the name
+    # right before the write, and refusing on any mismatch, is the write-time
+    # counterpart of the create path's own duplicate re-check just below.
+    if STILL_EXISTING="$(lookup_existing_ruleset)"; then
+        if test "$STILL_EXISTING" != "$EXISTING"; then
+            error "ruleset '$RULESET' on $REPO no longer resolves to id $EXISTING --"
+            if test -n "$STILL_EXISTING"; then
+                error "it now names id $STILL_EXISTING instead, renamed while this was"
+            else
+                error "renamed away while this was waiting on confirmation, and nothing"
+                error "else has taken the name."
+            fi
+            error "Refusing to write to id $EXISTING under a name it no longer owns."
+            error "Rerun to see the current plan."
+            exit 1
+        fi
+    else
+        error "could not check whether '$RULESET' still resolves to ruleset id"
+        error "$EXISTING on $REPO. Refusing to write under a name that could no"
+        error "longer be the one this run validated."
+        exit 1
+    fi
     refresh_body || { error "could not re-read ruleset '$RULESET' to write it"; exit 1; }
     gh api --method PUT "repos/$REPO/rulesets/$EXISTING" --input "$WORK/body" >/dev/null
     echo "$REPO: updated ruleset '$RULESET' (its scope is unchanged)"
@@ -852,6 +908,6 @@ else
         exit 1
     fi
     printf '%s' "$BODY" | gh api --method POST "repos/$REPO/rulesets" --input - >/dev/null
-    echo "$REPO: created ruleset '$RULESET' on $DEFAULT_BRANCH"
+    echo "$REPO: created ruleset '$RULESET' on $DEFAULT_BRANCH, main and master"
 fi
 describe_checks "$@"

--- a/repo-rules-audit
+++ b/repo-rules-audit
@@ -15,7 +15,7 @@
 # repo-rules does not touch (see below).
 #
 # Cost and reliability: free. Every call is GitHub's REST API (5,000
-# authenticated requests an hour); a run costs three or four calls per
+# authenticated requests an hour); a run costs four or five calls per
 # repository plus one per branch ruleset found on it -- a handful, in
 # practice. Expect well under a second. Every failure mode is loud: no gh
 # (refuses, exit 1), not authenticated (the first call fails, exit 1),
@@ -40,6 +40,17 @@
 # flags a default branch not literally named "main" -- this fleet's tooling
 # and docs assume that name, and a repo answering something else is a real
 # inconsistency, invisible from the branch's own rules.
+#
+# When auditing the default branch, it also checks -- same literal-match
+# discipline, same ruleset reads -- whether every ruleset that plainly
+# covers it also targets refs/heads/main and refs/heads/master: a ruleset
+# created before repo-rules widened its targeting only ever covers
+# ~DEFAULT_BRANCH, which leaves a branch literally named master (a leftover
+# from a rename, or one that was simply never renamed) free of every check
+# this fleet requires. Independent of any ruleset, it also warns whenever
+# the repository has an actual branch named "master" at all -- the backdoor
+# repo-rules' wider targeting exists to close, worth flagging on its own
+# since deleting the branch removes it outright.
 #
 # Exit status: 0 if every check and property held, 1 if anything did not (or
 # could not be read), 2 for a usage error. Scriptable: loop this over a
@@ -67,7 +78,10 @@ Usage: $PROGRAM [--branch NAME] OWNER/REPO [CHECK...]
 Report whether OWNER/REPO's branch (default: the repository's default
 branch) requires each CHECK to pass, requires conversation resolution and
 an up-to-date branch before merging, and blocks force pushes and deletion.
-Also reports any bypass actor on a ruleset that plainly covers the branch.
+Also reports any bypass actor on a ruleset that plainly covers the branch,
+and -- when auditing the default branch -- whether every covering ruleset
+also targets refs/heads/main and refs/heads/master. Always warns if the
+repository has an actual branch named "master".
 CHECK defaults to: $DEFAULT_CHECKS
 
   --branch NAME   Check this branch instead of the repository's default.
@@ -311,6 +325,8 @@ if gh api --paginate "repos/$REPO/rulesets?includes_parents=true" \
     --jq '.[] | select(.target == "branch" and .enforcement == "active") | .id' > "$WORK/ruleset_ids"; then
     : > "$WORK/bypassers"
     : > "$WORK/unevaluated"
+    : > "$WORK/undertargeted"
+    : > "$WORK/targeting_unevaluated"
     while read -r id; do
         test -n "$id" || continue
         gh api "repos/$REPO/rulesets/$id" > "$WORK/ruleset.$id" || {
@@ -343,11 +359,103 @@ if gh api --paginate "repos/$REPO/rulesets?includes_parents=true" \
                 jq -r --arg name "$name" \
                     '.bypass_actors[]? | "  \($name): \(.actor_type) \(.actor_id // "-") (\(.bypass_mode))"' \
                     "$WORK/ruleset.$id" >> "$WORK/bypassers" \
-                    || { error "could not read ruleset $id's bypass actors on $REPO"; exit 1; } ;;
+                    || { error "could not read ruleset $id's bypass actors on $REPO"; exit 1; }
+                # Only meaningful when $BRANCH IS the repository's real
+                # default (checked directly, not via ASKED_DEFAULT -- an
+                # explicit `--branch main` naming the actual default must
+                # still get this check; ASKED_DEFAULT is only "no --branch
+                # was given" and the two are not the same question): the
+                # three-ref convention (~DEFAULT_BRANCH, refs/heads/main,
+                # refs/heads/master) is repo-rules' own widened targeting for
+                # the default branch, not something a ruleset scoped to some
+                # other branch (release, say) has any reason to carry.
+                # `~ALL` covers every one of the three unconditionally, by
+                # definition of the token -- UNLESS `exclude` literally
+                # carves one back out, which is checked explicitly below:
+                # an include list is not the whole story, and a ruleset that
+                # includes all three but excludes refs/heads/master protects
+                # main while leaving master exactly as unprotected as if it
+                # had never been listed. `exclude` needs no glob check here:
+                # this whole block only runs for verdict "covers", and the
+                # verdict computation above already routes any glob in
+                # `exclude` to "unevaluated" before it reaches this case --
+                # so `$exc` arriving here is guaranteed to hold only literal
+                # entries.
+                #
+                # Literal coverage is checked FIRST, ahead of any glob in
+                # `include`: a ruleset that already has all three refs
+                # spelled out literally is fully evaluated regardless of
+                # what else `include` also contains, and a glob elsewhere in
+                # the list changes nothing about that. Only once a required
+                # ref is genuinely NOT covered by a literal entry does an
+                # unrelated glob become relevant -- it might reach that ref,
+                # or might not, and this script does not reimplement
+                # GitHub's ref matching to find out (same discipline as the
+                # branch-coverage check above) -- so THAT case, and only
+                # that case, is reported unevaluated rather than guessed at
+                # either way, alongside the other unevaluated rulesets.
+                if default_branch_matches; then
+                    result=$(jq -r '
+                        def is_literal: test("[*?\\[]") | not;
+                        (.conditions.ref_name.include // []) as $inc
+                        | (.conditions.ref_name.exclude // []) as $exc
+                        | ["~DEFAULT_BRANCH", "refs/heads/main", "refs/heads/master"] as $want
+                        # `. as $want | ($inc | index($want))`, not
+                        # `$inc | index(.)` -- piping into $inc first rebinds
+                        # `.` to $inc itself before index() ever sees the
+                        # wanted ref, so every entry came back "found"
+                        # regardless of $inc.
+                        | if ($inc | index("~ALL")) then
+                              ($want | map(select(. as $w | ($exc | index($w)) != null))) as $miss
+                              | if ($miss | length) == 0 then "complete|"
+                                else "missing|" + ($miss | join(", ")) end
+                          else
+                              ($want | map(select(. as $w
+                                            | (($inc | index($w)) == null)
+                                              or (($exc | index($w)) != null)))) as $miss
+                              | if ($miss | length) == 0 then "complete|"
+                                elif ($inc | any(is_literal | not)) then "unevaluated|"
+                                else "missing|" + ($miss | join(", ")) end
+                          end
+                    ' "$WORK/ruleset.$id") \
+                        || { error "could not read ruleset $id's conditions on $REPO"; exit 1; }
+                    status="${result%%|*}"
+                    detail="${result#*|}"
+                    case "$status" in
+                        missing)
+                            printf '  %s: does not target %s\n' "$name" "$detail" >> "$WORK/undertargeted" ;;
+                        unevaluated)
+                            printf '  %s (targeting not evaluated: another ref pattern is present)\n' \
+                                "$name" >> "$WORK/unevaluated"
+                            # Tracked separately from the shared unevaluated
+                            # bucket above: this one gates whether the
+                            # targeting-complete "[ok]" summary below may
+                            # print at all, not just whether this ruleset
+                            # gets a [CHECK] line -- an unresolved ruleset
+                            # must never sit silently under a claim that
+                            # every ruleset's targeting was confirmed.
+                            printf '  %s\n' "$name" >> "$WORK/targeting_unevaluated" ;;
+                        complete) : ;;
+                    esac
+                fi ;;
             unevaluated)
                 pattern=$(jq -r '.conditions.ref_name.include | join(", ")' "$WORK/ruleset.$id") \
                     || { error "could not read ruleset $id's conditions on $REPO"; exit 1; }
-                printf '  %s (matches: %s)\n' "$name" "$pattern" >> "$WORK/unevaluated" ;;
+                printf '  %s (matches: %s)\n' "$name" "$pattern" >> "$WORK/unevaluated"
+                # This is a SEPARATE unevaluated case from the one inside
+                # `covers)` above: here the branch-coverage verdict itself
+                # couldn't be determined (a glob in include, such as
+                # refs/heads/*, or a glob exclusion over an otherwise
+                # complete include) -- not "covers, but a required ref might
+                # be behind a glob". Either way this script cannot tell
+                # whether the ruleset covers $BRANCH at all, so it cannot
+                # tell whether the ruleset's targeting matters, and the
+                # targeting-complete "[ok]" summary below must stay
+                # suppressed on this ruleset too -- same file, same gate,
+                # for the same reason: a claim that every covering ruleset's
+                # targeting was confirmed cannot be made while one ruleset's
+                # coverage of the branch itself remains unknown.
+                printf '  %s\n' "$name" >> "$WORK/targeting_unevaluated" ;;
             excluded|not-covering) : ;;
         esac
     done < "$WORK/ruleset_ids"
@@ -361,8 +469,38 @@ if gh api --paginate "repos/$REPO/rulesets?includes_parents=true" \
         echo "  [CHECK] rulesets with a pattern this script did not evaluate -- check by hand:"
         cat "$WORK/unevaluated"
     fi
+    if default_branch_matches; then
+        if test -s "$WORK/undertargeted"; then
+            gap "a ruleset covering $BRANCH does not target all of the default branch, refs/heads/main and refs/heads/master:"
+            cat "$WORK/undertargeted"
+        elif test -s "$WORK/targeting_unevaluated"; then
+            # Neither ok nor gap: a ruleset's targeting genuinely could not
+            # be confirmed (a glob that might or might not reach a missing
+            # ref), so claiming "every ruleset ... targets ..." here would
+            # be a false all-clear over an audit that was never completed.
+            # The [CHECK] section above already named it for manual review.
+            :
+        else
+            ok "every ruleset covering $BRANCH targets the default branch, refs/heads/main and refs/heads/master"
+        fi
+    fi
 else
     error "could not list $REPO's rulesets to check for bypass actors"
+    exit 1
+fi
+
+# Independent of any ruleset: a branch literally named "master" left over
+# from a rename (or never renamed at all) is the backdoor repo-rules' wider
+# targeting exists to close, and it is worth flagging on its own -- deleting
+# the branch removes the backdoor outright, rather than merely fencing it
+# in with a ruleset that has to remember to keep covering it.
+if gh api "repos/$REPO/branches/master" >/dev/null 2>"$WORK/master_branch.err"; then
+    gap "a branch literally named 'master' exists -- delete it, or confirm every ruleset that protects $BRANCH also targets refs/heads/master"
+elif grep -q 'HTTP 404' "$WORK/master_branch.err"; then
+    ok "no branch literally named 'master'"
+else
+    error "could not check whether $REPO has a branch named 'master':"
+    sed 's/^/  /' "$WORK/master_branch.err" >&2
     exit 1
 fi
 

--- a/repo-rules-audit_test
+++ b/repo-rules-audit_test
@@ -40,10 +40,13 @@ CLEAN_RULES='[
 
 # make_gh: build a fake gh in a fresh dir and echo that dir.
 #   $1 = default branch name (used only if the script has to ask for it)
+#   $2 = whether repos/$REPO/branches/master should answer as existing
+#        (default: "false" -- no master branch, the ordinary case)
 make_gh() {
     dir="$(mktemp -d "$SUITE_TMP/fixture.XXXXXX")"
     mkdir -p "$dir/bin"
     printf '%s\n' "${1:-main}" > "$dir/default_branch"
+    printf '%s\n' "${2:-false}" > "$dir/master_branch_exists"
     : > "$dir/ruleset_ids"
     printf '%s' "$CLEAN_RULES" > "$dir/rules.json"
     : > "$dir/fail_on"
@@ -56,6 +59,16 @@ if test -s "$dir/fail_on" && echo "$*" | grep -qF "$(cat "$dir/fail_on")"; then
     exit 1
 fi
 case "$*" in
+    # Matched before the generic "repos/" case below: the master-branch
+    # existence probe is a plain GET on repos/OWNER/REPO/branches/master,
+    # which also contains "repos/" and would otherwise be swallowed by it.
+    *"/branches/master"*)
+        if test "$(cat "$dir/master_branch_exists")" = true; then
+            echo '{"name":"master"}'
+        else
+            echo "gh: HTTP 404: Not Found (https://api.github.com/repos/o/r/branches/master)" >&2
+            exit 1
+        fi ;;
     *"/rules/branches/"*) cat "$dir/rules.json" ;;
     *"/rulesets?"*)       cat "$dir/ruleset_ids" ;;
     *"/rulesets/"*)
@@ -165,6 +178,10 @@ assert_output "[ok] force pushes are blocked"
 assert_output "[ok] branch deletion is blocked"
 assert_output "[ok] no bypass actor"
 assert_output "[ok] the default branch is named 'main'"
+# Vacuously true: the fixture returns no rulesets at all, same as the
+# "no bypass actor" claim just above it.
+assert_output "[ok] every ruleset covering main targets the default branch, refs/heads/main and refs/heads/master"
+assert_output "[ok] no branch literally named 'master'"
 assert_no_output "GAP"
 finish_case
 
@@ -233,7 +250,7 @@ dir="$(make_gh)"
 echo 42 > "$dir/ruleset_ids"
 cat > "$dir/ruleset.42.json" <<'EOF'
 {"id":42,"name":"merge gates",
- "conditions":{"ref_name":{"include":["~DEFAULT_BRANCH"],"exclude":[]}},
+ "conditions":{"ref_name":{"include":["~DEFAULT_BRANCH","refs/heads/main","refs/heads/master"],"exclude":[]}},
  "bypass_actors":[{"actor_id":5,"actor_type":"RepositoryRole","bypass_mode":"always"}]}
 EOF
 run "$dir" mikelward/lanes gate
@@ -247,7 +264,7 @@ dir="$(make_gh)"
 echo 42 > "$dir/ruleset_ids"
 cat > "$dir/ruleset.42.json" <<'EOF'
 {"id":42,"name":"merge gates",
- "conditions":{"ref_name":{"include":["~DEFAULT_BRANCH"],"exclude":[]}},
+ "conditions":{"ref_name":{"include":["~DEFAULT_BRANCH","refs/heads/main","refs/heads/master"],"exclude":[]}},
  "bypass_actors":[]}
 EOF
 run "$dir" mikelward/lanes gate
@@ -393,12 +410,17 @@ assert_output "jq failed"
 assert_no_output "[GAP]"
 finish_case
 
-test_case "--branch overrides the default, skips asking for it, and skips the main-name check"
+test_case "--branch overrides the default and skips the main-name check, but still resolves the real default for the targeting check"
+# It no longer skips asking for the real default outright: default_branch_matches
+# needs it to tell "auditing a named branch that happens to be the default"
+# apart from "auditing some other branch entirely" (the targeting-check gate,
+# fixed below). What it still skips is the main-name check specifically --
+# ASKED_DEFAULT governs that one alone.
 dir="$(make_gh unused-branch)"
 run "$dir" --branch release mikelward/lanes gate
 assert_status 0
 assert_call "$dir" "/rules/branches/release"
-assert_no_call "$dir" "repos/mikelward/lanes --jq .default_branch"
+assert_call "$dir" "repos/mikelward/lanes --jq .default_branch"
 assert_no_output "the default branch is"
 finish_case
 
@@ -458,6 +480,252 @@ run "$dir" mikelward/lanes gate
 assert_status 1
 assert_output "could not read"
 assert_no_output "[GAP]"
+finish_case
+
+test_case "a ruleset covering the default branch that also targets main and master is clean"
+# Non-vacuous version of the earlier "fully gated" case: an actual ruleset is
+# present and its own conditions carry all three refs.
+dir="$(make_gh)"
+echo 42 > "$dir/ruleset_ids"
+cat > "$dir/ruleset.42.json" <<'EOF'
+{"id":42,"name":"merge gates",
+ "conditions":{"ref_name":{"include":["~DEFAULT_BRANCH","refs/heads/main","refs/heads/master"],"exclude":[]}},
+ "bypass_actors":[]}
+EOF
+run "$dir" mikelward/lanes gate
+assert_status 0
+assert_output "[ok] every ruleset covering main targets the default branch, refs/heads/main and refs/heads/master"
+finish_case
+
+test_case "a ruleset covering the default branch but missing refs/heads/master is a gap"
+# The backdoor itself: a ruleset created before repo-rules widened its
+# targeting only ever covers ~DEFAULT_BRANCH, leaving a literal master
+# branch outside every check it requires.
+dir="$(make_gh)"
+echo 42 > "$dir/ruleset_ids"
+cat > "$dir/ruleset.42.json" <<'EOF'
+{"id":42,"name":"merge gates",
+ "conditions":{"ref_name":{"include":["~DEFAULT_BRANCH"],"exclude":[]}},
+ "bypass_actors":[]}
+EOF
+run "$dir" mikelward/lanes gate
+assert_status 1
+assert_output "[GAP] a ruleset covering main does not target all of the default branch, refs/heads/main and refs/heads/master:"
+assert_output "merge gates: does not target refs/heads/main, refs/heads/master"
+finish_case
+
+test_case "an include listing all three refs but excluding master literally is still a gap"
+# An include list is not the whole story: a ruleset that includes all three
+# refs but literally excludes refs/heads/master leaves master exactly as
+# unprotected as if it had never been listed in include at all.
+dir="$(make_gh)"
+echo 42 > "$dir/ruleset_ids"
+cat > "$dir/ruleset.42.json" <<'EOF'
+{"id":42,"name":"merge gates",
+ "conditions":{"ref_name":{"include":["~DEFAULT_BRANCH","refs/heads/main","refs/heads/master"],"exclude":["refs/heads/master"]}},
+ "bypass_actors":[]}
+EOF
+run "$dir" mikelward/lanes gate
+assert_status 1
+assert_output "[GAP] a ruleset covering main does not target all of the default branch, refs/heads/main and refs/heads/master:"
+assert_output "merge gates: does not target refs/heads/master"
+finish_case
+
+test_case "a ~ALL ruleset that literally excludes master is still a gap"
+# Same bug, via the ~ALL shortcut: ~ALL covers everything only until an
+# exclude entry carves a branch back out.
+dir="$(make_gh)"
+echo 42 > "$dir/ruleset_ids"
+cat > "$dir/ruleset.42.json" <<'EOF'
+{"id":42,"name":"org gate",
+ "conditions":{"ref_name":{"include":["~ALL"],"exclude":["refs/heads/master"]}},
+ "bypass_actors":[]}
+EOF
+run "$dir" mikelward/lanes gate
+assert_status 1
+assert_output "org gate: does not target refs/heads/master"
+finish_case
+
+test_case "a glob in exclude never reaches the targeting check -- the verdict computation already routes it to unevaluated"
+# Not new coverage of the targeting check itself: the outer verdict logic
+# (exc_pattern) sends any ruleset with a glob in exclude to "unevaluated"
+# before verdict can ever be "covers", so the targeting jq's own $exc is
+# always fully literal by the time it runs. This pins that invariant --
+# same scenario the pre-existing "a non-literal exclude entry downgrades..."
+# test above exercises, confirmed here to also produce no targeting output.
+dir="$(make_gh)"
+echo 42 > "$dir/ruleset_ids"
+cat > "$dir/ruleset.42.json" <<'EOF'
+{"id":42,"name":"pattern-excluding gate",
+ "conditions":{"ref_name":{"include":["~DEFAULT_BRANCH","refs/heads/main","refs/heads/master"],"exclude":["refs/heads/ma-*"]}},
+ "bypass_actors":[]}
+EOF
+run "$dir" mikelward/lanes gate
+assert_status 0
+assert_output "[CHECK] rulesets with a pattern this script did not evaluate"
+assert_output "pattern-excluding gate (matches: ~DEFAULT_BRANCH, refs/heads/main, refs/heads/master)"
+assert_no_output "[GAP]"
+finish_case
+
+test_case "an unrelated literal exclude entry does not affect targeting completeness"
+# The regression case for the fix above: excluding some other branch
+# entirely must not itself trigger a gap or an unevaluated verdict.
+dir="$(make_gh)"
+echo 42 > "$dir/ruleset_ids"
+cat > "$dir/ruleset.42.json" <<'EOF'
+{"id":42,"name":"merge gates",
+ "conditions":{"ref_name":{"include":["~DEFAULT_BRANCH","refs/heads/main","refs/heads/master"],"exclude":["refs/heads/other"]}},
+ "bypass_actors":[]}
+EOF
+run "$dir" mikelward/lanes gate
+assert_status 0
+assert_output "[ok] every ruleset covering main targets the default branch, refs/heads/main and refs/heads/master"
+finish_case
+
+test_case "an explicit --branch naming the actual default branch still gets the targeting check"
+# ASKED_DEFAULT only means "no --branch was given" -- it is not the same
+# question as "is the audited branch the repository's real default", and
+# the targeting check is about the latter.
+dir="$(make_gh main)"
+echo 42 > "$dir/ruleset_ids"
+cat > "$dir/ruleset.42.json" <<'EOF'
+{"id":42,"name":"merge gates",
+ "conditions":{"ref_name":{"include":["~DEFAULT_BRANCH"],"exclude":[]}},
+ "bypass_actors":[]}
+EOF
+run "$dir" --branch main mikelward/lanes gate
+assert_status 1
+assert_output "[GAP] a ruleset covering main does not target all of the default branch, refs/heads/main and refs/heads/master:"
+assert_output "merge gates: does not target refs/heads/main, refs/heads/master"
+finish_case
+
+test_case "the targeting check does not apply to a ruleset scoped to a non-default branch"
+# --branch given explicitly: a ruleset legitimately scoped to something other
+# than the default branch (a release branch, say) has no reason to carry
+# repo-rules' default-branch convention, so this must stay silent.
+dir="$(make_gh)"
+echo 42 > "$dir/ruleset_ids"
+cat > "$dir/ruleset.42.json" <<'EOF'
+{"id":42,"name":"release gates",
+ "conditions":{"ref_name":{"include":["refs/heads/release"],"exclude":[]}},
+ "bypass_actors":[]}
+EOF
+run "$dir" --branch release mikelward/lanes gate
+assert_status 0
+assert_no_output "does not target"
+assert_no_output "targets the default branch"
+finish_case
+
+test_case "a ~ALL-scoped ruleset counts as targeting all three refs"
+dir="$(make_gh)"
+echo 42 > "$dir/ruleset_ids"
+cat > "$dir/ruleset.42.json" <<'EOF'
+{"id":42,"name":"org gate",
+ "conditions":{"ref_name":{"include":["~ALL"],"exclude":[]}},
+ "bypass_actors":[]}
+EOF
+run "$dir" mikelward/lanes gate
+assert_status 0
+assert_output "[ok] every ruleset covering main targets the default branch, refs/heads/main and refs/heads/master"
+finish_case
+
+test_case "a literal match alongside an unrelated glob is reported unevaluated, not clean or a gap"
+# The literal entry is enough to cover the branch (verdict "covers"), but a
+# glob elsewhere in the same include list might or might not also reach main
+# or master -- this script does not reimplement GitHub's ref matching to
+# find out, so it refuses to guess either way. And since targeting genuinely
+# could not be confirmed for this ruleset, the "[ok] every ruleset ... targets"
+# summary must not print either -- that would be a false all-clear over an
+# audit that was never completed.
+dir="$(make_gh)"
+echo 42 > "$dir/ruleset_ids"
+cat > "$dir/ruleset.42.json" <<'EOF'
+{"id":42,"name":"mixed gate",
+ "conditions":{"ref_name":{"include":["~DEFAULT_BRANCH","refs/heads/hotfix-*"],"exclude":[]}},
+ "bypass_actors":[]}
+EOF
+run "$dir" mikelward/lanes gate
+assert_status 0
+assert_output "[CHECK] rulesets with a pattern this script did not evaluate"
+assert_output "mixed gate (targeting not evaluated: another ref pattern is present)"
+assert_no_output "[GAP]"
+assert_no_output "[ok] every ruleset covering main targets the default branch, refs/heads/main and refs/heads/master"
+finish_case
+
+test_case "all three refs present literally alongside an unrelated glob is complete, not unevaluated"
+# Codex review: literal coverage must be checked FIRST. A ruleset that
+# already spells out all three refs literally is fully evaluated regardless
+# of what else include also contains -- flagging it for manual review just
+# because an unrelated glob (refs/heads/release-*, say) also sits in the
+# same list is a false "needs a human" over targeting that is demonstrably
+# already complete.
+dir="$(make_gh)"
+echo 42 > "$dir/ruleset_ids"
+cat > "$dir/ruleset.42.json" <<'EOF'
+{"id":42,"name":"fully covered gate",
+ "conditions":{"ref_name":{"include":["~DEFAULT_BRANCH","refs/heads/main","refs/heads/master","refs/heads/release-*"],"exclude":[]}},
+ "bypass_actors":[]}
+EOF
+run "$dir" mikelward/lanes gate
+assert_status 0
+assert_output "[ok] every ruleset covering main targets the default branch, refs/heads/main and refs/heads/master"
+assert_no_output "fully covered gate"
+assert_no_output "[GAP]"
+finish_case
+
+test_case "the outer branch-coverage unevaluated case also suppresses the targeting [ok] line"
+# A SEPARATE unevaluated path from the one above: here the ruleset's
+# coverage of $BRANCH itself can't be determined at all (include is a glob
+# with no literal match), so this script cannot tell whether the ruleset
+# covers main or what it targets -- distinct from "covers, but a required
+# ref might be behind a glob" (the case the earlier "mixed gate" test
+# covers). Either way, claiming "every ruleset ... targets ..." would be a
+# false all-clear over a ruleset whose relevance was never established.
+dir="$(make_gh)"
+echo 42 > "$dir/ruleset_ids"
+cat > "$dir/ruleset.42.json" <<'EOF'
+{"id":42,"name":"pattern-scoped gate",
+ "conditions":{"ref_name":{"include":["refs/heads/release-*"],"exclude":[]}},
+ "bypass_actors":[]}
+EOF
+run "$dir" mikelward/lanes gate
+assert_status 0
+assert_output "[CHECK] rulesets with a pattern this script did not evaluate"
+assert_output "pattern-scoped gate (matches: refs/heads/release-*)"
+assert_no_output "[GAP]"
+assert_no_output "[ok] every ruleset covering main targets the default branch, refs/heads/main and refs/heads/master"
+finish_case
+
+test_case "a repository with an actual master branch is a gap"
+dir="$(make_gh main true)"
+run "$dir" mikelward/lanes gate
+assert_status 1
+assert_output "[GAP] a branch literally named 'master' exists"
+finish_case
+
+test_case "a repository with no master branch stays clean on that check"
+dir="$(make_gh main false)"
+run "$dir" mikelward/lanes gate
+assert_status 0
+assert_output "[ok] no branch literally named 'master'"
+finish_case
+
+test_case "the master-branch check runs even when auditing a non-default branch"
+# It is a fact about the repository, not about whichever branch was named.
+dir="$(make_gh main true)"
+run "$dir" --branch release mikelward/lanes gate
+assert_status 1
+assert_output "[GAP] a branch literally named 'master' exists"
+finish_case
+
+test_case "a failed master-branch probe is reported, not read as a gap or a clean bill"
+dir="$(make_gh)"
+echo "/branches/master" > "$dir/fail_on"
+run "$dir" mikelward/lanes gate
+assert_status 1
+assert_output "could not check whether"
+assert_no_output "[GAP] a branch literally named"
+assert_no_output "[ok] no branch literally named"
 finish_case
 
 # ---------------------------------------------------------------------------

--- a/repo-rules_test
+++ b/repo-rules_test
@@ -634,6 +634,41 @@ assert_body "$dir" '~DEFAULT_BRANCH'
 assert_body "$dir" '"enforcement": "active"'
 finish_case
 
+test_case "creating targets the default branch, main and master together"
+# The backdoor this closes: a ruleset scoped only to ~DEFAULT_BRANCH leaves a
+# branch literally named master unprotected if the default branch was ever
+# renamed away from it (or never renamed at all).
+dir="$(make_gh 'test' '')"
+run_repo_rules "$dir" --force mikelward/lanes test
+assert_status 0
+assert_body "$dir" '"~DEFAULT_BRANCH"'
+assert_body "$dir" '"refs/heads/main"'
+assert_body "$dir" '"refs/heads/master"'
+assert_output "on main, main and master"
+finish_case
+
+test_case "refuses to create when another ruleset excludes rebase only on refs/heads/master"
+if test "$HAVE_JQ" = no; then skip_case "needs a jq binary"; finish_case; else
+# Before this change, a create-path ruleset only ever scoped itself to
+# ~DEFAULT_BRANCH, so a squash-only ruleset scoped to the literal master
+# branch alone would never have been checked at all. Now that a fresh
+# ruleset also targets refs/heads/master, this must be caught the same way
+# a conflict on the default branch already is.
+dir="$(make_gh 'test' '' '' '' 'required_status_checks' 'main' 'true' 'active' '99')"
+cat > "$dir/other_ruleset" <<'RULESET'
+{"id":99,"name":"legacy master squash policy","enforcement":"active",
+ "conditions":{"ref_name":{"include":["refs/heads/master"],"exclude":[]}},
+ "rules":[{"type":"pull_request","parameters":{
+    "allowed_merge_methods":["squash"]}}]}
+RULESET
+run_repo_rules "$dir" mikelward/lanes test
+assert_status 1
+assert_output "legacy master squash policy"
+assert_output "excludes rebase"
+assert_no_write "$dir"
+finish_case
+fi
+
 test_case "sees a check that only ever reported on a closed pull request"
 # A check running only on `pull_request` never reports on the default branch,
 # so a repository with nothing open would look as though it had never run.
@@ -1586,6 +1621,97 @@ assert_status 1
 assert_output "excludes rebase"
 assert_output "trunk squash policy"
 assert_no_write "$dir"
+finish_case
+fi
+
+test_case "refuses to write when the ruleset was renamed away while the prompt was open"
+if test "$HAVE_PTY" = no || test "$HAVE_JQ" = no; then skip_case "needs script(1) and jq"; finish_case; else
+# check_ruleset_ownership's own re-check (re-run right before the write, same
+# as everywhere else in this section) re-inspects id 42's enforcement and
+# rule types -- it catches someone editing what id 42 IS, but not someone
+# RENAMING '$RULESET' away from it while this was waiting on confirmation.
+# The PUT below addresses the ruleset by id, never by name, so without this
+# check it would silently write to whatever ruleset now holds id 42 while
+# claiming to have updated the one named 'merge gates'. The name resolves to
+# 42 on the early lookup (before the prompt) and to a DIFFERENT id, 77, on
+# the one right before the write.
+dir="$(mktemp -d "$SUITE_TMP/fixture.XXXXXX")"
+mkdir -p "$dir/bin"
+printf '0\n' > "$dir/lookup_reads"
+cat > "$dir/bin/gh" <<'GHEOF'
+#!/bin/sh
+d="$(dirname "$(dirname "$0")")"
+echo "$*" >> "$d/calls"
+skip=no; want=""; jqexpr=""; inputfile=""; method=""
+for arg in "$@"; do
+    if test "$skip" = yes; then
+        skip=no
+        case "$want" in --jq) jqexpr="$arg" ;; --input) inputfile="$arg" ;; esac
+        continue
+    fi
+    case "$arg" in
+        --method|--jq|--input|-H|--header) skip=yes; want="$arg" ;;
+        *) ;;
+    esac
+done
+prev=""
+for arg in "$@"; do
+    case "$prev" in --method) method="$arg" ;; esac
+    prev="$arg"
+done
+if test -n "$method" && test "$method" != GET; then
+    if test -n "$inputfile" && test "$inputfile" != -; then cp "$inputfile" "$d/body"
+    else cat > "$d/body"; fi
+    exit 0
+fi
+case "$*" in
+    *"includes_parents=false"*)
+        n="$(cat "$d/lookup_reads")"
+        if test "$n" -eq 0; then
+            echo 42
+            printf '1\n' > "$d/lookup_reads"
+        else
+            echo 77
+        fi ;;
+    *"/rulesets/42"*)
+        case "$jqexpr" in
+            *".rules[].type"*) echo active; echo required_status_checks ;;
+            *) echo '{"id":42,"name":"merge gates","target":"branch","enforcement":"active",
+                "conditions":{"ref_name":{"include":["~DEFAULT_BRANCH"],"exclude":[]}},
+                "rules":[{"type":"required_status_checks","parameters":{
+                   "strict_required_status_checks_policy":true,
+                   "required_status_checks":[{"context":"test"}]}}]}' | jq -r "$jqexpr" ;;
+        esac ;;
+    *"includes_parents=true"*) echo 42 ;;
+    *"repos/"*"/commits/"*"/check-runs"*) echo '"test"' ;;
+    *"repos/"*"/commits/"*"/status"*) : ;;
+    *"/pulls?"*) : ;;
+    *"/commits?"*) echo deadbee ;;
+    *"repos/"*)
+        case "$jqexpr" in
+            *allow_rebase_merge*) echo true ;;
+            *) echo main ;;
+        esac ;;
+esac
+GHEOF
+chmod +x "$dir/bin/gh"
+run_repo_rules_pty "$dir" 'y' mikelward/lanes test
+assert_status 1
+assert_output "no longer resolves"
+assert_output "id 77"
+assert_no_write "$dir"
+finish_case
+fi
+
+test_case "writes normally when the ruleset still resolves to the same id right before the write"
+if test "$HAVE_PTY" = no || test "$HAVE_JQ" = no; then skip_case "needs script(1) and jq"; finish_case; else
+# The regression case for the fix above: an ordinary run, where the name
+# resolves to the same id both times, must not be refused by the new check.
+dir="$(make_gh 'test' '42')"
+run_repo_rules_pty "$dir" 'y' mikelward/lanes test
+assert_status 0
+assert_output "updated ruleset"
+assert_body "$dir" '"context": "test"'
 finish_case
 fi
 


### PR DESCRIPTION
## The backdoor

A ruleset targeting only `~DEFAULT_BRANCH` (or only `main`) leaves a branch
literally named `master` unprotected: someone could push or merge straight
into it with none of the required checks applied. This just bit
mikelward/web, whose default branch was renamed `master` → `main` while
workflows kept pushing to the dead name.

## What `repo-rules` now does

A newly **created** ruleset's `conditions.ref_name.include` now names three
refs instead of one: `~DEFAULT_BRANCH`, `refs/heads/main`, and
`refs/heads/master`. `compute_scope`'s create-path fallback is kept in sync
so the merge-method conflict scan checks the real scope being written, not
the old single-ref one — a test confirms a squash-only ruleset scoped only
to `refs/heads/master` is now caught as a conflict, which it wasn't before.

An **update** to an existing ruleset still leaves its targeting alone, same
as every other field this script doesn't manage on that path (bypass
actors, enforcement, etc.) — see the updated header comment. That's what
`repo-rules-audit` is for.

**Also fixes a rename TOCTOU on the update path**, found during the Python
port's review (mikelward/repo#6, commit 5fe3c90, which fixed the same bug
there — no Codex thread on this repo, since Codex didn't flag it here).
`check_ruleset_ownership`'s re-check right before the write re-inspects id
`$EXISTING`'s enforcement and rule types, which catches someone editing
what that id *is* while the confirmation prompt was open, but not someone
*renaming* `'$RULESET'` away from it (or renaming a different ruleset onto
it) in that same window — the PUT addresses the ruleset by id, never by
name, so it would silently write to whatever ruleset now holds that id
while claiming to have updated the one named `'$RULESET'`. Now re-resolves
the name immediately before the write and refuses on any mismatch, fail
closed, mirroring the create path's own duplicate re-check just below it.

## What `repo-rules-audit` now checks

Two new, independent checks:

1. **Targeting completeness** (whenever the audited branch actually *is*
   the repository's real default — determined directly, not by whether
   `--branch` was given, so an explicit `--branch main` naming the real
   default still gets this check): for every ruleset that plainly covers
   it, does its `conditions.ref_name.include` contain all three refs — and
   does `conditions.ref_name.exclude` NOT literally carve one of them back
   out? An include list alone isn't the whole story: a ruleset that
   includes all three but excludes `refs/heads/master` leaves master exactly
   as unprotected as if it had never been listed. Missing/excluded refs are
   reported per ruleset. Same literal-match discipline as the existing
   bypass-actor scan — `~ALL` counts as covering all three (unless excluded).
   Literal coverage is checked *first*: a ruleset that already spells out
   all three refs literally is reported complete regardless of what other
   glob also sits in `include` (release-branch patterns and the like) —
   the glob only matters as a fallback for a ref that's genuinely not
   covered by any literal entry, and in that case the ruleset is reported
   unevaluated (a glob in `exclude` can never actually reach this check —
   the branch-coverage verdict computed earlier already routes it to
   unevaluated first). Either an unevaluated ruleset within `covers)`
   (a required ref genuinely behind a glob) *or* the branch-coverage
   verdict itself landing on `unevaluated` (an `include` that's only a
   glob, or a glob `exclude` over an otherwise-complete `include`)
   suppresses the `[ok] every ruleset ... targets ...` summary line —
   printing it would be a false all-clear over an audit that was never
   actually completed for that ruleset, whichever of the two paths it
   came from.
2. **A leftover `master` branch** (`GET /repos/{owner}/{repo}/branches/master`,
   `HTTP 404` in the ordinary case): independent of any ruleset, and
   regardless of which branch is being audited — deleting the branch
   removes the backdoor outright, rather than merely fencing it in.

## Tests

`repo-rules_test`: three new tests — the three refs present on create, a
squash-only ruleset scoped only to `refs/heads/master` now caught by the
conflict scan, and the rename-TOCTOU fix (both directions: a mismatched
second lookup is refused, an unchanged one still writes normally).

`repo-rules-audit_test`: new tests covering both directions of the
targeting check (clean with all three refs present; a gap naming the
missing ones), the `~ALL`/glob edge cases (including all-three-literal-
plus-an-unrelated-glob staying `ok`, and both the inner and outer
unevaluated paths correctly suppressing that same `ok` line), both
directions of the exclude fix (excluded ref still reported missing,
including via `~ALL`; an unrelated exclude entry stays clean), the
explicit-`--branch`-naming-the-real-default case, and both directions of
the master-branch check. Two pre-existing fixtures that used a single-ref
`["~DEFAULT_BRANCH"]` scope (testing bypass-actor behavior, unrelated to
targeting) were widened to the full three-ref set so they stay clean cases
for what they actually test.

`make test`: full suite green. `shellcheck -x` clean on all four changed
files.

## Review

Three rounds of Codex review, five findings total, all fixed:
excluded-ref false-clear, `ASKED_DEFAULT`-vs-real-default, literal-coverage
ordering ahead of a glob fallback, a contradictory `[ok]` over an
unevaluated ruleset (inner case), and the same contradiction via a second,
separate outer-verdict-unevaluated path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AoHridGxxapL68Y8fLwyRx