### PR TITLE
docs: Recognize a deferral in the merge-gate rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -355,8 +355,9 @@ reply, no offer to correct it. It is not a finding.
   a review is the attributable form, naming the commit it read. Findings
   arrive as review comments, as a top-level comment, or as a review — read
   `get_review_comments`, `get_comments` and `get_reviews` to the last page,
-  since all three page oldest first — and they block the merge until fixed
-  or rebutted; an acknowledgement is not an answer. Nothing from Codex since
+  since all three page oldest first — and they block the merge until fixed,
+  rebutted, or deferred (see *Deferring a finding* above); an acknowledgement
+  is not an answer. Nothing from Codex since
   the push, five minutes on, means it never picked it up — comment `@codex
   review`, once.
 - **Skip echo events silently.** Replies posted via the GitHub MCP come back


### PR DESCRIPTION
## What

Follow-up to #237. The deferring-a-finding rule makes "recorded in `TODO.md` + resolved" a **third** outcome for a Codex finding, but the *Read the Codex verdict* rule still said findings block the merge until "fixed or rebutted" — so drive-to-merge couldn't recognize a deferral. Updated to "fixed, rebutted, or deferred (see *Deferring a finding* above)."

Codex flagged this same gap on the sibling repos (root, repo); the fix is going fleet-wide (mesh already has it; conf phrases its verdict rule differently and needs no change).

Docs-only; `docs:` prefix. `CLAUDE.md` is a symlink to `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WyXXzjwfoTtF1fucYuuQBn

---
_Generated by [Claude Code](https://claude.ai/code/session_01WyXXzjwfoTtF1fucYuuQBn)_