### PR TITLE
build: Turn off the docs-lane PR-title lint

### DIFF
--- a/.github/lanes.conf
+++ b/.github/lanes.conf
@@ -17,3 +17,10 @@ prefixes docs todo
 # test.yml declares no workflow_dispatch trigger, so no dispatched run is
 # legitimate here: a PR-less dispatch is refused on every ref.
 dispatch-without-pr refuse
+
+# The title check exists for two reasons (see mikelward/lanes' lintPrefixes
+# comment): guarding a squash merge, and letting the PR list show at a
+# glance whether a PR changes behavior. This repo doesn't squash-merge, and
+# the PR-list benefit isn't worth the false positives it produces (Codex
+# reading the title instead of the commit subject it actually gates).
+lint-title no


### PR DESCRIPTION
## Summary
- Sets `lint-title no` in `.github/lanes.conf`. This repo rebase-merges (no squash), so the title-lint's squash-merge rationale doesn't apply here, and the PR-list-readability rationale isn't worth the false positives it just produced (Codex flagged a docs-only PR's title for lacking `docs:` while the actual commit subject already had it).

## Test plan
- Config-only change; no tests apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015chUGZx6mm1pxrLWSB7gPe

---
_Generated by [Claude Code](https://claude.ai/code/session_015chUGZx6mm1pxrLWSB7gPe)_