### PR TITLE
docs: Say to update the PR body before pushing, not after

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -275,7 +275,7 @@ reply, no offer to correct it. It is not a finding.
   not installed in the sandbox. If your client exposes neither, say so rather
   than guessing at the outcome of an operation you couldn't perform.
 - Open PRs ready for review (not draft) unless asked otherwise.
-- **Update the PR title and body with the push, not after it** — same step, so
+- **Update the PR title and body with the push — body first, then push** — so
   they describe the full, latest state of the branch, not the scope it had
   when it was opened. Re-read the diff against `origin/main` and patch
   whatever drifted, then post the PR link in the chat reply for that push, not


### PR DESCRIPTION
The rule said to update the title and body *"with the push, not after it"*. Every session read that as one action and then performed it as **push, then edit** — the natural order, since the push produces the diff the body describes.

Editing first is the cheaper order wherever `edited` is a pull-request trigger: an edit after a push starts a second run on the head just pushed, and the run whose verdict you want restarts from zero. Measured on a sibling where both orders happened on one PR minutes apart — edit-then-push wasted 10 seconds, push-then-edit wasted a run that had been going 4m56s across three heavy jobs.

**That reasoning does not apply here** — `test.yml` declares `pull_request:` with no `types:`, so its CI defaults to `[opened, synchronize, reopened]` and a body edit re-runs only `zizmor`. The rule lands anyway, and its reasoning is deliberately not in the file: the value is one standard followed everywhere, not a per-repo justification each session has to read. Identical wording across the fleet; piloted in mikelward/vcs#88 (merged).

Documentation only, so no `make test` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JdX4kfguYCrj5W23Yuv5TJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01JdX4kfguYCrj5W23Yuv5TJ)_