### PR TITLE
docs: Bound the wait before escalating past a Codex nudge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -369,7 +369,8 @@ reply, no offer to correct it. It is not a finding.
   rebutted, or deferred (see *Deferring a finding* above); an acknowledgement
   is not an answer. Nothing from Codex since the push, five minutes on, or a
   clean review that left no reaction, leaves the `codex` status pending —
-  comment `@codex review`, once.
+  comment `@codex review`, once; if that has not landed five minutes on,
+  escalate rather than poking again.
 - **Skip echo events silently.** Replies posted via the GitHub MCP come back
   moments later as webhook events authored by the same identity; if the body
   matches a comment you just posted, it's your own echo — continue without


### PR DESCRIPTION
The nudge clause said to comment `@codex review` once, then stopped — leaving
no bound on what to do if that retrigger also produced nothing. Read literally,
an agent could escalate the moment the poke was posted (the exact failure the
surrounding review flows already guard against), or keep poking indefinitely.

This adds the same five-minute bound the adjacent escalation rules and the
deferral bullet in this file already carry, so all three read consistently.

The sibling repos merged this wording earlier in the same pass; these four took
the unbounded version before the bound was settled. Documentation only — no
behavior change in the repo itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W76mu7wTiLTkRGu2NX7bFj

---
_Generated by [Claude Code](https://claude.ai/code/session_01W76mu7wTiLTkRGu2NX7bFj)_