### PR TITLE
Warn that these five tools are superseded by mikelward/repo's Python CLI

### DIFF
--- a/repo-list
+++ b/repo-list
@@ -1,6 +1,10 @@
 #!/bin/sh
 # List a GitHub account's repositories, one OWNER/REPO per line.
 #
+# Deprecated: superseded by `repo list` in mikelward/repo, a Python
+# rewrite with the same behavior. This script stays as-is; fixes and new
+# features go there instead. See that repo's AGENTS.md.
+#
 # Usage:
 #     repo-list [--owner OWNER] [--include-forks] [--include-archived]
 #     repo-list
@@ -48,6 +52,8 @@ INCLUDE_ARCHIVED=0
 error() {
     echo "$PROGRAM: $*" >&2
 }
+
+error "deprecated: superseded by 'repo list' in mikelward/repo (same behavior, actively maintained -- see that repo's README)"
 
 usage() {
     cat <<EOF

--- a/repo-list_test
+++ b/repo-list_test
@@ -21,6 +21,9 @@ trap 'rm -rf "$SUITE_TMP"' EXIT
 trap 'rm -rf "$SUITE_TMP"; exit 130' INT
 trap 'rm -rf "$SUITE_TMP"; exit 143' TERM
 REPO_LIST="$SCRIPT_DIR/repo-list"
+# repo-list prints this on every run, before anything else -- the assertions
+# below that check exact combined output need to account for it.
+DEPRECATION_LINE="repo-list: deprecated: superseded by 'repo list' in mikelward/repo (same behavior, actively maintained -- see that repo's README)"
 TESTS_RUN=0
 TESTS_PASSED=0
 TESTS_FAILED=0
@@ -176,7 +179,8 @@ forked/repo	true	false
 old/repo	false	true")"
 run_repo_list "$dir"
 assert_status 0
-assert_output_equals "a/repo
+assert_output_equals "$DEPRECATION_LINE
+a/repo
 b/repo"
 assert_call "$dir" "user/repos"
 finish_case
@@ -186,7 +190,8 @@ dir="$(make_gh mikelward "kept/repo	false	false
 forked/repo	true	false")"
 run_repo_list "$dir" --include-forks
 assert_status 0
-assert_output_equals "forked/repo
+assert_output_equals "$DEPRECATION_LINE
+forked/repo
 kept/repo"
 finish_case
 
@@ -195,7 +200,8 @@ dir="$(make_gh mikelward "kept/repo	false	false
 old/repo	false	true")"
 run_repo_list "$dir" --include-archived
 assert_status 0
-assert_output_equals "kept/repo
+assert_output_equals "$DEPRECATION_LINE
+kept/repo
 old/repo"
 finish_case
 
@@ -210,7 +216,8 @@ test_case "--owner matching self in a different case still uses user/repos"
 dir="$(make_gh mikelward "a/repo	false	false")"
 run_repo_list "$dir" --owner MikelWard
 assert_status 0
-assert_output_equals "a/repo"
+assert_output_equals "$DEPRECATION_LINE
+a/repo"
 assert_call "$dir" "user/repos"
 finish_case
 
@@ -238,7 +245,8 @@ test_case "--owner for a visible org uses orgs/OWNER/repos"
 dir="$(make_gh mikelward "" yes "org/private-repo	false	false" "")"
 run_repo_list "$dir" --owner some-org
 assert_status 0
-assert_output_equals "org/private-repo"
+assert_output_equals "$DEPRECATION_LINE
+org/private-repo"
 assert_call "$dir" "orgs/some-org/repos"
 finish_case
 
@@ -320,7 +328,7 @@ test_case "an empty fleet is success, not an error"
 dir="$(make_gh mikelward "")"
 run_repo_list "$dir"
 assert_status 0
-assert_output_equals ""
+assert_output_equals "$DEPRECATION_LINE"
 finish_case
 
 test_case "SIGTERM while gh is running aborts rather than resuming against a deleted WORK"
@@ -373,8 +381,10 @@ else
     wait "$run_pid" 2>/dev/null || status=$?
     output="$(cat "$dir/run.out")"
     assert_status 143
-    if test -n "$output"; then
-        echo "  FAIL: expected no output when killed mid-listing, got: $output"
+    # The deprecation notice prints unconditionally before any gh call, so
+    # it's expected here -- what must NOT appear is any partial listing.
+    if test "$output" != "$DEPRECATION_LINE"; then
+        echo "  FAIL: expected only the deprecation notice when killed mid-listing, got: $output"
         TEST_FAILED=1
     fi
 fi

--- a/repo-rules
+++ b/repo-rules
@@ -1,6 +1,11 @@
 #!/bin/bash
 # Manage a GitHub repository's branch ruleset: which checks a merge requires.
 #
+# Deprecated: ruleset composition is now part of `repo setup` in
+# mikelward/repo, a Python rewrite with the same behavior. This script
+# stays as-is; fixes and new features go there instead. See that repo's
+# AGENTS.md.
+#
 # Usage:
 #     repo-rules [--dry-run] [--force] [--ruleset NAME] OWNER/REPO [CHECK...]
 #     repo-rules --ruleset=gates owner/repo lanes codex
@@ -94,6 +99,12 @@ DEFAULT_CHECKS="lanes codex zizmor"
 error() {
     echo "$PROGRAM: $*" >&2
 }
+
+# Silenced when repo-setup is the caller -- it prints this same notice once
+# itself and sets this before shelling out here, so a single repo-setup run
+# doesn't repeat it once per repo-rules call.
+test -n "${REPO_TOOLS_DEPRECATION_SHOWN:-}" ||
+    error "deprecated: ruleset composition is now part of 'repo setup' in mikelward/repo (same behavior, actively maintained -- see that repo's README)"
 
 usage() {
     cat <<EOF

--- a/repo-rules-audit
+++ b/repo-rules-audit
@@ -2,6 +2,10 @@
 # Report whether a repository's default branch actually enforces a set of
 # merge gates, reading GitHub's own merged view rather than any one ruleset.
 #
+# Deprecated: superseded by `repo audit` in mikelward/repo, a Python
+# rewrite with the same behavior. This script stays as-is; fixes and new
+# features go there instead. See that repo's AGENTS.md.
+#
 # Usage:
 #     repo-rules-audit [--branch NAME] OWNER/REPO [CHECK...]
 #     repo-rules-audit owner/repo lanes codex
@@ -70,6 +74,8 @@ DEFAULT_CHECKS="lanes codex zizmor"
 error() {
     echo "$PROGRAM: $*" >&2
 }
+
+error "deprecated: superseded by 'repo audit' in mikelward/repo (same behavior, actively maintained -- see that repo's README)"
 
 usage() {
     cat <<EOF

--- a/repo-rules-audit_test
+++ b/repo-rules-audit_test
@@ -166,6 +166,13 @@ fi
 
 # ---------------------------------------------------------------------------
 
+test_case "prints its own deprecation notice"
+dir="$(make_gh)"
+run "$dir" mikelward/lanes gate codex
+assert_status 0
+assert_output "repo-rules-audit: deprecated: superseded by 'repo audit'"
+finish_case
+
 test_case "a fully gated branch reports clean and exits 0"
 dir="$(make_gh)"
 run "$dir" mikelward/lanes gate codex

--- a/repo-rules_test
+++ b/repo-rules_test
@@ -420,6 +420,27 @@ assert_output "would create"
 assert_no_write "$dir"
 finish_case
 
+test_case "prints its own deprecation notice when run standalone"
+dir="$(make_gh 'test
+codex' '')"
+run_repo_rules "$dir" --dry-run mikelward/lanes test codex
+assert_status 0
+assert_output "repo-rules: deprecated: ruleset composition is now part of 'repo setup'"
+finish_case
+
+test_case "suppresses its own deprecation notice when REPO_TOOLS_DEPRECATION_SHOWN is set"
+# What repo-setup exports before shelling out here, so a repo-setup-composed
+# run doesn't repeat the notice it already printed once itself.
+dir="$(make_gh 'test
+codex' '')"
+set +e
+output="$(PATH="$dir/bin:$PATH" REPO_TOOLS_DEPRECATION_SHOWN=1 "$REPO_RULES" --dry-run mikelward/lanes test codex 2>&1)"
+status=$?
+set -e
+assert_status 0
+assert_no_output "deprecated"
+finish_case
+
 test_case "--ruleset takes both forms"
 for form in "--ruleset gates" "--ruleset=gates"; do
     dir="$(make_gh 'test' '')"

--- a/repo-secrets
+++ b/repo-secrets
@@ -1,6 +1,10 @@
 #!/bin/bash
 # Set one GitHub Actions secret to one value across one or more repositories.
 #
+# Deprecated: superseded by `repo secrets` in mikelward/repo, a Python
+# rewrite with the same behavior. This script stays as-is; fixes and new
+# features go there instead. See that repo's AGENTS.md.
+#
 # Usage:
 #     repo-secrets [--dry-run] [--force] --name NAME [--env ENV] [--file PATH] OWNER/REPO...
 #     repo-list | xargs repo-secrets --force --name LANES_TOKEN --env lanes --file token.txt
@@ -91,6 +95,12 @@ FORCE=0
 error() {
     echo "$PROGRAM: $*" >&2
 }
+
+# Silenced when repo-setup is the caller -- it prints this same notice once
+# itself and sets this before shelling out here, so a single repo-setup run
+# doesn't repeat it once per repo-secrets call.
+test -n "${REPO_TOOLS_DEPRECATION_SHOWN:-}" ||
+    error "deprecated: superseded by 'repo secrets' in mikelward/repo (same behavior, actively maintained -- see that repo's README)"
 
 usage() {
     cat <<EOF

--- a/repo-secrets_test
+++ b/repo-secrets_test
@@ -291,6 +291,27 @@ assert_output "owner/repo: set 'TOKEN'"
 assert_written "$dir" owner_repo TOKEN sekrit
 finish_case
 
+test_case "prints its own deprecation notice when run standalone"
+dir="$(make_gh "")"
+printf 'sekrit' > "$dir/value.txt"
+run "$dir" --force --name TOKEN --file "$dir/value.txt" owner/repo
+assert_status 0
+assert_output "repo-secrets: deprecated: superseded by 'repo secrets'"
+finish_case
+
+test_case "suppresses its own deprecation notice when REPO_TOOLS_DEPRECATION_SHOWN is set"
+# What repo-setup exports before shelling out here, so a repo-setup-composed
+# run doesn't repeat the notice it already printed once itself.
+dir="$(make_gh "")"
+printf 'sekrit' > "$dir/value.txt"
+set +e
+output="$(PATH="$dir/bin:$PATH" REPO_TOOLS_DEPRECATION_SHOWN=1 "$REPO_SECRETS" --force --name TOKEN --file "$dir/value.txt" owner/repo 2>&1)"
+status=$?
+set -e
+assert_status 0
+assert_no_output "deprecated"
+finish_case
+
 test_case "sets an environment-scoped secret and creates the environment first, when it does not exist yet"
 dir="$(make_gh "")"
 printf 'sekrit' > "$dir/value.txt"

--- a/repo-setup
+++ b/repo-setup
@@ -3,6 +3,10 @@
 # fanned-out Actions secrets, and GitHub App installation membership, in
 # one call.
 #
+# Deprecated: superseded by `repo setup` in mikelward/repo, a Python
+# rewrite with the same behavior. This script stays as-is; fixes and new
+# features go there instead. See that repo's AGENTS.md.
+#
 # Usage:
 #     repo-setup [--dry-run] [--force] [--no-rules] [--rule CHECK]...
 #                [--secret NAME[@ENV]=PATH]... [--app SLUG]... OWNER/REPO
@@ -87,6 +91,13 @@ APPS=()
 error() {
     echo "$PROGRAM: $*" >&2
 }
+
+error "deprecated: superseded by 'repo setup' in mikelward/repo (same behavior, actively maintained -- see that repo's README)"
+# repo-setup shells out to repo-rules and repo-secrets (a dry-run preview
+# call, then a real apply call, per step) -- without this, a single
+# repo-setup invocation would print this same notice up to four more
+# times, once per child call, on top of the one just above.
+export REPO_TOOLS_DEPRECATION_SHOWN=1
 
 # A rule/secret/app value with an embedded newline would otherwise pass
 # through as a single array element (bash arrays don't split on it the way

--- a/repo-setup_test
+++ b/repo-setup_test
@@ -410,6 +410,25 @@ assert_status 0
 assert_call_count "$dir" "POST repos/owner/repo/rulesets" 1
 finish_case
 
+test_case "prints its own deprecation notice once, and suppresses repo-rules'/repo-secrets' own"
+# repo-setup shells out to the real repo-rules and repo-secrets (symlinked
+# into $dir/bin above), each via its own dry-run preview call plus a real
+# apply call -- so without the REPO_TOOLS_DEPRECATION_SHOWN handshake, this
+# single invocation would print the deprecation notice up to five times.
+dir="$(make_gh)"
+printf 'sekrit' > "$dir/value.txt"
+run "$dir" --force --secret TOKEN="$dir/value.txt" owner/repo
+assert_status 0
+notice_count="$(printf '%s\n' "$output" | grep -c "^repo-setup: deprecated:")"
+if test "$notice_count" -ne 1; then
+    echo "  FAIL: expected exactly one repo-setup deprecation notice, got $notice_count"
+    echo "  output: $output"
+    TEST_FAILED=1
+fi
+assert_no_output "repo-rules: deprecated"
+assert_no_output "repo-secrets: deprecated"
+finish_case
+
 test_case "--dry-run prints the combined plan and makes no writes at all"
 dir="$(make_gh)"
 printf 'sekrit' > "$dir/value.txt"


### PR DESCRIPTION
mikelward/repo's Python rewrite (`repo list`, `repo secrets`, `repo setup`, `repo audit`) reached full parity with this repository's five fleet tools once `repo-rules-audit` -- the last gap -- was ported as `repo audit` in mikelward/repo#8. Each of the five scripts here now says so, in both places someone would notice: a comment at the top of the source, and a one-line notice to stderr on every run.

## Design notes

- **stderr, never stdout.** `repo-list`'s own header comment says its output is meant to be piped into a fleet-wide loop (`repo-list | xargs repo-secrets ...`), so anything on stdout would corrupt that composition. The notice goes to stderr instead, everywhere.
- **Mapping:** `repo-list` → `repo list`, `repo-secrets` → `repo secrets`, `repo-setup` → `repo setup`, `repo-rules-audit` → `repo audit`. `repo-rules` folds into `repo setup`'s ruleset step -- there's no standalone `repo rules` subcommand in the Python CLI.
- **No duplicate noise from `repo-setup`.** It shells out to `repo-rules` and `repo-secrets` internally (a dry-run preview call, then a real apply call, per step), so without guarding those two, a single `repo-setup` invocation would print this same notice up to five times. `repo-setup` exports `REPO_TOOLS_DEPRECATION_SHOWN=1` before calling either, and both check it before printing their own notice -- so a standalone `repo-rules` or `repo-secrets` invocation still warns, but a `repo-setup`-composed one only shows `repo-setup`'s own notice once.

## Testing

`make test` -- full suite green (`repo-list_test` 18/18, `repo-secrets_test` 41/41, `repo-setup_test` 54/54, `repo-rules_test` 69/69, `repo-rules-audit_test` 46/46, plus every other script's suite untouched and still passing).

- `repo-list_test` updated, not loosened: it captures stdout+stderr combined and asserts several outputs byte-for-byte, which the new stderr line changes. A `DEPRECATION_LINE` variable and updated assertions keep the checks exact rather than switching them to substring matches.
- `repo-rules_test`, `repo-secrets_test`, and `repo-rules-audit_test` each gained a test asserting the standalone notice prints; `repo-rules_test` and `repo-secrets_test` also assert `REPO_TOOLS_DEPRECATION_SHOWN=1` suppresses it.
- `repo-setup_test` gained a test that runs a real ruleset + secret apply through the actual `repo-rules`/`repo-secrets` binaries (already symlinked into the test's fake PATH) and asserts exactly one deprecation notice reaches the combined output -- the handshake itself, not just its two halves in isolation.
- Verified each new suppression/composition test fails against a deliberately broken guard (a typo'd env var name) before confirming it passes against the real code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AoHridGxxapL68Y8fLwyRx