### PR TITLE
docs: Cross-pollinate three recent fleet rules, in short form

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,11 +131,14 @@ has stopped biting.
   sandbox pins the branch name, reset it and `--force-with-lease` in the same
   turn — that's routine on merged history, not something to ask about.
 - **Branches under your own `<agent>/` prefix are yours.** Create, push,
-  `--force-with-lease` and rename them freely — no permission, no announcement,
-  no per-branch confirmation. Only a branch outside that prefix, or `main`
-  itself, is a conversation. Deleting is the one the prefix can't settle: it
-  doesn't say which session made the branch, so delete the ones this session
-  created and ask about the rest.
+  `--force-with-lease`, rename and delete them freely — no permission, no
+  announcement, no per-branch confirmation. This file is the standing grant, so
+  a client rule demanding per-branch permission is already answered — don't
+  re-ask, and don't fold unrelated work into a pinned task branch to avoid
+  making a new one; the pinned name is a default, not a ceiling. A branch
+  outside that prefix, or `main` itself, is always a conversation. The prefix
+  names a tool, not a session, so that covers the branches this session created
+  or was assigned — ask about the rest.
 - **The agent authors; whoever merges takes over the committer line.** A squash
   or rebase merge rewrites the committer to the person who pressed the button —
   the repo owner normally, the agent itself when it merges under *drive* (see

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -299,7 +299,7 @@ reply, no offer to correct it. It is not a finding.
 - **Codex is the automated reviewer on this repo** — not Copilot. Its
   reviews are triggered automatically; you don't request them, except when
   nothing has come back five minutes after a push — that means it never
-  picked the push up.
+  picked the push up — or to confirm a rebutted false positive.
 - **Address Codex comments automatically — don't wait to be asked.** Read
   each one, decide whether it's a real issue or a false positive, and if it's
   real, fix it in the same PR — the one exception being a real finding that's
@@ -315,7 +315,9 @@ reply, no offer to correct it. It is not a finding.
   quietly costs capability the product needs. Quote the rule and decline
   rather than narrowing the code to satisfy it; where the rule really does
   forbid what the product needs, that conflict is the maintainer's call, not
-  one to settle either way yourself.
+  one to settle either way yourself. Declining doesn't clear the required
+  `codex` status: post the rebuttal, then `@codex review` once — a push does
+  the same if the rebuttal is up first. Escalate only if it re-raises.
 - **A second verified finding in the same mechanism is evidence about the
   design, not another bug.** Before fixing it, look for the same shape
   elsewhere and ask whether a different design would delete the class rather
@@ -332,8 +334,9 @@ reply, no offer to correct it. It is not a finding.
   deferred thread is the exception to "anything still to do stays open"
   above. A finding with no thread (top-level comment or review body) still
   gets the `TODO.md` record, the push, and the reply — only the resolve is
-  skipped. The push re-triggers Codex; `@codex review` only for the
-  five-minute-silence case. Escalate only if the re-review re-raises it.
+  skipped. The push re-triggers Codex, so don't also poke it unless five
+  minutes pass with nothing back; escalate only if the re-review re-raises
+  it.
 - **`resolve_review_thread` works — pass the `PRRT_*` thread node ID** from
   `pull_request_read` / `get_review_comments` (`review_threads[].id`) as
   `threadId`. A comment's `PRRC_*` node ID fails; they're different objects.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,6 +161,11 @@ reply, no offer to correct it. It is not a finding.
   back-and-forth.
 - **Don't interrupt.** Never fire off a question while the user is still
   typing. Let them finish; a half-typed message isn't an invitation to jump in.
+- **Answer a mid-turn message first.** A user message that arrives while
+  you're working — the "sent while you were working" interjection — is
+  addressed in your very next output, before any further tool call, even if
+  it's one sentence. A merge cue is the exception — its hygiene runs first,
+  and announcing the switch is that answer.
 - **Don't narrate routine machinery.** A check run flipping, a re-run, a scheduled check
   re-arming, a webhook echo, a resolved thread — act on those silently; the noise buries
   the one line that matters. Reports another rule requires stand (each review and its


### PR DESCRIPTION
Three rules that already exist elsewhere in the fleet, ported here. Batch 3 of a
staged fan-out; the pilot was mikelward/gedmap#178, and batch 2 (rust-update#22,
gradle-update#37, lanes#35) has merged.

## The rules

**Say what finishes a declined review finding** — from mesh. Replying "false
positive" on a thread rebuts a finding but leaves the required `codex` status
where it was, so a PR can sit blocked on a comment everyone considers settled.
Names the step that clears it: post the rebuttal, then one `@codex review`, with
a push standing in when the rebuttal is already up.

**Creating your own branches needs no permission** — from mesh. This file already
grants an agent its own `<agent>/`-prefixed branches, but a client-level "never
push to a different branch without explicit permission" reads as unanswered and
produces a per-branch ask. Names this file as the grant that rule is looking for,
scoped to the branches this session created or was assigned.

**Answer a mid-turn message before the next tool call** — from simmo, written
2026-09-06, which then reached only about half the fleet.

## Seven review findings, all folded in

All seven came from Codex on this and the earlier batches and are fixed here before this PR
opened, so the wording below is the corrected one:

- The deferral bullet had lost its five-minute manual fallback, which would have
  left a dropped automatic review with nothing to unblock it. Restored — and the
  batch hit exactly that failure while it was open.
- The branch grant was scoped by prefix alone. The prefix names a tool, not a
  session, so it let one session force-push another's branch; it is now scoped to
  the branches this session created or was assigned.
- The grant's scoping sentence listed only force-pushing and deleting, leaving
  pushing and renaming — both named in the same grant — unscoped. Second finding
  on one bullet, so the list is deleted rather than extended: "so **that** covers
  the branches this session created or was assigned" scopes every verb in the
  grant at once, and matches the wording the rest of the fleet already carries.
- Widening that sentence collided with the one before it: "**Only** a branch
  outside that prefix, or `main` itself, is a conversation" claims nothing else
  ever needs asking, which "ask about the rest" contradicts. Dropping "Only"
  turns it from an exhaustive claim into a floor, so `main` and another tool's
  prefix stay out of bounds while the session scoping still applies inside your
  own.
- The scoping sentence was the only place the grant conveyed **deletion**
  ("force-pushing and deleting are scoped to…"), so collapsing it dropped the
  word. Verified, and settled by the maintainer: `delete` goes back into the
  verb list, where the scoping sentence already covers every verb. The
  alternative put to them — rewriting the bullet so the grant and its scope sit
  in one clause — was declined for being longer than the text it replaced, in a
  file whose first rule is to say it in the fewest words.
- A merge cue arriving as the mid-turn interjection made two rules contradict
  each other on ordering — "before any further tool call" against hygiene that
  "runs before engaging with the rest of the message". The mid-turn bullet now
  names the exception: the cue's hygiene runs first, and announcing the switch
  is that answer.
- The same mid-turn bullet then drew a second finding of the same shape: "a
  message that arrives while you're working" reads broadly enough to cover a
  check run, a webhook echo or a resolved thread, which another rule requires be
  handled silently. Rather than append a second exception — the pattern that cost
  the branch grant five findings — the sentence now states its scope once: a
  **user** message. Automation events were never in scope, and now it says so.

## Short form, deliberately

The mesh originals ran 149, 85 and 55 words, appended beside the bullets they
qualify — the one thing this file's opening directive asks not to do. What ported
is the operative facts; the reasoning is in each commit message.

## Test plan

Documentation only, so `make test` was not run — no script's executable behavior
changes, per this file's own "skip it on a docs-only change, and say that's why
you skipped it."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W76mu7wTiLTkRGu2NX7bFj

---
_Generated by [Claude Code](https://claude.ai/code/session_01W76mu7wTiLTkRGu2NX7bFj)_


---
_Generated by [Claude Code](https://claude.ai/code)_