### PR TITLE
docs: Treat a second verified review finding as a design signal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -314,6 +314,11 @@ reply, no offer to correct it. It is not a finding.
   rather than narrowing the code to satisfy it; where the rule really does
   forbid what the product needs, that conflict is the maintainer's call, not
   one to settle either way yourself.
+- **A second verified finding in the same mechanism is evidence about the
+  design, not another bug.** Before fixing it, look for the same shape
+  elsewhere and ask whether a different design would delete the class rather
+  than the instance. Say what you chose on the thread; a design change is the
+  maintainer's call, autopilot included.
 - **Never leave a review comment thread silently dismissed.** Answer on the thread, then
   resolve it once the fix is on the head or the point is rebutted — a disagreement is an
   answer, so say why and resolve; anything still to do stays open. When you think a comment is a false positive,


### PR DESCRIPTION
## Summary
- Ports a rule from readmo's AGENTS.md, added there after the open-mode snapshot review (#700), where a redundant fallback authority cost nine review rounds to reconcile before being rewritten the way the existing pattern already worked.
- Generalizes past that one bug: a second VERIFIED finding in the same review mechanism is evidence about the design, not just another instance to patch — and a design change is the maintainer's call, not autopilot's.

## Test plan
- Docs-only change; no tests apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015chUGZx6mm1pxrLWSB7gPe

---
_Generated by [Claude Code](https://claude.ai/code/session_015chUGZx6mm1pxrLWSB7gPe)_