### PR TITLE
build: Take the four-hour sweep backstop from codex-review

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -1,7 +1,17 @@
 # Republishes Codex's review verdict as the `codex` commit status a ruleset
 # can require. Codex posts no check run, and a clean pass is only a reaction
-# on the pull request body -- which emits no webhook -- so this polls rather
-# than reacting to an event.
+# on the pull request body -- which emits no webhook -- so a verdict can
+# arrive with nothing to announce it.
+#
+# The event triggers below carry almost all of it: Codex edits its review
+# summary comment in place as a review starts and finishes, and an edit is an
+# `issue_comment` this workflow already wakes on. The schedule is the backstop
+# for what no event reports -- a verdict Codex never delivers, a run that
+# never picked a push up -- so it runs every four hours rather than hourly.
+# On a private repository each firing is billed by the minute, and a backstop
+# that fires 24 times a day to find nothing is the cost with none of the
+# benefit. The `:23` is deliberate: it dodges the on-the-hour stampede that
+# makes a runner queue.
 #
 # Every line below is deliberate, and each wrong setting produces no error at
 # all -- just a merge gate that quietly stops working, or one that can never
@@ -17,7 +27,7 @@
 name: codex-review
 on:
   schedule:
-    - cron: '23 * * * *'
+    - cron: '23 */4 * * *'
   pull_request_target:
     types: [opened, reopened, ready_for_review, synchronize, edited, closed]
   issue_comment:


### PR DESCRIPTION
`mikelward/codex-review#38` moved the canonical sweep from an hourly cron to `23 */4 * * *`. The events carry the verdict now — Codex edits its review summary comment in place as a review starts and finishes, and that edit is an `issue_comment` the workflow already wakes on — so the schedule is only the backstop for what no event reports.

This is one file, copied byte-for-byte from `templates/codex-review.yml` at the merged hub revision. The listener and the caller are unchanged. `mikelward/yaml-lite` piloted it (merged at `c67ff28`, no findings).

Until every consumer has migrated the hub accepts both shapes via `templates/superseded/hourly-sweep/`, so the ones still on the old file report a `notice:` rather than failing.

## Test plan

The sweep's schedule does change — it now fires every four hours instead of hourly — but nothing this repository *authors* changes: no script, no `sessionlib` contract, no `setup` dispatch. `make test` covers the shell utilities and has no case that this could affect, so there is nothing to add or run for it.

What does verify this change is the hub's own `check_consumer.py`, which reports `codex-review consumer setup is correct` against this tree with no notice — the byte-for-byte pin passing on the new shape rather than the superseded one. It runs here as a required check (`.github/workflows/codex-review-check.yml`), so the cron cannot drift or be removed without that check going red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GuLqX3NB5gRmCw8DV2RS5d