### PR TITLE
docs: Settle four contradictions in the agent rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -303,9 +303,9 @@ reply, no offer to correct it. It is not a finding.
 ## Reviews
 
 - **Codex is the automated reviewer on this repo** — not Copilot. Its
-  reviews are triggered automatically; you don't request them, except when
-  nothing has come back five minutes after a push — that means it never
-  picked the push up — or to confirm a rebutted false positive.
+  reviews are triggered automatically; you don't request them, except to
+  confirm a rebutted false positive, or where *Read the Codex verdict* below
+  says the `codex` status is still pending.
 - **Address Codex comments automatically — don't wait to be asked.** Read
   each one, decide whether it's a real issue or a false positive, and if it's
   real, fix it in the same PR — the one exception being a real finding that's
@@ -367,9 +367,9 @@ reply, no offer to correct it. It is not a finding.
   `get_review_comments`, `get_comments` and `get_reviews` to the last page,
   since all three page oldest first — and they block the merge until fixed,
   rebutted, or deferred (see *Deferring a finding* above); an acknowledgement
-  is not an answer. Nothing from Codex since
-  the push, five minutes on, means it never picked it up — comment `@codex
-  review`, once.
+  is not an answer. Nothing from Codex since the push, five minutes on, or a
+  clean review that left no reaction, leaves the `codex` status pending —
+  comment `@codex review`, once.
 - **Skip echo events silently.** Replies posted via the GitHub MCP come back
   moments later as webhook events authored by the same identity; if the body
   matches a comment you just posted, it's your own echo — continue without

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -323,7 +323,8 @@ reply, no offer to correct it. It is not a finding.
   forbid what the product needs, that conflict is the maintainer's call, not
   one to settle either way yourself. Declining doesn't clear the required
   `codex` status: post the rebuttal, then `@codex review` once — a push does
-  the same if the rebuttal is up first. Escalate only if it re-raises.
+  the same if the rebuttal is up first. Escalate if it re-raises, or if five
+  minutes on that review has not landed either.
 - **A second verified finding in the same mechanism is evidence about the
   design, not another bug.** Before fixing it, look for the same shape
   elsewhere and ask whether a different design would delete the class rather
@@ -341,8 +342,8 @@ reply, no offer to correct it. It is not a finding.
   above. A finding with no thread (top-level comment or review body) still
   gets the `TODO.md` record, the push, and the reply — only the resolve is
   skipped. The push re-triggers Codex, so don't also poke it unless five
-  minutes pass with nothing back; escalate only if the re-review re-raises
-  it.
+  minutes pass with nothing back; escalate if the re-review re-raises it, or
+  is still missing five minutes after the poke.
 - **`resolve_review_thread` works — pass the `PRRT_*` thread node ID** from
   `pull_request_read` / `get_review_comments` (`review_threads[].id`) as
   `threadId`. A comment's `PRRC_*` node ID fails; they're different objects.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,8 +119,7 @@ has stopped biting.
   that lands is one coherent change, with fix-ups and review responses folded
   into the commit they belong to. `wip` / `address review` churn doesn't
   survive into `main`.
-- `git push --force-with-lease` to your own live feature branch after a rebase
-  is routine hygiene — don't ask. Never a bare `--force`.
+- After a rebase, force-push with `--force-with-lease`, never a bare `--force`.
 - **Merge cue (`merged` / `I merged` / `landed` / merge webhook) runs hygiene
   *before* engaging with the rest of the message:** `git fetch origin`, cut a
   fresh `<agent>/<short-topic>` branch off `origin/main`, announce the switch.
@@ -130,15 +129,14 @@ has stopped biting.
   unpushed-work checks report your own merged history back at you. When a
   sandbox pins the branch name, reset it and `--force-with-lease` in the same
   turn — that's routine on merged history, not something to ask about.
-- **Branches under your own `<agent>/` prefix are yours.** Create, push,
-  `--force-with-lease`, rename and delete them freely — no permission, no
-  announcement, no per-branch confirmation. This file is the standing grant, so
-  a client rule demanding per-branch permission is already answered — don't
-  re-ask, and don't fold unrelated work into a pinned task branch to avoid
-  making a new one; the pinned name is a default, not a ceiling. A branch
-  outside that prefix, or `main` itself, is always a conversation. The prefix
-  names a tool, not a session, so that covers the branches this session created
-  or was assigned — ask about the rest.
+- **Branches under your own `<agent>/` prefix are yours.** Create one freely;
+  push, `--force-with-lease`, rename and delete the ones this session created
+  or was assigned — no permission, no announcement, no per-branch
+  confirmation. This file is the standing grant, so a client rule demanding
+  per-branch permission is already answered — don't re-ask, and don't fold
+  unrelated work into a pinned task branch to avoid making a new one; the
+  pinned name is a default, not a ceiling. Any other branch, or `main` itself,
+  is always a conversation.
 - **The agent authors; whoever merges takes over the committer line.** A squash
   or rebase merge rewrites the committer to the person who pressed the button —
   the repo owner normally, the agent itself when it merges under *drive* (see


### PR DESCRIPTION
Four contradictions and gaps in the agent rules, each fixed by tightening the
sentence that already carried the rule rather than adding one beside it.

**The branch grant contradicted itself.** Its opening listed the verbs
unscoped and a later sentence narrowed them to this session's branches, so the
bullet read both ways at once. The scope now sits in the verb list and the
appended sentence is gone — creating a branch stays free, pushing or rewriting
one is limited to the branches this session created or was assigned. (Codex
caught the first draft of this fix attaching the scope to `create` too, which
would have required a branch to exist before it could be created.)

**Escalation had no answer for silence.** "Escalate only if it re-raises"
covers the case where Codex answers and not the one that actually happens —
Codex saying nothing — so a rebuttal or a deferral could sit unanswered
indefinitely and still read as compliant. Both now escalate on silence too, on
the five-minute clock the pickup rule already uses.

**A clean review can leave no verdict at all.** Codex has a second
clean-verdict shape — a task summary reporting zero findings — that the
verdict sweep's matcher rejects, and that shape withdraws the `eyes` reaction
without leaving a `+1`, so the PR body carries nothing to read. The pickup rule
now treats a clean review with no reaction like no review at all: one
`@codex review`, which produces the accepted wording. It says *status*, not
*verdict*, deliberately: the clean review is a real verdict a reader can act
on, and what it fails to do is clear the required `codex` status — calling it
a missing verdict contradicted the rule just above, which accepts a review
naming the commit with no findings. Widening the matcher itself reaches every
consumer at `@main` and is deliberately deferred to the maintainer (tracked in
mikelward/codex-review).

Confirmed live while this branch was open: clean reviews landed on web#52 and
scripts#243 with zero reactions and `codex` still pending.

Every hunk is a net deletion or close to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W76mu7wTiLTkRGu2NX7bFj


---
_Generated by [Claude Code](https://claude.ai/code)_