### PR TITLE
Bump zizmor to 1.30.0

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -52,4 +52,4 @@ jobs:
       # GitHub API are skipped, deterministically, and the only fetch is
       # zizmor itself.
       - name: Scan the workflows
-        run: pipx run --spec zizmor==1.29.0 zizmor --no-progress --offline .
+        run: pipx run --spec zizmor==1.30.0 zizmor --no-progress --offline .


### PR DESCRIPTION
Bumps the pinned zizmor version used by the required `zizmor` check.

1.30.0 adds a `self-repository` audit for `uses: ./` steps. This repository has no such step (grepped for `uses: ./` and `uses: $/`; none found), and an offline `zizmor==1.30.0 --offline .` run against the current tree reports no findings, unchanged from 1.29.0.

`make test`: 54 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JMfTuAENyRbhFmMq8MkznA

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMfTuAENyRbhFmMq8MkznA)_