### PR TITLE
Add --purge-obsolete to remove old Sway/Hyprland desktop packages

### DIFF
--- a/setup
+++ b/setup
@@ -3,8 +3,8 @@
 #
 # Usage:
 #     setup [--gui | --no-gui] [--kde] [--minimal | --full] \
-#           [--no-install] [--ignore-errors] [--ssh | --no-ssh] [--no-npm] \
-#           [--github PREFIX] [-h | --help]
+#           [--no-install] [--purge-obsolete] [--ignore-errors] \
+#           [--ssh | --no-ssh] [--no-npm] [--github PREFIX] [-h | --help]
 #
 #  or, to bootstrap from scratch:
 #     curl -fsSL https://mikelward.com/setup | sh
@@ -134,6 +134,14 @@ MIN_DISK_GB="${MIN_DISK_GB:-15}"
 #   no  - skip every install step and only (re)apply configuration (--no-install)
 INSTALL=yes
 
+# Whether to purge the obsolete Sway/Hyprland desktop packages an earlier setup
+# installed (setup now builds only KDE Plasma + Krohnkite). One of:
+#   no  - leave them in place (the default)
+#   yes - purge the Sway/Hyprland-specific packages (--purge-obsolete)
+# Off by default because setup is also fetched via "curl | sh" onto machines
+# that may run Sway or Hyprland deliberately, where purging them would be hostile.
+PURGE_OBSOLETE=no
+
 # Whether to keep going after a command fails. One of:
 #   no  - abort on the first error, via set -e (the default)
 #   yes - keep going past failures (--ignore-errors)
@@ -199,8 +207,8 @@ EXTRAS=auto
 usage() {
     cat <<'USAGE'
 Usage: setup [--gui | --no-gui] [--kde] [--minimal | --full]
-             [--no-install] [--no-sudo] [--no-root] [--ignore-errors]
-             [--no-live-shortcuts]
+             [--no-install] [--purge-obsolete] [--no-sudo] [--no-root]
+             [--ignore-errors] [--no-live-shortcuts]
              [--ssh | --no-ssh] [--no-npm] [--github PREFIX] [-h | --help]
 
 Bootstrap a new machine: install packages, fonts, tools, and dotfiles.
@@ -219,6 +227,13 @@ Options:
                    artifacts into ~/.local via homepkg
   --no-install     Skip every install step (packages, fonts, uv, extras, root
                    config) and only (re)apply config. Forwarded to setup-kde/macos
+  --purge-obsolete Purge the Sway/Hyprland desktop packages an earlier setup
+                   installed (setup now builds only KDE Plasma + Krohnkite):
+                   the compositors, their lock/idle/bg helpers, the wlroots
+                   portals, and the shared bar/launcher/notification stack
+                   (waybar, fuzzel, swaync). Off by default; only removes
+                   packages that are installed, so it's safe to re-run. Leaves
+                   the generic Wayland utilities -- run autoremove for orphans
   --no-sudo        Run no sudo at all: every privileged command (package
                    installs included) is skipped up front instead of attempted,
                    so setup never prompts or stalls. For boxes with no sudo. A
@@ -451,6 +466,12 @@ while test $# -gt 0; do
             ;;
         --no-install)
             INSTALL=no
+            ;;
+        --purge-obsolete)
+            PURGE_OBSOLETE=yes
+            ;;
+        --no-purge-obsolete)
+            PURGE_OBSOLETE=no
             ;;
         --sudo)
             SUDO=yes
@@ -1041,6 +1062,139 @@ install_packages() {
         *)
             warn "Unsupported OS, skipping package installation"
             warn "Please install manually: bat curl fd fzf git git-delta golang jq joshuto kitty lf make mercurial npm p7zip python3 ripgrep shellcheck typescript unzip zoxide zsh"
+            ;;
+    esac
+}
+
+# --- Purge obsolete desktop packages ---
+
+# Packages an earlier setup installed for the Sway and Hyprland desktops, which
+# setup dropped when it settled on KDE Plasma + Krohnkite as its one desktop
+# (July 2026). apt/dnf never uninstall on their own, so a box that once ran the
+# old setup keeps them -- most visibly a sway-notification-center (swaync)
+# systemd user unit that keeps starting. --purge-obsolete removes them.
+#
+# Only the Sway/Hyprland-specific packages are named: the compositors, their
+# lock/idle/bg helpers, the wlroots portals, and the shared bar/launcher/
+# notification stack (waybar, fuzzel, swaync). The generic Wayland utilities the
+# old setup also pulled in (pipewire, network-manager-gnome, ...) are left
+# alone -- they're useful under KDE too, and autoremove is the tool for their
+# orphaned deps, which is why we point at it rather than running it ourselves.
+# Report whether package $1 is installed, telling the expected "not installed"
+# answer apart from a real package-database query failure (a corrupt or
+# unreadable db). A failure must never masquerade as "not installed": that would
+# drop an installed package from the purge and let it report success while
+# leaving the package -- the swaync unit included -- behind. On such a failure
+# this warns with the query's own error and returns 2; otherwise 0 (installed),
+# 1 (not), or 3 (installed but held on Debian -- the caller reports those and
+# leaves them alone). We filter to installed packages because passing an unknown
+# name to apt-get/dnf aborts the whole transaction.
+obsolete_pkg_installed() {
+    _op_pkg="$1"
+    _op_errf=$(mktemp) || {
+        warn "could not create a temp file to query $_op_pkg; leaving it out of the purge"
+        return 2
+    }
+    _op_ret=2
+    case "$OS" in
+        debian)
+            # dpkg-query exits 0 when it knows the package (status on stdout),
+            # 1 when no package matches (the not-installed answer), and >1 on a
+            # real error. The Status is "want eflag state": the state word (the
+            # last) says whether it's installed at all, whatever the desired
+            # action, and the want word (the first) flags a hold. A held package
+            # is installed but must not go into the -y purge -- apt-get -y aborts
+            # the whole transaction on a held change without
+            # --allow-change-held-packages -- so it gets its own return.
+            _op_status=$(dpkg-query -W -f='${Status}' "$_op_pkg" 2>"$_op_errf")
+            case $? in
+                0) case "${_op_status##* }" in
+                       installed)
+                           case "${_op_status%% *}" in
+                               hold) _op_ret=3 ;;
+                               *) _op_ret=0 ;;
+                           esac ;;
+                       *) _op_ret=1 ;;
+                   esac ;;
+                1) _op_ret=1 ;;
+            esac
+            ;;
+        redhat)
+            # rpm -q exits 0 when installed. A not-installed package exits
+            # non-zero with its message on stdout and nothing on stderr; a real
+            # error writes to stderr -- so stderr, not the exit code, separates
+            # the two, since rpm reuses exit 1 for both.
+            if rpm -q "$_op_pkg" >/dev/null 2>"$_op_errf"; then
+                _op_ret=0
+            elif ! test -s "$_op_errf"; then
+                _op_ret=1
+            fi
+            ;;
+    esac
+    if test "$_op_ret" -eq 2; then
+        warn "querying package $_op_pkg failed ($(cat "$_op_errf")); leaving it out of the purge"
+    fi
+    rm -f "$_op_errf"
+    return "$_op_ret"
+}
+
+purge_obsolete_packages() {
+    # The list is reconciled against the July 2026 removal commit's install
+    # paths, not memory: swaync ships as sway-notification-center on
+    # Debian/Ubuntu and SwayNotificationCenter on Fedora, but those paths fell
+    # back to the upstream "swaync" name, so it goes in the shared list too. The
+    # session manager uwsm and the tiler autotiling were installed on both. The
+    # generic Wayland utilities those paths also pulled in (pipewire, blueman,
+    # grim/slurp, the GTK portal, the polkit agent, ...) are deliberately left
+    # out -- they're useful under KDE too. The rest share names across distros.
+    obsolete="sway swaybg swayidle swaylock xdg-desktop-portal-wlr \
+              hyprland hypridle hyprlock swww xdg-desktop-portal-hyprland \
+              uwsm waybar fuzzel kanshi autotiling swaync"
+    case "$OS" in
+        debian) obsolete="$obsolete sway-notification-center" ;;
+        redhat) obsolete="$obsolete SwayNotificationCenter" ;;
+        *) info "No obsolete-package purge for this OS"; return 0 ;;
+    esac
+
+    # obsolete_pkg_installed warns and returns non-zero on a real query failure,
+    # so a package whose status can't be determined is left out of the purge
+    # rather than silently skipped. Held Debian packages (return 3) are split
+    # off: a hold is a deliberate "do not touch", and apt-get -y would abort the
+    # whole purge on one anyway, so report them and leave them rather than force
+    # them out -- but don't drop them silently.
+    installed=""
+    held=""
+    for pkg in $obsolete; do
+        # Capture the status via || so a non-zero "not installed"/"held"/error
+        # return doesn't trip set -e (it isn't in a condition context here).
+        _pkg_state=0
+        obsolete_pkg_installed "$pkg" || _pkg_state=$?
+        case $_pkg_state in
+            0) installed="$installed $pkg" ;;
+            3) held="$held $pkg" ;;
+        esac
+    done
+    if test -n "$held"; then
+        warn "held, not purging (run 'sudo apt-mark unhold PKG' and re-run, or purge manually):$held"
+    fi
+    if test -z "$installed"; then
+        info "No obsolete Sway/Hyprland packages to purge"
+        return 0
+    fi
+
+    info "Purging obsolete Sway/Hyprland packages:$installed"
+    case "$OS" in
+        debian)
+            # shellcheck disable=SC2086  # word-split the collected package list
+            sudo_or_warn apt-get purge -y $installed \
+                || warn "could not purge some obsolete packages; purge them manually"
+            info "Run 'sudo apt-get autoremove --purge' to sweep up any orphaned dependencies"
+            ;;
+        redhat)
+            # shellcheck disable=SC2086  # word-split the collected package list
+            sudo_or_warn dnf remove -y $installed \
+                || warn "could not remove some obsolete packages; remove them manually"
+            info "Run 'sudo dnf autoremove' to sweep up any orphaned dependencies"
             ;;
     esac
 }
@@ -1899,6 +2053,11 @@ if test "$INSTALL" = yes; then
     install_fnm
 else
     info "Skipping software installation (--no-install)"
+fi
+# A removal, not an install, so it's keyed on its own flag rather than $INSTALL:
+# --purge-obsolete --no-install is a valid "clean up, change nothing else" run.
+if test "$PURGE_OBSOLETE" = yes; then
+    purge_obsolete_packages
 fi
 generate_ssh_key
 if test "$GUI_ENABLED" -eq 1; then

--- a/setup_test
+++ b/setup_test
@@ -280,6 +280,88 @@ echo BOOTSTRAP_CONTINUED" 2>&1)"
     rm -rf "$linux_tmpdir"
 }
 
+# Run purge_obsolete_packages' Linux arm ($1: debian|redhat) against a mock
+# package manager and a mock package-query tool. $2 is a space-separated list of
+# packages the query reports as installed; $3 (optional) a single package whose
+# query the stub makes fail hard (corrupt-db style: stderr + a non-1 exit for
+# dpkg-query, stderr + exit 1 for rpm) to exercise the error path. Every other
+# name reports "not installed". This exercises the real filter -- which packages
+# actually reach apt-get purge / dnf remove -- rather than grepping the source.
+# Leaves $calls set to the package-manager invocation and $output/$status set.
+run_purge_obsolete() {
+    purge_os="$1"
+    purge_installed="$2"
+    purge_query_fail="$3"
+    purge_held="$4"
+    case "$purge_os" in
+        debian) purge_pm=apt-get ;;
+        redhat) purge_pm=dnf ;;
+        *) echo "run_purge_obsolete: unknown OS $purge_os" >&2; return 2 ;;
+    esac
+    purge_tmpdir="$(mktemp -d)"
+    purge_calls="$purge_tmpdir/calls"
+    cat > "$purge_tmpdir/$purge_pm" <<MOCK
+#!/bin/sh
+printf '%s\n' "$purge_pm \$*" >> "$purge_calls"
+exit 0
+MOCK
+    chmod +x "$purge_tmpdir/$purge_pm"
+    # The query stub answers "installed" (exit 0) only for names in
+    # $purge_installed, and fails hard for $purge_query_fail. The package name is
+    # the last argument in both callers (dpkg-query -W -f=... PKG, rpm -q PKG);
+    # walk $@ to get it, POSIXly, since the stub runs under /bin/sh. dpkg-query
+    # prints a three-word "want eflag state" Status to stdout on a match --
+    # "install ok installed" normally, "hold ok installed" for $purge_held (a
+    # held-but-installed package); on a hard failure it writes stderr and exits
+    # 2 (dpkg reserves exit 1 for "not installed"). rpm signals installed via
+    # exit 0 and a real error via stderr + a non-zero exit.
+    if test "$purge_os" = debian; then
+        cat > "$purge_tmpdir/dpkg-query" <<MOCK
+#!/bin/sh
+last=
+for a in "\$@"; do last=\$a; done
+if test -n "$purge_query_fail" && test "\$last" = "$purge_query_fail"; then
+    echo "dpkg-query: error: unable to read database" >&2; exit 2
+fi
+if test -n "$purge_held" && test "\$last" = "$purge_held"; then
+    echo "hold ok installed"; exit 0
+fi
+for _p in $purge_installed; do
+    if test "\$last" = "\$_p"; then echo "install ok installed"; exit 0; fi
+done
+exit 1
+MOCK
+        chmod +x "$purge_tmpdir/dpkg-query"
+    else
+        cat > "$purge_tmpdir/rpm" <<MOCK
+#!/bin/sh
+last=
+for a in "\$@"; do last=\$a; done
+if test -n "$purge_query_fail" && test "\$last" = "$purge_query_fail"; then
+    echo "error: rpmdb: damaged header" >&2; exit 1
+fi
+for _p in $purge_installed; do
+    if test "\$last" = "\$_p"; then exit 0; fi
+done
+exit 1
+MOCK
+        chmod +x "$purge_tmpdir/rpm"
+    fi
+
+    set +e
+    output="$(PATH="$purge_tmpdir:$PATH" \
+        sh -c "set -e
+OS=$purge_os
+sudo_or_warn() { \"\$@\"; }
+$(extract_functions "info warn obsolete_pkg_installed purge_obsolete_packages")
+purge_obsolete_packages
+echo BOOTSTRAP_CONTINUED" 2>&1)"
+    status=$?
+    set -e
+    calls="$(cat "$purge_calls" 2>/dev/null)"
+    rm -rf "$purge_tmpdir"
+}
+
 # Run install_file_managers against a sandboxed HOME with a recording homepkg
 # stub in SCRIPTS_DIR. $1 = which file managers already exist in ~/.local/bin
 # before the call: none (default) | both. Leaves $output/$status/$calls set.
@@ -1224,6 +1306,111 @@ test_file_managers_not_in_dnf_transaction() {
     assert_calls_lack "dnf install -y lf" &&
     assert_calls_lack "kde-desktop-environment" &&
     assert_calls_lack "dnf install -y kitty"
+}
+
+# --- --purge-obsolete: removing the old Sway/Hyprland desktop packages ---
+
+# The flag is accepted and documented. --help exits 0 (an unknown flag would
+# print "Unknown option" and exit 1), and the help text names the flag.
+test_purge_obsolete_flag_accepted_and_documented() {
+    run_setup --purge-obsolete --help
+    assert_status 0 &&
+    assert_output_contains "--purge-obsolete"
+}
+
+# Off by default, and the Main flow only purges when the flag turned it on --
+# a curl|sh run onto a box that deliberately runs Sway mustn't lose it.
+test_purge_obsolete_off_by_default() {
+    assert_source_contains "PURGE_OBSOLETE=no" &&
+    assert_source_contains 'test "$PURGE_OBSOLETE" = yes'
+}
+
+# Only the packages the query reports installed reach apt-get purge: swaync
+# (Debian's sway-notification-center) and waybar are removed, hyprland -- not
+# installed here -- is not named, and the run continues.
+test_purge_obsolete_purges_installed_debian() {
+    run_purge_obsolete debian "sway sway-notification-center waybar"
+    assert_status 0 &&
+    assert_output_contains "BOOTSTRAP_CONTINUED" &&
+    assert_calls_contain "apt-get purge -y" &&
+    assert_calls_contain "sway-notification-center" &&
+    assert_calls_contain "waybar" &&
+    assert_calls_lack "hyprland" &&
+    assert_output_contains "autoremove"
+}
+
+# The old setup fell back to the upstream "swaync" package name (and installed
+# autotiling), so a box may carry those rather than the distro-named packages.
+# Both must be in the candidate list, or the purge misses the very swaync unit
+# that motivated the flag.
+test_purge_obsolete_purges_fallback_names_debian() {
+    run_purge_obsolete debian "swaync autotiling"
+    assert_status 0 &&
+    assert_calls_contain "apt-get purge -y" &&
+    assert_calls_contain "swaync" &&
+    assert_calls_contain "autotiling"
+}
+
+# uwsm (the Wayland session manager the old paths installed for the Hyprland
+# session) is in the candidate list, so an installed one is purged.
+test_purge_obsolete_purges_uwsm_debian() {
+    run_purge_obsolete debian "uwsm"
+    assert_status 0 &&
+    assert_calls_contain "apt-get purge -y" &&
+    assert_calls_contain "uwsm"
+}
+
+# A held package is detected (not silently dropped) but kept out of the -y
+# purge -- apt-get -y aborts the whole transaction on a held change -- so it's
+# reported while the non-held candidates are still purged.
+test_purge_obsolete_reports_held_not_purged() {
+    run_purge_obsolete debian "waybar" "" "fuzzel"
+    assert_status 0 &&
+    assert_output_contains "held, not purging" &&
+    assert_output_contains "fuzzel" &&
+    assert_calls_contain "apt-get purge -y" &&
+    assert_calls_contain "waybar" &&
+    assert_calls_lack "fuzzel"
+}
+
+# A real query failure (corrupt db) must not look like "not installed": the
+# package is left out of the purge AND the failure is reported, not swallowed.
+test_purge_obsolete_query_failure_is_reported() {
+    run_purge_obsolete debian "waybar" "sway"
+    assert_status 0 &&
+    assert_output_contains "querying package sway failed" &&
+    assert_calls_contain "waybar" &&
+    assert_calls_lack "sway"
+}
+
+# Nothing installed -> nothing purged: no apt-get invocation, and it says so.
+test_purge_obsolete_nothing_installed_debian() {
+    run_purge_obsolete debian ""
+    assert_status 0 &&
+    assert_output_contains "No obsolete Sway/Hyprland packages to purge" &&
+    assert_calls_lack "apt-get purge"
+}
+
+# Fedora uses dnf remove and the SwayNotificationCenter package name.
+test_purge_obsolete_removes_installed_redhat() {
+    run_purge_obsolete redhat "sway SwayNotificationCenter"
+    assert_status 0 &&
+    assert_output_contains "BOOTSTRAP_CONTINUED" &&
+    assert_calls_contain "dnf remove -y" &&
+    assert_calls_contain "SwayNotificationCenter" &&
+    assert_calls_lack "waybar" &&
+    assert_output_contains "autoremove"
+}
+
+# The generic Wayland utilities the old setup also installed (pipewire and
+# friends) are deliberately out of the candidate list, so even when one is
+# installed it's never queried and never purged -- only the desktop-specific
+# waybar goes.
+test_purge_obsolete_leaves_generic_wayland_alone() {
+    run_purge_obsolete debian "pipewire waybar"
+    assert_status 0 &&
+    assert_calls_contain "waybar" &&
+    assert_calls_lack "pipewire"
 }
 
 # install_file_managers installs the missing ones from conda-forge via homepkg,
@@ -2244,6 +2431,26 @@ run_test "joshuto and lf are not attempted via apt" \
     test_file_managers_not_in_apt_transaction
 run_test "joshuto and lf are not attempted via dnf" \
     test_file_managers_not_in_dnf_transaction
+run_test "--purge-obsolete is accepted and documented" \
+    test_purge_obsolete_flag_accepted_and_documented
+run_test "obsolete-package purge is off by default" \
+    test_purge_obsolete_off_by_default
+run_test "purge removes only the installed Sway/Hyprland packages (Debian)" \
+    test_purge_obsolete_purges_installed_debian
+run_test "purge covers the swaync/autotiling fallback names (Debian)" \
+    test_purge_obsolete_purges_fallback_names_debian
+run_test "purge covers the uwsm session manager (Debian)" \
+    test_purge_obsolete_purges_uwsm_debian
+run_test "purge reports held packages and keeps them out of the -y purge (Debian)" \
+    test_purge_obsolete_reports_held_not_purged
+run_test "a package-query failure is reported, not treated as absent" \
+    test_purge_obsolete_query_failure_is_reported
+run_test "purge is a no-op when nothing obsolete is installed" \
+    test_purge_obsolete_nothing_installed_debian
+run_test "purge removes the installed packages via dnf (Fedora)" \
+    test_purge_obsolete_removes_installed_redhat
+run_test "purge leaves the generic Wayland utilities alone" \
+    test_purge_obsolete_leaves_generic_wayland_alone
 run_test "joshuto and lf install from conda-forge via homepkg" \
     test_file_managers_install_via_homepkg
 run_test "joshuto and lf install is skipped when already present" \


### PR DESCRIPTION
## What

Adds a `--purge-obsolete` flag to `setup` that removes the Sway and Hyprland
desktop packages an earlier `setup` installed, back when it supported those
compositors. `setup` dropped Sway/Hyprland support when it settled on KDE
Plasma + Krohnkite as its one desktop (commit `8d1c006`, July 2026), but
`apt`/`dnf` never uninstall on their own — so a machine that ran the old
`setup` keeps those packages around. The most visible symptom is a
`sway-notification-center` (swaync) **systemd user unit** under
`/usr/lib/systemd/user` that keeps starting on login, long after the desktop
was removed.

## How

- New opt-in flag `--purge-obsolete` (and `--no-purge-obsolete`), **off by
  default**. `setup` is also fetched via `curl … | sh` onto machines that may
  run Sway or Hyprland *deliberately*, where purging them would be hostile —
  so nothing is removed unless the flag is passed.
- `purge_obsolete_packages()` names only the desktop-specific packages,
  **reconciled against the July 2026 removal commit's install paths** rather
  than from memory: the compositors, their lock/idle/bg helpers, the wlroots
  portals, the `uwsm` session manager, `autotiling`, and the shared
  bar/launcher/notification stack (`waybar`, `fuzzel`, swaync — including the
  upstream `swaync` fallback name the old paths used, plus the distro names
  `sway-notification-center` / `SwayNotificationCenter`). The generic Wayland
  utilities those paths also pulled in (pipewire, blueman, grim/slurp, the GTK
  portal, the polkit agent, …) are deliberately left alone — they're useful
  under KDE too.
- Filters to packages that are **actually installed** before invoking the
  package manager (an unknown name would abort the whole `apt-get purge` /
  `dnf remove` transaction). The `obsolete_pkg_installed` helper reads a
  package's current dpkg/rpm *state* and:
  - distinguishes the expected "not installed" answer from a real
    package-database query failure — on a failure it **warns and leaves the
    package out** rather than silently treating it as absent, so a corrupt db
    can't make the purge claim success while leaving packages behind;
  - splits off **held** Debian packages (`hold ok installed`). A hold is a
    deliberate "do not touch", and `apt-get purge -y` aborts the *entire*
    transaction on a held change (without `--allow-change-held-packages`) — so
    held obsolete packages are **reported** (with how to unhold and re-run),
    not force-removed and not left silent, and one held package can't block the
    rest of the purge.
- Points the user at `autoremove` for the orphaned dependencies rather than
  sweeping them itself.
- Keyed independently of `--no-install`, so `--purge-obsolete --no-install` is
  a valid "clean up, change nothing else" run.
- Best-effort via `sudo_or_warn`, matching the rest of `setup`: a denied sudo
  or a failed purge warns and continues rather than aborting the bootstrap.

## Tests

Adds cases to `setup_test`, driven by a `run_purge_obsolete` harness that mocks
the package manager and the package-query tool (`dpkg-query`/`rpm`):

- flag is accepted and documented in `--help`
- off by default (source-level: `PURGE_OBSOLETE=no`, Main gated on the flag)
- Debian: only the installed packages reach `apt-get purge`; an uninstalled
  one (hyprland) is not named
- the `swaync`/`autotiling` fallback names are covered
- the `uwsm` session manager is covered
- a held package is reported and kept out of the `-y` purge while non-held
  candidates are still purged
- a real package-query failure is reported, not treated as absent
- no-op when nothing obsolete is installed (no package-manager call)
- Fedora: uses `dnf remove` and the `SwayNotificationCenter` package name
- generic Wayland utilities (pipewire) are never queried or purged

`make test` passes (full suite green); `shellcheck -x setup` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLi4s7XLjBRepJ3xYrme9m