### PR TITLE
Install zsh-autosuggestions alongside zoxide in setup

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -48,3 +48,13 @@ going forward.
       remove setup-managed tools (distinguishing them from independently
       installed copies) so an upgrade that retires one can clean it up.
       Deferred from #235, where the orphan was accepted.
+
+- [ ] **Install zsh-autosuggestions on the `--no-root` path.** The
+      privileged setup installs it from the distro package (apt/dnf/brew,
+      alongside zoxide), but under `--no-root` the distro step is skipped
+      and, unlike fzf/zoxide, it has no conda-forge package for homepkg to
+      fetch. So an unprivileged box gets no inline history ghost text. A
+      git clone of zsh-users/zsh-autosuggestions into
+      `~/.zsh/zsh-autosuggestions` (pinned to a tag) would cover every path
+      uniformly, since the conf shell config already checks that location
+      first; deferred from the setup PR that added the packaged steps.

--- a/setup
+++ b/setup
@@ -863,6 +863,13 @@ install_packages() {
             info "Installing zoxide"
             sudo_or_warn apt-get install -y --install-recommends zoxide \
                 || warn "could not install zoxide; z/zi directory jumps will be unavailable"
+            # zsh-autosuggestions (inline history ghost text) gets its own
+            # best-effort step for the same reason as zoxide: apt aborts the
+            # whole transaction on one unknown name, and older releases may not
+            # package it. The shell config skips it when it's missing.
+            info "Installing zsh-autosuggestions"
+            sudo_or_warn apt-get install -y --install-recommends zsh-autosuggestions \
+                || warn "could not install zsh-autosuggestions; inline history ghost text will be unavailable"
             # lf (terminal file manager) isn't in the Debian/Ubuntu repos, so
             # it's not attempted here -- install_file_managers installs it from
             # conda-forge via homepkg after the clone, on every profile.
@@ -938,6 +945,11 @@ install_packages() {
             info "Installing zoxide"
             sudo_or_warn dnf install -y zoxide \
                 || warn "could not install zoxide; z/zi directory jumps will be unavailable"
+            # Its own step, as with zoxide: dnf aborts the lot on one unknown
+            # name, and the shell config skips it when it's missing.
+            info "Installing zsh-autosuggestions"
+            sudo_or_warn dnf install -y zsh-autosuggestions \
+                || warn "could not install zsh-autosuggestions; inline history ghost text will be unavailable"
             # lf (terminal file manager) isn't in the base Fedora repos, so
             # it's not attempted here; install_file_managers installs it from
             # conda-forge via homepkg after the clone, on every profile.
@@ -1015,6 +1027,11 @@ install_packages() {
             info "Installing zoxide"
             brew install zoxide \
                 || warn "could not install zoxide; z/zi directory jumps will be unavailable"
+            # Its own step, matching zoxide; the shell config skips it when
+            # it's missing.
+            info "Installing zsh-autosuggestions"
+            brew install zsh-autosuggestions \
+                || warn "could not install zsh-autosuggestions; inline history ghost text will be unavailable"
             # lf (terminal file manager) is a CLI tool, not graphical, so
             # install it regardless of --no-gui (matching the Linux paths).
             info "Installing lf"
@@ -1056,7 +1073,7 @@ install_packages() {
             ;;
         *)
             warn "Unsupported OS, skipping package installation"
-            warn "Please install manually: bat curl fd fzf git git-delta golang jq kitty lf make mercurial npm p7zip python3 ripgrep shellcheck typescript unzip zoxide zsh"
+            warn "Please install manually: bat curl fd fzf git git-delta golang jq kitty lf make mercurial npm p7zip python3 ripgrep shellcheck typescript unzip zoxide zsh zsh-autosuggestions"
             ;;
     esac
 }
@@ -1652,8 +1669,10 @@ install_file_managers() {
 
 # --- Install the interactive shell tools with no packaged build ---
 
-# The conf repo's shell config wires up four optional tools. fzf and zoxide
-# are packaged (the distro sets above, or conda-forge via homepkg), but atuin
+# The conf repo's shell config wires up five optional tools. fzf, zoxide and
+# zsh-autosuggestions are packaged (installed from the distro sets above; fzf
+# and zoxide also come from conda-forge via homepkg on the --no-root path,
+# where zsh-autosuggestions has no equivalent yet -- see TODO.md), but atuin
 # and carapace are in neither the distro repos nor conda-forge, so they come
 # from their GitHub releases through homepkg's stateless github backend. That
 # needs no root, so the same call serves every path -- privileged, --no-root

--- a/setup_test
+++ b/setup_test
@@ -1260,10 +1260,11 @@ test_home_tools_include_node_toolchain() {
 
 # --- Interactive shell tools ---
 
-# The conf repo's shell config wires up fzf, zoxide, atuin and carapace. fzf
-# and zoxide are packaged everywhere setup runs, so they ride along in the
-# distro package lists and the homepkg core set. Package names go on their own
-# distro lines: apt/dnf abort the whole transaction on one unknown name.
+# The conf repo's shell config wires up fzf, zoxide, zsh-autosuggestions, atuin
+# and carapace. fzf, zoxide and zsh-autosuggestions are packaged everywhere
+# setup runs, each in its own best-effort per-platform step. Package names go
+# on their own distro lines: apt/dnf abort the whole transaction on one unknown
+# name.
 test_zoxide_is_a_core_package() {
     # In its own best-effort transaction per platform, never in the core
     # package list: apt/dnf reject the whole request on one unknown name,
@@ -1275,6 +1276,31 @@ test_zoxide_is_a_core_package() {
     assert_source_contains "could not install zoxide" &&
     assert_source_contains "unzip zoxide zsh" &&
     assert_source_contains 'tools="ripgrep fd bat fzf jq delta gh fnm zoxide lf"'
+}
+
+# zsh-autosuggestions (inline history ghost text) is packaged in the distros
+# too, so it takes the same best-effort per-platform steps as zoxide rather
+# than riding a core list.
+test_zsh_autosuggestions_is_a_best_effort_package() {
+    # Three install steps (apt, dnf, brew), never a bare entry in a core
+    # package list: one unknown name aborts the whole apt/dnf transaction, and
+    # older releases may not carry it. Plus the manual-install hint.
+    test "$(grep -c '^ *info "Installing zsh-autosuggestions"$' "$SETUP")" -eq 3 &&
+    test "$(grep -c '^ *zsh-autosuggestions \\$' "$SETUP")" -eq 0 &&
+    assert_source_contains "could not install zsh-autosuggestions" &&
+    assert_source_contains "zoxide zsh zsh-autosuggestions"
+}
+
+# The grep above proves the steps and messages exist; this runs the real
+# dispatch and asserts each package manager is actually asked for the
+# package, so a step that stops naming it can't pass on its message alone.
+test_zsh_autosuggestions_reaches_each_package_manager() {
+    run_linux_packages debian &&
+    assert_calls_contain "install-recommends zsh-autosuggestions" &&
+    run_linux_packages redhat &&
+    assert_calls_contain "dnf install -y zsh-autosuggestions" &&
+    run_macos_packages 0 &&
+    assert_calls_contain "brew install zsh-autosuggestions"
 }
 
 # lf is a terminal file manager with no reliable distro package (it's in
@@ -2421,6 +2447,10 @@ run_test "legacy root config fallback is logged with the remedy" \
     test_legacy_root_config_is_logged
 run_test "zoxide is installed as a core package" \
     test_zoxide_is_a_core_package
+run_test "zsh-autosuggestions is installed as a best-effort package" \
+    test_zsh_autosuggestions_is_a_best_effort_package
+run_test "zsh-autosuggestions reaches each package manager" \
+    test_zsh_autosuggestions_reaches_each_package_manager
 run_test "lf is not attempted via apt" \
     test_file_managers_not_in_apt_transaction
 run_test "lf is not attempted via dnf" \


### PR DESCRIPTION
The conf shell config now sources zsh-autosuggestions for inline history ghost text (mikelward/conf#314). This makes `setup` install it so a freshly bootstrapped box has it.

## What
A best-effort install step in each platform branch — apt, dnf, brew — mirroring exactly how zoxide is handled:
- its **own** transaction, because apt/dnf abort the whole request on one unknown name, and an older release may not package it;
- warns (doesn't fail) when it can't be installed;
- added to the manual-install hint for unsupported OSes.

It's packaged as `zsh-autosuggestions` on all three, and lands in a path the shell config already checks (`/usr/share/...`, `/usr/share/zsh/plugins/...`, `/opt/homebrew/share/...`, `/usr/local/share/...`), so no further wiring is needed.

## Not covered: `--no-root`
Under `--no-root` the distro step is skipped, and unlike fzf/zoxide it has no conda-forge package for homepkg to fetch — so an unprivileged box gets no ghost text. A git clone into `~/.zsh/zsh-autosuggestions` (which the shell config checks first) would cover every path uniformly; deferred to `TODO.md`.

## Testing
`make test` green. New test `test_zsh_autosuggestions_is_a_best_effort_package` mirrors the zoxide one: asserts the three per-platform install steps, that it's never a bare entry in a core package list, the warning, and the manual-install hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011MowX2tGPq6Acx5rcwiqtz

---
_Generated by [Claude Code](https://claude.ai/code/session_011MowX2tGPq6Acx5rcwiqtz)_