### PR TITLE
Remove joshuto from the install, keeping lf

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ repo).
 `setup --no-root` wires this in automatically: it runs unprivileged (implying
 `--no-sudo`, so the `apt`/`dnf` installs and every other privileged step are
 skipped) and installs the CLI tools via `homepkg` instead — the core set
-(`ripgrep fd bat fzf jq delta gh zoxide joshuto lf`) plus the extras (`helix jj nu`, unless
+(`ripgrep fd bat fzf jq delta gh zoxide lf`) plus the extras (`helix jj nu`, unless
 the minimal profile is in effect). `--no-sudo` on its own is just the mechanism
 (skip sudo); it assumes the tools are provided some other way.
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,20 @@
 # TODO
 
+## Prune a previously-installed joshuto on upgrade
+
+Removing joshuto from the install (its `tools` entry, the file-manager step,
+and the `homepkg` `TOOLS` registry) stops *new* setups from installing it, but
+does nothing for a machine where an earlier `setup` already installed joshuto
+through the managed mamba environment: the binary and its `~/.local/bin/joshuto`
+symlink linger, and because the registry entry is gone, `homepkg remove joshuto`
+now fails in `_require_known`, so there's no supported cleanup command either.
+
+Give upgrades a cleanup path: either prune the setup-managed joshuto (package +
+`~/.local/bin` symlink) during `setup`, or keep enough removal metadata that
+`homepkg remove joshuto` still works for a deregistered-but-installed tool.
+Out of scope for the removal PR itself, which only changes what gets installed
+going forward.
+
 ## Review and merge gates
 
 - [ ] **Add `zizmor` to the ruleset's required set** once it has reported

--- a/homepkg
+++ b/homepkg
@@ -104,7 +104,6 @@ TOOLS = {
     # Terminal file managers. Both have a conda-forge feedstock -- so they ride
     # the default mamba path and the offline bundle -- and a GitHub release for
     # --backend github. Each ships a single binary.
-    "joshuto":  {"conda": "joshuto",  "github": "kamiyaa/joshuto",    "bins": ["joshuto"]},
     "lf":       {"conda": "lf",       "github": "gokcehan/lf",        "bins": ["lf"]},
     # Node toolchain for the setup --no-root path: node/npm/tsc from conda-forge
     # instead of a distro package, plus fnm (which on root boxes comes from its

--- a/homepkg_test
+++ b/homepkg_test
@@ -1145,13 +1145,9 @@ check("registry maps carapace to carapace-bin releases",
       and hp.TOOLS["carapace"]["github"] == "carapace-sh/carapace-bin"
       and hp.TOOLS["carapace"]["bins"] == ["carapace"])
 
-# Terminal file managers. Both have a conda-forge feedstock, so they take the
-# default mamba path and ride the offline bundle; both also have a GitHub
-# release for --backend github. Each ships a single binary.
-check("registry maps joshuto to conda-forge with a joshuto bin",
-      hp.TOOLS["joshuto"]["conda"] == "joshuto"
-      and hp.TOOLS["joshuto"]["github"] == "kamiyaa/joshuto"
-      and hp.TOOLS["joshuto"]["bins"] == ["joshuto"])
+# Terminal file manager. lf has a conda-forge feedstock, so it takes the
+# default mamba path and rides the offline bundle; it also has a GitHub
+# release for --backend github, and ships a single binary.
 check("registry maps lf to conda-forge with an lf bin",
       hp.TOOLS["lf"]["conda"] == "lf"
       and hp.TOOLS["lf"]["github"] == "gokcehan/lf"

--- a/setup
+++ b/setup
@@ -863,10 +863,9 @@ install_packages() {
             info "Installing zoxide"
             sudo_or_warn apt-get install -y --install-recommends zoxide \
                 || warn "could not install zoxide; z/zi directory jumps will be unavailable"
-            # joshuto and lf (terminal file managers) aren't in the Debian/Ubuntu
-            # repos, so they're not attempted here -- install_file_managers
-            # installs them from conda-forge via homepkg after the clone, on
-            # every profile.
+            # lf (terminal file manager) isn't in the Debian/Ubuntu repos, so
+            # it's not attempted here -- install_file_managers installs it from
+            # conda-forge via homepkg after the clone, on every profile.
             # Node.js + tsc from the distro on the privileged path (setup-kde's
             # source-build fallback for Krohnkite needs tsc; its normal path
             # fetches a prebuilt release and needs neither). Under --no-root
@@ -939,10 +938,9 @@ install_packages() {
             info "Installing zoxide"
             sudo_or_warn dnf install -y zoxide \
                 || warn "could not install zoxide; z/zi directory jumps will be unavailable"
-            # joshuto and lf (terminal file managers) aren't in the base Fedora
-            # repos, so they're not attempted here; install_file_managers
-            # installs them from conda-forge via homepkg after the clone, on
-            # every profile.
+            # lf (terminal file manager) isn't in the base Fedora repos, so
+            # it's not attempted here; install_file_managers installs it from
+            # conda-forge via homepkg after the clone, on every profile.
             # Node.js + tsc from the distro on the privileged path (setup-kde's
             # source-build fallback for Krohnkite needs tsc; its normal path
             # fetches a prebuilt release and needs neither). Under --no-root
@@ -1017,13 +1015,10 @@ install_packages() {
             info "Installing zoxide"
             brew install zoxide \
                 || warn "could not install zoxide; z/zi directory jumps will be unavailable"
-            # joshuto and lf are terminal file managers -- CLI tools, not graphical,
-            # so install them regardless of --no-gui (matching the Linux paths).
-            # One brew install each so a formula rename can't take the other down.
-            for fm in joshuto lf; do
-                info "Installing $fm"
-                brew install "$fm" || warn "could not install $fm"
-            done
+            # lf (terminal file manager) is a CLI tool, not graphical, so
+            # install it regardless of --no-gui (matching the Linux paths).
+            info "Installing lf"
+            brew install lf || warn "could not install lf"
             # Node.js + tsc from Homebrew on the privileged path (setup-kde's
             # source-build fallback for Krohnkite needs tsc; its normal path
             # fetches a prebuilt release and needs neither). brew needs no
@@ -1061,7 +1056,7 @@ install_packages() {
             ;;
         *)
             warn "Unsupported OS, skipping package installation"
-            warn "Please install manually: bat curl fd fzf git git-delta golang jq joshuto kitty lf make mercurial npm p7zip python3 ripgrep shellcheck typescript unzip zoxide zsh"
+            warn "Please install manually: bat curl fd fzf git git-delta golang jq kitty lf make mercurial npm p7zip python3 ripgrep shellcheck typescript unzip zoxide zsh"
             ;;
     esac
 }
@@ -1526,7 +1521,7 @@ install_home_tools() {
     # fnm (Node version manager) is a convenience tool -- installed regardless
     # of --no-npm, mirroring the root path's install_fnm (which is skipped under
     # --no-root, so fnm comes from here instead).
-    tools="ripgrep fd bat fzf jq delta gh fnm zoxide joshuto lf"
+    tools="ripgrep fd bat fzf jq delta gh fnm zoxide lf"
     if test "$NPM" = yes; then
         # node/npm + tsc are the actual build toolchain for setup-kde's
         # Krohnkite source-build fallback (its normal path fetches a
@@ -1628,40 +1623,31 @@ install_home_tools() {
 
 # --- Install the terminal file managers with no reliable distro package ---
 
-# joshuto and lf aren't in the Debian/Ubuntu or base Fedora repos -- but both
-# are on conda-forge, so install them from there via homepkg rather than
-# attempting apt/dnf and warning about a miss we already expect.
+# lf isn't in the Debian/Ubuntu or base Fedora repos -- but it's on
+# conda-forge, so install it from there via homepkg rather than attempting
+# apt/dnf and warning about a miss we already expect.
 # Runs after the clone (homepkg lives in the scripts repo) on every profile, but
-# installs only what's missing: the --no-root path already got them from
+# installs only what's missing: the --no-root path already got it from
 # install_home_tools and macOS from Homebrew, so this is a no-op there and does
 # the real work only on a privileged Linux box. homepkg installs into
 # ~/.local/bin, not necessarily on setup's own PATH, so check there too.
-missing_file_managers() {
-    missing=""
-    for tool in joshuto lf; do
-        if ! command -v "$tool" >/dev/null 2>&1 \
-                && ! test -x "$HOME/.local/bin/$tool"; then
-            missing="$missing $tool"
-        fi
-    done
-    printf '%s' "$missing"
+lf_missing() {
+    ! command -v lf >/dev/null 2>&1 && ! test -x "$HOME/.local/bin/lf"
 }
 
 install_file_managers() {
     homepkg="$SCRIPTS_DIR/homepkg"
     if ! test -x "$homepkg"; then
-        warn "homepkg not found in the scripts repo; skipping joshuto and lf"
+        warn "homepkg not found in the scripts repo; skipping lf"
         return 0
     fi
-    file_managers="$(missing_file_managers)"
-    if test -z "$file_managers"; then
-        info "joshuto and lf already installed"
+    if ! lf_missing; then
+        info "lf already installed"
         return 0
     fi
-    info "Installing$file_managers from conda-forge via homepkg (~/.local, no root)"
-    # shellcheck disable=SC2086  # deliberate word split: one arg per tool
-    "$homepkg" install $file_managers \
-        || warn "could not install$file_managers via homepkg; install manually if you want them"
+    info "Installing lf from conda-forge via homepkg (~/.local, no root)"
+    "$homepkg" install lf \
+        || warn "could not install lf via homepkg; install manually if you want it"
 }
 
 # --- Install the interactive shell tools with no packaged build ---
@@ -2100,10 +2086,10 @@ else
     info "Skipping heavyweight extras (helix, jj, nushell); minimal profile"
 fi
 
-# atuin/carapace are small static binaries with no packaged build, and joshuto/lf
-# have no reliable distro package -- both come from homepkg once the scripts
+# atuin/carapace are small static binaries with no packaged build, and lf
+# has no reliable distro package -- all come from homepkg once the scripts
 # repo (and with it homepkg) is on disk, on every profile (including --minimal).
-# install_file_managers is a no-op where they're already installed (--no-root
+# install_file_managers is a no-op where lf is already installed (--no-root
 # via install_home_tools, macOS via Homebrew).
 if test "$INSTALL" = yes; then
     install_shell_tools

--- a/setup_test
+++ b/setup_test
@@ -378,17 +378,15 @@ printf '%s\n' "homepkg \$*" >> "$fm_calls"
 MOCK
     chmod +x "$fm_scripts/homepkg"
     if test "$fm_present" = both; then
-        for _t in joshuto lf; do
-            printf '#!/bin/sh\n' > "$fm_home/.local/bin/$_t"
-            chmod +x "$fm_home/.local/bin/$_t"
-        done
+        printf '#!/bin/sh\n' > "$fm_home/.local/bin/lf"
+        chmod +x "$fm_home/.local/bin/lf"
     fi
 
     set +e
     output="$(sh -c "set -e
 HOME='$fm_home'
 SCRIPTS_DIR='$fm_scripts'
-$(extract_functions "info warn missing_file_managers install_file_managers")
+$(extract_functions "info warn lf_missing install_file_managers")
 install_file_managers
 echo BOOTSTRAP_CONTINUED" 2>&1)"
     status=$?
@@ -1276,23 +1274,22 @@ test_zoxide_is_a_core_package() {
     test "$(grep -c '^ *zoxide \\$' "$SETUP")" -eq 0 &&
     assert_source_contains "could not install zoxide" &&
     assert_source_contains "unzip zoxide zsh" &&
-    assert_source_contains 'tools="ripgrep fd bat fzf jq delta gh fnm zoxide joshuto lf"'
+    assert_source_contains 'tools="ripgrep fd bat fzf jq delta gh fnm zoxide lf"'
 }
 
-# joshuto and lf are terminal file managers with no reliable distro package
-# (neither is in Debian/Ubuntu or the base Fedora repos), so they come from
-# conda-forge via homepkg -- not from apt/dnf, where attempting them would only
+# lf is a terminal file manager with no reliable distro package (it's in
+# neither Debian/Ubuntu nor the base Fedora repos), so it comes from
+# conda-forge via homepkg -- not from apt/dnf, where attempting it would only
 # warn about a miss we already expect. These run the real dispatch and assert
 # the commands issued, rather than grepping the source.
 
-# The distro transactions must NOT name joshuto/lf: a release that lacks them
-# can't abort the core install, and there's no "unavailable" warning. (kitty/kde-*
-# stay out too, confirming the GUI-off run.)
+# The distro transactions must NOT name lf: a release that lacks it can't abort
+# the core install, and there's no "unavailable" warning. (kitty/kde-* stay out
+# too, confirming the GUI-off run.)
 test_file_managers_not_in_apt_transaction() {
     run_linux_packages debian
     assert_status 0 &&
     assert_output_contains "BOOTSTRAP_CONTINUED" &&
-    assert_calls_lack "joshuto" &&
     assert_calls_lack "recommends lf" &&
     assert_calls_lack "kde-standard" &&
     assert_calls_lack "install -y --install-recommends kitty"
@@ -1302,7 +1299,6 @@ test_file_managers_not_in_dnf_transaction() {
     run_linux_packages redhat
     assert_status 0 &&
     assert_output_contains "BOOTSTRAP_CONTINUED" &&
-    assert_calls_lack "joshuto" &&
     assert_calls_lack "dnf install -y lf" &&
     assert_calls_lack "kde-desktop-environment" &&
     assert_calls_lack "dnf install -y kitty"
@@ -1413,17 +1409,17 @@ test_purge_obsolete_leaves_generic_wayland_alone() {
     assert_calls_lack "pipewire"
 }
 
-# install_file_managers installs the missing ones from conda-forge via homepkg,
+# install_file_managers installs lf from conda-forge via homepkg when missing,
 # post-clone and on every profile (so a privileged Linux box, where apt/dnf
-# skipped them and install_home_tools didn't run, still gets them).
+# skipped it and install_home_tools didn't run, still gets it).
 test_file_managers_install_via_homepkg() {
     run_install_file_managers none
     assert_status 0 &&
     assert_output_contains "BOOTSTRAP_CONTINUED" &&
-    assert_calls_contain "homepkg install joshuto lf"
+    assert_calls_contain "homepkg install lf"
 }
 
-# ...and it's a no-op where they're already present (macOS via Homebrew, or the
+# ...and it's a no-op where lf is already present (macOS via Homebrew, or the
 # --no-root path via install_home_tools) -- no second copy in ~/.local/bin.
 test_file_managers_skipped_when_present() {
     run_install_file_managers both
@@ -1432,14 +1428,14 @@ test_file_managers_skipped_when_present() {
     test -z "$calls"
 }
 
-# The rootless path still invokes homepkg with joshuto and lf in the tools it
-# installs -- so --no-root and the offline mamba bundle (which carries the whole
-# registry) get them without needing install_file_managers.
+# The rootless path still invokes homepkg with lf in the tools it installs --
+# so --no-root and the offline mamba bundle (which carries the whole registry)
+# get it without needing install_file_managers.
 test_file_managers_are_in_the_homepkg_core_set() {
     run_home_tools_helix absent
     assert_status 0 &&
     assert_calls_contain "homepkg install ripgrep" &&
-    assert_calls_contain " zoxide joshuto lf"
+    assert_calls_contain " zoxide lf"
 }
 
 # update-alternatives only covers x-terminal-emulator. What makes Plasma's own
@@ -1496,7 +1492,6 @@ test_macos_brew_failures_are_not_fatal() {
     assert_output_contains "BOOTSTRAP_CONTINUED" &&
     assert_output_contains "some core Homebrew packages could not be installed" &&
     assert_output_contains "could not install zoxide" &&
-    assert_output_contains "could not install joshuto" &&
     assert_output_contains "could not install lf" &&
     assert_output_contains "could not install node" &&
     assert_output_contains "could not install tsc" &&
@@ -1511,7 +1506,6 @@ test_macos_brew_failure_still_attempts_later_steps() {
     run_macos_packages 0
     assert_status 0 &&
     assert_calls_contain "brew install zoxide" &&
-    assert_calls_contain "brew install joshuto" &&
     assert_calls_contain "brew install lf" &&
     assert_calls_contain "brew install --cask android-platform-tools" &&
     assert_calls_contain "brew install kitty"
@@ -2427,9 +2421,9 @@ run_test "legacy root config fallback is logged with the remedy" \
     test_legacy_root_config_is_logged
 run_test "zoxide is installed as a core package" \
     test_zoxide_is_a_core_package
-run_test "joshuto and lf are not attempted via apt" \
+run_test "lf is not attempted via apt" \
     test_file_managers_not_in_apt_transaction
-run_test "joshuto and lf are not attempted via dnf" \
+run_test "lf is not attempted via dnf" \
     test_file_managers_not_in_dnf_transaction
 run_test "--purge-obsolete is accepted and documented" \
     test_purge_obsolete_flag_accepted_and_documented
@@ -2451,11 +2445,11 @@ run_test "purge removes the installed packages via dnf (Fedora)" \
     test_purge_obsolete_removes_installed_redhat
 run_test "purge leaves the generic Wayland utilities alone" \
     test_purge_obsolete_leaves_generic_wayland_alone
-run_test "joshuto and lf install from conda-forge via homepkg" \
+run_test "lf installs from conda-forge via homepkg" \
     test_file_managers_install_via_homepkg
-run_test "joshuto and lf install is skipped when already present" \
+run_test "lf install is skipped when already present" \
     test_file_managers_skipped_when_present
-run_test "joshuto and lf are in the homepkg core set" \
+run_test "lf is in the homepkg core set" \
     test_file_managers_are_in_the_homepkg_core_set
 run_test "kitty is set as the KDE terminal on Debian" \
     test_kde_terminal_set_on_debian


### PR DESCRIPTION
## What

Removes joshuto from `setup`'s install, going back to `lf` alone as the terminal file manager.

joshuto was added in #235 (replacing yazi); `lf` covers the need, so this drops joshuto:

- `install_home_tools`' core tool set (`tools=…`) — joshuto removed.
- The macOS Homebrew file-manager step — now just `brew install lf`.
- The conda-forge file-manager install — now lf-only, via a simpler `lf_missing` check in place of the `missing_file_managers` list helper.
- The `homepkg` `TOOLS` registry — joshuto entry removed.
- The unsupported-OS manual-install list and README tool list.

Tests updated throughout to assert the lf-only behavior (`make test` green).

Note: `lf`'s install path is unchanged — this only removes joshuto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WyXXzjwfoTtF1fucYuuQBn

---
_Generated by [Claude Code](https://claude.ai/code/session_01WyXXzjwfoTtF1fucYuuQBn)_