### PR TITLE
build: Lowercase the CI workflow name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: ci
 
 on:
   push:


### PR DESCRIPTION
The workflow `name:` field read `CI` while the filename (`ci.yml`) and `simmo` already use lowercase `ci`. This lowercases the display name to match the fleet standard.

Cosmetic only — the required check is the `lanes` job name, not the workflow display name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0181uDZo6dzQmAaN7razZwbo

---
_Generated by [Claude Code](https://claude.ai/code/session_0181uDZo6dzQmAaN7razZwbo)_