### PR TITLE
Rename the CI workflow test.yml to ci.yml

### DIFF
--- a/.github/lanes.conf
+++ b/.github/lanes.conf
@@ -14,7 +14,7 @@ docs **/*.md
 # TODO.md edit.
 prefixes docs todo
 
-# test.yml declares no workflow_dispatch trigger, so no dispatched run is
+# ci.yml declares no workflow_dispatch trigger, so no dispatched run is
 # legitimate here: a PR-less dispatch is refused on every ref.
 dispatch-without-pr refuse
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: test
+name: CI
 
 on:
   push:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -22,7 +22,7 @@ rules:
         # consumer-side check calls needs its own entry — the action
         # reference above does not cover it.
         "mikelward/codex-review/.github/workflows/check-consumer.yml": ref-pin
-        # `@main` is likewise the release for the docs-lane engine test.yml
+        # `@main` is likewise the release for the docs-lane engine ci.yml
         # invokes — same repo-tracked-deliberately reasoning as
         # codex-review above.
         "mikelward/lanes": ref-pin


### PR DESCRIPTION
`repo setup`'s scaffold ships the lanes classify→gate workflow as `.github/workflows/ci.yml`, and mesh/vcs/unixtools/root already use that name. repo, conf and scripts were the holdouts calling the same workflow `test.yml` — and this repo's is the case that prompted it: `test.yml` is already the scaffold's `ci.yml` done better, wiring the real `test` job (`make test`) into the gate instead of a placeholder.

The scaffold matches by **path**, so a bootstrap run here would see `ci.yml` as missing and add a second workflow — a redundant `lanes` gate beside this one. Converging on the filename the scaffold expects makes the path match find it and add nothing.

Rename only. The required check is the job named `lanes`, not the file or the workflow's `name:`, so the ruleset is unaffected. `name: test` → `name: CI` to match the other repos, and the two comment references (`.github/lanes.conf` and `.github/zizmor.yml`) are updated to the new filename. CI/config only — no script behavior changed, so `make test` doesn't apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0181uDZo6dzQmAaN7razZwbo

---
_Generated by [Claude Code](https://claude.ai/code/session_0181uDZo6dzQmAaN7razZwbo)_