### PR TITLE
Install yazi and lf, with offline-bundle support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ repo).
 `setup --no-root` wires this in automatically: it runs unprivileged (implying
 `--no-sudo`, so the `apt`/`dnf` installs and every other privileged step are
 skipped) and installs the CLI tools via `homepkg` instead — the core set
-(`ripgrep fd bat fzf jq delta gh zoxide`) plus the extras (`helix jj nu`, unless
+(`ripgrep fd bat fzf jq delta gh zoxide yazi lf`) plus the extras (`helix jj nu`, unless
 the minimal profile is in effect). `--no-sudo` on its own is just the mechanism
 (skip sudo); it assumes the tools are provided some other way.
 

--- a/homepkg
+++ b/homepkg
@@ -98,6 +98,12 @@ TOOLS = {
     "zoxide":   {"conda": "zoxide",   "github": "ajeetdsouza/zoxide", "bins": ["zoxide"]},
     "atuin":    {"conda": None,       "github": "atuinsh/atuin",      "bins": ["atuin"]},
     "carapace": {"conda": None,       "github": "carapace-sh/carapace-bin", "bins": ["carapace"]},
+    # Terminal file managers. Both have a conda-forge feedstock -- so they ride
+    # the default mamba path and the offline bundle -- and a GitHub release for
+    # --backend github. yazi ships two binaries: the file manager (yazi) and its
+    # CLI helper (ya); lf is a single binary.
+    "yazi":     {"conda": "yazi",     "github": "sxyazi/yazi",        "bins": ["yazi", "ya"]},
+    "lf":       {"conda": "lf",       "github": "gokcehan/lf",        "bins": ["lf"]},
     # Node toolchain for the setup --no-root path: node/npm/tsc from conda-forge
     # instead of a distro package, plus fnm (which on root boxes comes from its
     # own curl installer -- no conda there yet). npm/npx ride along in the nodejs

--- a/homepkg_test
+++ b/homepkg_test
@@ -1145,6 +1145,19 @@ check("registry maps carapace to carapace-bin releases",
       and hp.TOOLS["carapace"]["github"] == "carapace-sh/carapace-bin"
       and hp.TOOLS["carapace"]["bins"] == ["carapace"])
 
+# Terminal file managers. Both have a conda-forge feedstock, so they take the
+# default mamba path and ride the offline bundle; both also have a GitHub
+# release for --backend github. yazi ships two binaries (the file manager and
+# its `ya` CLI helper); lf is a single binary.
+check("registry maps yazi to conda-forge with yazi/ya bins",
+      hp.TOOLS["yazi"]["conda"] == "yazi"
+      and hp.TOOLS["yazi"]["github"] == "sxyazi/yazi"
+      and hp.TOOLS["yazi"]["bins"] == ["yazi", "ya"])
+check("registry maps lf to conda-forge with an lf bin",
+      hp.TOOLS["lf"]["conda"] == "lf"
+      and hp.TOOLS["lf"]["github"] == "gokcehan/lf"
+      and hp.TOOLS["lf"]["bins"] == ["lf"])
+
 # Krohnkite: no conda-forge feedstock, no GitHub repo -- its release lives on
 # Codeberg, pinned to a specific (beta) tag rather than "latest", and it's not
 # a CLI tool so it carries no "bins".

--- a/setup
+++ b/setup
@@ -842,6 +842,16 @@ install_packages() {
             info "Installing zoxide"
             sudo_or_warn apt-get install -y --install-recommends zoxide \
                 || warn "could not install zoxide; z/zi directory jumps will be unavailable"
+            # yazi and lf are terminal file managers -- CLI tools, useful on
+            # headless boxes too, so install them regardless of --no-gui. One
+            # transaction each: apt rejects the whole request on one unknown
+            # name, and neither is in every release's repos (lf isn't packaged
+            # for Debian/Ubuntu; yazi is missing from older ones).
+            for fm in yazi lf; do
+                info "Installing $fm"
+                sudo_or_warn apt-get install -y --install-recommends "$fm" \
+                    || warn "$fm unavailable via apt; it also comes from conda-forge (homepkg install $fm) or its release page"
+            done
             # Node.js + tsc from the distro on the privileged path (setup-kde's
             # source-build fallback for Krohnkite needs tsc; its normal path
             # fetches a prebuilt release and needs neither). Under --no-root
@@ -878,10 +888,6 @@ install_packages() {
                 info "Installing gdbus (live shortcut updates)"
                 sudo_or_warn apt-get install -y --install-recommends libglib2.0-bin \
                     || warn "libglib2.0-bin unavailable via apt; setup-kde will fall back to asking for a logout unless python3-dbus is installed"
-                # yazi (terminal file manager) is often not in the default repos;
-                # install it separately so its absence doesn't block the rest.
-                sudo_or_warn apt-get install -y --install-recommends yazi \
-                    || warn "yazi unavailable via apt; install with 'cargo install --locked yazi-fm yazi-cli'"
             fi
             ;;
         redhat)
@@ -918,6 +924,15 @@ install_packages() {
             info "Installing zoxide"
             sudo_or_warn dnf install -y zoxide \
                 || warn "could not install zoxide; z/zi directory jumps will be unavailable"
+            # yazi and lf are terminal file managers -- CLI tools, useful on
+            # headless boxes too, so install them regardless of --no-gui. One
+            # transaction each, matching the Debian branch: dnf aborts the whole
+            # request on one unknown name, and yazi may need a COPR.
+            for fm in yazi lf; do
+                info "Installing $fm"
+                sudo_or_warn dnf install -y "$fm" \
+                    || warn "$fm unavailable via dnf; it also comes from conda-forge (homepkg install $fm) or its release page"
+            done
             # Node.js + tsc from the distro on the privileged path (setup-kde's
             # source-build fallback for Krohnkite needs tsc; its normal path
             # fetches a prebuilt release and needs neither). Under --no-root
@@ -953,10 +968,6 @@ install_packages() {
                 info "Installing gdbus (live shortcut updates)"
                 sudo_or_warn dnf install -y glib2 \
                     || warn "glib2 unavailable via dnf; setup-kde will fall back to asking for a logout unless python3-dbus is installed"
-                # yazi (terminal file manager) may need a COPR; install it
-                # separately so its absence doesn't block the rest.
-                sudo_or_warn dnf install -y yazi \
-                    || warn "yazi unavailable via dnf; install with 'cargo install --locked yazi-fm yazi-cli'"
             fi
             ;;
         macos)
@@ -996,6 +1007,13 @@ install_packages() {
             info "Installing zoxide"
             brew install zoxide \
                 || warn "could not install zoxide; z/zi directory jumps will be unavailable"
+            # yazi and lf are terminal file managers -- CLI tools, not graphical,
+            # so install them regardless of --no-gui (matching the Linux paths).
+            # One brew install each so a formula rename can't take the other down.
+            for fm in yazi lf; do
+                info "Installing $fm"
+                brew install "$fm" || warn "could not install $fm"
+            done
             # Node.js + tsc from Homebrew on the privileged path (setup-kde's
             # source-build fallback for Krohnkite needs tsc; its normal path
             # fetches a prebuilt release and needs neither). brew needs no
@@ -1033,7 +1051,7 @@ install_packages() {
             ;;
         *)
             warn "Unsupported OS, skipping package installation"
-            warn "Please install manually: bat curl fd fzf git git-delta golang jq kitty make mercurial npm p7zip python3 ripgrep shellcheck typescript unzip zoxide zsh"
+            warn "Please install manually: bat curl fd fzf git git-delta golang jq kitty lf make mercurial npm p7zip python3 ripgrep shellcheck typescript unzip yazi zoxide zsh"
             ;;
     esac
 }
@@ -1365,7 +1383,7 @@ install_home_tools() {
     # fnm (Node version manager) is a convenience tool -- installed regardless
     # of --no-npm, mirroring the root path's install_fnm (which is skipped under
     # --no-root, so fnm comes from here instead).
-    tools="ripgrep fd bat fzf jq delta gh fnm zoxide"
+    tools="ripgrep fd bat fzf jq delta gh fnm zoxide yazi lf"
     if test "$NPM" = yes; then
         # node/npm + tsc are the actual build toolchain for setup-kde's
         # Krohnkite source-build fallback (its normal path fetches a

--- a/setup_test
+++ b/setup_test
@@ -241,6 +241,45 @@ echo BOOTSTRAP_CONTINUED" 2>&1)"
     rm -rf "$macos_tmpdir"
 }
 
+# Run install_packages' Linux arm ($1: debian|redhat) against a mock package
+# manager that records every invocation and succeeds, with the GUI off. This
+# exercises the real dispatch -- which install commands are actually issued --
+# rather than grepping the source, so it can prove yazi/lf are installed even
+# under --no-gui (they sit outside the GUI block) and that the GUI-only packages
+# are not. NPM=no keeps the node/tsc steps out of the recorded calls.
+#   Leaves $calls set to the package-manager invocations.
+run_linux_packages() {
+    linux_os="$1"
+    case "$linux_os" in
+        debian) linux_pm=apt-get ;;
+        redhat) linux_pm=dnf ;;
+        *) echo "run_linux_packages: unknown OS $linux_os" >&2; return 2 ;;
+    esac
+    linux_tmpdir="$(mktemp -d)"
+    linux_calls="$linux_tmpdir/calls"
+    cat > "$linux_tmpdir/$linux_pm" <<MOCK
+#!/bin/sh
+printf '%s\n' "$linux_pm \$*" >> "$linux_calls"
+exit 0
+MOCK
+    chmod +x "$linux_tmpdir/$linux_pm"
+
+    set +e
+    output="$(PATH="$linux_tmpdir:$PATH" \
+        sh -c "set -e
+OS=$linux_os
+NPM=no
+GUI_ENABLED=0
+sudo_or_warn() { \"\$@\"; }
+$(extract_functions "info warn install_packages")
+install_packages
+echo BOOTSTRAP_CONTINUED" 2>&1)"
+    status=$?
+    set -e
+    calls="$(cat "$linux_calls" 2>/dev/null)"
+    rm -rf "$linux_tmpdir"
+}
+
 # Run the two "homepkg is missing" warning paths with SCRIPTS_DIR pointed at a
 # home-shaped path that doesn't exist. Both functions bail right after warning,
 # so this exercises exactly the messages under test -- and the path is what the
@@ -743,7 +782,7 @@ test_sudo_calls_are_guarded() {
 # manual-install hint for unsupported OSes.
 test_unzip_installed() {
     assert_source_contains "unzip" &&
-    assert_source_contains "typescript unzip zoxide zsh"
+    assert_source_contains "typescript unzip yazi zoxide zsh"
 }
 
 # --- fnm ---
@@ -771,8 +810,6 @@ test_fnm_installed() {
 
 # The extras arrive prebuilt now -- Homebrew bottles or release artifacts -- so
 # setup builds nothing from source and installs no Rust toolchain of its own.
-# (The yazi hints still name a cargo command for the user to run by hand; those
-# are messages, not installs.)
 test_no_source_builds() {
     assert_source_not_contains "sh.rustup.rs" &&
     assert_source_not_contains "rustup update" &&
@@ -1121,8 +1158,53 @@ test_zoxide_is_a_core_package() {
     test "$(grep -c '^ *info "Installing zoxide"$' "$SETUP")" -eq 3 &&
     test "$(grep -c '^ *zoxide \\$' "$SETUP")" -eq 0 &&
     assert_source_contains "could not install zoxide" &&
-    assert_source_contains "unzip zoxide zsh" &&
-    assert_source_contains 'tools="ripgrep fd bat fzf jq delta gh fnm zoxide"'
+    assert_source_contains "yazi zoxide zsh" &&
+    assert_source_contains 'tools="ripgrep fd bat fzf jq delta gh fnm zoxide yazi lf"'
+}
+
+# yazi and lf are terminal file managers: CLI tools that are useful headless,
+# not desktop apps, so they install on every path regardless of --no-gui and
+# ride the homepkg core set (and thus the offline mamba bundle) rather than
+# sitting in the GUI-only block. yazi used to live in the GUI block with a
+# cargo-install hint; that hint is gone now that conda-forge (homepkg) provides
+# both. These run the real dispatch and assert the commands issued, rather than
+# grepping the source: a grep can't prove the install stays outside the GUI
+# guard or that homepkg is actually invoked (not just named in a warning).
+
+# Debian: yazi and lf install even with the GUI off, so they reach a headless
+# box -- and the GUI-only packages (kitty, kde-standard) do not, confirming the
+# GUI really is off and the file managers sit outside that block.
+test_file_managers_install_headless_debian() {
+    run_linux_packages debian
+    assert_status 0 &&
+    assert_output_contains "BOOTSTRAP_CONTINUED" &&
+    assert_calls_contain "apt-get install -y --install-recommends yazi" &&
+    assert_calls_contain "apt-get install -y --install-recommends lf" &&
+    assert_calls_lack "kde-standard" &&
+    assert_calls_lack "install -y --install-recommends kitty"
+}
+
+# Fedora: the same, via dnf.
+test_file_managers_install_headless_redhat() {
+    run_linux_packages redhat
+    assert_status 0 &&
+    assert_output_contains "BOOTSTRAP_CONTINUED" &&
+    assert_calls_contain "dnf install -y yazi" &&
+    assert_calls_contain "dnf install -y lf" &&
+    assert_calls_lack "kde-desktop-environment" &&
+    assert_calls_lack "dnf install -y kitty"
+}
+
+# The rootless path actually invokes homepkg with yazi and lf in the tools it
+# installs -- so --no-root and the offline mamba bundle (which carries the whole
+# registry, homepkg install reconciling it) get them too. The old cargo hint is
+# gone now that conda-forge provides both.
+test_file_managers_are_in_the_homepkg_core_set() {
+    run_home_tools_helix absent
+    assert_status 0 &&
+    assert_calls_contain "homepkg install ripgrep" &&
+    assert_calls_contain " zoxide yazi lf" &&
+    assert_source_not_contains "cargo install --locked yazi-fm yazi-cli"
 }
 
 # update-alternatives only covers x-terminal-emulator. What makes Plasma's own
@@ -1179,6 +1261,8 @@ test_macos_brew_failures_are_not_fatal() {
     assert_output_contains "BOOTSTRAP_CONTINUED" &&
     assert_output_contains "some core Homebrew packages could not be installed" &&
     assert_output_contains "could not install zoxide" &&
+    assert_output_contains "could not install yazi" &&
+    assert_output_contains "could not install lf" &&
     assert_output_contains "could not install node" &&
     assert_output_contains "could not install tsc" &&
     assert_output_contains "could not install android-platform-tools" &&
@@ -1192,6 +1276,8 @@ test_macos_brew_failure_still_attempts_later_steps() {
     run_macos_packages 0
     assert_status 0 &&
     assert_calls_contain "brew install zoxide" &&
+    assert_calls_contain "brew install yazi" &&
+    assert_calls_contain "brew install lf" &&
     assert_calls_contain "brew install --cask android-platform-tools" &&
     assert_calls_contain "brew install kitty"
 }
@@ -2098,6 +2184,12 @@ run_test "legacy root config fallback is logged with the remedy" \
     test_legacy_root_config_is_logged
 run_test "zoxide is installed as a core package" \
     test_zoxide_is_a_core_package
+run_test "yazi and lf install headlessly on Debian, not just under GUI" \
+    test_file_managers_install_headless_debian
+run_test "yazi and lf install headlessly on Fedora, not just under GUI" \
+    test_file_managers_install_headless_redhat
+run_test "yazi and lf are in the homepkg core set" \
+    test_file_managers_are_in_the_homepkg_core_set
 run_test "kitty is set as the KDE terminal on Debian" \
     test_kde_terminal_set_on_debian
 run_test "kitty is set as the KDE terminal on Fedora" \


### PR DESCRIPTION
## What

Installs the terminal file managers **yazi** and **lf** from `setup`, and adds both to the rootless `homepkg` path so they ride the offline mamba/conda bundle.

## Why

Before this, `yazi` was installed only inside the GUI block (apt/dnf) and `lf` not at all — and neither reached the `homepkg` rootless path, so the offline bundle (`setup --no-root`, air-gapped installs) couldn't carry them.

## Changes

- **`homepkg` registry**: add `yazi` (conda-forge `yazi`, GitHub `sxyazi/yazi`, bins `yazi`/`ya`) and `lf` (conda-forge `lf`, GitHub `gokcehan/lf`, bin `lf`). Both have a conda-forge feedstock, so they're pulled into the whole-registry `homepkg bundle` and the default mamba install automatically; the GitHub release backend is the fallback. Verified against conda-forge (`yazi` ships `bin/ya` + `bin/yazi`; `lf` ships `bin/lf`) and the current GitHub releases.
- **`setup`**: treat them as core CLI tools, not desktop apps — they're useful headless — so install them on every path regardless of `--no-gui`:
  - apt / dnf / brew: their own best-effort transaction each (one unknown name aborts the whole request, and neither is packaged everywhere).
  - the `homepkg` core tools list, so `--no-root` and the offline bundle get them too.
  - The old yazi `cargo install` hints are gone now that conda-forge provides both; the manual-install hint for unsupported OSes lists them.
- **Docs/tests**: README core-set list updated; `homepkg_test` registry checks and `setup_test` core-install checks added; existing assertions updated. `make test` passes.

## Note on cost/reliability

No new external dependency on a hot path — both come from the same conda-forge / GitHub-release mechanisms `setup` already uses, and installs are best-effort (a failure warns and continues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WyXXzjwfoTtF1fucYuuQBn

---
_Generated by [Claude Code](https://claude.ai/code/session_01WyXXzjwfoTtF1fucYuuQBn)_