### PR TITLE
Add missing fleet CI scaffold files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  classify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      docs_only: ${{ steps.lane.outputs.docs_only }}
+      base_sha: ${{ steps.lane.outputs.base_sha }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - uses: mikelward/lanes@main
+        id: lane
+        with:
+          mode: classify
+          pr: ${{ github.event.pull_request.number }}
+
+  # TODO: replace this with the project's real jobs (test, build, lint,
+  # ...), each carrying `needs: classify` and
+  # `if: needs.classify.outputs.docs_only != 'true'`. Add each job's name
+  # to the `lanes` job's own `needs:` and `results:` below, and delete this
+  # placeholder once a real job exists -- see mikelward/lanes's README for
+  # the documented shape.
+  placeholder:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: classify
+    if: needs.classify.outputs.docs_only != 'true'
+    steps:
+      - run: echo "no real jobs yet -- see the TODO in this file"
+
+  lanes:
+    name: lanes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [classify, placeholder]
+    if: always()
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - uses: mikelward/lanes@main
+        with:
+          mode: gate
+          pr: ${{ github.event.pull_request.number }}
+          classify-result: ${{ needs.classify.result }}
+          base-sha: ${{ needs.classify.outputs.base_sha }}
+          results: placeholder=${{ needs.placeholder.result }}


### PR DESCRIPTION
Opened by `repo setup`: the fleet's standard CI scaffold files this
repository was missing.

- `.github/workflows/ci.yml`

Added through a pull request rather than pushed to the default branch so
that the checks they install actually run: `lanes` and `zizmor` report on
this pull request itself, which is what lets a required-checks ruleset
name them. `codex` cannot report here -- its status-writing workflow runs
under `pull_request_target`, which GitHub takes from the BASE branch's
copy, so the pull request adding that workflow is the one pull request it
cannot run on; it starts reporting on the first pull request opened after
this one merges.

Nothing already in the repository was touched: only paths that were
absent are added.
