### PR TITLE
docs: cross-pollinate the siblings' newer agent conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,10 +204,12 @@ reply, no offer to correct it. It is not a finding.
   conversations resolved: where CI is the only requirement it merges before
   Codex has answered, and an open review comment holds nothing back on its own.
   - Settle the fired trigger first thing in the turn, not last. It may have
-    silently re-armed rather than retired, so update it rather than adding a
-    second chain.
+    silently re-armed rather than retired — update the one that survived,
+    replace the one that didn't, and end the turn with exactly one pending.
   - Check the fire time you got against the one you asked for — a 4-minute
-    request has come back as 64. Re-time it, or say the watch isn't armed.
+    request has come back as 64. Prefer a relative delay: the scheduler's
+    clock is not this container's, so an absolute time computed here can be
+    rejected as already past. Re-time it, or say the watch isn't armed.
   - A few minutes out while CI or the current head's Codex verdict is
     outstanding; longer once only a human is left; short again after a push.
   - A PR reading `dirty` — always — or `behind` where the ruleset requires

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -302,7 +302,14 @@ reply, no offer to correct it. It is not a finding.
   (rebase / `--fixup`) rather than tacking on an "address review" commit.
   Group several small fixes into one commit when they share a topic.
 - **Judge every review comment on merit, whoever wrote it.** Verify the claim
-  before acting; if it doesn't hold up, reply saying why and decline.
+  before acting; if it doesn't hold up, reply saying why and decline. A
+  comment citing a rule is a *reading* of that rule, not the rule — check what
+  the rule actually says. Codex misreads the privacy rules especially, and in
+  one direction: stricter always feels safer, so an over-strict finding
+  quietly costs capability the product needs. Quote the rule and decline
+  rather than narrowing the code to satisfy it; where the rule really does
+  forbid what the product needs, that conflict is the maintainer's call, not
+  one to settle either way yourself.
 - **Never leave a review comment thread silently dismissed.** Answer on the thread, then
   resolve it once the fix is on the head or the point is rebutted — a disagreement is an
   answer, so say why and resolve; anything still to do stays open. When you think a comment is a false positive,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -271,11 +271,11 @@ reply, no offer to correct it. It is not a finding.
   not installed in the sandbox. If your client exposes neither, say so rather
   than guessing at the outcome of an operation you couldn't perform.
 - Open PRs ready for review (not draft) unless asked otherwise.
-- **On every push, update the PR title and body** so they describe the full,
-  latest state of the branch — not the scope it had when it was opened.
-  Re-read the diff against `origin/main` and patch whatever drifted, then post
-  the PR link in the chat reply for that push, not only at the end of the
-  conversation.
+- **Update the PR title and body with the push, not after it** — same step, so
+  they describe the full, latest state of the branch, not the scope it had
+  when it was opened. Re-read the diff against `origin/main` and patch
+  whatever drifted, then post the PR link in the chat reply for that push, not
+  only at the end of the conversation.
 - **"Drive to merge"** is the PR stretch of *drive* (see **Autonomy**
   above): open the PR, wait for the automatic Codex review, address every
   review comment — fix it if you agree, reply on the thread saying why if


### PR DESCRIPTION
Ports three recent AGENTS.md changes from the sibling repos.

- **Settle the fired trigger and prefer a relative delay.** A fired scheduled check can silently re-arm rather than retire, so the turn ends with exactly one pending rather than a second chain beside the first; and an absolute fire time computed in the container can be rejected as already past, because the scheduler's clock is not this container's.
- **Push back on a review comment that over-reads a rule.** A comment citing a rule is a *reading* of that rule, not the rule. The automated reviewer misreads the privacy rules in particular, and in one direction — a stricter reading always feels like the safe answer, so an over-strict finding quietly costs capability. Quote the rule and decline rather than narrowing the code to satisfy it; where the rule really does forbid what the code needs, that conflict is the maintainer's call. *(Trimmed after review: an earlier draft listed three exhaustive outcomes, which swallowed the plain false-positive, deferral and post-merge paths the file already had, and ran long for a file that mandates brevity.)*
- **Refresh the PR body with the push, not after it.** Ported from mikelward/typelauncher: read as two steps, the refresh becomes a follow-up that gets skipped, and the PR view then describes the scope the branch had when it opened.

Documentation only — no executable behavior changed, so `make test` was not run.