### PR TITLE
setup: install yazi and lf from conda-forge, not apt/dnf

### DIFF
--- a/setup
+++ b/setup
@@ -842,16 +842,10 @@ install_packages() {
             info "Installing zoxide"
             sudo_or_warn apt-get install -y --install-recommends zoxide \
                 || warn "could not install zoxide; z/zi directory jumps will be unavailable"
-            # yazi and lf are terminal file managers -- CLI tools, useful on
-            # headless boxes too, so install them regardless of --no-gui. One
-            # transaction each: apt rejects the whole request on one unknown
-            # name, and neither is in every release's repos (lf isn't packaged
-            # for Debian/Ubuntu; yazi is missing from older ones).
-            for fm in yazi lf; do
-                info "Installing $fm"
-                sudo_or_warn apt-get install -y --install-recommends "$fm" \
-                    || warn "$fm unavailable via apt; it also comes from conda-forge (homepkg install $fm) or its release page"
-            done
+            # yazi and lf (terminal file managers) aren't in the Debian/Ubuntu
+            # repos, so they're not attempted here -- install_file_managers
+            # installs them from conda-forge via homepkg after the clone, on
+            # every profile.
             # Node.js + tsc from the distro on the privileged path (setup-kde's
             # source-build fallback for Krohnkite needs tsc; its normal path
             # fetches a prebuilt release and needs neither). Under --no-root
@@ -924,15 +918,10 @@ install_packages() {
             info "Installing zoxide"
             sudo_or_warn dnf install -y zoxide \
                 || warn "could not install zoxide; z/zi directory jumps will be unavailable"
-            # yazi and lf are terminal file managers -- CLI tools, useful on
-            # headless boxes too, so install them regardless of --no-gui. One
-            # transaction each, matching the Debian branch: dnf aborts the whole
-            # request on one unknown name, and yazi may need a COPR.
-            for fm in yazi lf; do
-                info "Installing $fm"
-                sudo_or_warn dnf install -y "$fm" \
-                    || warn "$fm unavailable via dnf; it also comes from conda-forge (homepkg install $fm) or its release page"
-            done
+            # yazi and lf (terminal file managers) aren't in the base Fedora
+            # repos -- yazi needs a COPR -- so they're not attempted here;
+            # install_file_managers installs them from conda-forge via homepkg
+            # after the clone, on every profile.
             # Node.js + tsc from the distro on the privileged path (setup-kde's
             # source-build fallback for Krohnkite needs tsc; its normal path
             # fetches a prebuilt release and needs neither). Under --no-root
@@ -1483,6 +1472,44 @@ install_home_tools() {
     fi
 }
 
+# --- Install the terminal file managers with no reliable distro package ---
+
+# yazi and lf aren't in the Debian/Ubuntu repos, and yazi needs a COPR on
+# Fedora -- but both are on conda-forge, so install them from there via homepkg
+# rather than attempting apt/dnf and warning about a miss we already expect.
+# Runs after the clone (homepkg lives in the scripts repo) on every profile, but
+# installs only what's missing: the --no-root path already got them from
+# install_home_tools and macOS from Homebrew, so this is a no-op there and does
+# the real work only on a privileged Linux box. homepkg installs into
+# ~/.local/bin, not necessarily on setup's own PATH, so check there too.
+missing_file_managers() {
+    missing=""
+    for tool in yazi lf; do
+        if ! command -v "$tool" >/dev/null 2>&1 \
+                && ! test -x "$HOME/.local/bin/$tool"; then
+            missing="$missing $tool"
+        fi
+    done
+    printf '%s' "$missing"
+}
+
+install_file_managers() {
+    homepkg="$SCRIPTS_DIR/homepkg"
+    if ! test -x "$homepkg"; then
+        warn "homepkg not found in the scripts repo; skipping yazi and lf"
+        return 0
+    fi
+    file_managers="$(missing_file_managers)"
+    if test -z "$file_managers"; then
+        info "yazi and lf already installed"
+        return 0
+    fi
+    info "Installing$file_managers from conda-forge via homepkg (~/.local, no root)"
+    # shellcheck disable=SC2086  # deliberate word split: one arg per tool
+    "$homepkg" install $file_managers \
+        || warn "could not install$file_managers via homepkg; install manually if you want them"
+}
+
 # --- Install the interactive shell tools with no packaged build ---
 
 # The conf repo's shell config wires up four optional tools. fzf and zoxide
@@ -1914,11 +1941,14 @@ else
     info "Skipping heavyweight extras (helix, jj, nushell); minimal profile"
 fi
 
-# atuin/carapace are small static binaries with no packaged build, so they're
-# installed on every profile (including --minimal) once the scripts repo --
-# and with it homepkg -- is on disk.
+# atuin/carapace are small static binaries with no packaged build, and yazi/lf
+# have no reliable distro package -- both come from homepkg once the scripts
+# repo (and with it homepkg) is on disk, on every profile (including --minimal).
+# install_file_managers is a no-op where they're already installed (--no-root
+# via install_home_tools, macOS via Homebrew).
 if test "$INSTALL" = yes; then
     install_shell_tools
+    install_file_managers
 fi
 
 start_services

--- a/setup_test
+++ b/setup_test
@@ -280,6 +280,41 @@ echo BOOTSTRAP_CONTINUED" 2>&1)"
     rm -rf "$linux_tmpdir"
 }
 
+# Run install_file_managers against a sandboxed HOME with a recording homepkg
+# stub in SCRIPTS_DIR. $1 = which file managers already exist in ~/.local/bin
+# before the call: none (default) | both. Leaves $output/$status/$calls set.
+run_install_file_managers() {
+    fm_present="${1:-none}"
+    fm_tmpdir="$(mktemp -d)"
+    fm_home="$fm_tmpdir/home"
+    fm_calls="$fm_tmpdir/calls"
+    fm_scripts="$fm_home/scripts"
+    mkdir -p "$fm_home/.local/bin" "$fm_scripts"
+    cat > "$fm_scripts/homepkg" <<MOCK
+#!/bin/sh
+printf '%s\n' "homepkg \$*" >> "$fm_calls"
+MOCK
+    chmod +x "$fm_scripts/homepkg"
+    if test "$fm_present" = both; then
+        for _t in yazi lf; do
+            printf '#!/bin/sh\n' > "$fm_home/.local/bin/$_t"
+            chmod +x "$fm_home/.local/bin/$_t"
+        done
+    fi
+
+    set +e
+    output="$(sh -c "set -e
+HOME='$fm_home'
+SCRIPTS_DIR='$fm_scripts'
+$(extract_functions "info warn missing_file_managers install_file_managers")
+install_file_managers
+echo BOOTSTRAP_CONTINUED" 2>&1)"
+    status=$?
+    set -e
+    calls="$(cat "$fm_calls" 2>/dev/null)"
+    rm -rf "$fm_tmpdir"
+}
+
 # Run the two "homepkg is missing" warning paths with SCRIPTS_DIR pointed at a
 # home-shaped path that doesn't exist. Both functions bail right after warning,
 # so this exercises exactly the messages under test -- and the path is what the
@@ -1162,43 +1197,58 @@ test_zoxide_is_a_core_package() {
     assert_source_contains 'tools="ripgrep fd bat fzf jq delta gh fnm zoxide yazi lf"'
 }
 
-# yazi and lf are terminal file managers: CLI tools that are useful headless,
-# not desktop apps, so they install on every path regardless of --no-gui and
-# ride the homepkg core set (and thus the offline mamba bundle) rather than
-# sitting in the GUI-only block. yazi used to live in the GUI block with a
-# cargo-install hint; that hint is gone now that conda-forge (homepkg) provides
-# both. These run the real dispatch and assert the commands issued, rather than
-# grepping the source: a grep can't prove the install stays outside the GUI
-# guard or that homepkg is actually invoked (not just named in a warning).
+# yazi and lf are terminal file managers with no reliable distro package (yazi
+# isn't in Debian/Ubuntu; it needs a COPR on Fedora), so they come from
+# conda-forge via homepkg -- not from apt/dnf, where attempting them would only
+# warn about a miss we already expect. These run the real dispatch and assert
+# the commands issued, rather than grepping the source.
 
-# Debian: yazi and lf install even with the GUI off, so they reach a headless
-# box -- and the GUI-only packages (kitty, kde-standard) do not, confirming the
-# GUI really is off and the file managers sit outside that block.
-test_file_managers_install_headless_debian() {
+# The distro transactions must NOT name yazi/lf: a release that lacks them can't
+# abort the core install, and there's no "unavailable" warning. (kitty/kde-*
+# stay out too, confirming the GUI-off run.)
+test_file_managers_not_in_apt_transaction() {
     run_linux_packages debian
     assert_status 0 &&
     assert_output_contains "BOOTSTRAP_CONTINUED" &&
-    assert_calls_contain "apt-get install -y --install-recommends yazi" &&
-    assert_calls_contain "apt-get install -y --install-recommends lf" &&
+    assert_calls_lack "yazi" &&
+    assert_calls_lack "recommends lf" &&
     assert_calls_lack "kde-standard" &&
     assert_calls_lack "install -y --install-recommends kitty"
 }
 
-# Fedora: the same, via dnf.
-test_file_managers_install_headless_redhat() {
+test_file_managers_not_in_dnf_transaction() {
     run_linux_packages redhat
     assert_status 0 &&
     assert_output_contains "BOOTSTRAP_CONTINUED" &&
-    assert_calls_contain "dnf install -y yazi" &&
-    assert_calls_contain "dnf install -y lf" &&
+    assert_calls_lack "yazi" &&
+    assert_calls_lack "dnf install -y lf" &&
     assert_calls_lack "kde-desktop-environment" &&
     assert_calls_lack "dnf install -y kitty"
 }
 
-# The rootless path actually invokes homepkg with yazi and lf in the tools it
+# install_file_managers installs the missing ones from conda-forge via homepkg,
+# post-clone and on every profile (so a privileged Linux box, where apt/dnf
+# skipped them and install_home_tools didn't run, still gets them).
+test_file_managers_install_via_homepkg() {
+    run_install_file_managers none
+    assert_status 0 &&
+    assert_output_contains "BOOTSTRAP_CONTINUED" &&
+    assert_calls_contain "homepkg install yazi lf"
+}
+
+# ...and it's a no-op where they're already present (macOS via Homebrew, or the
+# --no-root path via install_home_tools) -- no second copy in ~/.local/bin.
+test_file_managers_skipped_when_present() {
+    run_install_file_managers both
+    assert_status 0 &&
+    assert_output_contains "already installed" &&
+    test -z "$calls"
+}
+
+# The rootless path still invokes homepkg with yazi and lf in the tools it
 # installs -- so --no-root and the offline mamba bundle (which carries the whole
-# registry, homepkg install reconciling it) get them too. The old cargo hint is
-# gone now that conda-forge provides both.
+# registry) get them without needing install_file_managers. The old cargo hint
+# is gone now that conda-forge provides both.
 test_file_managers_are_in_the_homepkg_core_set() {
     run_home_tools_helix absent
     assert_status 0 &&
@@ -2192,10 +2242,14 @@ run_test "legacy root config fallback is logged with the remedy" \
     test_legacy_root_config_is_logged
 run_test "zoxide is installed as a core package" \
     test_zoxide_is_a_core_package
-run_test "yazi and lf install headlessly on Debian, not just under GUI" \
-    test_file_managers_install_headless_debian
-run_test "yazi and lf install headlessly on Fedora, not just under GUI" \
-    test_file_managers_install_headless_redhat
+run_test "yazi and lf are not attempted via apt" \
+    test_file_managers_not_in_apt_transaction
+run_test "yazi and lf are not attempted via dnf" \
+    test_file_managers_not_in_dnf_transaction
+run_test "yazi and lf install from conda-forge via homepkg" \
+    test_file_managers_install_via_homepkg
+run_test "yazi and lf install is skipped when already present" \
+    test_file_managers_skipped_when_present
 run_test "yazi and lf are in the homepkg core set" \
     test_file_managers_are_in_the_homepkg_core_set
 run_test "kitty is set as the KDE terminal on Debian" \


### PR DESCRIPTION
## What

`yazi` and `lf` are no longer attempted via apt/dnf. They aren't in the Debian/Ubuntu repos (and `yazi` needs a COPR on Fedora), so the old code only **warned** about a miss we already expect — and never actually installed them on the privileged path. Now they come from **conda-forge via `homepkg`**, from the place that actually works.

## How

- Removed `yazi`/`lf` from the apt and dnf install steps.
- New `install_file_managers` (mirrors `install_shell_tools`): installs the **missing** ones via `homepkg install`, after the scripts repo — and with it `homepkg` — is on disk, on every profile. It's a no-op where they're already provided:
  - `--no-root` Linux → `install_home_tools` already installs them,
  - macOS → Homebrew,
  - so it does the real work only on a **privileged Linux** box.
- Runs post-clone deliberately: `install_packages` runs before the scripts repo is cloned, so `homepkg` doesn't exist yet at that point.

## Why this shape

An earlier draft tried apt → fall back to homepkg, but that (a) still printed the apt failure for a miss we already expect, (b) couldn't work on a fresh `curl | sh` run (homepkg not cloned yet at `install_packages` time), and (c) risked aborting under `set -e` when both failed. Installing directly from conda-forge post-clone avoids all three.

**Cost/reliability**: no new dependency — this is the existing `homepkg` mechanism (already used for the `--no-root` set and for atuin/carapace). First use bootstraps micromamba from conda-forge (one-time download, free); offline it warns, non-fatally.

## Tests

`setup_test`: the apt and dnf transactions no longer name `yazi`/`lf`; `install_file_managers` installs the missing ones via `homepkg` and is a no-op when both are already present (no second copy in `~/.local/bin`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WyXXzjwfoTtF1fucYuuQBn