### PR TITLE
docs: Point the report cross-reference at the findings rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,8 +160,8 @@ reply, no offer to correct it. It is not a finding.
   typing. Let them finish; a half-typed message isn't an invitation to jump in.
 - **Don't narrate routine machinery.** A check run flipping, a re-run, a scheduled check
   re-arming, a webhook echo, a resolved thread — act on those silently; the noise buries
-  the one line that matters. Reports another rule requires stand (the Codex SHA and
-  comment count, a CI timing regression).
+  the one line that matters. Reports another rule requires stand (each review and its
+  findings, a CI timing regression).
 - **Don't report your own caught-and-fixed mistakes.** A wrong turn you noticed
   and corrected before it reached anything is not news — no "one thing worth
   flagging", no narration of the recovery. Say it only when it left something


### PR DESCRIPTION
Follow-up to the review-restatement rule.

That rule now covers any reviewer and asks for a bullet per finding, but the cross-reference under *Talking to the user* still described the required report as "the Codex SHA and comment count" — the shape it had before. An agent leaning on the don't-narrate-routine-machinery exception could read that as license to emit the old gate-state one-liner and omit the findings, which is exactly the behavior the rule exists to stop.

Now reads "each review and its findings, a CI timing regression".

Codex found this on the sibling PR in `simmo`; the same stale reference is in nine repos and this is one of them.

Documentation only, so `make test` was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013maZS3vwyEdBmViyiJoym5

---
_Generated by [Claude Code](https://claude.ai/code/session_013maZS3vwyEdBmViyiJoym5)_