### PR TITLE
install-bundle: unpack the closure into the prefix instead of building an env

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,13 @@ homepkg install-bundle tools.tgz
 `bundle` with no tool names is the one-shot: it covers the whole registry,
 taking each tool from wherever it comes from. Tools with a conda-forge package
 go in as a solved dependency closure alongside the micromamba binary that
-replays it, so the target builds a correct environment with no network at all;
-the few with no feedstock (`atuin`, `carapace`) go in as static release assets.
-`install-bundle` replays whichever payloads the bundle carries.
+unpacks it, so `install-bundle` lays the packages flat into the prefix
+(`bin`/`lib`/`share`) with no network and no environment at all; the few with
+no feedstock (`atuin`, `carapace`) go in as static release assets.
+`install-bundle` unpacks whichever payloads the bundle carries. These are plain
+files in the prefix — `homepkg update` / `remove` manage only the online mamba
+env, not bundle-unpacked tools; to refresh those, install a newer bundle over
+them.
 
 The `github` variant builds a bundle of release assets only. It needs explicit
 tool names, since not every registered tool publishes one (`typescript` is

--- a/homepkg
+++ b/homepkg
@@ -34,9 +34,12 @@ Push bundles (build on an online host, install on an air-gapped target):
     homepkg install-bundle tools.tgz                  # target: install offline
 
 A bundle carries whatever each tool needs: the solved conda closure for the
-tools with a conda-forge package, release assets for the ones without, and the
-micromamba to replay the closure with. `bundle` with no tool names covers the
-whole registry, so one file provisions a machine with no network at all.
+tools with a conda-forge package, release assets for the ones without, and a
+micromamba to unpack the closure with. install-bundle unpacks each conda
+package straight into the prefix (bin/lib/share), additively -- no env, no
+solver, so it needs no fresh prefix and leaves whatever's already installed in
+place. `bundle` with no tool names covers the whole registry, so one file
+provisions a machine with no network at all.
 
 Tool names are logical (ripgrep, fd, ...); the registry maps each to its conda
 package and its GitHub or Codeberg repo.
@@ -135,6 +138,14 @@ def warn(msg):
 
 
 class HomepkgError(Exception):
+    pass
+
+
+class BundlePartial(HomepkgError):
+    """A bundle installed some of its tools but not all -- distinct from a
+    HomepkgError that installed nothing, so install-bundle can exit with a code
+    that tells a caller (setup) to keep what landed rather than fall back to a
+    full online install."""
     pass
 
 
@@ -1086,9 +1097,10 @@ def remove_mamba(tools, prefix, plat, dry_run):
 #
 # Build a self-contained bundle on an online host, copy it to an air-gapped
 # target, install offline. The mamba bundle carries the solved dependency
-# closure plus micromamba, so the target builds a correct env with no network.
-# The github bundle carries static release assets (smaller; self-contained
-# tools only). A bundle is a .tar.gz of manifest.json + a backend payload.
+# closure plus micromamba, which install-bundle uses to unpack each package
+# flat into the prefix -- no env, no network. The github bundle carries static
+# release assets (smaller; self-contained tools only). A bundle is a .tar.gz of
+# manifest.json + a backend payload.
 
 def _write_bundle(out, srcdir):
     with tarfile.open(out, "w:gz") as tf:
@@ -1316,49 +1328,223 @@ def bundle_codeberg(tools, out, dry_run):
     info(f"wrote {out} ({os.path.getsize(out) // 1024} KiB)")
 
 
-def _localize_explicit(explicit_path, pkgs_dir):
-    """Rewrite the explicit lockfile's URLs to file:// paths in the bundle."""
-    out = []
-    for line in open(explicit_path):
-        line = line.rstrip("\n")
-        if line.startswith("http"):
-            url, _, frag = line.partition("#")
-            local = os.path.join(pkgs_dir, os.path.basename(url))
-            out.append("file://" + local + (("#" + frag) if frag else ""))
-        else:
-            out.append(line)
-    return "\n".join(out) + "\n"
+def _assert_tree_within(srcroot, dest, prefix_real):
+    """Raise unless every destination *directory* for srcroot's real-dir tree
+    resolves inside the prefix. A populated prefix may hold a directory symlink
+    (<prefix>/lib -> /elsewhere) that os.makedirs/shutil.move would follow,
+    writing a package's files outside the prefix -- so each directory we'd
+    create or descend is checked before any file is moved (see
+    _unpack_conda_pkg), and an escaping destination is refused before anything
+    has been replaced.
+
+    Only directories are checked, not leaves: a colliding leaf (a file, or a
+    symlink pointing outside) is unlinked before its replacement is moved in
+    (_move_tree), so its own target is never followed -- realpath-checking it
+    would wrongly refuse the additive last-writer-wins replacement. A symlinked
+    directory in the payload is likewise moved as a leaf and never descended
+    (os.walk with followlinks=False doesn't recurse into it), so it needs no
+    check on its target either.
+
+    A type mismatch between the payload and an existing destination is refused
+    in this whole-package pass rather than resolved by deletion (os.walk yields
+    parents before children, so the shallower destination is always caught
+    first):
+      - a destination directory blocked by a pre-existing non-directory (a file,
+        or a dangling/foreign symlink) -- otherwise _move_tree's makedirs raises
+        FileExistsError partway through the package;
+      - a destination leaf (a file, or a symlink moved whole) landing on a
+        pre-existing real directory -- otherwise its _rm_any would rmtree that
+        directory and its unrelated contents.
+    Only same-type collisions -- leaf over leaf, dir over dir -- are replaced or
+    merged (last writer wins); a package never deletes across types."""
+    for dirpath, dirs, files in os.walk(srcroot):
+        rel = os.path.relpath(dirpath, srcroot)
+        destdir = dest if rel == "." else os.path.join(dest, rel)
+        if not _within(prefix_real, destdir):
+            raise HomepkgError(f"refusing to write outside the prefix: {destdir}")
+        if os.path.lexists(destdir) and not os.path.isdir(destdir):
+            raise HomepkgError(
+                f"refusing to replace a non-directory with a directory: {destdir}")
+        # Leaves: plain files, plus symlinked subdirectories (moved as leaves,
+        # not descended -- os.walk with followlinks=False lists but doesn't
+        # recurse). A leaf over a real directory would rmtree it.
+        leaves = list(files) + [d for d in dirs
+                                if os.path.islink(os.path.join(dirpath, d))]
+        for name in leaves:
+            dst = os.path.join(destdir, name)
+            if os.path.isdir(dst) and not os.path.islink(dst):
+                raise HomepkgError(
+                    f"refusing to replace a directory with a non-directory: {dst}")
 
 
-def _install_bundle_mamba(td, manifest, prefix, dry_run):
-    env = mamba_env(prefix)
-    # A bundle's explicit lock is a complete env solved only for its own tools.
-    # Replaying it into an existing env would replace/downgrade shared deps and
-    # could break tools already there, so require a fresh env: bundle all tools
-    # together, or install into a clean prefix.
-    if os.path.isdir(os.path.join(env, "conda-meta")):
-        raise HomepkgError(
-            f"{env} already has a homepkg env; install-bundle needs a fresh env "
-            "(bundle all tools together, or use a different --prefix)")
-    # Use a prefix-owned micromamba only: an already-installed one here, else
-    # the static binary shipped in the bundle. Never an arbitrary PATH one,
-    # which may be wrong-arch, old, or dynamically linked.
-    mm = os.path.join(prefix, "bin", "micromamba")
-    if not os.path.exists(mm) and not dry_run:
-        os.makedirs(os.path.dirname(mm), exist_ok=True)
-        shutil.copy2(os.path.join(td, "micromamba"), mm)
-        _ensure_executable(mm)
-    offline = os.path.join(td, "offline.txt")
-    with open(offline, "w") as fh:
-        fh.write(_localize_explicit(os.path.join(td, "explicit.txt"),
-                                    os.path.join(td, "pkgs")))
-    info(f"installing {', '.join(manifest['tools'])} offline into {env}")
+def _move_tree(srcroot, dest):
+    """Move everything under srcroot into dest at the same relative path,
+    creating directories and overwriting a colliding leaf -- a file or a symlink
+    (unlinked, not followed), so a shared file two bundles both ship is
+    last-writer-wins. A symlinked directory in the payload is moved whole rather
+    than descended into (os.walk with followlinks=False lists it but doesn't
+    recurse), so that part of the payload isn't dropped with the temp dir.
+    Additive: a leaf already in dest that srcroot doesn't carry is left
+    untouched. Destinations must already have been validated with
+    _assert_tree_within."""
+    for dirpath, dirs, files in os.walk(srcroot):
+        rel = os.path.relpath(dirpath, srcroot)
+        destdir = dest if rel == "." else os.path.join(dest, rel)
+        os.makedirs(destdir, exist_ok=True)
+        leaves = list(files)
+        leaves += [d for d in dirs if os.path.islink(os.path.join(dirpath, d))]
+        for name in leaves:
+            dst = os.path.join(destdir, name)
+            _rm_any(dst)
+            shutil.move(os.path.join(dirpath, name), dst)
+
+
+def _unpack_conda_pkg(mm, pkg_path, prefix):
+    """Unpack one conda package flat into <prefix> using micromamba's own
+    extractor, so the target needs no zstd of its own.
+
+    micromamba writes the package's bin/lib/share plus an info/ metadata dir
+    into a directory. We extract into a temp dir inside the prefix (a sibling of
+    the final files, so the moves are same-filesystem renames), move everything
+    but info/ into place, and drop the temp -- so each package's info/ can't
+    collide and a failed extract never lands a half-written tree in the prefix.
+    There's no conda link step, hence no prefix rewriting: self-contained
+    compiled tools work (the registry's tools are), but a package that hardcodes
+    its build prefix in a script would not -- the same limit as --backend conda.
+    """
+    import subprocess
+    os.makedirs(prefix, exist_ok=True)
+    prefix_real = os.path.realpath(prefix)
+    xd = tempfile.mkdtemp(dir=prefix, prefix=".homepkg-unpack-")
+    try:
+        subprocess.run([mm, "package", "extract", pkg_path, xd],
+                       check=True, stdout=subprocess.DEVNULL)
+        entries = [(os.path.join(xd, n), os.path.join(prefix, n))
+                   for n in os.listdir(xd) if n != "info"]  # info/ is metadata
+        # Validate the WHOLE package before moving any of it, so a later
+        # top-level tree that escapes the prefix (or a type mismatch anywhere)
+        # can't leave an earlier one (bin/) already replaced. A directory tree
+        # goes through _assert_tree_within; a top-level leaf (a file or a
+        # symlink) can't write outside its single-component prefix path, but
+        # must not land on a pre-existing real directory -- _rm_any would rmtree
+        # it (the nested case is covered inside _assert_tree_within).
+        for src, dst in entries:
+            if os.path.isdir(src) and not os.path.islink(src):
+                _assert_tree_within(src, dst, prefix_real)
+            elif os.path.isdir(dst) and not os.path.islink(dst):
+                raise HomepkgError(
+                    f"refusing to replace a directory with a non-directory: {dst}")
+        for src, dst in entries:
+            if os.path.isdir(src) and not os.path.islink(src):
+                _move_tree(src, dst)
+            else:
+                _rm_any(dst)
+                shutil.move(src, dst)
+    finally:
+        # The payload is already in the prefix, so a failed cleanup isn't fatal
+        # -- but don't hide it (ignore_errors=True would): a stranded
+        # .homepkg-unpack-* dir left unreported would pile up across installs.
+        try:
+            shutil.rmtree(xd)
+        except OSError as exc:
+            warn(f"could not remove unpack staging dir {xd}: {exc}")
+
+
+def _pkg_hashes(explicit_path):
+    """Map each package filename in a bundle's explicit.txt to its recorded
+    (algo, hexdigest), so install can verify the shipped bytes before extract --
+    the check the old `micromamba create --file` path did for free. Lines are
+    '<url>#<md5hex>' or '<url>#sha256:<hex>' (see _explicit_frag)."""
+    hashes = {}
+    if not os.path.exists(explicit_path):
+        return hashes
+    with open(explicit_path) as fh:
+        for line in fh:
+            line = line.strip()
+            if not line or line.startswith("@") or "#" not in line:
+                continue
+            url, frag = line.rsplit("#", 1)
+            fn = os.path.basename(url)
+            if frag.startswith("sha256:"):
+                hashes[fn] = ("sha256", frag[len("sha256:"):])
+            elif frag:
+                hashes[fn] = ("md5", frag)
+    return hashes
+
+
+def _verify_pkg_hash(fn, path, algo_hex):
+    algo, want = algo_hex
+    got = hashlib.new(algo, open(path, "rb").read()).hexdigest()
+    if got != want:
+        raise HomepkgError(f"{fn}: {algo} mismatch ({got} != {want})")
+
+
+def _conda_tools_missing(tools, prefix):
+    """Of `tools`, return those whose registry binaries aren't in <prefix>/bin,
+    making the ones that are present executable. A tool not in this homepkg's
+    registry is skipped with a warning rather than raising (see _link_bins). Used
+    both for the normal post-unpack report and, on a mid-closure unpack failure,
+    to mark only the tools that didn't land -- so a partial conda unpack reports
+    partial rather than installed-nothing."""
+    missing = []
+    for tool in tools:
+        meta = TOOLS.get(tool)
+        if meta is None:
+            warn(f"{tool}: not in this homepkg's registry; unpacked into the "
+                 "prefix but its binaries weren't verified")
+            continue
+        tool_missing = False
+        for b in meta["bins"]:
+            path = os.path.join(prefix, "bin", b)
+            if os.path.exists(path):
+                _ensure_executable(path)
+            else:
+                tool_missing = True
+        if tool_missing:
+            missing.append(tool)
+    return missing
+
+
+def _install_bundle_conda(td, manifest, prefix, dry_run):
+    """Install a bundle's conda closure by unpacking every package straight into
+    <prefix>, additively -- no env, no solver, no fresh-prefix requirement.
+
+    The closure was solved when the bundle was built, so pkgs/ already holds
+    every dependency; conda's $ORIGIN/../lib rpaths make the binaries run from
+    the prefix. Unpacking leaves whatever an earlier bundle put in the prefix in
+    place (a shared file is overwritten, last writer wins) -- so a re-run, or a
+    second bundle, just adds to what's there. Returns the tools whose binaries
+    didn't land, same contract as _install_bundle_github.
+    """
+    tools = manifest["tools"]
+    pkgdir = os.path.join(td, "pkgs")
+    pkgs = sorted(os.listdir(pkgdir)) if os.path.isdir(pkgdir) else []
+    info(f"unpacking {len(pkgs)} packages for {', '.join(tools)} into {prefix}")
     if dry_run:
-        info(f"  would run micromamba create --offline -p {env} --file {offline}")
-        return
-    _run_mamba(mm, prefix, ["create", "-y", "-p", env, "--offline",
-                            "--file", offline], False)
-    _link_bins(manifest["tools"], prefix)
+        info(f"  would unpack {len(pkgs)} packages into {prefix}")
+        return []
+    # The bundle ships a target-arch micromamba; use it to decompress (its own
+    # zstd), never a PATH one that may be wrong-arch or dynamically linked.
+    mm = os.path.join(td, "micromamba")
+    _ensure_executable(mm)
+    # Verify every package against explicit.txt's recorded hash before
+    # extracting any of them, so a corrupt or substituted closure member fails
+    # before the prefix is touched rather than after garbage has been unpacked.
+    hashes = _pkg_hashes(os.path.join(td, "explicit.txt"))
+    for fn in pkgs:
+        _require_basename(fn, "package file")
+        want = hashes.get(fn)
+        if want:
+            _verify_pkg_hash(fn, os.path.join(pkgdir, fn), want)
+        else:
+            warn(f"{fn}: no hash in explicit.txt; skipping verification")
+    for fn in pkgs:
+        _unpack_conda_pkg(mm, os.path.join(pkgdir, fn), prefix)
+    # Report a tool whose binaries didn't land (a truncated bundle).
+    missing = _conda_tools_missing(tools, prefix)
+    if not missing:
+        info(f"  unpacked {', '.join(tools)} into {prefix}/bin")
+    return missing
 
 
 def _install_bundle_github(td, manifest, prefix, dry_run):
@@ -1438,41 +1624,71 @@ def install_bundle(bundle_file, prefix, plat, dry_run):
                 "(pass --arch to override)")
         info(f"bundle: {backend}, platform {got}")
         failed = []
+        attempted = 0
         if backend == "combined":
-            # One bundle, both payloads: conda tools first (the env install
-            # wants a fresh prefix), then the static release assets. The two
-            # are independent, so a closure that can't be replayed -- an env
-            # already present, say -- mustn't cost you the static binaries.
+            # One bundle, several payloads: unpack the conda closure, then the
+            # static release assets. They're independent, so a conda unpack that
+            # fails partway (a truncated package, say) mustn't cost the static
+            # binaries -- catch a hard failure and mark just the conda tools.
             if "mamba" in manifest:
+                mtools = manifest["mamba"].get("tools", [])
+                attempted += len(mtools)
                 try:
-                    _install_bundle_mamba(td, manifest["mamba"], prefix, dry_run)
+                    failed.extend(_install_bundle_conda(
+                        td, manifest["mamba"], prefix, dry_run))
                 except Exception as exc:
-                    # Anything the replay can raise: our own "env already
-                    # exists", micromamba exiting non-zero (CalledProcessError),
-                    # a truncated payload. Narrowing this to HomepkgError would
-                    # let the commonest failure of all -- the create itself --
-                    # skip the static assets below.
                     warn(f"conda tools: {exc}")
-                    failed.extend(manifest["mamba"].get("tools", ["conda tools"]))
+                    # A conda closure is solved as a unit: a package failing
+                    # mid-unpack can leave an earlier tool's dependencies short,
+                    # and bin-presence can't tell a this-run install from one an
+                    # earlier bundle left. So don't salvage "landed" tools from a
+                    # broken closure -- mark the whole conda set failed. The
+                    # static github/codeberg halves are independent and still
+                    # install, so a bundle whose conda half fails while its
+                    # assets land is still partial (exit 2), not nothing.
+                    failed.extend(mtools or ["conda tools"])
             if "github" in manifest:
+                attempted += len(manifest["github"].get("tools", []))
                 failed.extend(_install_bundle_github(
                     td, manifest["github"], prefix, dry_run))
             if "codeberg" in manifest:
+                attempted += len(manifest["codeberg"].get("tools", []))
                 failed.extend(_install_bundle_codeberg(
                     td, manifest["codeberg"], prefix, dry_run))
         elif backend == "mamba":
-            _install_bundle_mamba(td, manifest, prefix, dry_run)
+            mtools = manifest.get("tools", [])
+            attempted = len(mtools)
+            try:
+                failed.extend(_install_bundle_conda(td, manifest, prefix, dry_run))
+            except Exception as exc:
+                # Same as the combined path: a mid-closure failure fails the
+                # whole conda set rather than salvaging unverifiable partials.
+                warn(f"conda tools: {exc}")
+                failed.extend(mtools or ["conda tools"])
         elif backend == "github":
+            attempted = len(manifest.get("tools", []))
             failed.extend(_install_bundle_github(td, manifest, prefix, dry_run))
         elif backend == "codeberg":
+            attempted = len(manifest.get("tools", []))
             failed.extend(_install_bundle_codeberg(td, manifest, prefix, dry_run))
         else:
             raise HomepkgError(f"unknown bundle backend: {backend}")
+        if attempted == 0:
+            # An empty manifest (a combined bundle with no payload sections, or
+            # any backend naming no tools) installs nothing -- a hard failure,
+            # not success, so setup falls back to the online install rather than
+            # accepting an invalid bundle and skipping it.
+            raise HomepkgError("bundle declares no tools to install")
         if failed:
             # Non-zero so the caller can fall back to installing them online
-            # (setup does), while everything the bundle did carry stays put.
-            raise HomepkgError(
-                f"bundle installed without: {', '.join(failed)}")
+            # (setup does), while everything the bundle did carry stays put. A
+            # partial install (some tools landed) is distinct from one that
+            # landed nothing -- BundlePartial lets install-bundle exit 2 vs 1 so
+            # setup only falls back to the online install in the latter case.
+            msg = f"bundle installed without: {', '.join(failed)}"
+            if 0 < len(failed) < attempted:
+                raise BundlePartial(msg)
+            raise HomepkgError(msg)
 
 
 # --- CLI ---------------------------------------------------------------------
@@ -1550,6 +1766,12 @@ def main(argv=None):
         try:
             install_bundle(args.tools[0], args.prefix,
                            _resolve_plat(p, args.arch), args.dry_run)
+        except BundlePartial as e:
+            # Some tools landed, some didn't. Exit 2 (not 1) so a caller keeps
+            # the partial install -- setup adds ~/.local/bin to PATH for what
+            # landed rather than falling back to a full online install.
+            warn(str(e))
+            return 2
         except Exception as e:
             warn(str(e))
             return 1

--- a/homepkg_test
+++ b/homepkg_test
@@ -1328,18 +1328,6 @@ with tempfile.TemporaryDirectory() as td:
 
 # --- push bundles ------------------------------------------------------------
 
-# The explicit lockfile's remote URLs are rewritten to local file:// paths (in
-# the bundle's pkgs dir) for the offline replay, preserving the hash fragment.
-with tempfile.TemporaryDirectory() as td:
-    exp = os.path.join(td, "explicit.txt")
-    with open(exp, "w") as f:
-        f.write("@EXPLICIT\n"
-                "https://conda.anaconda.org/conda-forge/linux-64/jq-1.8.2-h0.conda#abc\n")
-    res = hp._localize_explicit(exp, "/b/pkgs").splitlines()
-    check("_localize_explicit keeps @EXPLICIT", res[0] == "@EXPLICIT")
-    check("_localize_explicit rewrites url to a local file:// path",
-          res[1] == "file:///b/pkgs/jq-1.8.2-h0.conda#abc")
-
 # A combined bundle carries both payloads. Only the github half is exercised
 # end-to-end here (the mamba half needs micromamba and a solved closure), but
 # install_bundle has to find and replay it from the "github" sub-object rather
@@ -1456,25 +1444,61 @@ with tempfile.TemporaryDirectory() as td:
     hp._write_bundle(bundle, src)
     prefix = os.path.join(td, "prefix")
 
-    def _replay_fails(*args, **kwargs):
-        raise subprocess.CalledProcessError(1, ["micromamba", "create"])
+    def _unpack_fails(*args, **kwargs):
+        raise subprocess.CalledProcessError(1, ["micromamba", "package", "extract"])
 
-    _orig = hp._install_bundle_mamba
-    hp._install_bundle_mamba = _replay_fails
+    _orig = hp._install_bundle_conda
+    hp._install_bundle_conda = _unpack_fails
     _err = None
     try:
         hp.install_bundle(bundle, prefix, ("linux", "x86_64"), False)
     except hp.HomepkgError as e:
         _err = e
     finally:
-        hp._install_bundle_mamba = _orig
-    check("a failed conda replay still leaves the release assets installed",
+        hp._install_bundle_conda = _orig
+    check("a failed conda unpack still leaves the release assets installed",
           os.access(os.path.join(prefix, "bin", "atuin"), os.X_OK))
-    check("a failed conda replay reports the tools it couldn't install",
+    check("a failed conda unpack reports the tools it couldn't install",
           _err is not None and "jq" in str(_err))
 
-# A combined manifest naming an unknown backend still errors rather than
-# silently installing nothing.
+# A conda closure is solved as a unit, so a package failing mid-unpack fails the
+# WHOLE conda set -- even a tool whose binary happened to land isn't salvaged
+# (its dependencies may be short, and a preexisting binary can't be told from a
+# this-run one). A mamba-only bundle that fails this way is installed-nothing
+# (exit 1, not a BundlePartial); the static halves of a combined bundle are
+# independent and still make it partial (see the release-assets test above).
+with tempfile.TemporaryDirectory() as td:
+    src = os.path.join(td, "src")
+    os.makedirs(src)
+    with open(os.path.join(src, "manifest.json"), "w") as f:
+        json.dump({"format": 1, "backend": "mamba", "platform": "linux/x86_64",
+                   "tools": ["jq", "fd"]}, f)
+    bundle = os.path.join(td, "conda-fails.tar.gz")
+    hp._write_bundle(bundle, src)
+    prefix = os.path.join(td, "prefix")
+
+    def _lands_jq_then_fails(td_, manifest, pfx, dry):
+        os.makedirs(os.path.join(pfx, "bin"), exist_ok=True)
+        open(os.path.join(pfx, "bin", "jq"), "w").close()   # jq's binary landed
+        raise RuntimeError("extract failed on a later package")
+
+    _orig = hp._install_bundle_conda
+    hp._install_bundle_conda = _lands_jq_then_fails
+    _err = None
+    try:
+        hp.install_bundle(bundle, prefix, ("linux", "x86_64"), False)
+    except hp.HomepkgError as e:
+        _err = e
+    finally:
+        hp._install_bundle_conda = _orig
+    check("a mid-closure conda failure fails the whole set, not a salvaged partial",
+          _err is not None and not isinstance(_err, hp.BundlePartial))
+    check("a mid-closure conda failure names every conda tool, jq's landed binary included",
+          _err is not None and "jq" in str(_err) and "fd" in str(_err))
+
+# A combined manifest with no payload sections installs nothing -- a hard
+# failure, not silent success, so setup's staged-bundle path falls back to the
+# online install rather than accepting an empty bundle.
 with tempfile.TemporaryDirectory() as td:
     src = os.path.join(td, "src")
     os.makedirs(src)
@@ -1485,9 +1509,10 @@ with tempfile.TemporaryDirectory() as td:
     _err = None
     try:
         hp.install_bundle(bundle, os.path.join(td, "prefix"), ("linux", "x86_64"), False)
-    except Exception as e:  # noqa: BLE001
+    except hp.HomepkgError as e:
         _err = e
-    check("install-bundle tolerates a combined bundle with neither half", _err is None)
+    check("a combined bundle with no payload sections is an installed-nothing failure",
+          _err is not None and not isinstance(_err, hp.BundlePartial))
 
 # The tool split is what makes one bundle enough: everything with a
 # conda-forge package goes through the closure, the rest through releases.
@@ -1877,35 +1902,328 @@ with tempfile.TemporaryDirectory() as td:
         raised = True
     check("_safe_extract_tar rejects special files (FIFO)", raised)
 
-# install-bundle creates a fresh env but adds to an existing one, matching the
-# normal install path. _run_mamba/_link_bins are stubbed to stay offline.
-_bundle_cmds = []
-_saved_rm, _saved_lb = hp._run_mamba, hp._link_bins
-hp._run_mamba = lambda mm, prefix, args, dry: _bundle_cmds.append(args[0])
-hp._link_bins = lambda tools, prefix: None
+# _move_tree moves a tree in, overwrites a colliding file (last writer wins),
+# and leaves unrelated files already there alone -- the additive part of an
+# unpack.
+with tempfile.TemporaryDirectory() as td:
+    src = os.path.join(td, "src")
+    os.makedirs(src)
+    open(os.path.join(src, "new"), "w").close()
+    with open(os.path.join(src, "shared"), "w") as f:
+        f.write("new")
+    dest = os.path.join(td, "dest")
+    os.makedirs(dest)
+    open(os.path.join(dest, "old"), "w").close()               # unrelated
+    with open(os.path.join(dest, "shared"), "w") as f:
+        f.write("old")                                          # collision
+    hp._move_tree(src, dest)
+    check("_move_tree adds new files",
+          os.path.exists(os.path.join(dest, "new")))
+    check("_move_tree leaves unrelated files untouched",
+          os.path.exists(os.path.join(dest, "old")))
+    check("_move_tree overwrites a collision (last writer wins)",
+          open(os.path.join(dest, "shared")).read() == "new")
+
+# _assert_tree_within refuses a destination that resolves outside the prefix
+# through a pre-existing directory symlink (e.g. <prefix>/lib -> /elsewhere),
+# so unpacking a bundle into a populated prefix can't write outside --prefix.
+with tempfile.TemporaryDirectory() as td:
+    prefix = os.path.join(td, "prefix")
+    os.makedirs(prefix)
+    outside = os.path.join(td, "outside")
+    os.makedirs(outside)
+    os.symlink(outside, os.path.join(prefix, "lib"))
+    src = os.path.join(td, "src")
+    os.makedirs(src)
+    open(os.path.join(src, "evil"), "w").close()
+    raised = False
+    try:
+        hp._assert_tree_within(src, os.path.join(prefix, "lib"),
+                               os.path.realpath(prefix))
+    except hp.HomepkgError:
+        raised = True
+    check("_assert_tree_within refuses a destination that escapes the prefix",
+          raised)
+
+# _assert_tree_within also refuses when a required destination directory is
+# blocked by a pre-existing non-directory (e.g. <prefix>/share/cache is a file
+# but the package needs it as a directory) -- caught in the whole-package
+# validation pass so the package refuses before _move_tree's makedirs would
+# raise partway through and leave it half-applied.
+with tempfile.TemporaryDirectory() as td:
+    prefix = os.path.join(td, "prefix")
+    os.makedirs(os.path.join(prefix, "share"))
+    open(os.path.join(prefix, "share", "cache"), "w").close()   # a file where a dir is needed
+    src = os.path.join(td, "src")                                # payload: cache/data
+    os.makedirs(os.path.join(src, "cache"))
+    open(os.path.join(src, "cache", "data"), "w").close()
+    raised = False
+    try:
+        hp._assert_tree_within(src, os.path.join(prefix, "share"),
+                               os.path.realpath(prefix))
+    except hp.HomepkgError:
+        raised = True
+    check("_assert_tree_within refuses a directory blocked by an existing file",
+          raised)
+
+# The mirror case: a payload leaf (a file or a symlink) that would land on a
+# pre-existing real directory is refused too -- _move_tree's _rm_any would
+# rmtree that directory and its unrelated contents. Caught in the preflight, so
+# nothing is deleted.
+with tempfile.TemporaryDirectory() as td:
+    prefix = os.path.join(td, "prefix")
+    os.makedirs(os.path.join(prefix, "share", "tool"))
+    open(os.path.join(prefix, "share", "tool", "keep"), "w").close()  # unrelated content
+    src = os.path.join(td, "src")                                     # payload: a FILE "tool"
+    os.makedirs(src)
+    open(os.path.join(src, "tool"), "w").close()
+    raised = False
+    try:
+        hp._assert_tree_within(src, os.path.join(prefix, "share"),
+                               os.path.realpath(prefix))
+    except hp.HomepkgError:
+        raised = True
+    check("_assert_tree_within refuses a leaf colliding with an existing directory",
+          raised)
+    check("the refusal leaves the existing directory's contents untouched",
+          os.path.exists(os.path.join(prefix, "share", "tool", "keep")))
+
+# _move_tree carries a symlinked directory in the payload across whole: os.walk
+# lists it but doesn't recurse into it, so a naive files-only move would drop it
+# with the temp dir (a conda package can ship a directory symlink).
+with tempfile.TemporaryDirectory() as td:
+    src = os.path.join(td, "src")
+    os.makedirs(os.path.join(src, "real"))
+    open(os.path.join(src, "real", "f"), "w").close()
+    os.symlink("real", os.path.join(src, "linkdir"))       # dir symlink in payload
+    dest = os.path.join(td, "dest")
+    os.makedirs(dest)
+    hp._move_tree(src, dest)
+    check("_move_tree preserves a payload directory symlink",
+          os.path.islink(os.path.join(dest, "linkdir")))
+    check("_move_tree carries the real directory alongside it",
+          os.path.exists(os.path.join(dest, "real", "f")))
+
+# A colliding destination leaf that is itself a symlink pointing OUTSIDE the
+# prefix is replaced, not refused: _move_tree unlinks the link (not its target)
+# before moving the bundled file in, and _assert_tree_within checks only
+# directories -- so the additive last-writer-wins replacement isn't wrongly
+# rejected, and the symlink's former target is left alone.
+with tempfile.TemporaryDirectory() as td:
+    prefix = os.path.join(td, "prefix")
+    os.makedirs(os.path.join(prefix, "bin"))
+    outside = os.path.join(td, "outside")
+    with open(outside, "w") as f:
+        f.write("system")
+    os.symlink(outside, os.path.join(prefix, "bin", "rg"))   # <prefix>/bin/rg escapes
+    src = os.path.join(td, "src")
+    os.makedirs(src)
+    with open(os.path.join(src, "rg"), "w") as f:
+        f.write("bundled")
+    ok = True
+    try:
+        hp._assert_tree_within(src, os.path.join(prefix, "bin"),
+                               os.path.realpath(prefix))
+    except hp.HomepkgError:
+        ok = False
+    check("_assert_tree_within allows a colliding leaf symlink (checks dirs only)",
+          ok)
+    hp._move_tree(src, os.path.join(prefix, "bin"))
+    check("a colliding leaf symlink is replaced by the bundled file",
+          not os.path.islink(os.path.join(prefix, "bin", "rg"))
+          and open(os.path.join(prefix, "bin", "rg")).read() == "bundled")
+    check("replacing a leaf symlink leaves its former target untouched",
+          open(outside).read() == "system")
+
+# _unpack_conda_pkg validates the WHOLE package before moving any of it: a later
+# top-level tree that escapes the prefix must not leave an earlier one already
+# moved. Stub the extractor to lay down a bin/ (fine) beside a lib/ whose prefix
+# destination is an escaping symlink; the unpack must raise and touch neither.
+with tempfile.TemporaryDirectory() as td:
+    prefix = os.path.join(td, "prefix")
+    os.makedirs(prefix)
+    outside = os.path.join(td, "outside")
+    os.makedirs(outside)
+    os.symlink(outside, os.path.join(prefix, "lib"))     # <prefix>/lib escapes
+    def _fake_extract(cmd, **kw):
+        xd = cmd[-1]
+        os.makedirs(os.path.join(xd, "bin"))
+        open(os.path.join(xd, "bin", "tool"), "w").close()
+        os.makedirs(os.path.join(xd, "lib"))
+        open(os.path.join(xd, "lib", "libx.so"), "w").close()
+        os.makedirs(os.path.join(xd, "info"))
+        class _R:
+            returncode = 0
+        return _R()
+    import subprocess as _sp
+    _saved_run = _sp.run
+    _sp.run = _fake_extract
+    raised = False
+    try:
+        hp._unpack_conda_pkg("mm", "pkg.conda", prefix)
+    except hp.HomepkgError:
+        raised = True
+    finally:
+        _sp.run = _saved_run
+    check("_unpack_conda_pkg refuses a package with an escaping tree", raised)
+    check("_unpack_conda_pkg moved nothing when a later tree escapes",
+          not os.path.exists(os.path.join(prefix, "bin", "tool"))
+          and not os.path.exists(os.path.join(outside, "libx.so")))
+
+# _unpack_conda_pkg warns (rather than silently swallowing) if the staging dir
+# can't be removed, and still completes the install -- the payload is already in
+# the prefix, but a stranded .homepkg-unpack-* dir mustn't pile up unreported.
+with tempfile.TemporaryDirectory() as td:
+    prefix = os.path.join(td, "prefix")
+    os.makedirs(prefix)
+    def _fake_extract_ok(cmd, **kw):
+        xd = cmd[-1]
+        os.makedirs(os.path.join(xd, "bin"))
+        open(os.path.join(xd, "bin", "tool"), "w").close()
+        os.makedirs(os.path.join(xd, "info"))
+        class _R:
+            returncode = 0
+        return _R()
+    def _boom(*a, **k):
+        raise OSError("cleanup boom")
+    import subprocess as _sp
+    _saved_run = _sp.run
+    _saved_rmtree = hp.shutil.rmtree
+    _saved_warn = hp.warn
+    _warned = []
+    _sp.run = _fake_extract_ok
+    hp.shutil.rmtree = _boom
+    hp.warn = lambda msg: _warned.append(msg)
+    try:
+        hp._unpack_conda_pkg("mm", "pkg.conda", prefix)
+    finally:
+        _sp.run = _saved_run
+        hp.shutil.rmtree = _saved_rmtree
+        hp.warn = _saved_warn
+    check("_unpack_conda_pkg still installs the payload when cleanup fails",
+          os.path.exists(os.path.join(prefix, "bin", "tool")))
+    check("_unpack_conda_pkg warns when the staging dir can't be removed",
+          any("staging dir" in m for m in _warned))
+
+# install-bundle unpacks each conda package flat into the prefix, additively --
+# no env, no fresh-prefix requirement. _unpack_conda_pkg's body needs a real
+# micromamba, so it's stubbed to drop a binary named for the package; the
+# orchestration (what lands, what's reported) is what's under test.
+_saved_unpack = hp._unpack_conda_pkg
+def _fake_unpack(mm, pkg, prefix):
+    b = os.path.basename(pkg).split("-")[0]
+    os.makedirs(os.path.join(prefix, "bin"), exist_ok=True)
+    open(os.path.join(prefix, "bin", b), "w").close()
+hp._unpack_conda_pkg = _fake_unpack
 try:
     with tempfile.TemporaryDirectory() as td:
-        bdir = os.path.join(td, "b")
-        os.makedirs(os.path.join(bdir, "pkgs"))
-        with open(os.path.join(bdir, "explicit.txt"), "w") as f:
-            f.write("@EXPLICIT\n")
-        open(os.path.join(bdir, "micromamba"), "w").close()
-        prefix = os.path.join(td, "prefix")  # no micromamba here yet
-        hp._install_bundle_mamba(bdir, {"tools": ["jq"]}, prefix, False)
-        check("install-bundle copies the bundled micromamba into the prefix",
-              os.path.exists(os.path.join(prefix, "bin", "micromamba")))
-        check("install-bundle creates a fresh env", _bundle_cmds[-1] == "create")
-        # A second bundle into the same env is refused -- an explicit lock must
-        # not be replayed additively over an existing env.
-        os.makedirs(os.path.join(hp.mamba_env(prefix), "conda-meta"))
-        raised = False
-        try:
-            hp._install_bundle_mamba(bdir, {"tools": ["jq"]}, prefix, False)
-        except hp.HomepkgError:
-            raised = True
-        check("install-bundle refuses to reuse an existing env", raised)
+        pkgdir = os.path.join(td, "pkgs")
+        os.makedirs(pkgdir)
+        for fn in ("jq-1.8.2-h0.conda", "oniguruma-6-h0.conda"):  # tool + a dep
+            open(os.path.join(pkgdir, fn), "w").close()
+        open(os.path.join(td, "micromamba"), "w").close()
+        prefix = os.path.join(td, "prefix")
+        os.makedirs(os.path.join(prefix, "bin"))
+        open(os.path.join(prefix, "bin", "earlier"), "w").close()  # an earlier bundle
+        missing = hp._install_bundle_conda(td, {"tools": ["jq"]}, prefix, False)
+        check("_install_bundle_conda unpacks the tool's binary onto PATH",
+              os.path.exists(os.path.join(prefix, "bin", "jq")))
+        check("_install_bundle_conda leaves an earlier bundle's tool in place",
+              os.path.exists(os.path.join(prefix, "bin", "earlier")))
+        check("_install_bundle_conda reports nothing missing when the bin lands",
+              missing == [])
+        missing2 = hp._install_bundle_conda(td, {"tools": ["jq"]}, prefix, False)
+        check("_install_bundle_conda re-runs over a populated prefix without error",
+              missing2 == [])
+    # A tool whose binary the bundle didn't carry is reported (a truncated bundle).
+    with tempfile.TemporaryDirectory() as td:
+        os.makedirs(os.path.join(td, "pkgs"))
+        open(os.path.join(td, "micromamba"), "w").close()
+        prefix = os.path.join(td, "prefix")
+        check("_install_bundle_conda reports a tool whose binary didn't land",
+              hp._install_bundle_conda(td, {"tools": ["jq"]}, prefix, False) == ["jq"])
+    # A tool absent from the registry is skipped, not a KeyError.
+    with tempfile.TemporaryDirectory() as td:
+        pkgdir = os.path.join(td, "pkgs")
+        os.makedirs(pkgdir)
+        open(os.path.join(pkgdir, "nosuchtool-1-h0.conda"), "w").close()
+        open(os.path.join(td, "micromamba"), "w").close()
+        prefix = os.path.join(td, "prefix")
+        check("_install_bundle_conda skips a tool not in the registry",
+              hp._install_bundle_conda(td, {"tools": ["nosuchtool"]}, prefix, False) == [])
 finally:
-    hp._run_mamba, hp._link_bins = _saved_rm, _saved_lb
+    hp._unpack_conda_pkg = _saved_unpack
+
+# _pkg_hashes parses explicit.txt's per-url hash fragments (conda's bare md5, or
+# the modern sha256: form) keyed by package filename.
+with tempfile.TemporaryDirectory() as td:
+    ep = os.path.join(td, "explicit.txt")
+    with open(ep, "w") as f:
+        f.write("@EXPLICIT\n"
+                "https://conda.anaconda.org/conda-forge/linux-64/jq-1.8.2-h0.conda#" + "a" * 32 + "\n"
+                "https://conda.anaconda.org/conda-forge/linux-64/oniguruma-6-h0.conda#sha256:" + "b" * 64 + "\n")
+    h = hp._pkg_hashes(ep)
+    check("_pkg_hashes reads a bare md5 fragment",
+          h.get("jq-1.8.2-h0.conda") == ("md5", "a" * 32))
+    check("_pkg_hashes reads a sha256: fragment",
+          h.get("oniguruma-6-h0.conda") == ("sha256", "b" * 64))
+
+# _install_bundle_conda verifies each package against explicit.txt before
+# extracting ANY of them: a corrupt/substituted closure member fails before the
+# prefix is touched, so nothing is unpacked.
+with tempfile.TemporaryDirectory() as td:
+    pkgdir = os.path.join(td, "pkgs")
+    os.makedirs(pkgdir)
+    with open(os.path.join(pkgdir, "jq-1.8.2-h0.conda"), "wb") as f:
+        f.write(b"corrupt bytes")
+    open(os.path.join(td, "micromamba"), "w").close()
+    with open(os.path.join(td, "explicit.txt"), "w") as f:
+        f.write("@EXPLICIT\nhttps://x/linux-64/jq-1.8.2-h0.conda#" + "0" * 32 + "\n")
+    prefix = os.path.join(td, "prefix")
+    _unpacked = []
+    _saved_unpack2 = hp._unpack_conda_pkg
+    hp._unpack_conda_pkg = lambda mm, p, pre: _unpacked.append(p)
+    raised = False
+    try:
+        hp._install_bundle_conda(td, {"tools": ["jq"]}, prefix, False)
+    except hp.HomepkgError:
+        raised = True
+    finally:
+        hp._unpack_conda_pkg = _saved_unpack2
+    check("_install_bundle_conda rejects a package whose bytes fail the hash", raised)
+    check("_install_bundle_conda unpacks nothing when a hash mismatches",
+          _unpacked == [])
+
+# install-bundle's exit code tells a partial install from one that installed
+# nothing, so setup falls back to the online install only in the latter case:
+# 0 = everything landed, 2 = some landed and some didn't, 1 = nothing landed
+# (or a hard failure). Build github bundles by hand and drive the CLI (main).
+with tempfile.TemporaryDirectory() as td:
+    def _gh_bundle(name, tools, present):
+        src = os.path.join(td, name + "-src")
+        os.makedirs(os.path.join(src, "assets"))
+        for e in tools:
+            if e["tool"] in present:
+                _make_targz(os.path.join(src, "assets", e["asset"]),
+                            {"t-1.0/" + e["bins"][0]: b"#!/bin/sh\n"})
+        with open(os.path.join(src, "manifest.json"), "w") as f:
+            json.dump({"format": 1, "backend": "github",
+                       "platform": "linux/x86_64", "tools": tools}, f)
+        out = os.path.join(td, name + ".tar.gz")
+        hp._write_bundle(out, src)
+        return out
+    two = [{"tool": "ripgrep", "asset": "rg.tar.gz", "bins": ["rg"]},
+           {"tool": "atuin", "asset": "atuin.tar.gz", "bins": ["atuin"]}]
+    one = [{"tool": "ripgrep", "asset": "rg.tar.gz", "bins": ["rg"]}]
+    def _ib(bundle):
+        return hp.main(["--prefix", os.path.join(td, "p-" + os.path.basename(bundle)),
+                        "--arch", "linux/x86_64", "install-bundle", bundle])
+    check("install-bundle exits 0 when every tool lands",
+          _ib(_gh_bundle("full", one, {"ripgrep"})) == 0)
+    check("install-bundle exits 2 on a partial install (some tools landed)",
+          _ib(_gh_bundle("partial", two, {"ripgrep"})) == 2)
+    check("install-bundle exits 1 when nothing landed",
+          _ib(_gh_bundle("none", one, set())) == 1)
 
 # a tampered github-bundle manifest can't escape the prefix: asset/bin names
 # with .. or absolute paths are rejected.

--- a/setup
+++ b/setup
@@ -1402,15 +1402,12 @@ install_home_tools() {
         warn "shpool is not installed by setup (no prebuilt artifact); sessions fall back to tmux unless it's installed some other way"
     fi
 
-    # Optimistic provisioning. On a FRESH env, prefer a prebuilt bundle (which
-    # installs fully offline); otherwise install the requested set online.
-    # install-bundle needs a fresh env, so the bundle only applies on the first
-    # provision. Look for a bundle at $HOMEPKG_BUNDLE, then homepkg-bundle.tgz
-    # beside the scripts repo or in $HOME. Build one on an online host with
-    # "homepkg bundle -o homepkg-bundle.tgz" (no args = every tool).
-    #
-    # TODO: a pinned/--frozen (+ --no-bundle) flag pair to skip the optimistic
-    #   online reconcile/refresh, for a reproducible bundle-exact install.
+    # Prefer a prebuilt bundle if one is staged (it unpacks its full contents
+    # flat into the prefix -- offline, no network, no env); otherwise install
+    # the requested set online into a managed conda env. Look for a bundle at
+    # $HOMEPKG_BUNDLE, then homepkg-bundle.tgz beside the scripts repo or in
+    # $HOME (build one online with "homepkg bundle -o homepkg-bundle.tgz" -- no
+    # args = every tool).
     env_dir="$HOME/.local/share/homepkg/env"   # mirrors homepkg's <prefix>/share/homepkg/env
     bundle=""
     for cand in "${HOMEPKG_BUNDLE:-}" "$SCRIPTS_DIR/homepkg-bundle.tgz" "$HOME/homepkg-bundle.tgz"; do
@@ -1421,41 +1418,32 @@ install_home_tools() {
     done
 
     provisioned=no
-    if test -n "$bundle" && ! test -d "$env_dir/conda-meta"; then
-        # A bundle installs its FULL contents in one shot (install-bundle can't
-        # cherry-pick), so --minimal/--no-npm don't trim it. Then reconcile the
-        # requested set online with `install $tools`: this ADDS any requested
-        # tool the bundle lacked -- e.g. a partial $HOMEPKG_BUNDLE missing tsc,
-        # which a bare `update` would never add since it only touches packages
-        # already in the env -- and freshens them. Offline it warns and we rely
-        # on whatever the bundle carried.
+    if test -n "$bundle"; then
+        # A bundle unpacks its FULL contents (install-bundle can't cherry-pick),
+        # so --minimal/--no-npm don't trim it.
         info "Installing CLI tools from bundle (offline-capable): $bundle"
-        info "  a bundle installs its full contents; --minimal/--no-npm and an already-installed jj don't trim it"
+        info "  a bundle unpacks its full contents additively; --minimal/--no-npm don't trim it"
         if "$homepkg" install-bundle "$bundle"; then
             provisioned=yes
         else
-            # install-bundle exits non-zero when it couldn't install
-            # everything the manifest listed -- a release asset the bundle
-            # was built without, say -- having installed the rest. So what
-            # follows is a top-up rather than a redo.
-            warn "the bundle didn't provide everything; topping up online"
+            rc=$?
+            # install-bundle exits 2 for a partial install (a tool the bundle
+            # was built without didn't land, the rest did) and 1 when it
+            # installed nothing (wrong platform, unreadable bundle). Keep a
+            # partial -- the PATH block below covers what landed; on a total
+            # failure fall through to the online install, so a connected box
+            # still gets its tools (on an air-gapped box that also fails,
+            # harmlessly).
+            if test "$rc" -eq 2; then
+                warn "the bundle didn't provide everything (offline?); using what it did unpack"
+                provisioned=yes
+            else
+                warn "the staged bundle installed nothing (wrong platform / unreadable?); falling back to the online install"
+            fi
         fi
-        # shellcheck disable=SC2086  # $tools is a space-separated list expanded into multiple args
-        if "$homepkg" install $tools; then
-            provisioned=yes
-        elif test "$provisioned" = yes; then
-            warn "installed the bundle; couldn't reconcile the requested tools online (offline?)"
-        elif test -d "$env_dir/conda-meta"; then
-            # A partial install-bundle still built the env out of whatever it
-            # carried, so an offline top-up failure doesn't make this run
-            # unprovisioned: the steps below still have to put ~/.local/bin on
-            # PATH for the tools that did land.
-            warn "couldn't top up the missing tools online (offline?); keeping what the bundle installed"
-            provisioned=yes
-        else
-            warn "the bundle installed nothing and the online top-up failed (offline?)"
-        fi
-    else
+    fi
+
+    if test "$provisioned" = no; then
         test "$MINIMAL_ENABLED" -eq 0 \
             || info "Skipping heavyweight CLI extras (helix, jj, nushell); minimal profile"
         info "Installing CLI tools into a home prefix via homepkg: $tools"
@@ -1479,16 +1467,16 @@ install_home_tools() {
         *) PATH="$HOME/.local/bin:$PATH" ;;
     esac
 
-    # This path's helix comes from conda-forge, with its runtime inside the
+    # The online path's helix comes from conda-forge with its runtime inside the
     # homepkg env, so a symlink left in the config directory by another install
     # path has to go -- hx searches there first. Gate on the hx that will
     # actually run being the env's, not merely on some hx existing: homepkg
     # links the env's binaries into ~/.local/bin but deliberately leaves a
     # conflicting regular file alone, so on a box that installed the release hx
     # first, that release binary is still what runs -- and clearing the runtime
-    # symlink would take its grammars away. Gating on the link rather than on
-    # the minimal profile also covers a full bundle, which can install helix
-    # even under --minimal.
+    # symlink would take its grammars away. A bundle-unpacked hx is a regular
+    # file that carries its own runtime under the prefix's share/, so it doesn't
+    # match this gate and needs no clearing.
     if test -L "$HOME/.local/bin/hx" \
             && test "$(readlink "$HOME/.local/bin/hx")" = "$env_dir/bin/hx"; then
         clear_managed_helix_runtime

--- a/setup_test
+++ b/setup_test
@@ -1860,32 +1860,40 @@ test_home_tools_keeps_the_runtime_when_no_hx_landed() {
     assert_eq "$helix_link_target" "$ht_payload"
 }
 
-# On a fresh env, install_home_tools prefers a prebuilt bundle (which installs
-# offline). A bundle installs its full contents, so afterward it reconciles the
-# requested set online with "install $tools" -- adding any requested tool the
-# bundle lacked (a bare "update" wouldn't) and freshening -- rather than only
-# updating what's already present. An existing env or a missing bundle takes the
-# online install. Discovery: $HOMEPKG_BUNDLE, or homepkg-bundle.tgz beside the
-# scripts repo / in $HOME.
+# install_home_tools prefers a staged bundle: if one is present it unpacks it
+# (offline, flat into the prefix) and stops; otherwise it installs the set
+# online into a managed conda env. No online reconcile after the bundle --
+# unpack (flat) and the online install (env) are different mechanisms and
+# mustn't be layered on one run. Discovery: $HOMEPKG_BUNDLE, or
+# homepkg-bundle.tgz beside the scripts repo / in $HOME.
 test_home_tools_uses_bundle_optimistically() {
     assert_source_contains '"$homepkg" install-bundle "$bundle"' &&
     assert_source_contains 'HOMEPKG_BUNDLE' &&
     assert_source_contains 'homepkg-bundle.tgz' &&
-    assert_source_contains 'conda-meta' &&
-    assert_source_contains "a bundle installs its full contents" &&
-    assert_source_contains "couldn't reconcile the requested tools online"
+    assert_source_contains "a bundle unpacks its full contents additively" &&
+    # A staged bundle wins outright -- no env gate, no conda-meta probe.
+    assert_source_contains 'if test -n "$bundle"; then' &&
+    assert_source_not_contains 'conda-meta' &&
+    # No online reconcile after the bundle (that would build a shadowing env).
+    assert_source_not_contains "couldn't reconcile the requested tools online"
 }
 
-# install-bundle exits non-zero when the bundle was short of a tool, having
-# installed the rest. If the online top-up then fails too (offline), the env
-# is still there with whatever the bundle carried, so the run counts as
-# provisioned -- otherwise install_home_tools returns before putting
-# ~/.local/bin on PATH and later steps (setup-kde needs tsc) can't find the
-# tools that did land.
+# install-bundle exits 2 for a partial install (some tools landed, one the
+# bundle was built without didn't) and 1 when it installed nothing. On 2 setup
+# trusts the partial -- ~/.local/bin goes on PATH for what landed (unpack builds
+# no env marker to consult). On a total failure (wrong platform, unreadable
+# bundle) it falls through to the online install, so a connected box still gets
+# its tools. The online block is gated on provisioned, not on there being no
+# bundle, so that fall-through reaches it.
 test_home_tools_provisioned_by_a_partial_bundle() {
-    assert_source_contains 'elif test -d "\$env_dir/conda-meta"; then' &&
-    assert_source_contains "keeping what the bundle installed" &&
-    assert_source_contains "the bundle installed nothing and the online top-up failed"
+    assert_source_contains 'rc=$?' &&
+    assert_source_contains 'if test "$rc" -eq 2; then' &&
+    assert_source_contains "the bundle didn't provide everything (offline?); using what it did unpack" &&
+    assert_source_contains "falling back to the online install" &&
+    assert_source_contains 'if test "$provisioned" = no; then' &&
+    # provisioned=yes on bundle-success, partial (rc 2), and online-success --
+    # the three PATH-carrying outcomes.
+    test "$(grep -c '^ *provisioned=yes$' "$SETUP")" -ge 3
 }
 
 # A failed pull on an EXISTING checkout (e.g. offline) must warn and continue,


### PR DESCRIPTION
## What

`homepkg install-bundle` now **unpacks** a bundle's conda closure straight into the prefix (`bin`/`lib`/`share`), additively — instead of replaying it into a shared conda env — and `setup` consumes it under the new contract.

## Why

Replaying the pre-solved closure into one shared env was the wrong shape for an offline/air-gapped target: it required a **fresh env** (so a re-run or a second bundle forced an `rm -rf` of a good env) and couldn't **add** to what an earlier bundle installed. (Started from a bundle carrying the new `yazi`/`lf` tools failing to land.)

## homepkg

- Each conda package is unpacked with the **bundled micromamba's own extractor** (`micromamba package extract`) into a temp dir inside the prefix, its payload moved into place — so the target needs no `zstd`, a failed extract lands nothing, and per-package `info/` never collides.
- **Verified before extract**: each package is checked against the hash `explicit.txt` records (the check the old `micromamba create --file` path did for free), before any extract — so a corrupt or substituted closure member fails before the prefix is touched.
- **Additive**: a re-run or a second bundle just adds to the prefix; earlier tools stay (a shared file is overwritten, last-writer-wins). No fresh-prefix requirement, no `rm -rf`.
- **Stays inside `--prefix`, refuses type mismatches**: the whole package is validated before any move — every destination directory must resolve within the prefix (so a pre-existing directory symlink `<prefix>/lib -> /elsewhere` can't redirect a write outside it), and a type mismatch is refused rather than resolved by deletion (a directory blocked by an existing non-directory, or a leaf landing on an existing real directory whose `_rm_any` would rmtree unrelated files). Only same-type collisions are replaced: a colliding leaf (file or symlink) is unlinked before its replacement lands — so an escaping leaf symlink is replaced, not followed — and a payload directory symlink is moved whole rather than dropped. A refusal never leaves a half-applied package.
- Conda's `$ORIGIN/../lib` rpaths make the binaries run from the prefix — the flat layout `--backend conda` already uses. No conda link step / prefix rewriting: self-contained compiled tools (the registry's) work; a package that hardcodes its build prefix in a script would not — same limit as `--backend conda`.
- **Exit codes**: `install-bundle` exits `0` when every tool landed, `2` on a partial install (some landed, some didn't), and `1` when it installed nothing — so a caller can tell a partial install from a total failure.

## setup

`install_home_tools` prefers a staged bundle outright:
- if a bundle is present it **unpacks it and stops** — no `conda-meta` gate, no online reconcile afterward (unpack lays flat files; the online install builds an env symlinked onto `PATH` — separate mechanisms that mustn't be layered on one run);
- a **partial** bundle (exit 2) still counts as provisioned, so `~/.local/bin` reaches `PATH` for the tools that landed;
- a bundle that **installed nothing** (exit 1: wrong platform, unreadable) falls through to the online install, so a connected box still gets its tools;
- with no bundle staged, it installs the tool set online into the managed env.

The managed env stays the well-lit path for the **online** `homepkg install` / `update` / `remove`; only the offline bundle replay changes.

Verified end-to-end: a `jq`+`lf` bundle installs and both run; a second bundle (`ripgrep`) installs into the same prefix with no `rm -rf` and leaves `jq`/`lf` in place.

## Tests

`homepkg_test`: `_move_tree` (additive last-writer-wins, payload directory symlink preserved, colliding escaping leaf symlink replaced); `_assert_tree_within` (refuses an escaping destination directory, a directory blocked by a file, and a leaf colliding with a real directory; allows a colliding leaf symlink); `_unpack_conda_pkg` (whole-package validation moves nothing when a later tree escapes; warns but still installs when staging-dir cleanup fails); `_pkg_hashes` / hash verification (rejects a package whose bytes fail the recorded hash before unpacking anything); `_install_bundle_conda` (unpacks onto PATH, leaves an earlier bundle's tools, re-runs cleanly, reports a tool whose binary didn't land, skips an unknown tool); and the `install-bundle` exit codes (0/2/1). `setup_test`: the bundle path has no `conda-meta` gate and no reconcile; a partial bundle (exit 2) still provisions; a total failure (exit 1) falls through to the online install. `make test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WyXXzjwfoTtF1fucYuuQBn