### PR TITLE
setup: install joshuto instead of yazi as the file manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ repo).
 `setup --no-root` wires this in automatically: it runs unprivileged (implying
 `--no-sudo`, so the `apt`/`dnf` installs and every other privileged step are
 skipped) and installs the CLI tools via `homepkg` instead — the core set
-(`ripgrep fd bat fzf jq delta gh zoxide yazi lf`) plus the extras (`helix jj nu`, unless
+(`ripgrep fd bat fzf jq delta gh zoxide joshuto lf`) plus the extras (`helix jj nu`, unless
 the minimal profile is in effect). `--no-sudo` on its own is just the mechanism
 (skip sudo); it assumes the tools are provided some other way.
 

--- a/TODO.md
+++ b/TODO.md
@@ -21,3 +21,15 @@
       gates, and auto-merge. A ruleset on the default branch requiring
       the gates, the `codex` status, conversation resolution and
       up-to-date branches, with the auto-merge setting enabled.
+
+## setup / homepkg
+
+- [ ] **Purge setup-managed tools that are retired from the registry.**
+      Dropping a tool from homepkg's `TOOLS` (e.g. `yazi`, replaced by
+      `joshuto` in #235) only stops *installing* it: `install_mamba` /
+      `_link_bins` never remove an already-installed package, so it
+      lingers orphaned in the managed env, and `homepkg remove <tool>`
+      rejects it as unknown once the registry entry is gone. Add a way to
+      remove setup-managed tools (distinguishing them from independently
+      installed copies) so an upgrade that retires one can clean it up.
+      Deferred from #235, where the orphan was accepted.

--- a/homepkg
+++ b/homepkg
@@ -103,9 +103,8 @@ TOOLS = {
     "carapace": {"conda": None,       "github": "carapace-sh/carapace-bin", "bins": ["carapace"]},
     # Terminal file managers. Both have a conda-forge feedstock -- so they ride
     # the default mamba path and the offline bundle -- and a GitHub release for
-    # --backend github. yazi ships two binaries: the file manager (yazi) and its
-    # CLI helper (ya); lf is a single binary.
-    "yazi":     {"conda": "yazi",     "github": "sxyazi/yazi",        "bins": ["yazi", "ya"]},
+    # --backend github. Each ships a single binary.
+    "joshuto":  {"conda": "joshuto",  "github": "kamiyaa/joshuto",    "bins": ["joshuto"]},
     "lf":       {"conda": "lf",       "github": "gokcehan/lf",        "bins": ["lf"]},
     # Node toolchain for the setup --no-root path: node/npm/tsc from conda-forge
     # instead of a distro package, plus fnm (which on root boxes comes from its

--- a/homepkg_test
+++ b/homepkg_test
@@ -1147,12 +1147,11 @@ check("registry maps carapace to carapace-bin releases",
 
 # Terminal file managers. Both have a conda-forge feedstock, so they take the
 # default mamba path and ride the offline bundle; both also have a GitHub
-# release for --backend github. yazi ships two binaries (the file manager and
-# its `ya` CLI helper); lf is a single binary.
-check("registry maps yazi to conda-forge with yazi/ya bins",
-      hp.TOOLS["yazi"]["conda"] == "yazi"
-      and hp.TOOLS["yazi"]["github"] == "sxyazi/yazi"
-      and hp.TOOLS["yazi"]["bins"] == ["yazi", "ya"])
+# release for --backend github. Each ships a single binary.
+check("registry maps joshuto to conda-forge with a joshuto bin",
+      hp.TOOLS["joshuto"]["conda"] == "joshuto"
+      and hp.TOOLS["joshuto"]["github"] == "kamiyaa/joshuto"
+      and hp.TOOLS["joshuto"]["bins"] == ["joshuto"])
 check("registry maps lf to conda-forge with an lf bin",
       hp.TOOLS["lf"]["conda"] == "lf"
       and hp.TOOLS["lf"]["github"] == "gokcehan/lf"

--- a/setup
+++ b/setup
@@ -842,7 +842,7 @@ install_packages() {
             info "Installing zoxide"
             sudo_or_warn apt-get install -y --install-recommends zoxide \
                 || warn "could not install zoxide; z/zi directory jumps will be unavailable"
-            # yazi and lf (terminal file managers) aren't in the Debian/Ubuntu
+            # joshuto and lf (terminal file managers) aren't in the Debian/Ubuntu
             # repos, so they're not attempted here -- install_file_managers
             # installs them from conda-forge via homepkg after the clone, on
             # every profile.
@@ -918,10 +918,10 @@ install_packages() {
             info "Installing zoxide"
             sudo_or_warn dnf install -y zoxide \
                 || warn "could not install zoxide; z/zi directory jumps will be unavailable"
-            # yazi and lf (terminal file managers) aren't in the base Fedora
-            # repos -- yazi needs a COPR -- so they're not attempted here;
-            # install_file_managers installs them from conda-forge via homepkg
-            # after the clone, on every profile.
+            # joshuto and lf (terminal file managers) aren't in the base Fedora
+            # repos, so they're not attempted here; install_file_managers
+            # installs them from conda-forge via homepkg after the clone, on
+            # every profile.
             # Node.js + tsc from the distro on the privileged path (setup-kde's
             # source-build fallback for Krohnkite needs tsc; its normal path
             # fetches a prebuilt release and needs neither). Under --no-root
@@ -996,10 +996,10 @@ install_packages() {
             info "Installing zoxide"
             brew install zoxide \
                 || warn "could not install zoxide; z/zi directory jumps will be unavailable"
-            # yazi and lf are terminal file managers -- CLI tools, not graphical,
+            # joshuto and lf are terminal file managers -- CLI tools, not graphical,
             # so install them regardless of --no-gui (matching the Linux paths).
             # One brew install each so a formula rename can't take the other down.
-            for fm in yazi lf; do
+            for fm in joshuto lf; do
                 info "Installing $fm"
                 brew install "$fm" || warn "could not install $fm"
             done
@@ -1040,7 +1040,7 @@ install_packages() {
             ;;
         *)
             warn "Unsupported OS, skipping package installation"
-            warn "Please install manually: bat curl fd fzf git git-delta golang jq kitty lf make mercurial npm p7zip python3 ripgrep shellcheck typescript unzip yazi zoxide zsh"
+            warn "Please install manually: bat curl fd fzf git git-delta golang jq joshuto kitty lf make mercurial npm p7zip python3 ripgrep shellcheck typescript unzip zoxide zsh"
             ;;
     esac
 }
@@ -1372,7 +1372,7 @@ install_home_tools() {
     # fnm (Node version manager) is a convenience tool -- installed regardless
     # of --no-npm, mirroring the root path's install_fnm (which is skipped under
     # --no-root, so fnm comes from here instead).
-    tools="ripgrep fd bat fzf jq delta gh fnm zoxide yazi lf"
+    tools="ripgrep fd bat fzf jq delta gh fnm zoxide joshuto lf"
     if test "$NPM" = yes; then
         # node/npm + tsc are the actual build toolchain for setup-kde's
         # Krohnkite source-build fallback (its normal path fetches a
@@ -1474,9 +1474,9 @@ install_home_tools() {
 
 # --- Install the terminal file managers with no reliable distro package ---
 
-# yazi and lf aren't in the Debian/Ubuntu repos, and yazi needs a COPR on
-# Fedora -- but both are on conda-forge, so install them from there via homepkg
-# rather than attempting apt/dnf and warning about a miss we already expect.
+# joshuto and lf aren't in the Debian/Ubuntu or base Fedora repos -- but both
+# are on conda-forge, so install them from there via homepkg rather than
+# attempting apt/dnf and warning about a miss we already expect.
 # Runs after the clone (homepkg lives in the scripts repo) on every profile, but
 # installs only what's missing: the --no-root path already got them from
 # install_home_tools and macOS from Homebrew, so this is a no-op there and does
@@ -1484,7 +1484,7 @@ install_home_tools() {
 # ~/.local/bin, not necessarily on setup's own PATH, so check there too.
 missing_file_managers() {
     missing=""
-    for tool in yazi lf; do
+    for tool in joshuto lf; do
         if ! command -v "$tool" >/dev/null 2>&1 \
                 && ! test -x "$HOME/.local/bin/$tool"; then
             missing="$missing $tool"
@@ -1496,12 +1496,12 @@ missing_file_managers() {
 install_file_managers() {
     homepkg="$SCRIPTS_DIR/homepkg"
     if ! test -x "$homepkg"; then
-        warn "homepkg not found in the scripts repo; skipping yazi and lf"
+        warn "homepkg not found in the scripts repo; skipping joshuto and lf"
         return 0
     fi
     file_managers="$(missing_file_managers)"
     if test -z "$file_managers"; then
-        info "yazi and lf already installed"
+        info "joshuto and lf already installed"
         return 0
     fi
     info "Installing$file_managers from conda-forge via homepkg (~/.local, no root)"
@@ -1941,7 +1941,7 @@ else
     info "Skipping heavyweight extras (helix, jj, nushell); minimal profile"
 fi
 
-# atuin/carapace are small static binaries with no packaged build, and yazi/lf
+# atuin/carapace are small static binaries with no packaged build, and joshuto/lf
 # have no reliable distro package -- both come from homepkg once the scripts
 # repo (and with it homepkg) is on disk, on every profile (including --minimal).
 # install_file_managers is a no-op where they're already installed (--no-root

--- a/setup_test
+++ b/setup_test
@@ -244,9 +244,9 @@ echo BOOTSTRAP_CONTINUED" 2>&1)"
 # Run install_packages' Linux arm ($1: debian|redhat) against a mock package
 # manager that records every invocation and succeeds, with the GUI off. This
 # exercises the real dispatch -- which install commands are actually issued --
-# rather than grepping the source, so it can prove yazi/lf are installed even
-# under --no-gui (they sit outside the GUI block) and that the GUI-only packages
-# are not. NPM=no keeps the node/tsc steps out of the recorded calls.
+# rather than grepping the source, so it can prove the file managers are NOT
+# attempted via apt/dnf and that the GUI-only packages are not installed under
+# --no-gui. NPM=no keeps the node/tsc steps out of the recorded calls.
 #   Leaves $calls set to the package-manager invocations.
 run_linux_packages() {
     linux_os="$1"
@@ -296,7 +296,7 @@ printf '%s\n' "homepkg \$*" >> "$fm_calls"
 MOCK
     chmod +x "$fm_scripts/homepkg"
     if test "$fm_present" = both; then
-        for _t in yazi lf; do
+        for _t in joshuto lf; do
             printf '#!/bin/sh\n' > "$fm_home/.local/bin/$_t"
             chmod +x "$fm_home/.local/bin/$_t"
         done
@@ -817,7 +817,7 @@ test_sudo_calls_are_guarded() {
 # manual-install hint for unsupported OSes.
 test_unzip_installed() {
     assert_source_contains "unzip" &&
-    assert_source_contains "typescript unzip yazi zoxide zsh"
+    assert_source_contains "typescript unzip zoxide zsh"
 }
 
 # --- fnm ---
@@ -1193,24 +1193,24 @@ test_zoxide_is_a_core_package() {
     test "$(grep -c '^ *info "Installing zoxide"$' "$SETUP")" -eq 3 &&
     test "$(grep -c '^ *zoxide \\$' "$SETUP")" -eq 0 &&
     assert_source_contains "could not install zoxide" &&
-    assert_source_contains "yazi zoxide zsh" &&
-    assert_source_contains 'tools="ripgrep fd bat fzf jq delta gh fnm zoxide yazi lf"'
+    assert_source_contains "unzip zoxide zsh" &&
+    assert_source_contains 'tools="ripgrep fd bat fzf jq delta gh fnm zoxide joshuto lf"'
 }
 
-# yazi and lf are terminal file managers with no reliable distro package (yazi
-# isn't in Debian/Ubuntu; it needs a COPR on Fedora), so they come from
+# joshuto and lf are terminal file managers with no reliable distro package
+# (neither is in Debian/Ubuntu or the base Fedora repos), so they come from
 # conda-forge via homepkg -- not from apt/dnf, where attempting them would only
 # warn about a miss we already expect. These run the real dispatch and assert
 # the commands issued, rather than grepping the source.
 
-# The distro transactions must NOT name yazi/lf: a release that lacks them can't
-# abort the core install, and there's no "unavailable" warning. (kitty/kde-*
+# The distro transactions must NOT name joshuto/lf: a release that lacks them
+# can't abort the core install, and there's no "unavailable" warning. (kitty/kde-*
 # stay out too, confirming the GUI-off run.)
 test_file_managers_not_in_apt_transaction() {
     run_linux_packages debian
     assert_status 0 &&
     assert_output_contains "BOOTSTRAP_CONTINUED" &&
-    assert_calls_lack "yazi" &&
+    assert_calls_lack "joshuto" &&
     assert_calls_lack "recommends lf" &&
     assert_calls_lack "kde-standard" &&
     assert_calls_lack "install -y --install-recommends kitty"
@@ -1220,7 +1220,7 @@ test_file_managers_not_in_dnf_transaction() {
     run_linux_packages redhat
     assert_status 0 &&
     assert_output_contains "BOOTSTRAP_CONTINUED" &&
-    assert_calls_lack "yazi" &&
+    assert_calls_lack "joshuto" &&
     assert_calls_lack "dnf install -y lf" &&
     assert_calls_lack "kde-desktop-environment" &&
     assert_calls_lack "dnf install -y kitty"
@@ -1233,7 +1233,7 @@ test_file_managers_install_via_homepkg() {
     run_install_file_managers none
     assert_status 0 &&
     assert_output_contains "BOOTSTRAP_CONTINUED" &&
-    assert_calls_contain "homepkg install yazi lf"
+    assert_calls_contain "homepkg install joshuto lf"
 }
 
 # ...and it's a no-op where they're already present (macOS via Homebrew, or the
@@ -1245,16 +1245,14 @@ test_file_managers_skipped_when_present() {
     test -z "$calls"
 }
 
-# The rootless path still invokes homepkg with yazi and lf in the tools it
+# The rootless path still invokes homepkg with joshuto and lf in the tools it
 # installs -- so --no-root and the offline mamba bundle (which carries the whole
-# registry) get them without needing install_file_managers. The old cargo hint
-# is gone now that conda-forge provides both.
+# registry) get them without needing install_file_managers.
 test_file_managers_are_in_the_homepkg_core_set() {
     run_home_tools_helix absent
     assert_status 0 &&
     assert_calls_contain "homepkg install ripgrep" &&
-    assert_calls_contain " zoxide yazi lf" &&
-    assert_source_not_contains "cargo install --locked yazi-fm yazi-cli"
+    assert_calls_contain " zoxide joshuto lf"
 }
 
 # update-alternatives only covers x-terminal-emulator. What makes Plasma's own
@@ -1311,7 +1309,7 @@ test_macos_brew_failures_are_not_fatal() {
     assert_output_contains "BOOTSTRAP_CONTINUED" &&
     assert_output_contains "some core Homebrew packages could not be installed" &&
     assert_output_contains "could not install zoxide" &&
-    assert_output_contains "could not install yazi" &&
+    assert_output_contains "could not install joshuto" &&
     assert_output_contains "could not install lf" &&
     assert_output_contains "could not install node" &&
     assert_output_contains "could not install tsc" &&
@@ -1326,7 +1324,7 @@ test_macos_brew_failure_still_attempts_later_steps() {
     run_macos_packages 0
     assert_status 0 &&
     assert_calls_contain "brew install zoxide" &&
-    assert_calls_contain "brew install yazi" &&
+    assert_calls_contain "brew install joshuto" &&
     assert_calls_contain "brew install lf" &&
     assert_calls_contain "brew install --cask android-platform-tools" &&
     assert_calls_contain "brew install kitty"
@@ -2242,15 +2240,15 @@ run_test "legacy root config fallback is logged with the remedy" \
     test_legacy_root_config_is_logged
 run_test "zoxide is installed as a core package" \
     test_zoxide_is_a_core_package
-run_test "yazi and lf are not attempted via apt" \
+run_test "joshuto and lf are not attempted via apt" \
     test_file_managers_not_in_apt_transaction
-run_test "yazi and lf are not attempted via dnf" \
+run_test "joshuto and lf are not attempted via dnf" \
     test_file_managers_not_in_dnf_transaction
-run_test "yazi and lf install from conda-forge via homepkg" \
+run_test "joshuto and lf install from conda-forge via homepkg" \
     test_file_managers_install_via_homepkg
-run_test "yazi and lf install is skipped when already present" \
+run_test "joshuto and lf install is skipped when already present" \
     test_file_managers_skipped_when_present
-run_test "yazi and lf are in the homepkg core set" \
+run_test "joshuto and lf are in the homepkg core set" \
     test_file_managers_are_in_the_homepkg_core_set
 run_test "kitty is set as the KDE terminal on Debian" \
     test_kde_terminal_set_on_debian


### PR DESCRIPTION
## What

Drops `yazi` in favor of **joshuto** (a ranger-like terminal file manager) across the whole install path and the homepkg registry. `lf` is unchanged.

## Why

Per maintainer request. joshuto is a lighter, single-binary file manager with built-in multi-select (`space`), invert/select-all (`t`), visual-range selection (`V`), and — unlike lf — background file operations with a progress bar in the status line, so it doesn't hang the UI on slow copies.

## How

- **homepkg registry** (`TOOLS`): `yazi` → `joshuto` (`conda: joshuto`, `github: kamiyaa/joshuto`, one bin). joshuto has a conda-forge feedstock, so it rides the default mamba path and the offline bundle exactly as yazi did; its GitHub release assets use the Rust target-triple naming the `--backend github` token scheme already matches. It ships a single binary (`joshuto`), not yazi's pair (`yazi` + `ya`).
- **`setup`**: swapped in `install_home_tools`' core set, the apt/dnf skip comments, the macOS `brew` loop, `install_file_managers` (the post-clone conda-forge install), and the unsupported-OS manual-install hint.
- **`README.md`**: the documented core-set list.

## Tests

`setup_test` and `homepkg_test` updated to assert joshuto in place of yazi (registry mapping, the apt/dnf transactions still don't name it, the post-clone homepkg install, the homepkg core set, and the macOS brew path). `make test` green — `setup_test` 108/108, `homepkg_test` 245/245.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WyXXzjwfoTtF1fucYuuQBn

---
_Generated by [Claude Code](https://claude.ai/code/session_01WyXXzjwfoTtF1fucYuuQBn)_