### PR TITLE
docs: Key the Codex re-request rules to the status, not to a review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -341,9 +341,8 @@ reply, no offer to correct it. It is not a finding.
   deferred thread is the exception to "anything still to do stays open"
   above. A finding with no thread (top-level comment or review body) still
   gets the `TODO.md` record, the push, and the reply — only the resolve is
-  skipped. The push re-triggers Codex, so don't also poke it unless five
-  minutes pass with nothing back; escalate if the re-review re-raises it, or
-  is still missing five minutes after the poke.
+  skipped. The push re-triggers Codex, so poke only as *Read the Codex
+  verdict* allows; escalate if the re-review re-raises it.
 - **`resolve_review_thread` works — pass the `PRRT_*` thread node ID** from
   `pull_request_read` / `get_review_comments` (`review_threads[].id`) as
   `threadId`. A comment's `PRRC_*` node ID fails; they're different objects.
@@ -369,8 +368,8 @@ reply, no offer to correct it. It is not a finding.
   rebutted, or deferred (see *Deferring a finding* above); an acknowledgement
   is not an answer. Nothing from Codex since the push, five minutes on, or a
   clean review that left no reaction, leaves the `codex` status pending —
-  comment `@codex review`, once; if that has not landed five minutes on,
-  escalate rather than poking again.
+  comment `@codex review`, once; escalate rather than poking again if the
+  status is still pending five minutes later.
 - **Skip echo events silently.** Replies posted via the GitHub MCP come back
   moments later as webhook events authored by the same identity; if the body
   matches a comment you just posted, it's your own echo — continue without


### PR DESCRIPTION
Pilot for a fleet-wide wording fix; the other seven repos follow only if this
one reads right.

Both clauses escalated only when **no review arrived**. A re-review that lands
and again leaves no reaction satisfies that condition, so the escalation never
fires and the single poke is already spent — with the required `codex` status
still pending and no next step. That is not hypothetical: seven pull requests
hit exactly that state today across six repositories, each one a Codex review
reporting no findings in a shape the verdict sweep does not recognize.

Both now key on the status, which covers "nothing came back" and "something
came back that did not clear it" alike. The deferral clause also carried its own
copy of the condition; it now points at the one rule instead of restating the
corrected version, so the two cannot drift apart again.

Net deletion of a line. Documentation only — no script behavior changes, so
`make test` was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W76mu7wTiLTkRGu2NX7bFj

---
_Generated by [Claude Code](https://claude.ai/code/session_01W76mu7wTiLTkRGu2NX7bFj)_