### PR TITLE
docs: keep chat replies free of step-by-step narration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,6 +158,10 @@ reply, no offer to correct it. It is not a finding.
   back-and-forth.
 - **Don't interrupt.** Never fire off a question while the user is still
   typing. Let them finish; a half-typed message isn't an invitation to jump in.
+- **Don't narrate routine machinery.** A check run flipping, a re-run, a scheduled check
+  re-arming, a webhook echo, a resolved thread — act on those silently; the noise buries
+  the one line that matters. Reports another rule requires stand (the Codex SHA and
+  comment count, a CI timing regression).
 - **Don't report your own caught-and-fixed mistakes.** A wrong turn you noticed
   and corrected before it reached anything is not news — no "one thing worth
   flagging", no narration of the recovery. Say it only when it left something


### PR DESCRIPTION
## Summary
- Ports the `AGENTS.md` rule added in `mikelward/snoozemo`'s [c9a8049](https://github.com/mikelward/snoozemo/commit/c9a804929d262e0817372a1d924e815797957380): a new "Don't narrate routine machinery" bullet under *Talking to the user*, adapted with this repo's own report obligations (Codex SHA + comment count, a CI timing regression).
- The existing "keep replies short" and "don't report your own caught mistakes" bullets each covered a piece of this; neither named the routine machinery itself — a check run flipping, a re-run, a scheduled check re-arming, a webhook echo, a resolved thread — as the thing not to narrate.
- Docs-only change; no behavior affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182HQMUyzNpiAtzUU4uE4GE

---
_Generated by [Claude Code](https://claude.ai/code/session_0182HQMUyzNpiAtzUU4uE4GE)_